### PR TITLE
Implement missing MetaData #unwrap methods

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -133,7 +133,16 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     public <T> T unwrap(Class<T> iface) throws SQLException
     {
         DriverJDBCVersion.checkSupportsJDBC4();
-        throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+        T t;
+        try
+        {
+            t = iface.cast(this);
+        }
+        catch (ClassCastException e)
+        {
+            throw new SQLServerException(e.getMessage(), e);
+        }
+        return t;
     }
 
     private void checkClosed() throws SQLServerException 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -638,7 +638,16 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
 	public <T> T unwrap(Class<T> iface) throws SQLException
 	{
 		DriverJDBCVersion.checkSupportsJDBC4();
-		throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+		T t;
+		try
+		{
+			t = iface.cast(this);
+		}
+		catch (ClassCastException e)
+		{
+			throw new SQLServerException(e.getMessage(), e);
+		}
+		return t;
 	}
 
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -86,7 +86,16 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     public <T> T unwrap(Class<T> iface) throws SQLException
     {
         DriverJDBCVersion.checkSupportsJDBC4();
-        throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+        T t;
+        try
+        {
+            t = iface.cast(this);
+        }
+        catch (ClassCastException e)
+        {
+            throw new SQLServerException(e.getMessage(), e);
+        }
+        return t;
     }
 
     public String getCatalogName(int column) throws SQLServerException


### PR DESCRIPTION
The driver currently implements some #unwrap methods but for MetaData

 * implement DatabaseMetaData#unwrap
 * implement ParameterMetaData#unwrap
 * implement ResultSetMetaData#unwrap
 * use for spaces for indentation where spaces are used
 * use tabs for indentation where tabs are used