### PR TITLE
Remove redundant type casts

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -3517,8 +3517,7 @@ final class TDSWriter
 						TDS.BASE_YEAR_1900);
 
 		// Next, figure out the number of milliseconds since midnight of the current day.
-		int millisSinceMidnight = (int)
-				1000 * calendar.get(Calendar.SECOND) + // Seconds into the current minute
+		int millisSinceMidnight = 1000 * calendar.get(Calendar.SECOND) + // Seconds into the current minute
 				60 * 1000 * calendar.get(Calendar.MINUTE) + // Minutes into the current hour
 				60 * 60 * 1000 * calendar.get(Calendar.HOUR_OF_DAY); // Hours into the current day
 
@@ -4780,7 +4779,7 @@ final class TDSWriter
 				int currentColumn = 0;
 				while(columnsIterator.hasNext())
 				{
-					Map.Entry<Integer, SQLServerMetaData> columnPair = (Map.Entry<Integer, SQLServerMetaData>)columnsIterator.next();
+					Map.Entry<Integer, SQLServerMetaData> columnPair = columnsIterator.next();
 
 					// If useServerDefault is set, client MUST NOT emit TvpColumnData for the associated column
 					if (columnPair.getValue().useServerDefault) 
@@ -5033,7 +5032,7 @@ final class TDSWriter
 
 		while(columnsIterator.hasNext())
 		{
-			Map.Entry<Integer, SQLServerMetaData> pair = (Map.Entry<Integer, SQLServerMetaData>)columnsIterator.next();
+			Map.Entry<Integer, SQLServerMetaData> pair = columnsIterator.next();
 			JDBCType jdbcType = JDBCType.of(pair.getValue().javaSqlType);
 			boolean useServerDefault = pair.getValue().useServerDefault;
 			// ULONG ; UserType of column
@@ -5161,7 +5160,7 @@ final class TDSWriter
 		while(columnsIterator.hasNext())
 		{
 			byte flags = 0;
-			Map.Entry<Integer, SQLServerMetaData> pair = (Map.Entry<Integer, SQLServerMetaData>)columnsIterator.next();
+			Map.Entry<Integer, SQLServerMetaData> pair = columnsIterator.next();
 			SQLServerMetaData metaData = pair.getValue();
 
 			if( SQLServerSortOrder.Ascending == metaData.sortOrder )
@@ -5245,7 +5244,7 @@ final class TDSWriter
 			}
 			else if (isPLP)
 			{
-				writeLong((long) nValueLen); //actual length
+				writeLong(nValueLen); //actual length
 			}
 			else
 			{
@@ -5275,13 +5274,13 @@ final class TDSWriter
 
 	void writeCryptoMetaData() throws SQLServerException
 	{
-		writeByte((byte) cryptoMeta.cipherAlgorithmId);
-		writeByte((byte) cryptoMeta.encryptionType.getValue());
-		writeInt((int) cryptoMeta.cekTableEntry.getColumnEncryptionKeyValues().get(0).databaseId);
-		writeInt((int) cryptoMeta.cekTableEntry.getColumnEncryptionKeyValues().get(0).cekId);
-		writeInt((int) cryptoMeta.cekTableEntry.getColumnEncryptionKeyValues().get(0).cekVersion);
+		writeByte(cryptoMeta.cipherAlgorithmId);
+		writeByte(cryptoMeta.encryptionType.getValue());
+		writeInt(cryptoMeta.cekTableEntry.getColumnEncryptionKeyValues().get(0).databaseId);
+		writeInt(cryptoMeta.cekTableEntry.getColumnEncryptionKeyValues().get(0).cekId);
+		writeInt(cryptoMeta.cekTableEntry.getColumnEncryptionKeyValues().get(0).cekVersion);
 		writeBytes(cryptoMeta.cekTableEntry.getColumnEncryptionKeyValues().get(0).cekMdVersion);
-		writeByte((byte) cryptoMeta.normalizationRuleVersion);
+		writeByte(cryptoMeta.normalizationRuleVersion);
 	}
 
 	void writeRPCByteArray(

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -914,7 +914,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 				isStreaming = (DataTypes.SHORT_VARTYPE_MAX_BYTES < baseDestPrecision);
 			
 			// Send CryptoMetaData
-			tdsWriter.writeShort((short) destCryptoMeta.getOrdinal());	// Ordinal
+			tdsWriter.writeShort(destCryptoMeta.getOrdinal());	// Ordinal
 			tdsWriter.writeBytes(userType);		// usertype
 			//	BaseTypeInfo
 			writeTypeInfo(tdsWriter,
@@ -926,9 +926,9 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 					isStreaming,	 
 					srcNullable, 
 					true);
-			tdsWriter.writeByte((byte) destCryptoMeta.cipherAlgorithmId);
-			tdsWriter.writeByte((byte) destCryptoMeta.encryptionType.getValue());
-			tdsWriter.writeByte((byte) destCryptoMeta.normalizationRuleVersion);
+			tdsWriter.writeByte(destCryptoMeta.cipherAlgorithmId);
+			tdsWriter.writeByte(destCryptoMeta.encryptionType.getValue());
+			tdsWriter.writeByte(destCryptoMeta.normalizationRuleVersion);
 		}
 		
 		/*
@@ -1250,9 +1250,9 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 	    		tdsWriter.writeShort((short) destCekTable.getSize());
 	    		for (int cekIndx = 0; cekIndx < destCekTable.getSize(); cekIndx++)
 	    		{
-		    		tdsWriter.writeInt((int) destCekTable.getCekTableEntry(cekIndx).getColumnEncryptionKeyValues().get(0).databaseId);
-		    		tdsWriter.writeInt((int) destCekTable.getCekTableEntry(cekIndx).getColumnEncryptionKeyValues().get(0).cekId);
-		    		tdsWriter.writeInt((int) destCekTable.getCekTableEntry(cekIndx).getColumnEncryptionKeyValues().get(0).cekVersion);
+		    		tdsWriter.writeInt(destCekTable.getCekTableEntry(cekIndx).getColumnEncryptionKeyValues().get(0).databaseId);
+		    		tdsWriter.writeInt(destCekTable.getCekTableEntry(cekIndx).getColumnEncryptionKeyValues().get(0).cekId);
+		    		tdsWriter.writeInt(destCekTable.getCekTableEntry(cekIndx).getColumnEncryptionKeyValues().get(0).cekVersion);
 		    		tdsWriter.writeBytes(destCekTable.getCekTableEntry(cekIndx).getColumnEncryptionKeyValues().get(0).cekMdVersion);
 		    		
 		    		// We don't need to send the keys. So count for EncryptionKeyValue is 0 in EK_INFO TDS rule.
@@ -2831,7 +2831,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 	    		else
 	    			tdsWriter.writeByte((byte) 0x0A);
 	    		
-	    		tdsWriter.writeDateTimeOffset( (DateTimeOffset) colValue, bulkScale, destSSType);
+	    		tdsWriter.writeDateTimeOffset(colValue, bulkScale, destSSType);
 			}
 			break;
 	
@@ -3167,11 +3167,11 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 			{
 			case java.sql.Types.TIMESTAMP:
 			case java.sql.Types.TIME:
-				return (Timestamp) null; 
+				return null;
 			case java.sql.Types.DATE:
-				return (java.sql.Date) null;
+				return null;
 			case microsoft.sql.Types.DATETIMEOFFSET:
-				return (DateTimeOffset) null;			
+				return null;
 			}			
 		}	
 		
@@ -3443,7 +3443,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 					{
 						int intValue = (int) value;
 						short shortValue = (short) intValue;
-						longValue = new Long((short) shortValue);
+						longValue = new Long(shortValue);
 					}
 					else  longValue = new Long((short) value);
 
@@ -3558,7 +3558,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 	        	byteValue = DDC.convertBigDecimalToBytes(bigDataValue, bigDataValue.scale()) ;
 	    		byte[] decimalbyteValue = new byte[16];
 	    		// removing the precision and scale information from the decimalToByte array
-	    		System.arraycopy((byte[])byteValue, 2, decimalbyteValue, 0, ((byte[])byteValue).length - 2);
+	    		System.arraycopy(byteValue, 2, decimalbyteValue, 0, byteValue.length - 2);
 	    		return decimalbyteValue;
 	        	
 	        case SMALLMONEY:
@@ -3577,7 +3577,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable
 	        	ByteBuffer bbuf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
 	        	bbuf.putInt((int) (moneyVal >> 32)).array();
 	        	bbuf.putInt((int) moneyVal).array();
-	        	return (byte[]) bbuf.array();
+	        	return bbuf.array();
 	        	
 	        default:
 	        	 MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_UnsupportedDataTypeAE"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -491,7 +491,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             resultsReader());
 
         if(null != value)
-            activeStream = (Closeable) value.getStream();        
+            activeStream = value.getStream();
         return value;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionCertificateStoreProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionCertificateStoreProvider.java
@@ -240,7 +240,7 @@ public final class SQLServerColumnEncryptionCertificateStoreProvider extends SQL
 				for (Enumeration<String> enumeration = keyStore.aliases(); enumeration.hasMoreElements();)
 				{
 
-					String alias = (String) enumeration.nextElement();
+					String alias = enumeration.nextElement();
 				
 					X509Certificate publicCertificate = (X509Certificate) keyStore.getCertificate(alias);
 		
@@ -250,7 +250,7 @@ public final class SQLServerColumnEncryptionCertificateStoreProvider extends SQL
 						Key keyPrivate = null;
 						try
 						{
-							keyPrivate = (Key) keyStore.getKey(
+							keyPrivate = keyStore.getKey(
 								alias,
 								"".toCharArray());
 							if (null == keyPrivate) 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
@@ -197,7 +197,7 @@ public class SQLServerColumnEncryptionJavaKeyStoreProvider extends SQLServerColu
         try
         {
             X509Certificate publicCertificate = (X509Certificate) keyStore.getCertificate(alias);
-            Key keyPrivate = (Key) keyStore.getKey(alias,keyStorePwd);
+            Key keyPrivate = keyStore.getKey(alias,keyStorePwd);
             if (null == publicCertificate )
             {
                 // Certificate not found. Throw an exception.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3795,10 +3795,10 @@ public class SQLServerConnection implements ISQLServerConnection
 
 		// Send total length (length of token plus 4 bytes for the token length field)
 		// If we were sending a nonce, this would include that length as well
-		tdsWriter.writeInt((int)accessToken.length + 4);
+		tdsWriter.writeInt(accessToken.length + 4);
 
 		// Send length of token
-		tdsWriter.writeInt((int)accessToken.length);
+		tdsWriter.writeInt(accessToken.length);
 
 		// Send federated authentication access token.
 		tdsWriter.writeBytes(accessToken, 0, accessToken.length);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -131,7 +131,7 @@ public final class SQLServerDataTable {
 				if((null != values) && (currentColumn < values.length) && (null != values[currentColumn]))
 					val = (null == values[currentColumn]) ? null : values[currentColumn] ;
 				currentColumn++;
-				Map.Entry<Integer, SQLServerDataColumn> pair = (Map.Entry<Integer, SQLServerDataColumn>)columnsIterator.next();
+				Map.Entry<Integer, SQLServerDataColumn> pair = columnsIterator.next();
 				SQLServerDataColumn currentColumnMetadata = pair.getValue();
 				JDBCType jdbcType = JDBCType.of(pair.getValue().javaSqlType);
 
@@ -200,13 +200,13 @@ public final class SQLServerDataTable {
 							rowValues[pair.getKey()] = null;
 						//java.sql.Date, java.sql.Time and java.sql.Timestamp are subclass of java.util.Date
 						else if (val instanceof java.util.Date)
-							rowValues[pair.getKey()] = ((java.util.Date) val).toString();
+							rowValues[pair.getKey()] = val.toString();
 						else if(val instanceof microsoft.sql.DateTimeOffset)
-							rowValues[pair.getKey()] = ((microsoft.sql.DateTimeOffset) val).toString();
+							rowValues[pair.getKey()] = val.toString();
 						else if(val instanceof OffsetDateTime)
-							rowValues[pair.getKey()] = ((OffsetDateTime) val).toString();
+							rowValues[pair.getKey()] = val.toString();
 						else if(val instanceof OffsetTime)
-							rowValues[pair.getKey()] = ((OffsetTime) val).toString();
+							rowValues[pair.getKey()] = val.toString();
 						else
 							rowValues[pair.getKey()] = (null == val) ? null : (String) val;
 						break;
@@ -227,7 +227,7 @@ public final class SQLServerDataTable {
 
 					case CHAR:
 						if(val instanceof UUID && (val != null))
-							val = ((UUID)val).toString();
+							val = val.toString();
 					case VARCHAR:
 					case NCHAR:
 					case NVARCHAR:

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -579,7 +579,7 @@ public final class SQLServerDriver implements java.sql.Driver
             result.connect(connectProperties, null);
         }
         loggerExternal.exiting(getClassNameLogging(),  "connect", result); 
-        return (java.sql.Connection) result;
+        return result;
     }
 	
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
@@ -99,7 +99,8 @@ public class SQLServerPooledConnection implements PooledConnection {
 						SQLServerException.getErrString("R_physicalConnectionIsClosed"),
 						"", true);
 			}
-			// Check with security manager to insure caller has rights to connect.
+
+			// Check with security manager to insure caller has rights to connect.
 			// This will throw a SecurityException if the caller does not have proper rights.
 			physicalConnection.doSecurityCheck();
 			if (pcLogger.isLoggable(Level.FINE))				
@@ -164,7 +165,7 @@ public class SQLServerPooledConnection implements PooledConnection {
 
 				if (listener == null) continue;
 
-				ConnectionEvent ev = new ConnectionEvent(this, (SQLException) e);
+				ConnectionEvent ev = new ConnectionEvent(this, e);
 				if (null == e)
 				{
 					if (pcLogger.isLoggable(Level.FINER))				

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -28,7 +28,7 @@ public final class SQLServerResource extends ListResourceBundle
 {
 	static String getResource(String key)
 	{
-		return ((ListResourceBundle) SQLServerResource.getBundle("com.microsoft.sqlserver.jdbc.SQLServerResource")).getString(key);
+		return SQLServerResource.getBundle("com.microsoft.sqlserver.jdbc.SQLServerResource").getString(key);
 	}
 
 	protected Object[][]  getContents()

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2142,7 +2142,7 @@ public class SQLServerResultSet implements ISQLServerResultSet
                 toString()));
 
         if(null != value)
-            activeStream = (Closeable) value.getStream();
+            activeStream = value.getStream();
         return value;
     }
     
@@ -4943,7 +4943,7 @@ public class SQLServerResultSet implements ISQLServerResultSet
             loggerExternal.entering(getClassNameLogging(),  "updateObject",  new Object[]{index, obj});
 
         checkClosed();
-        updateObject(index, obj, (Integer) null, null, null, false);
+        updateObject(index, obj, null, null, null, false);
 
         loggerExternal.exiting(getClassNameLogging(), "updateObject");
     }
@@ -6230,7 +6230,7 @@ public class SQLServerResultSet implements ISQLServerResultSet
         updateObject(
             findColumn(columnName),
             x,
-            (Integer) null,
+                null,
             null, 
             null,
             false);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet42.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet42.java
@@ -49,7 +49,7 @@ public class SQLServerResultSet42 extends SQLServerResultSet implements ISQLServ
 
 		checkClosed();
 		// getVendorTypeNumber() returns the same constant integer values as in java.sql.Types
-		updateObject(index, obj, (Integer) null, JDBCType.of(targetSqlType.getVendorTypeNumber()), null, false);
+		updateObject(index, obj, null, JDBCType.of(targetSqlType.getVendorTypeNumber()), null, false);
 
 		loggerExternal.exiting(getClassNameLogging(), "updateObject");
 	}
@@ -137,7 +137,7 @@ public class SQLServerResultSet42 extends SQLServerResultSet implements ISQLServ
 		updateObject(
 				findColumn(columnName),
 				obj,
-				(Integer)null,
+                null,
 				JDBCType.of(targetSqlType.getVendorTypeNumber()), 
 				null,
 				false);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/TVP.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/TVP.java
@@ -141,7 +141,7 @@ class TVP {
 		}
 		else if (TVPType.SQLServerDataTable == tvpType)
 		{
-			 Map.Entry<Integer,Object[]> rowPair = (Map.Entry<Integer,Object[]>) sourceDataTableRowIterator.next();
+			 Map.Entry<Integer,Object[]> rowPair = sourceDataTableRowIterator.next();
 			 return rowPair.getValue();	
 		}
 		else
@@ -183,7 +183,7 @@ class TVP {
 		Iterator<Entry<Integer, SQLServerDataColumn>> columnsIterator = dataTableMetaData.entrySet().iterator();
 		while(columnsIterator.hasNext())
 		{
-			Map.Entry<Integer, SQLServerDataColumn> pair = (Map.Entry<Integer, SQLServerDataColumn>)columnsIterator.next();
+			Map.Entry<Integer, SQLServerDataColumn> pair = columnsIterator.next();
 			// duplicate column names for the dataTable will be checked in the SQLServerDataTable.
 			columnMetadata.put(
 					pair.getKey(), 
@@ -245,7 +245,7 @@ class TVP {
 		Iterator<Entry<Integer, SQLServerMetaData>> columnsIterator = columnMetadata.entrySet().iterator();
 		while(columnsIterator.hasNext())
 		{
-			Map.Entry<Integer, SQLServerMetaData> columnPair = (Map.Entry<Integer, SQLServerMetaData>)columnsIterator.next();
+			Map.Entry<Integer, SQLServerMetaData> columnPair = columnsIterator.next();
 			SQLServerSortOrder columnSortOrder = columnPair.getValue().sortOrder;
 			int columnSortOrdinal = columnPair.getValue().sortOrdinal;
 			

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -893,7 +893,7 @@ final class Util {
 		case STRING:
 			if (JDBCType.GUID == jdbcType){
 				String guidTemplate = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
-				return ((null == value) ? 0 : ((String)guidTemplate).length());
+				return ((null == value) ? 0 : guidTemplate.length());
 			}
 			else if (JDBCType.TIMESTAMP == jdbcType ||
 					JDBCType.TIME == jdbcType ||
@@ -920,15 +920,15 @@ final class Util {
 				}
 				else{
 					if(0 == ((BigDecimal)value).intValue()){
-						String s = "" + ((BigDecimal)value);
+						String s = "" + value;
 						s = s.replaceAll("\\.", "");
 						s = s.replaceAll("\\-", "");
 						length = s.length();
 					}
 					//if the value is in scientific notation format
-					else if (("" + ((BigDecimal)value)).contains("E")){
+					else if (("" + value).contains("E")){
 						DecimalFormat dform = new DecimalFormat("###.#####");
-						String s = dform.format((BigDecimal)value);  
+						String s = dform.format(value);
 						s = s.replaceAll("\\.", "");
 						s = s.replaceAll("\\-", "");
 						length = s.length();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -1926,7 +1926,7 @@ final class DTV
 							byteValue = ((String)value).getBytes();
 						}
 
-						op.execute(this, (byte[]) byteValue);
+						op.execute(this, byteValue);
 					}
 					else
 						op.execute(this, (String) value);
@@ -1937,7 +1937,7 @@ final class DTV
 				if(null!=cryptoMeta)
 				{
 					byteValue = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN).putLong(((Integer)value).longValue()).array();
-					op.execute(this, (byte[]) byteValue);
+					op.execute(this, byteValue);
 				}
 				else
 					op.execute(this, (Integer) value);
@@ -2001,7 +2001,7 @@ final class DTV
 					}
 
 					byteValue = ByteBuffer.allocate((Float.SIZE/ Byte.SIZE)).order(ByteOrder.LITTLE_ENDIAN).putFloat((Float)value).array();
-					op.execute(this, (byte[]) byteValue);
+					op.execute(this, byteValue);
 				}
 				else
 					op.execute(this, (Float) value);
@@ -2031,7 +2031,7 @@ final class DTV
 						ByteBuffer bbuf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
 						bbuf.putInt((int) (moneyVal >> 32)).array();
 						bbuf.putInt((int) moneyVal).array();
-						op.execute(this, (byte[]) bbuf.array());
+						op.execute(this, bbuf.array());
 					}
 					else
 					{
@@ -2093,7 +2093,7 @@ final class DTV
 				if(null!=cryptoMeta)
 				{
 					byteValue = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN).putLong((byte)value & 0xFF).array();
-					op.execute(this, (byte[]) byteValue);
+					op.execute(this, byteValue);
 				}
 				else
 					op.execute(this, (Byte) value);
@@ -2103,7 +2103,7 @@ final class DTV
 				if(null!=cryptoMeta)
 				{
 					byteValue = ByteBuffer.allocate((Long.SIZE/ Byte.SIZE)).order(ByteOrder.LITTLE_ENDIAN).putLong((Long)value).array();
-					op.execute(this, (byte[]) byteValue);
+					op.execute(this, byteValue);
 				}
 				else
 					op.execute(this, (Long) value);
@@ -2122,7 +2122,7 @@ final class DTV
 						throw new SQLServerException(form.format(new Object[] {jdbcType}), null, 0, null);            			
 					}
 					byteValue = ByteBuffer.allocate((Double.SIZE/ Byte.SIZE)).order(ByteOrder.LITTLE_ENDIAN).putDouble((Double)value).array();
-					op.execute(this, (byte[]) byteValue);
+					op.execute(this, byteValue);
 				}
 				else
 					op.execute(this, (Double) value);
@@ -2132,7 +2132,7 @@ final class DTV
 				if(null!=cryptoMeta)
 				{
 					byteValue = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN).putLong((short)value).array();
-					op.execute(this, (byte[]) byteValue);
+					op.execute(this, byteValue);
 				}
 				else
 					op.execute(this, (Short) value);
@@ -2142,7 +2142,7 @@ final class DTV
 				if(null!=cryptoMeta)
 				{
 					byteValue = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN).putLong((Boolean)value ? 1: 0).array();
-					op.execute(this, (byte[]) byteValue);
+					op.execute(this, byteValue);
 				}
 				else
 					op.execute(this, (Boolean) value);


### PR DESCRIPTION
Getting rid of redundant type casts makes the code a lot easier to read, and there is no downside to removing them.