### PR TITLE
Implement missing MetaData #isWrapperFor methods

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -121,8 +121,8 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         DriverJDBCVersion.checkSupportsJDBC4();
-        // This class cannot be unwrapped
-        return false;
+        boolean f = iface.isInstance(this);
+        return f;
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -585,8 +585,8 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         DriverJDBCVersion.checkSupportsJDBC4();
-        // This class cannot be unwrapped
-        return false;
+        boolean f = iface.isInstance(this);
+        return f;
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -64,8 +64,8 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         DriverJDBCVersion.checkSupportsJDBC4();
-        // This class cannot be unwrapped
-        return false;
+        boolean f = iface.isInstance(this);
+        return f;
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1,0 +1,40 @@
+/*
+ * Microsoft JDBC Driver for SQL Server
+ * 
+ * Copyright(c) Microsoft Corporation All rights reserved.
+ * 
+ * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.databasemetadata;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.testframework.AbstractTest;
+
+@RunWith(JUnitPlatform.class)
+public class DatabaseMetaDataTest extends AbstractTest {
+    
+    /**
+     * Verify DatabaseMetaData#isWrapperFor and DatabaseMetaData#unwrap.
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testDatabaseMetaDataWrapper() throws SQLException {
+        try (Connection con = DriverManager.getConnection(connectionString)) {
+            DatabaseMetaData databaseMetaData = con.getMetaData();
+            assertTrue(databaseMetaData.isWrapperFor(DatabaseMetaData.class));
+            assertSame(databaseMetaData, databaseMetaData.unwrap(DatabaseMetaData.class));
+        }
+    }
+
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/parametermetadata/ParameterMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/parametermetadata/ParameterMetaDataTest.java
@@ -1,0 +1,57 @@
+/*
+ * Microsoft JDBC Driver for SQL Server
+ * 
+ * Copyright(c) Microsoft Corporation All rights reserved.
+ * 
+ * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.parametermetadata;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.util.RandomUtil;
+
+@RunWith(JUnitPlatform.class)
+public class ParameterMetaDataTest extends AbstractTest {
+    private static final String tableName = "[" + RandomUtil.getIdentifier("StatementParam") + "]";
+    
+    /**
+     * Test ParameterMetaData#isWrapperFor and ParameterMetaData#unwrap.
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testParameterMetaDataWrapper() throws SQLException {
+        try (Connection con = DriverManager.getConnection(connectionString);
+             Statement stmt = con.createStatement()) {
+
+            stmt.executeUpdate("create table " + tableName + " (col1 int identity(1,1) primary key)");
+            try {
+                String query = "SELECT * from " + tableName + " where col1 = ?";
+                
+                try (PreparedStatement pstmt = con.prepareStatement(query)) {
+                    ParameterMetaData parameterMetaData = pstmt.getParameterMetaData();
+                    assertTrue(parameterMetaData.isWrapperFor(ParameterMetaData.class));
+                    assertSame(parameterMetaData, parameterMetaData.unwrap(ParameterMetaData.class));
+                }
+            } finally {
+                stmt.executeUpdate("drop table if exists " + tableName);
+            }
+
+        }
+    }
+
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -8,11 +8,14 @@
 package com.microsoft.sqlserver.jdbc.resultset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
@@ -20,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
+import com.microsoft.sqlserver.jdbc.ISQLServerResultSet;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.util.RandomUtil;
 
@@ -73,4 +77,29 @@ public class ResultSetTest extends AbstractTest {
             con.close();
         }
     }
+
+    /**
+     * Tests ResultSet#isWrapperFor and ResultSet#unwrap.
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testTesultSetWrapper() throws SQLException {
+        try (Connection con = DriverManager.getConnection(connectionString);
+             Statement stmt = con.createStatement()) {
+            
+            stmt.executeUpdate("create table " + tableName + " (col1 int, col2 text, col3 int identity(1,1) primary key)");
+            
+            try (ResultSet rs = stmt.executeQuery("select * from " + tableName)) {
+                assertTrue(rs.isWrapperFor(ResultSet.class));
+                assertTrue(rs.isWrapperFor(ISQLServerResultSet.class));
+
+                assertSame(rs, rs.unwrap(ResultSet.class));
+                assertSame(rs, rs.unwrap(ISQLServerResultSet.class));
+            } finally {
+                stmt.executeUpdate("drop table if exists " + tableName);
+            }
+        }
+    }
+    
 }


### PR DESCRIPTION
The driver currently implements all #unwrap methods but some of the
matching #isWrapperFor methods are missing. This is caused by the fix
for #12 which should also have included the #isWrapperFor methods.

 - implement DatabaseMetaData#isWrapperFor
 - implement ParameterMetaData#isWrapperFor
 - implement ResultSetMetaData#isWrapperFor