### PR TITLE
Use Charset throughout

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -468,7 +468,7 @@ final class DDC
 	 */
 	static final Object convertStringToObject(
 			String stringVal,
-			String charset,
+			Charset charset,
 			JDBCType jdbcType,
 			StreamType streamType) throws UnsupportedEncodingException, IllegalArgumentException
 	{

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -21,6 +21,7 @@ package com.microsoft.sqlserver.jdbc;
 import java.io.*;
 import java.nio.*;
 import java.nio.channels.*;
+import java.nio.charset.Charset;
 import java.net.*;
 import java.math.*;
 import java.util.concurrent.*;
@@ -3946,7 +3947,7 @@ final class TDSWriter
 			Reader reader,
 			long advertisedLength,
 			boolean isDestBinary,
-			String charSet) throws SQLServerException
+			Charset charSet) throws SQLServerException
 	{
 		assert DataTypes.UNKNOWN_STREAM_LENGTH == advertisedLength || advertisedLength >= 0;
 
@@ -3997,25 +3998,16 @@ final class TDSWriter
 
 				for (int charsCopied = 0; charsCopied < charsToWrite; ++charsCopied)
 				{
-					try
+					if(null == charSet)
 					{
-						if(null == charSet)
-						{
-							streamByteBuffer[charsCopied] = (byte)(streamCharBuffer[charsCopied] & 0xFF);
-						}
-						else
-						{
-							// encoding as per collation
-							streamByteBuffer[charsCopied] = new String(streamCharBuffer[charsCopied] +
-									"")
-									.getBytes(charSet)[0];
-						}
+						streamByteBuffer[charsCopied] = (byte)(streamCharBuffer[charsCopied] & 0xFF);
 					}
-					catch (UnsupportedEncodingException e)
+					else
 					{
-						throw new SQLServerException(
-								SQLServerException.getErrString("R_encodingErrorWritingTDS"),
-								e);
+						// encoding as per collation
+						streamByteBuffer[charsCopied] = new String(streamCharBuffer[charsCopied] +
+								"")
+								.getBytes(charSet)[0];
 					}
 				}
 				writeBytes(streamByteBuffer, 0, charsToWrite);
@@ -7257,7 +7249,7 @@ final class TDSReader
 
 			try
 			{
-				return DDC.convertStringToObject(sb.toString(), Encoding.UNICODE.charsetName(), jdbcType, streamType);
+				return DDC.convertStringToObject(sb.toString(), Encoding.UNICODE.charset(), jdbcType, streamType);
 			}
 			catch (UnsupportedEncodingException e)
 			{

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ReaderInputStream.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ReaderInputStream.java
@@ -66,26 +66,14 @@ class ReaderInputStream extends InputStream
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
     private ByteBuffer encodedChars = EMPTY_BUFFER;
 
-    ReaderInputStream(Reader reader, String charsetName, long readerLength) throws UnsupportedEncodingException
+    ReaderInputStream(Reader reader, Charset charset, long readerLength)
     {
         assert reader != null;
-        assert charsetName != null;
+        assert charset != null;
         assert DataTypes.UNKNOWN_STREAM_LENGTH == readerLength || readerLength >= 0;
 
         this.reader = reader;
-        try
-        {
-            this.charset = Charset.forName(charsetName);
-        }
-        catch (IllegalCharsetNameException e)
-        {
-            throw new UnsupportedEncodingException(e.getMessage());
-        }
-        catch (UnsupportedCharsetException e)
-        {
-            throw new UnsupportedEncodingException(e.getMessage());
-        }
-
+        this.charset = charset;
         this.readerLength = readerLength;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -2552,31 +2551,22 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 	    				}
 	    				else
 	    				{	    					
-                                try
+                                tdsWriter.writeShort((short) (colValueStr.length()));
+                                // converting string into destination collation using Charset
+
+                                SQLCollation destCollation = destColumnMetadata
+                                    .get(destColOrdinal).collation;
+                                if (null != destCollation)
                                 {
-                                    tdsWriter.writeShort((short) (colValueStr.length()));
-                                    // converting string into destination collation using Charset
+                                    tdsWriter.writeBytes(colValueStr.getBytes(
+                                        destColumnMetadata.get(destColOrdinal).collation
+                                            .getCharset()));
 
-                                    SQLCollation destCollation = destColumnMetadata
-                                        .get(destColOrdinal).collation;
-                                    if (null != destCollation)
-                                    {
-                                        tdsWriter.writeBytes(colValueStr.getBytes(
-                                            destColumnMetadata.get(destColOrdinal).collation
-                                                .getCharset()));
-
-                                    }
-                                    else
-                                    {
-                                        tdsWriter.writeBytes(colValueStr.getBytes());
-                                    }
                                 }
-                            catch (UnsupportedEncodingException e)
-                            {
-                                throw new SQLServerException(
-                                    SQLServerException.getErrString("R_encodingErrorWritingTDS"),
-                                    e);
-                            }	    					
+                                else
+                                {
+                                    tdsWriter.writeBytes(colValueStr.getBytes());
+                                }
 	    				}
 	    			}
 	    		}

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
@@ -24,6 +24,8 @@ import java.text.*;
 import java.util.*;
 import java.util.logging.*;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
 /**
 * SQLServerClob represents a character LOB object and implements java.sql.Clob.
 */
@@ -186,16 +188,8 @@ abstract class SQLServerClobBase implements Serializable
         if (null != sqlCollation && !sqlCollation.supportsAsciiConversion())
             DataTypes.throwConversionError(getDisplayClassName(), "AsciiStream");
 
-        InputStream getterStream;
-        try
-        {
-            // Need to use a BufferedInputStream since the stream returned by this method is assumed to support mark/reset
-            getterStream = new BufferedInputStream(new ReaderInputStream(new StringReader(value), "US-ASCII", value.length()));
-        }
-        catch (UnsupportedEncodingException unsupportedEncodingException)
-        {
-            throw new SQLServerException(unsupportedEncodingException.getMessage(), null, 0, unsupportedEncodingException);
-        }
+        // Need to use a BufferedInputStream since the stream returned by this method is assumed to support mark/reset
+        InputStream getterStream = new BufferedInputStream(new ReaderInputStream(new StringReader(value), US_ASCII, value.length()));
 
         activeStreams.add(getterStream);
         return getterStream;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSQLXML.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSQLXML.java
@@ -101,7 +101,6 @@ final class SQLServerSQLXML implements java.sql.SQLXML
             ByteArrayOutputStreamToInputStream strm = new ByteArrayOutputStreamToInputStream();
             // Need to beat a stream out of docValue
             TransformerFactory factory;
-            Writer wr=null;
             try
             {
                 factory = TransformerFactory.newInstance();
@@ -126,14 +125,7 @@ final class SQLServerSQLXML implements java.sql.SQLXML
             assert null ==outputStreamValue;
             assert null == docValue;
             assert null !=strValue;
-            try
-            {
-                o = new ByteArrayInputStream(strValue.getBytes(Encoding.UNICODE.charsetName())); 
-            }
-            catch (UnsupportedEncodingException ex)
-            {
-                throw new SQLServerException(null, ex.getMessage(), null, 0, true);
-            }
+            o = new ByteArrayInputStream(strValue.getBytes(Encoding.UNICODE.charset())); 
         }
         assert null != o;
         isFreed = true; // we have consumed the data 
@@ -252,16 +244,7 @@ final class SQLServerSQLXML implements java.sql.SQLXML
         checkWriteXML();
         isUsed = true;
         outputStreamValue = new ByteArrayOutputStreamToInputStream();
-        java.io.Writer wrt=null;
-        try
-        {
-            wrt = new OutputStreamWriter(outputStreamValue, Encoding.UNICODE.charsetName());
-        }
-        catch (UnsupportedEncodingException ex)
-        {
-            throw new SQLServerException(null, ex.getMessage(), null, 0, true);
-        }
-        return wrt;
+        return new OutputStreamWriter(outputStreamValue, Encoding.UNICODE.charset());
     }
     public Reader getCharacterStream() throws SQLException
     {
@@ -309,16 +292,7 @@ final class SQLServerSQLXML implements java.sql.SQLXML
         }
 
         byte byteContents[] = contents.getBytes();
-        String ret = null;
-        try
-        {
-            ret = new String(byteContents,0, byteContents.length, Encoding.UNICODE.charsetName() );
-        }
-        catch (UnsupportedEncodingException ex)
-        {
-            throw new SQLServerException(null, ex.getMessage(), null, 0, true);
-        }
-        return ret;    
+        return new String(byteContents,0, byteContents.length, Encoding.UNICODE.charset() );
     }
     public void setString(String value)  throws SQLException
     {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -619,15 +619,7 @@ final class Util {
 	{
 		try
 		{
-			return new String(b, offset, byteLength, Encoding.UNICODE.charsetName());
-		}
-		catch (UnsupportedEncodingException ex)
-		{
-			String txtMsg = SQLServerException.checkAndAppendClientConnId(SQLServerException.getErrString("R_stringReadError"), conn);
-			MessageFormat form = new MessageFormat(txtMsg);
-			Object[] msgArgs = {new Integer(offset)};
-			// Re-throw SQLServerException if conversion fails.
-			throw new SQLServerException(null, form.format(msgArgs), null, 0, true);
+			return new String(b, offset, byteLength, Encoding.UNICODE.charset());
 		}
 		catch (IndexOutOfBoundsException  ex)
 		{

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -26,6 +26,7 @@ import java.util.*;
 import java.math.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
 import java.sql.*;
 import java.text.MessageFormat;
 import java.time.*;
@@ -325,26 +326,10 @@ final class DTV
 				}
 				else
 				{
-					ReaderInputStream clobStream = null;
-
-					try
-					{
-						clobStream = new ReaderInputStream(
-								clobReader,
-								collation.getCharset(),
-								clobLength);
-					}
-					catch (UnsupportedEncodingException ex)
-					{
-						MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_encodingErrorWritingTDS"));
-						Object[] msgArgs = {new String(ex.getMessage())};
-						SQLServerException.makeFromDriverError(
-								conn,
-								null, 
-								form.format(msgArgs),
-								null,
-								true);
-					}
+					ReaderInputStream clobStream = new ReaderInputStream(
+						clobReader,
+						collation.getCharset(),
+						clobLength);
 
 					tdsWriter.writeRPCInputStream(
 							name,
@@ -2347,21 +2332,7 @@ final class AppDTVImpl extends DTVImpl
 
 				if (null != strValue)
 				{
-					try
-					{
-						nativeEncoding = strValue.getBytes(collation.getCharset());
-					}
-					catch (UnsupportedEncodingException ex)
-					{
-						MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_encodingErrorWritingTDS"));
-						Object[] msgArgs = {new String(ex.getMessage())};
-						SQLServerException.makeFromDriverError(
-								con,
-								null, 
-								form.format(msgArgs),
-								null, // Don't close the connection
-								true);
-					}
+					nativeEncoding = strValue.getBytes(collation.getCharset());
 				}
 
 				dtv.setValue(nativeEncoding, JavaType.BYTEARRAY);
@@ -2631,26 +2602,10 @@ final class AppDTVImpl extends DTVImpl
 					JDBCType.LONGVARCHAR == jdbcType ||
 					JDBCType.CLOB == jdbcType))
 			{
-				ReaderInputStream streamValue = null;
-
-				try
-				{
-					streamValue = new ReaderInputStream(
+				ReaderInputStream streamValue = new ReaderInputStream(
 							readerValue,
 							collation.getCharset(),
 							readerLength);
-				}
-				catch (UnsupportedEncodingException ex)
-				{
-					MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_encodingErrorWritingTDS"));
-					Object[] msgArgs = {new String(ex.getMessage())};
-					SQLServerException.makeFromDriverError(
-							con,
-							null, 
-							form.format(msgArgs),
-							null, // Don't close the connection
-							true);
-				}
 
 				dtv.setValue(streamValue, JavaType.INPUTSTREAM);
 
@@ -2780,7 +2735,7 @@ final class TypeInfo
 
 	// Collation (will be null for non-textual types).
 	private SQLCollation collation; 
-	private String charset;
+	private Charset charset;
 
 	SSType getSSType() { return ssType; }
 	SSLenType getSSLenType() { return ssLenType; }
@@ -2791,7 +2746,7 @@ final class TypeInfo
 	int getScale() { return scale; }
 	SQLCollation getSQLCollation() { return collation; }
 	void setSQLCollation(SQLCollation collation) { this.collation = collation; }
-	String getCharset() { return charset; }
+	Charset getCharset() { return charset; }
 	boolean isNullable() { return 0x0001 == (flags & 0x0001); }
 	boolean isCaseSensitive() { return 0x0002 == (flags & 0x0002); }
 	boolean isSparseColumnSet() { return 0x0400 == (flags & 0x0400); }
@@ -3085,7 +3040,7 @@ final class TypeInfo
 				typeInfo.displaySize = typeInfo.precision = typeInfo.maxLength / 2;
 				typeInfo.ssType = SSType.NCHAR;
 				typeInfo.collation = tdsReader.readCollation();
-				typeInfo.charset = Encoding.UNICODE.charsetName();
+				typeInfo.charset = Encoding.UNICODE.charset();
 			}
 		}),
 
@@ -3111,7 +3066,7 @@ final class TypeInfo
 					tdsReader.throwInvalidTDS();
 				}
 				typeInfo.collation = tdsReader.readCollation();
-				typeInfo.charset = Encoding.UNICODE.charsetName();
+				typeInfo.charset = Encoding.UNICODE.charset();
 			}
 		}),
 
@@ -3126,7 +3081,7 @@ final class TypeInfo
 				typeInfo.ssType = SSType.NTEXT;
 				typeInfo.displaySize = typeInfo.precision = Integer.MAX_VALUE / 2;
 				typeInfo.collation = tdsReader.readCollation();
-				typeInfo.charset = Encoding.UNICODE.charsetName();
+				typeInfo.charset = Encoding.UNICODE.charset();
 			}
 		}),
 
@@ -3185,7 +3140,7 @@ final class TypeInfo
 				typeInfo.ssLenType = SSLenType.PARTLENTYPE;
 				typeInfo.ssType = SSType.XML;
 				typeInfo.displaySize = typeInfo.precision = Integer.MAX_VALUE / 2;
-				typeInfo.charset = Encoding.UNICODE.charsetName();
+				typeInfo.charset = Encoding.UNICODE.charset();
 			}
 		}),
 


### PR DESCRIPTION
The driver spends a lot of time converting from Charset to String and
from String to Charset. Every time checked exceptions have to be
caught. In addition the Charset lookup code is quite involved. It would
be simpler to use Charset everywhere.