### PR TITLE
Fix StreamError class comment

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamError.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamError.java
@@ -21,9 +21,6 @@ package com.microsoft.sqlserver.jdbc;
 
 /**
 * StreamError represents a TDS error or message event.
-*
-* NOTE: Insure that this class is kept serializable because it is held by 
-* the SQLServerException object which is required to be serializable.
 */
 
 final class StreamError extends StreamPacket


### PR DESCRIPTION
The StreamError class comment says it's serializable because it is held
by SQLServerException. Both statements are wrong.