### PR TITLE
Remove private from enum constructors

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
@@ -97,7 +97,7 @@ enum TDSType
             valuesTypes[s.intValue] = s;
     }
 
-    private TDSType(int intValue)
+    TDSType(int intValue)
     {
         this.intValue = intValue;
     }
@@ -175,7 +175,7 @@ enum SSType
     static final BigDecimal MIN_VALUE_SMALLMONEY = new BigDecimal("-214748.3648");
     
     
-    private SSType(Category category, String name, JDBCType jdbcType)
+    SSType(Category category, String name, JDBCType jdbcType)
     {
         this.category = category;
         this.name = name;
@@ -375,9 +375,9 @@ enum SSType
         private final SSType.Category from;
         private final EnumSet<JDBCType.Category> to;
 
-        private GetterConversion(
-            SSType.Category from,
-            EnumSet<JDBCType.Category> to)
+        GetterConversion(
+                SSType.Category from,
+                EnumSet<JDBCType.Category> to)
         {
             this.from = from;
             this.to = to;
@@ -423,7 +423,7 @@ enum StreamType
     // Display string to use when describing this stream type in traces and error messages
     private final String name;
 
-    private StreamType(JDBCType jdbcType, String name)
+    StreamType(JDBCType jdbcType, String name)
     {
         this.jdbcType = jdbcType;
         this.name = name;
@@ -596,7 +596,7 @@ enum JavaType
     private final JDBCType jdbcTypeFromJavaType;
     private static double jvmVersion = 0.0; 
 
-    private JavaType(Class<?> javaClass, JDBCType jdbcTypeFromJavaType)
+    JavaType(Class<?> javaClass, JDBCType jdbcTypeFromJavaType)
     {
         this.javaClass = javaClass;
         this.jdbcTypeFromJavaType = jdbcTypeFromJavaType;
@@ -794,9 +794,9 @@ enum JavaType
 		private final EnumSet<JDBCType> to;
 		private final JavaType from;
 
-		private SetterConversionAE(
-				JavaType from,
-				EnumSet<JDBCType> to)
+		SetterConversionAE(
+                JavaType from,
+                EnumSet<JDBCType> to)
 		{
 			this.from = from;
 			this.to = to;
@@ -889,7 +889,7 @@ enum JDBCType
     private final String className;
     final String className() { return className; }
 
-    private JDBCType(Category category, int intValue, String className)
+    JDBCType(Category category, int intValue, String className)
     {
         this.category = category;
         this.intValue = intValue;
@@ -1095,9 +1095,9 @@ enum JDBCType
         private final JDBCType.Category from;
         private final EnumSet<JDBCType.Category> to;
 
-        private SetterConversion(
-            JDBCType.Category from,
-            EnumSet<JDBCType.Category> to)
+        SetterConversion(
+                JDBCType.Category from,
+                EnumSet<JDBCType.Category> to)
         {
             this.from = from;
             this.to = to;
@@ -1307,9 +1307,9 @@ enum JDBCType
         private final JDBCType.Category from;
         private final EnumSet<SSType.Category> to;
 
-        private UpdaterConversion(
-            JDBCType.Category from,
-            EnumSet<SSType.Category> to)
+        UpdaterConversion(
+                JDBCType.Category from,
+                EnumSet<SSType.Category> to)
         {
             this.from = from;
             this.to = to;
@@ -1623,9 +1623,9 @@ enum JDBCType
         private final JDBCType from;
         private final EnumSet<SSType> to;
 
-        private NormalizationAE(
-    		JDBCType from,
-            EnumSet<SSType> to)
+        NormalizationAE(
+                JDBCType from,
+                EnumSet<SSType> to)
         {
             this.from = from;
             this.to = to;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
@@ -573,10 +573,10 @@ enum Encoding
     private boolean jvmSupportConfirmed = false;
     private Charset charset;
 
-    private Encoding(
-        String charsetName,
-        boolean supportsAsciiConversion,
-        boolean hasAsciiCompatibleSBCS)
+    Encoding(
+            String charsetName,
+            boolean supportsAsciiConversion,
+            boolean hasAsciiCompatibleSBCS)
     {
         this.charsetName = charsetName;
         this.supportsAsciiConversion = supportsAsciiConversion;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -74,7 +74,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 		// procs on or after katmai
         private final String katProc;
 
-        private CallableHandles(String name, String katName)
+        CallableHandles(String name, String katName)
         {
             this.preKatProc = name;
             this.katProc = katName;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -191,7 +191,7 @@ enum ApplicationIntent
 	private String value;
 	
 	//constructor that sets the string value of the enum
-	private ApplicationIntent(String value)
+	ApplicationIntent(String value)
 	{
 		this.value = value;
 	}
@@ -255,7 +255,7 @@ enum SQLServerDriverStringProperty
 	private String name;
 	private String defaultValue;
 
-	private SQLServerDriverStringProperty(String name, String defaultValue)		
+	SQLServerDriverStringProperty(String name, String defaultValue)
 	{
 		this.name = name;
 	 	this.defaultValue = defaultValue;
@@ -283,7 +283,7 @@ enum SQLServerDriverIntProperty
 	private String name;
 	private int defaultValue;
 
-	private SQLServerDriverIntProperty(String name, int defaultValue)		
+	SQLServerDriverIntProperty(String name, int defaultValue)
 	{
 		this.name = name;
 		this.defaultValue = defaultValue;
@@ -317,7 +317,7 @@ enum SQLServerDriverBooleanProperty
 	private String name;
 	private boolean defaultValue;
 
-	private SQLServerDriverBooleanProperty(String name, boolean defaultValue)		
+	SQLServerDriverBooleanProperty(String name, boolean defaultValue)
 	{
 		this.name = name;
 		this.defaultValue = defaultValue;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3447,7 +3447,7 @@ final class TypeInfo
 			}
 		}
 
-		private Builder(
+		Builder(
 				TDSType tdsType,
 				Strategy strategy)
 		{


### PR DESCRIPTION
The private modifier is not required on an enum constructor as it is implicitly private.