### PR TITLE
Use StandardCharsets where possible

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -25,6 +25,8 @@ import java.nio.*;
 import java.text.*;
 import java.util.*;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
 /**
  * Utility class for all Data Dependant Conversions (DDC).
  */
@@ -532,7 +534,7 @@ final class DDC
 			case CHARACTER:
 				return new StringReader(stringVal);
 			case ASCII:
-				return new ByteArrayInputStream(stringVal.getBytes("US-ASCII"));
+				return new ByteArrayInputStream(stringVal.getBytes(US_ASCII));
 			case BINARY:
 				return new ByteArrayInputStream(stringVal.getBytes());
 
@@ -622,7 +624,7 @@ final class DDC
 					}
 					else
 					{
-						return new ByteArrayInputStream((new String(stream.getBytes(), typeInfo.getCharset())).getBytes("US-ASCII"));
+						return new ByteArrayInputStream((new String(stream.getBytes(), typeInfo.getCharset())).getBytes(US_ASCII));
 					}
 				}
 				else if (StreamType.CHARACTER == getterArgs.streamType ||
@@ -1357,7 +1359,7 @@ final class AsciiFilteredUnicodeInputStream extends InputStream
 	private AsciiFilteredUnicodeInputStream( Reader rd) throws SQLServerException
 	{
 		containedReader = rd;
-		asciiCharSet = Charset.forName("US-ASCII");
+		asciiCharSet = US_ASCII;
 	}
 
 	public void close() throws IOException

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAeadAes256CbcHmac256EncryptionKey.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAeadAes256CbcHmac256EncryptionKey.java
@@ -19,10 +19,11 @@
 
 package com.microsoft.sqlserver.jdbc;
 
-import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
 
 /**
  * Encryption key class which consist of following 4 keys :
@@ -81,7 +82,7 @@ import java.text.MessageFormat;
             // By default Java is big endian, we are getting bytes in little endian(LE in UTF-16LE)
             // to make it compatible with C# driver which is little endian
             encKeyBuff = SQLServerSecurityUtility.getHMACWithSHA256(
-                encryptionKeySaltFormat.getBytes("UTF-16LE"),
+                encryptionKeySaltFormat.getBytes(UTF_16LE),
                 rootKey,
                 encKeyBuff.length);
 
@@ -90,7 +91,7 @@ import java.text.MessageFormat;
             // Derive mac key from root key
             byte[] macKeyBuff = new byte[keySizeInBytes];
             macKeyBuff = SQLServerSecurityUtility.getHMACWithSHA256(
-                macKeySaltFormat.getBytes("UTF-16LE"),
+                macKeySaltFormat.getBytes(UTF_16LE),
                 rootKey,
                 macKeyBuff.length);
 
@@ -99,17 +100,10 @@ import java.text.MessageFormat;
             // Derive the initialization vector from root key
             byte[] ivKeyBuff = new byte[keySizeInBytes];
             ivKeyBuff = SQLServerSecurityUtility.getHMACWithSHA256(
-                ivKeySaltFormat.getBytes("UTF-16LE"),
+                ivKeySaltFormat.getBytes(UTF_16LE),
                 rootKey,
                 ivKeyBuff.length);
             ivKey = new SQLServerSymmetricKey(ivKeyBuff);
-        }
-        catch (UnsupportedEncodingException e)
-        {
-            MessageFormat form = new MessageFormat(
-                SQLServerException.getErrString("R_unsupportedEncoding"));
-            Object[] msgArgs = { "UTF-16LE" };
-            throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
         }
         catch (InvalidKeyException  | NoSuchAlgorithmException e)
         {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAeadAes256CbcHmac256Factory.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAeadAes256CbcHmac256Factory.java
@@ -19,13 +19,12 @@
 
 package com.microsoft.sqlserver.jdbc;
 
-import java.io.UnsupportedEncodingException;
-import java.sql.SQLException;
 import java.text.MessageFormat;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.xml.bind.DatatypeConverter;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Factory for SQLServerAeadAes256CbcHmac256Algorithm
@@ -49,40 +48,33 @@ import javax.xml.bind.DatatypeConverter;
 	    }
 		String factoryKey="";
 		
-		try {
-			StringBuffer factoryKeyBuilder=new StringBuffer();
-			factoryKeyBuilder.append(
-					DatatypeConverter.printBase64Binary(
-							new String(
-									columnEncryptionKey.getRootKey(),
-									"UTF-8"
-							).getBytes()
-					)
-			);
+		StringBuffer factoryKeyBuilder=new StringBuffer();
+		factoryKeyBuilder.append(
+				DatatypeConverter.printBase64Binary(
+						new String(
+								columnEncryptionKey.getRootKey(),
+								UTF_8
+						).getBytes()
+				)
+		);
 
-			factoryKeyBuilder.append(":");
-			factoryKeyBuilder.append(encryptionType);
-			factoryKeyBuilder.append(":");
-			factoryKeyBuilder.append(algorithmVersion);
-			
-			factoryKey =factoryKeyBuilder.toString();
-			
-			 SQLServerAeadAes256CbcHmac256Algorithm aesAlgorithm;
-			 
-			 if(!encryptionAlgorithms.containsKey(factoryKey)){
-				 SQLServerAeadAes256CbcHmac256EncryptionKey encryptedKey = new SQLServerAeadAes256CbcHmac256EncryptionKey(columnEncryptionKey.getRootKey(), SQLServerAeadAes256CbcHmac256Algorithm.algorithmName);
-				 aesAlgorithm = new SQLServerAeadAes256CbcHmac256Algorithm(encryptedKey, encryptionType, algorithmVersion);
-				 encryptionAlgorithms.putIfAbsent(factoryKey, aesAlgorithm);
-			 }
+		factoryKeyBuilder.append(":");
+		factoryKeyBuilder.append(encryptionType);
+		factoryKeyBuilder.append(":");
+		factoryKeyBuilder.append(algorithmVersion);
+		
+		factoryKey =factoryKeyBuilder.toString();
+		
+		 SQLServerAeadAes256CbcHmac256Algorithm aesAlgorithm;
+		 
+		 if(!encryptionAlgorithms.containsKey(factoryKey)){
+			 SQLServerAeadAes256CbcHmac256EncryptionKey encryptedKey = new SQLServerAeadAes256CbcHmac256EncryptionKey(columnEncryptionKey.getRootKey(), SQLServerAeadAes256CbcHmac256Algorithm.algorithmName);
+			 aesAlgorithm = new SQLServerAeadAes256CbcHmac256Algorithm(encryptedKey, encryptionType, algorithmVersion);
+			 encryptionAlgorithms.putIfAbsent(factoryKey, aesAlgorithm);
+		 }
 		 
 		 
 		
-		} catch (UnsupportedEncodingException e) {
-		    MessageFormat form = new MessageFormat(
-                SQLServerException.getErrString("R_unsupportedEncoding"));
-            Object[] msgArgs = { "UTF-8" };
-            throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
-		}
 		return encryptionAlgorithms.get(factoryKey);
 	}
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -28,7 +28,6 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.ResultSet;
@@ -53,6 +52,9 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.Vector;
 import java.util.logging.Level;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import javax.sql.RowSet;
 
@@ -3524,7 +3526,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 	 	            Object[] msgArgs = { srcJdbcType, destJdbcType };
 	 	            throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
 	        	}
-	    		return ((String)value).getBytes(Charset.forName("UTF-8"));
+	    		return ((String)value).getBytes(UTF_8);
 	    	
 	    	case NCHAR:
 	    	case NVARCHAR:
@@ -3536,7 +3538,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 	 	            Object[] msgArgs = { srcJdbcType, destJdbcType };
 	 	            throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
 	        	}
-	    		return ((String)value).getBytes(Charset.forName("UTF-16LE"));
+	    		return ((String)value).getBytes(UTF_16LE);
 	    	
 	    	case REAL:
 	        case FLOAT:

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
@@ -19,7 +19,6 @@
  
 package com.microsoft.sqlserver.jdbc;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
@@ -30,6 +30,8 @@ import java.text.MessageFormat;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+
 import org.apache.http.impl.client.HttpClientBuilder;
 import com.microsoft.azure.keyvault.KeyVaultClient;
 import com.microsoft.azure.keyvault.KeyVaultClientImpl;
@@ -284,15 +286,7 @@ public class SQLServerColumnEncryptionAzureKeyVaultProvider extends SQLServerCol
 		byte[] version = new byte[] { firstVersion[0] };
 
 		// Get the Unicode encoded bytes of cultureinvariant lower case masterKeyPath
-		byte[] masterKeyPathBytes = null;
-		try {
-			masterKeyPathBytes = masterKeyPath.toLowerCase().getBytes("UTF-16LE");
-		} catch (UnsupportedEncodingException e) {
-			MessageFormat form = new MessageFormat(
-					SQLServerException.getErrString("R_unsupportedEncoding"));
-			Object[] msgArgs = { "UTF-16LE" };
-			throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
-		}
+		byte[] masterKeyPathBytes = masterKeyPath.toLowerCase().getBytes(UTF_16LE);
 
 		byte[] keyPathLength = new byte[2];
 		keyPathLength[0] = (byte)(((short)masterKeyPathBytes.length) & 0xff);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
@@ -23,7 +23,6 @@ package com.microsoft.sqlserver.jdbc;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.InvalidKeyException;
@@ -45,6 +44,8 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
 import com.microsoft.sqlserver.jdbc.KeyStoreProviderCommon;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
 
 public class SQLServerColumnEncryptionJavaKeyStoreProvider extends SQLServerColumnEncryptionKeyStoreProvider
 {
@@ -254,15 +255,7 @@ public class SQLServerColumnEncryptionJavaKeyStoreProvider extends SQLServerColu
     	 CertificateDetails certificateDetails = getCertificateDetails(masterKeyPath);
     	 byte [] cipherText=encryptRSAOAEP(plainTextColumnEncryptionKey, certificateDetails);
     	 byte[] cipherTextLength=getLittleEndianBytesFromShort((short)cipherText.length);
-    	 byte[] masterKeyPathBytes;
-    	 
-		try {
-			masterKeyPathBytes = masterKeyPath.toLowerCase().getBytes(
-					"UTF-16LE");
-		} catch (UnsupportedEncodingException e) {
-            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_unsupportedEncoding"));
-            throw new SQLServerException(form.format(new Object[] {"UTF-16LE"}), null, 0, null);
-		}
+    	 byte[] masterKeyPathBytes = masterKeyPath.toLowerCase().getBytes(UTF_16LE);
     	 
 		byte[] keyPathLength=getLittleEndianBytesFromShort((short)masterKeyPathBytes.length);
     	 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -32,6 +32,8 @@ import java.text.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+
 /**
  * SQLServerConnection implements a JDBC connection to SQL Server.
  * SQLServerConnections support JDBC connection pooling and may be either physical JDBC connections
@@ -1234,14 +1236,7 @@ public class SQLServerConnection implements ISQLServerConnection
 			sPropValue = activeConnectionProperties.getProperty(sPropKey);
 			if (null != sPropValue)
 			{
-				try {
-					accessTokenInByte = sPropValue.getBytes("UTF-16LE");
-				} catch (UnsupportedEncodingException e) {
-					MessageFormat form = new MessageFormat(
-							SQLServerException.getErrString("R_unsupportedEncoding"));
-					Object[] msgArgs = { "UTF-16LE" };
-					throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
-				}
+				accessTokenInByte = sPropValue.getBytes(UTF_16LE);
 			}
 
 			if((null != accessTokenInByte) && 0 == accessTokenInByte.length)
@@ -3552,13 +3547,7 @@ public class SQLServerConnection implements ISQLServerConnection
 				try {
 					byte[] dataArray = new byte[dataLen];
 					System.arraycopy(tokenData, dataOffset, dataArray, 0, dataLen);
-					data = new String(dataArray, "UTF-16LE");
-				}
-				catch(UnsupportedEncodingException e){
-					MessageFormat form = new MessageFormat(
-							SQLServerException.getErrString("R_unsupportedEncoding"));
-					Object[] msgArgs = { "UTF-16LE" };
-					throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
+					data = new String(dataArray, UTF_16LE);
 				}
 				catch(Exception e){
 					connectionlogger.severe(toString() + "Failed to read FedAuthInfoData.");
@@ -3724,16 +3713,7 @@ public class SQLServerConnection implements ISQLServerConnection
 
 		byte[] accessTokenFromDLL = dllInfo.accessTokenBytes;
 
-		String accessToken = null;
-		try {
-			accessToken =  new String(accessTokenFromDLL, "UTF-16LE");
-		}
-		catch (UnsupportedEncodingException e) {
-			MessageFormat form = new MessageFormat(
-					SQLServerException.getErrString("R_unsupportedEncoding"));
-			Object[] msgArgs = { "UTF-16LE" };
-			throw new SQLServerException(null, form.format(msgArgs), null, 0, false);
-		}
+		String accessToken =  new String(accessTokenFromDLL, UTF_16LE);
 
 		SqlFedAuthToken fedAuthToken = new SqlFedAuthToken(accessToken, dllInfo.expiresIn);
 
@@ -3754,15 +3734,7 @@ public class SQLServerConnection implements ISQLServerConnection
 
 		TDSWriter tdsWriter = fedAuthCommand.startRequest(TDS.PKT_FEDAUTH_TOKEN_MESSAGE);
 
-		byte[] accessToken = null;
-		try {
-			accessToken = fedAuthToken.accessToken.getBytes("UTF-16LE");
-		} catch (UnsupportedEncodingException e) {
-			MessageFormat form = new MessageFormat(
-					SQLServerException.getErrString("R_unsupportedEncoding"));
-			Object[] msgArgs = { "UTF-16LE" };
-			throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
-		}
+		byte[] accessToken = fedAuthToken.accessToken.getBytes(UTF_16LE);
 
 		// Send total length (length of token plus 4 bytes for the token length field)
 		// If we were sending a nonce, this would include that length as well

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSymmetricKeyCache.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSymmetricKeyCache.java
@@ -19,13 +19,14 @@
 
 package com.microsoft.sqlserver.jdbc;
 
-import java.io.UnsupportedEncodingException;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import static java.util.concurrent.TimeUnit.*;
 
@@ -123,16 +124,7 @@ final class SQLServerSymmetricKeyCache
 			String keyLookupValue=null;
 			keyLookupValuebuffer.append(":");
 	
-			try
-			{
-				keyLookupValuebuffer.append(DatatypeConverter.printBase64Binary((new String(keyInfo.encryptedKey,"UTF-8")).getBytes()));
-			}
-			catch (UnsupportedEncodingException e)
-			{
-				MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_unsupportedEncoding"));
-				Object[] msgArgs = { "UTF-8" };
-				throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
-			}
+			keyLookupValuebuffer.append(DatatypeConverter.printBase64Binary((new String(keyInfo.encryptedKey,UTF_8)).getBytes()));
 	
 			keyLookupValuebuffer.append(":");
 			keyLookupValuebuffer.append(keyInfo.keyStoreName);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -26,10 +26,11 @@ import java.util.*;
 import java.math.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 import java.sql.*;
 import java.text.MessageFormat;
 import java.time.*;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
 
 import com.microsoft.sqlserver.jdbc.JavaType.SetterConversionAE;
 
@@ -1911,7 +1912,7 @@ final class DTV
 						// Each character is represented using 2 bytes in NVARCHAR
 						else if((JDBCType.NVARCHAR == jdbcTypeSetByUser) || (JDBCType.NCHAR == jdbcTypeSetByUser) || (JDBCType.LONGNVARCHAR == jdbcTypeSetByUser))
 						{
-							byteValue = ((String)value).getBytes(Charset.forName("UTF-16LE"));
+							byteValue = ((String)value).getBytes(UTF_16LE);
 						}
 						// Each character is represented using 1 bytes in VARCHAR
 						else if((JDBCType.VARCHAR == jdbcTypeSetByUser) || (JDBCType.CHAR == jdbcTypeSetByUser) || (JDBCType.LONGVARCHAR == jdbcTypeSetByUser))


### PR DESCRIPTION
Since Java 1.7 there is the StandardCharsets class which provides
constants for frequently used Charsets. Using this also allows us to
remove several UnsupportedEncodingException catch blocks.

 * use StandardCharsets in String constructors where possible
 * use StandardCharsets in #getBytes where possible
 * use StandardCharsets instead of Charset.foreName where possible