### PR TITLE
Bulk copy with AE

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -799,11 +799,15 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
             isStreaming = (DataTypes.SHORT_VARTYPE_MAX_BYTES < bulkPrecision) || (DataTypes.SHORT_VARTYPE_MAX_BYTES < destPrecision);
         }
 
+        CryptoMetadata destCryptoMeta = destColumnMetadata.get(destColumnIndex).cryptoMeta;
+        
         /*
-         * if source is encrypted and destination is unenecrypted use destination sql type to send since there is no way of finding if source is
-         * encrypted without accessing the resultset, send destination type if source resultset set is of type SQLServer and encryption is enabled
+         * if source is encrypted and destination is unenecrypted, use destination's sql type to send since there is no way of finding if source is
+         * encrypted without accessing the resultset.
+         * 
+         * Send destination type if source resultset set is of type SQLServer, encryption is enabled and destination column is not encrypted
          */
-        if ((sourceResultSet instanceof SQLServerResultSet) && (connection.isColumnEncryptionSettingEnabled())) {
+        if ((sourceResultSet instanceof SQLServerResultSet) && (connection.isColumnEncryptionSettingEnabled()) && (null != destCryptoMeta)) {
             bulkJdbcType = destColumnMetadata.get(destColumnIndex).jdbcType;
             bulkPrecision = destPrecision;
             bulkScale = destColumnMetadata.get(destColumnIndex).scale;
@@ -839,8 +843,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
             writeTypeInfo(tdsWriter, bulkJdbcType, bulkScale, bulkPrecision, destSSType, collation, isStreaming, srcNullable, false);
         }
 
-        CryptoMetadata destCryptoMeta = null;
-        if ((null != (destCryptoMeta = destColumnMetadata.get(destColumnIndex).cryptoMeta))) {
+        if (null != destCryptoMeta) {
             int baseDestJDBCType = destCryptoMeta.baseTypeInfo.getSSType().getJDBCType().asJavaSqlType();
             int baseDestPrecision = destCryptoMeta.baseTypeInfo.getPrecision();
 
@@ -1268,8 +1271,13 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
         }
         bulkPrecision = validateSourcePrecision(srcPrecision, bulkJdbcType, destPrecision);
 
-        // if encrypted source and unencrypted destination combination
-        if ((sourceResultSet instanceof SQLServerResultSet) && (connection.isColumnEncryptionSettingEnabled())) {
+        /*
+         * if source is encrypted and destination is unenecrypted, use destination's sql type to send since there is no way of finding if source is
+         * encrypted without accessing the resultset.
+         * 
+         * Send destination type if source resultset set is of type SQLServer, encryption is enabled and destination column is not encrypted
+         */
+        if ((sourceResultSet instanceof SQLServerResultSet) && (connection.isColumnEncryptionSettingEnabled()) && (null != destCryptoMeta)) {
             bulkJdbcType = destColumnMetadata.get(destColIndx).jdbcType;
             bulkPrecision = destPrecision;
             bulkScale = destColumnMetadata.get(destColIndx).scale;


### PR DESCRIPTION
For bulkcopy without AE, driver uses source data type to send data. Applying the same rule if destination column is not encrypted.
Only instance where destination data type is used in bulkcopy is when destination is encrypted (due to normalization).