### PR TITLE
Allow authenticating using Kerberos and a Principal/Password.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
@@ -87,7 +87,6 @@ final class KerbAuthentication extends SSPIAuthentication {
                     else {
                         Map<String, String> confDetails = new HashMap<String, String>();
                         confDetails.put("useTicketCache", "true");
-                        confDetails.put("doNotPrompt", "true");
                         appConf = new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule",
                                 AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, confDetails);
                         if (authLogger.isLoggable(Level.FINER))
@@ -144,14 +143,16 @@ final class KerbAuthentication extends SSPIAuthentication {
                     AccessControlContext context = AccessController.getContext();
                     currentSubject = Subject.getSubject(context);
                     if (null == currentSubject) {
-                        lc = new LoginContext(CONFIGNAME);
+                        lc = new LoginContext(CONFIGNAME, new KerbCallback(con));
                         lc.login();
                         // per documentation LoginContext will instantiate a new subject.
                         currentSubject = lc.getSubject();
                     }
                 }
                 catch (LoginException le) {
+                    authLogger.fine("Failed to login due to " + le.getClass().getName() + ":" + le.getMessage());
                     con.terminate(SQLServerException.DRIVER_ERROR_NONE, SQLServerException.getErrString("R_integratedAuthenticationFailed"), le);
+                    return;
                 }
 
                 if (authLogger.isLoggable(Level.FINER)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
@@ -139,19 +139,33 @@ final class KerbAuthentication extends SSPIAuthentication {
             }
             else {
                 Subject currentSubject = null;
+                KerbCallback callback = new KerbCallback(con);
                 try {
                     AccessControlContext context = AccessController.getContext();
                     currentSubject = Subject.getSubject(context);
                     if (null == currentSubject) {
-                        lc = new LoginContext(CONFIGNAME, new KerbCallback(con));
+                        lc = new LoginContext(CONFIGNAME, callback);
                         lc.login();
                         // per documentation LoginContext will instantiate a new subject.
                         currentSubject = lc.getSubject();
                     }
                 }
                 catch (LoginException le) {
-                    authLogger.fine("Failed to login due to " + le.getClass().getName() + ":" + le.getMessage());
-                    con.terminate(SQLServerException.DRIVER_ERROR_NONE, SQLServerException.getErrString("R_integratedAuthenticationFailed"), le);
+                    if (authLogger.isLoggable(Level.FINE)) {
+                        authLogger.fine(toString() + "Failed to login using Kerberos due to " + le.getClass().getName() + ":" + le.getMessage());
+                    }
+                    try {
+                        // Not very clean since it raises an Exception, but we are sure we are cleaning well everything
+                        con.terminate(SQLServerException.DRIVER_ERROR_NONE, SQLServerException.getErrString("R_integratedAuthenticationFailed"), le);
+                    } catch (SQLServerException alwaysTriggered) {
+                        String message = String.format("%s due to %s (%s)", alwaysTriggered.getMessage(), le.getClass().getName(), le.getMessage());
+                        if (callback.getUsernameRequested() != null) {
+                            message = String.format("Login failed for Kerberos principal '%s'. %s", callback.getUsernameRequested(), message);
+                        }
+                        // By throwing Exception with LOGON_FAILED -> we avoid looping for connection
+                        // In this case, authentication will never work anyway -> fail fast
+                        throw new SQLServerException(message, alwaysTriggered.getSQLState(), SQLServerException.LOGON_FAILED, le);
+                    }
                     return;
                 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
@@ -13,6 +13,7 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -158,9 +159,11 @@ final class KerbAuthentication extends SSPIAuthentication {
                         // Not very clean since it raises an Exception, but we are sure we are cleaning well everything
                         con.terminate(SQLServerException.DRIVER_ERROR_NONE, SQLServerException.getErrString("R_integratedAuthenticationFailed"), le);
                     } catch (SQLServerException alwaysTriggered) {
-                        String message = String.format("%s due to %s (%s)", alwaysTriggered.getMessage(), le.getClass().getName(), le.getMessage());
+                        String message =  MessageFormat.format(SQLServerException.getErrString("R_kerberosLoginFailed"),
+                                                               alwaysTriggered.getMessage(), le.getClass().getName(), le.getMessage());
                         if (callback.getUsernameRequested() != null) {
-                            message = String.format("Login failed for Kerberos principal '%s'. %s", callback.getUsernameRequested(), message);
+                            message = MessageFormat.format(SQLServerException.getErrString("R_kerberosLoginFailedForUsername"),
+                                                           callback.getUsernameRequested(), message);
                         }
                         // By throwing Exception with LOGON_FAILED -> we avoid looping for connection
                         // In this case, authentication will never work anyway -> fail fast

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbCallback.java
@@ -19,23 +19,24 @@ public class KerbCallback implements CallbackHandler {
         this.con = con;
     }
 
-    private static String getAnyOf(Callback callback, Properties properties, String... names)
-            throws UnsupportedCallbackException {
+    private static String getAnyOf(Callback callback,
+            Properties properties,
+            String... names) throws UnsupportedCallbackException {
         for (String name : names) {
             String val = properties.getProperty(name);
             if (val != null && !val.trim().isEmpty()) {
                 return val;
             }
         }
-        throw new UnsupportedCallbackException(callback,
-                "Cannot get any of properties: " + Arrays.toString(names) + " from con properties");
+        throw new UnsupportedCallbackException(callback, "Cannot get any of properties: " + Arrays.toString(names) + " from con properties");
     }
 
     /**
      * If a name was retrieved By Kerberos, return it.
+     *
      * @return null if callback was not called or username was not provided
      */
-    public String getUsernameRequested(){
+    public String getUsernameRequested() {
         return usernameRequested;
     }
 
@@ -44,16 +45,15 @@ public class KerbCallback implements CallbackHandler {
         for (int i = 0; i < callbacks.length; i++) {
             Callback callback = callbacks[i];
             if (callback instanceof NameCallback) {
-                usernameRequested = getAnyOf(callback, con.activeConnectionProperties,
-                                             "user", SQLServerDriverStringProperty.USER.name());
+                usernameRequested = getAnyOf(callback, con.activeConnectionProperties, "user", SQLServerDriverStringProperty.USER.name());
                 ((NameCallback) callback).setName(usernameRequested);
-            } else if (callback instanceof PasswordCallback) {
-                String password = getAnyOf(callback, con.activeConnectionProperties,
-                        "password", SQLServerDriverStringProperty.PASSWORD.name());
-                ((PasswordCallback) callbacks[i])
-                        .setPassword(password.toCharArray());
+            }
+            else if (callback instanceof PasswordCallback) {
+                String password = getAnyOf(callback, con.activeConnectionProperties, "password", SQLServerDriverStringProperty.PASSWORD.name());
+                ((PasswordCallback) callbacks[i]).setPassword(password.toCharArray());
 
-            } else {
+            }
+            else {
                 throw new UnsupportedCallbackException(callback, "Unrecognized Callback type: " + callback.getClass());
             }
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbCallback.java
@@ -1,0 +1,53 @@
+package com.microsoft.sqlserver.jdbc;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+public class KerbCallback implements CallbackHandler {
+
+    private final SQLServerConnection con;
+
+    KerbCallback(SQLServerConnection con) {
+        this.con = con;
+    }
+
+    private static String getAnyOf(Callback callback, Properties properties, String... names)
+            throws UnsupportedCallbackException {
+        for (String name : names) {
+            String val = properties.getProperty(name);
+            if (val != null && !val.trim().isEmpty()) {
+                return val;
+            }
+        }
+        throw new UnsupportedCallbackException(callback,
+                "Cannot get any of properties: " + Arrays.toString(names) + " from con properties");
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        for (int i = 0; i < callbacks.length; i++) {
+            Callback callback = callbacks[i];
+            if (callback instanceof NameCallback) {
+                ((NameCallback) callback).setName(getAnyOf(callback, con.activeConnectionProperties,
+                        "user", SQLServerDriverStringProperty.USER.name()));
+            } else if (callback instanceof PasswordCallback) {
+                String password = getAnyOf(callback, con.activeConnectionProperties,
+                        "password", SQLServerDriverStringProperty.PASSWORD.name());
+                ((PasswordCallback) callbacks[i])
+                        .setPassword(password.toCharArray());
+
+            } else {
+                throw new UnsupportedCallbackException(callback, "Unrecognized Callback type: " + callback.getClass());
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -380,5 +380,7 @@ public final class SQLServerResource extends ListResourceBundle {
 				{"R_invalidFipsEncryptConfig", "Could not enable FIPS due to either encrypt is not true or using trusted certificate settings."},
 				{"R_invalidFipsProviderConfig", "Could not enable FIPS due to invalid FIPSProvider or TrustStoreType."},
 				{"R_serverPreparedStatementDiscardThreshold", "The serverPreparedStatementDiscardThreshold {0} is not valid."},
+				{"R_kerberosLoginFailedForUsername", "Cannot login with Kerberos principal {0}, check your credentials. {1}"},
+				{"R_kerberosLoginFailed", "Kerberos Login failed: {0} due to {1} ({2})"},
     };
 }


### PR DESCRIPTION
This closes #66 

This patch allow to authenticate using kerberos using the previous
methods (eg: keytab) or specifying user/password either in properties
or in connect method.

This allows to use GUIs for instance to connect using Kerberos without
having a sql user.


If fixes issue #66  