### PR TITLE
Read SQL Server error message if status flag has DONE_ERROR set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ local.properties
 .classpath
 .settings/
 .loadpath
-*.class
 
 # External tool builders
 .externalToolBuilders/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ local.properties
 .classpath
 .settings/
 .loadpath
+*.class
 
 # External tool builders
 .externalToolBuilders/

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -6844,6 +6844,17 @@ final class TDSReader
 		return currentPacket.payload[payloadOffset] & 0xFF;
 	}
 
+
+	final short peekStatusFlag() throws SQLServerException {
+		// skip the current packet(i.e, TDS packet type) and peek into the status flag (USHORT)
+		if (payloadOffset + 3 <= currentPacket.payloadLength) {
+			short value = Util.readShort(currentPacket.payload, payloadOffset + 1);
+			return value;
+		}
+
+		return Util.readShort(readWrappedBytes(3), 1);
+	}
+	
 	final int readUnsignedByte() throws SQLServerException
 	{
 		// Ensure that we have a packet to read from.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -6852,7 +6852,10 @@ final class TDSReader
 			return value;
 		}
 
-		return Util.readShort(readWrappedBytes(3), 1);
+		// as per TDS protocol, TDS_DONE packet should always be followed by status flag
+		// throw exception if status packet is not available 
+		throwInvalidTDS();
+		return 0;
 	}
 	
 	final int readUnsignedByte() throws SQLServerException

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -336,6 +336,7 @@ public class SQLServerResultSet implements ISQLServerResultSet
 				int packetType = tdsReader.peekTokenType();
 				if (TDS.TDS_DONE == packetType) {
 					short status = tdsReader.peekStatusFlag();
+					// check if status flag has DONE_ERROR set i.e., 0x2
 					if ((status & 0x0002) != 0) {
 						// Consume the DONE packet if there is error
 						StreamDone doneToken = new StreamDone();


### PR DESCRIPTION
When using client side cursors, if end of TDS packet is reached, check the status flag for error and handle it.