### PR TITLE
Access test resource path as URI

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -141,10 +142,11 @@ public class BulkCopyCSVTest extends AbstractTest {
         try {
             String className = new Object() {
             }.getClass().getEnclosingClass().getName();
-            String location = Class.forName(className).getProtectionDomain().getCodeSource().getLocation().getPath();
-            return location + "/";
+            String location = Class.forName(className).getProtectionDomain().getCodeSource().getLocation().getPath()+ "/";
+            URI uri = new URI(location.toString());
+            return uri.getPath();
         }
-        catch (ClassNotFoundException e) {
+        catch (Exception e) {
             fail("Failed to get CSV file path. " + e.getMessage());
         }
         return null;


### PR DESCRIPTION
Access test resource path as URI to avoid white space read as %20 in URL