### PR TITLE
Updates to build scipt to exclude long running test cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,18 +58,45 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-	compile 'com.microsoft.azure:azure-keyvault:0.9.7'
-	
-	testCompile 'junit:junit:4.12',
-	'org.junit.platform:junit-platform-console:1.0.0-M3',
-	'org.junit.platform:junit-platform-commons:1.0.0-M3',
-	'org.junit.platform:junit-platform-engine:1.0.0-M3',
-	'org.junit.platform:junit-platform-launcher:1.0.0-M3',
-	'org.junit.platform:junit-platform-runner:1.0.0-M3',
-	'org.junit.platform:junit-platform-surefire-provider:1.0.0-M3',
-	'org.junit.jupiter:junit-jupiter-api:5.0.0-M3',
-	'org.junit.jupiter:junit-jupiter-engine:5.0.0-M3'
+//enable junit gradle plugin
+buildscript {
+	repositories {
+		mavenCentral()
+
+	}
+	dependencies {
+		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M3'
+
+	}
 }
 
+apply plugin: 'org.junit.platform.gradle.plugin'
 
+ext.junit4Version        = '4.12'
+ext.junitPlatformVersion = '1.0.0-M3'
+ext.junitJupiterVersion  = '5.0.0-M3'
+
+junitPlatform {
+	filters {
+		tags {
+			// comment out the exclude property to run all tests
+			exclude 'slow'
+		}
+	}
+}
+
+dependencies {
+
+	compile 'com.microsoft.azure:azure-keyvault:0.9.7'
+		
+	// JUnit Jupiter API and TestEngine implementation
+	testCompile("junit:junit:${junit4Version}")
+	testCompile("org.junit.platform:junit-platform-console:${junitPlatformVersion}")
+	testCompile("org.junit.platform:junit-platform-commons:${junitPlatformVersion}")
+	testCompile("org.junit.platform:junit-platform-engine:${junitPlatformVersion}")
+	testCompile("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
+	testCompile("org.junit.platform:junit-platform-runner:${junitPlatformVersion}")
+	testCompile("org.junit.platform:junit-platform-surefire-provider:${junitPlatformVersion}")
+	testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
+	testCompile("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<junit.jupiter.version>5.0.0-M3</junit.jupiter.version>
+		<junit.platform.version>1.0.0-M3</junit.platform.version>
 	</properties>
-	
+	  
 	<dependencies>
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
@@ -62,59 +64,51 @@
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-console</artifactId>
-			<version>1.0.0-M3</version>
+			<version>${junit.platform.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-commons</artifactId>
-			<version>1.0.0-M3</version>
+			<version>${junit.platform.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-engine</artifactId>
-			<version>1.0.0-M3</version>
+			<version>${junit.platform.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.0.0-M3</version>
+			<version>${junit.platform.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-runner</artifactId>
-			<version>1.0.0-M3</version>
+			<version>${junit.platform.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-surefire-provider</artifactId>
-			<version>1.0.0-M3</version>
+			<version>${junit.platform.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.0.0-M3</version>
+			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.0.0-M3</version>
+			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>	
-  	<!-- 
-	<dependency>
-  		<groupId>org.junit.vintage</groupId>
-		<artifactId>junit-vintage-engine</artifactId>	
-  		<version>4.12.0-M3</version>
-  		<scope>test</scope>
-  	</dependency>	
-  	 -->	
 	</dependencies>
 
 	<profiles>
@@ -145,7 +139,7 @@
 								</manifest>
 							</archive>
 						</configuration>
-					</plugin>   
+					</plugin> 
 				</plugins>
 			</build>
 		</profile>
@@ -184,11 +178,11 @@
 				</plugins>
 			</build>
 		</profile>
-
+		
 	</profiles>
 
 	<build>
-
+	
 		<resources>
 			<resource>
 				<directory>${basedir}</directory>
@@ -212,6 +206,24 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19</version>
+				<configuration>
+					<properties>
+						<!-- Comment out the excludeTags to run all tests -->
+						<excludeTags>slow</excludeTags>
+					</properties>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.junit.platform</groupId>
+						<artifactId>junit-platform-surefire-provider</artifactId>
+						<version>${junit.platform.version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			
 		</plugins>


### PR DESCRIPTION
Build script will now exclude long running testcases that are marked with 'slow' tag. User needs to comment out the exclude property to run entire test suite.
