### PR TITLE
Implement Driver#getParentLogger

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -34,7 +34,9 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
     // dsLogger is logger used for all SQLServerDataSource instances. 
     static final java.util.logging.Logger dsLogger = java.util.logging.Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDataSource");
     static final java.util.logging.Logger loggerExternal =
-                            java.util.logging.Logger.getLogger("com.microsoft.sqlserver.jdbc.DataSource");
+                            java.util.logging.Logger.getLogger("com.microsoft.sqlserver.jdbc.DataSource"); 
+    static final private java.util.logging.Logger parentLogger =
+            java.util.logging.Logger.getLogger("com.microsoft.sqlserver.jdbc");
     final private String loggingClassName;
     private boolean trustStorePasswordStripped = false; 
     private static final long serialVersionUID = 654861379544314296L;
@@ -117,8 +119,7 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
     {
         DriverJDBCVersion.checkSupportsJDBC41();
 
-    	// The driver currently does not implement JDDBC 4.1 APIs
-    	throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));    	    	
+        return parentLogger;
     }
     
     // Core Connection property setters/getters.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -1024,6 +1024,8 @@ public final class SQLServerDriver implements java.sql.Driver
         }
         static final private java.util.logging.Logger loggerExternal =
             java.util.logging.Logger.getLogger("com.microsoft.sqlserver.jdbc.Driver"); 
+        static final private java.util.logging.Logger parentLogger =
+                java.util.logging.Logger.getLogger("com.microsoft.sqlserver.jdbc"); 
         final private String loggingClassName;
         String getClassNameLogging()
         {
@@ -1278,8 +1280,7 @@ public final class SQLServerDriver implements java.sql.Driver
     public Logger getParentLogger() throws SQLFeatureNotSupportedException{
         DriverJDBCVersion.checkSupportsJDBC41();
 
-    	// The driver currently does not implement JDDBC 4.1 APIs
-        throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+        return parentLogger;
      }   
     
    /*L0*/ public boolean jdbcCompliant() {


### PR DESCRIPTION
Implement getParentLogger

The driver and data source use JUL for logging but do not implement
#getParentLogger.

This commit contains the following changes:

 * implement Driver#getParentLogger
 * implement DataSource#getParentLogger
 * use "com.microsoft.sqlserver.jdbc" as the parent logger
 * instead of spaces and tabs on the same line for indentation use
   spaces only
 * remove the comments
   "The driver currently does not implement JDDBC 4.1 APIs".
   While technically true these specific methods are implemented now.
 * follow driver naming conventions rather than Java naming conventions
 * follow driver conventions modifier location rather than Java
   conventions
 * no tests added since I couldn't find any existing tests for the
   driver oder data source class
