### PR TITLE
Remove unnecessary modifiers on interfaces

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerBulkRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerBulkRecord.java
@@ -32,7 +32,7 @@ public interface ISQLServerBulkRecord
      * 
      * @return Set of ordinals for the columns.
      */
-    public Set<Integer> getColumnOrdinals();
+    Set<Integer> getColumnOrdinals();
     
     /**
      * Get the name of the given column.
@@ -40,7 +40,7 @@ public interface ISQLServerBulkRecord
      * @param column Column ordinal
      * @return Name of the column
      */
-    public String getColumnName(int column);
+    String getColumnName(int column);
     
     /**
      * Get the JDBC data type of the given column.
@@ -48,7 +48,7 @@ public interface ISQLServerBulkRecord
      * @param column Column ordinal
      * @return JDBC data type of the column
      */
-    public int getColumnType(int column);
+    int getColumnType(int column);
     
     /**
      * Get the precision for the given column.
@@ -56,7 +56,7 @@ public interface ISQLServerBulkRecord
      * @param column Column ordinal
      * @return Precision of the column
      */
-    public int getPrecision(int column);
+    int getPrecision(int column);
     
     /**
      * Get the scale for the given column.
@@ -64,7 +64,7 @@ public interface ISQLServerBulkRecord
      * @param column Column ordinal
      * @return Scale of the column
      */
-    public int getScale(int column);
+    int getScale(int column);
     
     /**
      * Indicates whether the column represents an identity column.
@@ -72,7 +72,7 @@ public interface ISQLServerBulkRecord
      * @param column Column ordinal
      * @return True if the column is an identity column; false otherwise.
      */
-    public boolean isAutoIncrement(int column);
+    boolean isAutoIncrement(int column);
     
     /**
      * Gets the data for the current row as an array of Objects.
@@ -84,7 +84,7 @@ public interface ISQLServerBulkRecord
      * @return The data for the row.
 	 * @throws SQLServerException If there are any errors in obtaining the data.
      */
-    public Object[] getRowData() throws SQLServerException;
+    Object[] getRowData() throws SQLServerException;
     
     /**
      * Advances to the next data row.
@@ -92,5 +92,5 @@ public interface ISQLServerBulkRecord
      * @return True if rows are available; false if there are no more rows
      * @throws SQLServerException If there are any errors in advancing to the next row.
      */
-    public boolean next() throws SQLServerException;
+    boolean next() throws SQLServerException;
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement.java
@@ -37,7 +37,7 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
 	 * if a database access error occurs or
      * this method is called on a closed <code>CallableStatement</code>
 	 */
-    public void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset x)  throws SQLException;
+    void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset x)  throws SQLException;
 	
 	/**
      * Gets the DateTimeOffset value of parameter with index parameterIndex
@@ -47,7 +47,7 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
 	 * if a database access error occurs or
      * this method is called on a closed <code>CallableStatement</code>
      */
-    public microsoft.sql.DateTimeOffset getDateTimeOffset(int parameterIndex) throws SQLException;
+    microsoft.sql.DateTimeOffset getDateTimeOffset(int parameterIndex) throws SQLException;
 	
 	/**
      * Gets the DateTimeOffset value of parameter with name parameterName
@@ -57,6 +57,6 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
 	 * if a database access error occurs or
      * this method is called on a closed <code>CallableStatement</code>
      */
-    public microsoft.sql.DateTimeOffset getDateTimeOffset(String parameterName) throws SQLException;
+    microsoft.sql.DateTimeOffset getDateTimeOffset(String parameterName) throws SQLException;
 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement42.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement42.java
@@ -27,11 +27,11 @@ import java.sql.SQLType;
  */
 public interface ISQLServerCallableStatement42 extends ISQLServerCallableStatement, ISQLServerPreparedStatement42{
 
-	public void registerOutParameter(int index, SQLType sqlType) throws SQLServerException;
+	void registerOutParameter(int index, SQLType sqlType) throws SQLServerException;
 
-	public void registerOutParameter (int index, SQLType sqlType, String typeName) throws SQLServerException;
+	void registerOutParameter(int index, SQLType sqlType, String typeName) throws SQLServerException;
 
-	public void registerOutParameter(int index, SQLType sqlType, int scale) throws SQLServerException;
+	void registerOutParameter(int index, SQLType sqlType, int scale) throws SQLServerException;
 
 	/**
 	 * Registers the parameter in ordinal position index to be of JDBC type sqlType. All OUT parameters must be registered before a stored procedure is executed.
@@ -44,11 +44,11 @@ public interface ISQLServerCallableStatement42 extends ISQLServerCallableStateme
 	 * @param scale the desired number of digits to the right of the decimal point. It must be greater than or equal to zero.
 	 * @throws SQLServerException If any errors occur.
 	 */
-	public void registerOutParameter(int index, SQLType sqlType, int precision, int scale) throws SQLServerException;
+    void registerOutParameter(int index, SQLType sqlType, int precision, int scale) throws SQLServerException;
 
-	public void setObject(String sCol, Object obj, SQLType jdbcType) throws SQLServerException;
+	void setObject(String sCol, Object obj, SQLType jdbcType) throws SQLServerException;
 
-	public void setObject(String sCol, Object obj, SQLType jdbcType, int scale) throws SQLServerException;
+	void setObject(String sCol, Object obj, SQLType jdbcType, int scale) throws SQLServerException;
 
 	/**
 	 * Sets the value of the designated parameter with the given object.
@@ -60,11 +60,11 @@ public interface ISQLServerCallableStatement42 extends ISQLServerCallableStateme
 	 * @param forceEncrypt true if force encryption is on, false if force encryption is off
 	 * @throws SQLServerException If any errors occur.
 	 */
-	public void setObject(String sCol, Object obj, SQLType jdbcType, int scale, boolean forceEncrypt) throws SQLServerException;
+    void setObject(String sCol, Object obj, SQLType jdbcType, int scale, boolean forceEncrypt) throws SQLServerException;
 
-	public void registerOutParameter(String parameterName, SQLType sqlType, String typeName) throws SQLServerException;
+	void registerOutParameter(String parameterName, SQLType sqlType, String typeName) throws SQLServerException;
 
-	public void registerOutParameter(String parameterName, SQLType sqlType, int scale) throws SQLServerException;
+	void registerOutParameter(String parameterName, SQLType sqlType, int scale) throws SQLServerException;
 
 	/**
 	 * Registers the parameter in ordinal position index to be of JDBC type sqlType. All OUT parameters must be registered before a stored procedure is executed.
@@ -77,7 +77,7 @@ public interface ISQLServerCallableStatement42 extends ISQLServerCallableStateme
 	 * @param scale the desired number of digits to the right of the decimal point. It must be greater than or equal to zero.
 	 * @throws SQLServerException If any errors occur.
 	 */
-	public void registerOutParameter(String parameterName, SQLType sqlType, int precision, int scale) throws SQLServerException;
+    void registerOutParameter(String parameterName, SQLType sqlType, int precision, int scale) throws SQLServerException;
 
-	public void registerOutParameter(String parameterName, SQLType sqlType) throws SQLServerException;
+	void registerOutParameter(String parameterName, SQLType sqlType) throws SQLServerException;
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
@@ -29,7 +29,7 @@ public interface ISQLServerConnection extends java.sql.Connection
 {
     // Transaction types.
 	// TRANSACTION_SNAPSHOT corresponds to -> SET TRANSACTION ISOLATION LEVEL SNAPSHOT
-	public final static int TRANSACTION_SNAPSHOT = 0x1000;
+    int TRANSACTION_SNAPSHOT = 0x1000;
 	
 	/**
 	 * Gets the connection ID of the most recent connection attempt, regardless of whether the attempt succeeded or failed.
@@ -37,6 +37,6 @@ public interface ISQLServerConnection extends java.sql.Connection
 	 * failure after the connection request is initiated and the pre-login handshake.
 	 * @throws SQLException If any errors occur.
 	 */
-	public UUID getClientConnectionId() throws SQLException;
+    UUID getClientConnectionId() throws SQLException;
 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataRecord.java
@@ -31,14 +31,14 @@ public interface ISQLServerDataRecord
 	 * @param column the first column is 1, the second is 2, and so on
 	 * @return SQLServerMetaData of column
 	 */
-	public SQLServerMetaData getColumnMetaData(int column);
+    SQLServerMetaData getColumnMetaData(int column);
 	
     /**
      * Get the column count.
      * 
      * @return Set of ordinals for the columns.
      */
-    public int getColumnCount();
+    int getColumnCount();
             
     /**
      * Gets the data for the current row as an array of Objects.
@@ -49,13 +49,13 @@ public interface ISQLServerDataRecord
      * 
      * @return The data for the row.
      */
-    public Object[] getRowData();
+    Object[] getRowData();
     
     /**
      * Advances to the next data row.
      * 
      * @return True if rows are available; false if there are no more rows
      */
-    public boolean next();	
+    boolean next();
 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
@@ -30,326 +30,326 @@ public interface ISQLServerDataSource extends CommonDataSource
 	 * Sets the application intent.
 	 * @param applicationIntent A String that contains the application intent.
 	 */
-    public void setApplicationIntent(String applicationIntent);
+    void setApplicationIntent(String applicationIntent);
 	
 	/**
      * Returns the application intent.
      * @return A String that contains the application intent.
      */
-    public String getApplicationIntent();
+    String getApplicationIntent();
 	
 	/**
      * Sets the application name.
      * @param applicationName A String that contains the name of the application.
      */
-	public void setApplicationName(String applicationName);
+    void setApplicationName(String applicationName);
 	
 	/**
 	 * Returns the application name.
 	 * @return A String that contains the application name, or "Microsoft JDBC Driver for SQL Server" if no value is set.
 	 */
-    public String getApplicationName();
+    String getApplicationName();
 	
 	/**
      * Sets the database name to connect to.
      * @param databaseName A String that contains the database name.
      */
-    public void setDatabaseName(String databaseName);
+    void setDatabaseName(String databaseName);
 	
 	/**
      * Returns the database name.
      * @return A String that contains the database name or null if no value is set.
      */
-    public String getDatabaseName();
+    String getDatabaseName();
 	
 	/**
      * Sets the SQL Server instance name.
      * @param instanceName A String that contains the instance name.
      */
-    public void setInstanceName(String instanceName);
+    void setInstanceName(String instanceName);
 	
 	/**
      * Returns the SQL Server instance name.
      * @return A String that contains the instance name, or null if no value is set.
      */
-    public String getInstanceName();
+    String getInstanceName();
 	
 	/**
      * Sets a Boolean value that indicates if the integratedSecurity property is enabled.
      * @param enable true if integratedSecurity is enabled. Otherwise, false.
      */
-    public void setIntegratedSecurity(boolean enable);
+    void setIntegratedSecurity(boolean enable);
 	
 	/**
      * Sets a Boolean value that indicates if the lastUpdateCount property is enabled.
      * @param lastUpdateCount true if lastUpdateCount is enabled. Otherwise, false.
      */
-    public void setLastUpdateCount(boolean lastUpdateCount);
+    void setLastUpdateCount(boolean lastUpdateCount);
 	
 	/**
      * Returns a Boolean value that indicates if the lastUpdateCount property is enabled.
      * @return true if lastUpdateCount is enabled. Otherwise, false.
      */
-    public boolean getLastUpdateCount();
+    boolean getLastUpdateCount();
 	
 	/**
      * Sets a Boolean value that indicates if the encrypt property is enabled.
      * @param encrypt true if the Secure Sockets Layer (SSL) encryption is enabled between the client and the SQL Server. Otherwise, false.
      */
-    public void setEncrypt(boolean encrypt);
+    void setEncrypt(boolean encrypt);
 	
 	/**
      * Returns a Boolean value that indicates if the encrypt property is enabled.
      * @return true if encrypt is enabled. Otherwise, false.
      */
-    public boolean getEncrypt();
+    boolean getEncrypt();
 	
 	/**
      * Sets a Boolean value that indicates if the trustServerCertificate property is enabled.
      * @param e true if the server Secure Sockets Layer (SSL) certificate should be automatically trusted when the communication layer is encrypted using SSL. Otherwise, false.
      */
-    public void setTrustServerCertificate(boolean e);
+    void setTrustServerCertificate(boolean e);
 	
 	/**
      * Returns a Boolean value that indicates if the trustServerCertificate property is enabled.
      * @return true if trustServerCertificate is enabled. Otherwise, false.
      */
-    public boolean getTrustServerCertificate();
+    boolean getTrustServerCertificate();
 	
 	/**
      * Sets the path (including file name) to the certificate trustStore file.
      * @param st A String that contains the path (including file name) to the certificate trustStore file.
      */
-    public void setTrustStore(String st);
+    void setTrustStore(String st);
 	
 	/**
      * Returns the path (including file name) to the certificate trustStore file.
      * @return A String that contains the path (including file name) to the certificate trustStore file, or null if no value is set.
      */
-    public String getTrustStore();
+    String getTrustStore();
 	
 	/**
      * Sets the password that is used to check the integrity of the trustStore data.
      * @param p A String that contains the password that is used to check the integrity of the trustStore data.
      */
-    public void setTrustStorePassword(String p);
+    void setTrustStorePassword(String p);
 	
 	/**
      * Sets the host name to be used in validating the SQL Server Secure Sockets Layer (SSL) certificate.
      * @param host A String that contains the host name.
      */
-    public void setHostNameInCertificate(String host);
+    void setHostNameInCertificate(String host);
 	
 	/**
      * Returns the host name used in validating the SQL Server Secure Sockets Layer (SSL) certificate.
      * @return A String that contains the host name, or null if no value is set.
      */
-    public String getHostNameInCertificate();
+    String getHostNameInCertificate();
 	
 	/**
      * Sets an int value that indicates the number of milliseconds to wait before the database reports a lock time out.
      * @param lockTimeout An int value that contains the number of milliseconds to wait.
      */
-    public void setLockTimeout(int lockTimeout);
+    void setLockTimeout(int lockTimeout);
 	
 	/**
      * Returns an int value that indicates the number of milliseconds that the database will wait before reporting a lock time out.
      * @return An int value that contains the number of milliseconds that the database will wait.
      */
-    public int getLockTimeout();
+    int getLockTimeout();
 	
 	/**
      * Sets the password that will be used to connect to SQL Server.
      * @param password A String that contains the password.
      */
-    public void setPassword(String password);
+    void setPassword(String password);
 	
 	/**
      * Sets the port number to be used to communicate with SQL Server.
      * @param portNumber An int value that contains the port number.
      */
-    public void setPortNumber(int portNumber);
+    void setPortNumber(int portNumber);
 	
 	/**
      * Returns the current port number that is used to communicate with SQL Server.
      * @return An int value that contains the current port number.
      */
-    public int getPortNumber();
+    int getPortNumber();
 	
 	/**
      * Sets the default cursor type that is used for all result sets that are created by using this SQLServerDataSource object.
      * @param selectMethod A String value that contains the default cursor type.
      */
-    public void setSelectMethod(String selectMethod);
+    void setSelectMethod(String selectMethod);
 	
 	/**
      * Returns the default cursor type used for all result sets that are created by using this SQLServerDataSource object.
      * @return A String value that contains the default cursor type.
      */
-    public String getSelectMethod();
+    String getSelectMethod();
 	
 	/**
      * Sets the response buffering mode for connections created by using this SQLServerDataSource object.
      * @param respo A String that contains the buffering and streaming mode. The valid mode can be one of the following case-insensitive Strings: full or adaptive.
      */
-    public void setResponseBuffering(String respo);
+    void setResponseBuffering(String respo);
 	
 	/**
      * Returns the response buffering mode for this SQLServerDataSource object.
      * @return A String that contains a lower-case full or adaptive.
      */
-    public String getResponseBuffering();
+    String getResponseBuffering();
 	
 	/**
      * Modifies the setting of the sendTimeAsDatetime connection property.
      * @param sendTimeAsDatetime A Boolean value. When true, causes java.sql.Time values to be sent to the server as SQL Server datetime types.
 	 * When false, causes java.sql.Time values to be sent to the server as SQL Server time types.
      */
-    public void setSendTimeAsDatetime(boolean sendTimeAsDatetime);
+    void setSendTimeAsDatetime(boolean sendTimeAsDatetime);
 	
 	/**
      * This method was added in SQL Server JDBC Driver 3.0. Returns the setting of the sendTimeAsDatetime connection property.
      * @return true if java.sql.Time values will be sent to the server as a SQL Server datetime type. false if java.sql.Time values will be sent
 	 * to the server as a SQL Server time type.
      */
-    public boolean getSendTimeAsDatetime();
+    boolean getSendTimeAsDatetime();
 	
 	/**
      * Sets a boolean value that indicates if sending string parameters to the server in UNICODE format is enabled.
      * @param sendStringParametersAsUnicode true if string parameters are sent to the server in UNICODE format. Otherwise, false.
      */
-    public void setSendStringParametersAsUnicode(boolean sendStringParametersAsUnicode);
+    void setSendStringParametersAsUnicode(boolean sendStringParametersAsUnicode);
 	
 	/**
      * Returns a boolean value that indicates if sending string parameters to the server in UNICODE format is enabled.
      * @return true if string parameters are sent to the server in UNICODE format. Otherwise, false.
      */
-    public boolean getSendStringParametersAsUnicode();
+    boolean getSendStringParametersAsUnicode();
 	
 	/**
      * Sets the name of the computer that is running SQL Server.
      * @param serverName A String that contains the server name.
      */
-    public void setServerName(String serverName);
+    void setServerName(String serverName);
 	
 	/**
      * Returns the name of the SQL Server instance.
      * @return A String that contains the server name or null if no value is set.
      */
-    public String getServerName();
+    String getServerName();
 	
 	/**
      * Sets the name of the failover server that is used in a database mirroring configuration.
      * @param serverName A String that contains the failover server name.
      */
-    public void setFailoverPartner(String serverName);
+    void setFailoverPartner(String serverName);
 	
 	/**
      * Returns the name of the failover server that is used in a database mirroring configuration.
      * @return A String that contains the name of the failover partner, or null if none is set.
      */
-    public String getFailoverPartner();
+    String getFailoverPartner();
 	
 	/**
      * Sets the value of the multiSubnetFailover connection property.
      * @param multiSubnetFailover The new value of the multiSubnetFailover connection property.
      */
-    public void setMultiSubnetFailover(boolean multiSubnetFailover);
+    void setMultiSubnetFailover(boolean multiSubnetFailover);
 	
 	/**
      * Returns the value of the multiSubnetFailover connection property.
      * @return Returns true or false, depending on the current setting of the connection property.
      */
-    public boolean getMultiSubnetFailover();
+    boolean getMultiSubnetFailover();
 	
 	/**
      * Sets the user name that is used to connect the data source.
      * @param user A String that contains the user name.
      */
-    public void setUser(String user);
+    void setUser(String user);
 	
 	/**
      * Returns the user name that is used to connect the data source.
      * @return A String that contains the user name.
      */
-    public String getUser();
+    String getUser();
 	
 	/**
      * Sets the name of the client computer name that is used to connect to the data source.
      * @param workstationID A String that contains the client computer name.
      */
-    public void setWorkstationID(String workstationID);
+    void setWorkstationID(String workstationID);
 	
 	/**
      * Returns the name of the client computer name that is used to connect to the data source.
      * @return A String that contains the client computer name.
      */
-    public String getWorkstationID();
+    String getWorkstationID();
 	
 	/**
      * Sets a Boolean value that indicates if converting SQL states to XOPEN compliant states is enabled.
      * @param xopenStates true if converting SQL states to XOPEN compliant states is enabled. Otherwise, false.
      */
-    public void setXopenStates(boolean xopenStates);
+    void setXopenStates(boolean xopenStates);
 	
 	/**
      * Returns a boolean value that indicates if converting SQL states to XOPEN compliant states is enabled.
      * @return true if converting SQL states to XOPEN compliant states is enabled. Otherwise, false.
      */
-    public boolean getXopenStates();
+    boolean getXopenStates();
 	
 	/**
      * Sets the URL that is used to connect to the data source.
      * @param url A String that contains the URL.
      */
-    public void setURL(String url);
+    void setURL(String url);
 	
 	/**
      * Returns the URL that is used to connect to the data source.
      * @return A String that contains the URL.
      */
-    public String getURL();
+    String getURL();
 	
 	/**
      * Sets the description of the data source.
      * @param description A String that contains the description.
      */
-    public void setDescription(String description);
+    void setDescription(String description);
 	
 	/**
      * Returns a description of the data source.
      * @return A String that contains the data source description or null if no value is set.
      */
-    public String getDescription();
+    String getDescription();
 	
 	/**
      * Sets the current network packet size used to communicate with SQL Server, specified in bytes.
      * @param packetSize An int value containing the network packet size.
      */
-    public void setPacketSize(int packetSize);
+    void setPacketSize(int packetSize);
 	
 	/**
      * Returns the current network packet size used to communicate with SQL Server, specified in bytes.
      * @return An int value containing the current network packet size.
      */
-    public int getPacketSize();
+    int getPacketSize();
 	
 	/**
      * Indicates the kind of integrated security you want your application to use.
      * @param authenticationScheme Values are "JavaKerberos" and the default "NativeAuthentication".
      */
-	public void setAuthenticationScheme(String authenticationScheme);
+    void setAuthenticationScheme(String authenticationScheme);
 	
 	/**
 	 * Sets the server spn
 	 * @param serverSpn A String that contains the server spn
 	 */
-	public void setServerSpn(String serverSpn);
+    void setServerSpn(String serverSpn);
 	
 	/**
 	 * Returns the server spn
 	 * @return A String that contains the server spn
 	 */
-	public String getServerSpn();
+    String getServerSpn();
 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement.java
@@ -32,6 +32,6 @@ public interface ISQLServerPreparedStatement extends java.sql.PreparedStatement,
      * marker in the SQL statement; if a database access error occurs or
      * this method is called on a closed <code>PreparedStatement</code>
 	 */
-    public void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x)  throws SQLException;
+    void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x)  throws SQLException;
 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement42.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement42.java
@@ -27,9 +27,9 @@ import java.sql.SQLType;
  */
 public interface ISQLServerPreparedStatement42 extends ISQLServerPreparedStatement{
 
-	public void setObject(int index, Object obj, SQLType jdbcType) throws SQLServerException;
+	void setObject(int index, Object obj, SQLType jdbcType) throws SQLServerException;
 
-	public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLServerException;
+	void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLServerException;
 
 	/**
      * Sets the value of the designated parameter with the given object.
@@ -49,7 +49,7 @@ public interface ISQLServerPreparedStatement42 extends ISQLServerPreparedStateme
      * parameter marker in the SQL statement; if a database access error occurs
      * or this method is called on a closed {@code PreparedStatement}
      */
-	public void setObject(int parameterIndex, Object x, SQLType targetSqlType, Integer precision, Integer scale) throws SQLServerException;
+    void setObject(int parameterIndex, Object x, SQLType targetSqlType, Integer precision, Integer scale) throws SQLServerException;
 
 	/**
      * Sets the value of the designated parameter with the given object.
@@ -71,5 +71,5 @@ public interface ISQLServerPreparedStatement42 extends ISQLServerPreparedStateme
      * parameter marker in the SQL statement; if a database access error occurs
      * or this method is called on a closed {@code PreparedStatement}
      */
-	public void setObject(int parameterIndex, Object x, SQLType targetSqlType, Integer precision, Integer scale, boolean forceEncrypt) throws SQLServerException;
+    void setObject(int parameterIndex, Object x, SQLType targetSqlType, Integer precision, Integer scale, boolean forceEncrypt) throws SQLServerException;
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet.java
@@ -24,16 +24,16 @@ import java.sql.SQLException;
 public interface ISQLServerResultSet extends java.sql.ResultSet
 {
     
-    public static final int TYPE_SS_DIRECT_FORWARD_ONLY        = 2003; // TYPE_FORWARD_ONLY + 1000
-    public static final int TYPE_SS_SERVER_CURSOR_FORWARD_ONLY = 2004; // TYPE_FORWARD_ONLY + 1001
-    public static final int TYPE_SS_SCROLL_STATIC              = 1004; // TYPE_SCROLL_INSENSITIVE
-    public static final int TYPE_SS_SCROLL_KEYSET              = 1005; // TYPE_SCROLL_SENSITIVE
-    public static final int TYPE_SS_SCROLL_DYNAMIC             = 1006; // TYPE_SCROLL_SENSITIVE + 1
+    int TYPE_SS_DIRECT_FORWARD_ONLY        = 2003; // TYPE_FORWARD_ONLY + 1000
+    int TYPE_SS_SERVER_CURSOR_FORWARD_ONLY = 2004; // TYPE_FORWARD_ONLY + 1001
+    int TYPE_SS_SCROLL_STATIC              = 1004; // TYPE_SCROLL_INSENSITIVE
+    int TYPE_SS_SCROLL_KEYSET              = 1005; // TYPE_SCROLL_SENSITIVE
+    int TYPE_SS_SCROLL_DYNAMIC             = 1006; // TYPE_SCROLL_SENSITIVE + 1
 
     /* SQL Server concurrency values */
-    public static final int CONCUR_SS_OPTIMISTIC_CC    = 1008; // CONCUR_UPDATABLE
-    public static final int CONCUR_SS_SCROLL_LOCKS     = 1009; // CONCUR_UPDATABLE + 1
-    public static final int CONCUR_SS_OPTIMISTIC_CCVAL = 1010; // CONCUR_UPDATABLE + 2
+    int CONCUR_SS_OPTIMISTIC_CC    = 1008; // CONCUR_UPDATABLE
+    int CONCUR_SS_SCROLL_LOCKS     = 1009; // CONCUR_UPDATABLE + 1
+    int CONCUR_SS_OPTIMISTIC_CCVAL = 1010; // CONCUR_UPDATABLE + 2
 
 	/**
      * Retrieves the value of the designated column as a microsoft.sql.DateTimeOffset object, given a zero-based column ordinal.
@@ -41,7 +41,7 @@ public interface ISQLServerResultSet extends java.sql.ResultSet
      * @return A DateTimeOffset Class object.
      * @throws SQLException when an error occurs
      */
-    public microsoft.sql.DateTimeOffset getDateTimeOffset(int columnIndex) throws SQLException;
+    microsoft.sql.DateTimeOffset getDateTimeOffset(int columnIndex) throws SQLException;
     
 	/**
      * Retrieves the value of the column specified as a microsoft.sql.DateTimeOffset object, given a column name.
@@ -49,7 +49,7 @@ public interface ISQLServerResultSet extends java.sql.ResultSet
      * @return A DateTimeOffset Class object.
      * @throws SQLException when an error occurs
      */
-	public microsoft.sql.DateTimeOffset getDateTimeOffset(String columnName) throws SQLException;
+    microsoft.sql.DateTimeOffset getDateTimeOffset(String columnName) throws SQLException;
 	
 	/**
      * Updates the value of the column specified to the DateTimeOffset Class value, given a zero-based column ordinal.
@@ -57,7 +57,7 @@ public interface ISQLServerResultSet extends java.sql.ResultSet
      * @param x A DateTimeOffset Class object.
      * @throws SQLException when an error occurs
      */
-    public void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x) throws SQLException;
+    void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x) throws SQLException;
 	
 	/**
      * Updates the value of the column specified to the DateTimeOffset Class value, given a column name.
@@ -65,6 +65,6 @@ public interface ISQLServerResultSet extends java.sql.ResultSet
      * @param x A DateTimeOffset Class object.
      * @throws SQLException when an error occurs
      */
-    public void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x) throws SQLException;
+    void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x) throws SQLException;
     
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet42.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet42.java
@@ -27,9 +27,9 @@ import java.sql.SQLType;
  */
 public interface ISQLServerResultSet42 extends ISQLServerResultSet{
 
-	public void updateObject(int index, Object obj, SQLType targetSqlType) throws SQLServerException;
+	void updateObject(int index, Object obj, SQLType targetSqlType) throws SQLServerException;
 
-	public void updateObject(int index, Object obj, SQLType targetSqlType, int scale) throws SQLServerException;
+	void updateObject(int index, Object obj, SQLType targetSqlType, int scale) throws SQLServerException;
 
 	/**
 	 * Updates the designated column with an Object value. The updater methods are used to update column values in the current row or the insert row. 
@@ -48,9 +48,9 @@ public interface ISQLServerResultSet42 extends ISQLServerResultSet{
 	 *  encryption on parameters.
 	 * @throws SQLServerException If any errors occur.
 	 */
-	public void updateObject(int index, Object obj, SQLType targetSqlType, int scale, boolean forceEncrypt) throws SQLServerException;
+    void updateObject(int index, Object obj, SQLType targetSqlType, int scale, boolean forceEncrypt) throws SQLServerException;
 
-	public void updateObject(String columnName, Object obj, SQLType targetSqlType, int scale) throws SQLServerException;
+	void updateObject(String columnName, Object obj, SQLType targetSqlType, int scale) throws SQLServerException;
 
 	/**
 	 * 
@@ -70,7 +70,7 @@ public interface ISQLServerResultSet42 extends ISQLServerResultSet{
 	 *  encryption on parameters.
 	 * @throws SQLServerException If any errors occur.
 	 */
-	public void updateObject(String columnName, Object obj, SQLType targetSqlType, int scale, boolean forceEncrypt) throws SQLServerException;
+    void updateObject(String columnName, Object obj, SQLType targetSqlType, int scale, boolean forceEncrypt) throws SQLServerException;
 
-	public void updateObject(String columnName, Object obj, SQLType targetSqlType) throws SQLServerException;
+	void updateObject(String columnName, Object obj, SQLType targetSqlType) throws SQLServerException;
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerStatement.java
@@ -35,12 +35,12 @@ public interface ISQLServerStatement extends java.sql.Statement
      * @param value A String that contains the response buffering mode. The valid mode can be one of the following case-insensitive Strings: full or adaptive.
      * @throws SQLServerException If there are any errors in setting the response buffering mode.
      */
-    public  void setResponseBuffering(String value) throws SQLServerException;
+    void setResponseBuffering(String value) throws SQLServerException;
 	
 	/**
      * Retrieves the response buffering mode for this SQLServerStatement object.
      * @return A String that contains a lower-case full or adaptive.
      * @throws SQLServerException If there are any errors in retrieving the response buffering mode.
      */
-    public  String getResponseBuffering() throws SQLServerException;
+    String getResponseBuffering() throws SQLServerException;
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerKeyVaultAuthenticationCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerKeyVaultAuthenticationCallback.java
@@ -29,5 +29,5 @@ public interface SQLServerKeyVaultAuthenticationCallback{
 	 * @param scope - The scope of the authentication request.
 	 * @return access token
 	 */
-	public String getAccessToken(String authority, String resource, String scope);
+    String getAccessToken(String authority, String resource, String scope);
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3288,7 +3288,7 @@ final class TypeInfo
 			 * @param tdsReader the TDSReader used to set the fields of typeInfo to the correct values
 			 * @throws SQLServerException when an error occurs
 			 */
-			public void apply(TypeInfo typeInfo, TDSReader tdsReader) throws SQLServerException;
+			void apply(TypeInfo typeInfo, TDSReader tdsReader) throws SQLServerException;
 		}
 
 		private static final class FixedLenStrategy implements Strategy

--- a/src/test/java/com/microsoft/sqlserver/testframework/SQLGeneratorIF.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/SQLGeneratorIF.java
@@ -31,7 +31,7 @@ public interface SQLGeneratorIF {
 	 * @param tableName table name
 	 * @return
 	 */
-	public String isTableExist(String tableName);
+    String isTableExist(String tableName);
 	
 	/**
 	 * Checking if column exists or not
@@ -39,21 +39,21 @@ public interface SQLGeneratorIF {
 	 * @param columnName ColumnName
 	 * @return boolean 
 	 */
-	public String isColumnExists(String tableName, String columnName);
+    String isColumnExists(String tableName, String columnName);
 	
 	/**
 	 * This will give you actual query for create table.
 	 * @param table {@link DBTable}
 	 * @return SQL Query in String
 	 */
-	public String createTable(DBTable table);
+    String createTable(DBTable table);
 	
 	/**
 	 * This will give you query for Drop Table. 
 	 * @param tableName
 	 * @return Query in String
 	 */
-	public String dropTable(String tableName);
+    String dropTable(String tableName);
 
 
 	/**
@@ -62,7 +62,7 @@ public interface SQLGeneratorIF {
 	 * @param values {@link DBValue}
 	 * @return Query in String
 	 */
-	public String insertData(String tableName, DBValue[] values);
+    String insertData(String tableName, DBValue[] values);
 	
 	/**
 	 * Creates query for inserting data
@@ -70,5 +70,5 @@ public interface SQLGeneratorIF {
 	 * @param lstValues {@link List}
 	 * @return  Query in String
 	 */
-	public String insertData(String tableName, List<Object> lstValues);
+    String insertData(String tableName, List<Object> lstValues);
 }


### PR DESCRIPTION
Methods declared in interfaces are implicitly public, therefore the public modifier is not required.