### PR TITLE
Upgrade azure-keyvault to 0.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>azure-keyvault</artifactId>
-			<version>0.9.3</version>
+			<version>0.9.7</version>
 		</dependency>
 		
 		<!-- dependency for running tests -->


### PR DESCRIPTION
Just a minor version bump fro `0.9.3` to `0.9.7`. The changelog can be found [here](https://github.com/Azure/azure-sdk-for-java/blob/0.9/ChangeLog.txt).

As far as I can tell the only changes are introducing caching, and a bugfix to do with JSON deserialization.