### PR TITLE
Fix random failure in BulkCopyColumnMapping test

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnMappingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnMappingTest.java
@@ -202,8 +202,8 @@ public class BulkCopyColumnMappingTest extends BulkCopyTestSetUp {
     @DisplayName("BulkCopy:test implicit mismatched column mapping")
     void testImplicitMismatchCM() {
 
-        // create dest table with different schema from source table
-        DBTable destTable = new DBTable(true);
+        // create non unicode dest table with different schema from source table
+        DBTable destTable = new DBTable(true, false, true);
         stmt.createTable(destTable);
 
         // set up bulkCopy with explicit column mapping

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBSchema.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBSchema.java
@@ -87,6 +87,83 @@ public class DBSchema {
             // Other types
         }
     }
+    
+    /**
+     * 
+     * @param autoGenerateSchema
+     * @param alternateSchema
+     */
+    DBSchema(boolean autoGenerateSchema, boolean alternateSchema) {
+        sqlTypes = new ArrayList<SqlType>();
+        if (autoGenerateSchema && !alternateSchema) {
+            // Exact Numeric
+            sqlTypes.add(new SqlBigInt());
+            sqlTypes.add(new SqlInt());
+            sqlTypes.add(new SqlSmallInt());
+            sqlTypes.add(new SqlTinyInt());
+            sqlTypes.add(new SqlBit());
+            sqlTypes.add(new SqlDecimal());
+            sqlTypes.add(new SqlNumeric());
+            sqlTypes.add(new SqlMoney());
+            sqlTypes.add(new SqlSmallMoney());
+            // Appx Numeric
+            sqlTypes.add(new SqlFloat());
+            sqlTypes.add(new SqlReal());
+            // Character
+            sqlTypes.add(new SqlChar());
+            sqlTypes.add(new SqlVarChar());
+            // Unicode
+            sqlTypes.add(new SqlNChar());
+            sqlTypes.add(new SqlNVarChar());
+            // Temporal
+            sqlTypes.add(new SqlDateTime());
+            sqlTypes.add(new SqlDate());
+            sqlTypes.add(new SqlTime());
+            sqlTypes.add(new SqlSmallDateTime());
+            sqlTypes.add(new SqlDateTime2());
+            sqlTypes.add(new SqlDateTimeOffset());
+            // Binary
+            sqlTypes.add(new SqlBinary());
+            sqlTypes.add(new SqlVarBinary());
+
+            // TODO:
+            // Other types
+        }
+        if (autoGenerateSchema && alternateSchema) {
+            // Exact Numeric
+            sqlTypes.add(new SqlBigInt());
+            sqlTypes.add(new SqlTinyInt());
+            sqlTypes.add(new SqlInt());
+            sqlTypes.add(new SqlSmallInt());
+            sqlTypes.add(new SqlBit());
+            sqlTypes.add(new SqlSmallMoney());
+            sqlTypes.add(new SqlDecimal());
+            sqlTypes.add(new SqlNumeric());
+            sqlTypes.add(new SqlMoney());
+            // Appx Numeric
+            sqlTypes.add(new SqlReal());
+            sqlTypes.add(new SqlFloat());
+            // Character
+            sqlTypes.add(new SqlVarChar());
+            sqlTypes.add(new SqlChar());
+            // Unicode
+            sqlTypes.add(new SqlNVarChar());
+            sqlTypes.add(new SqlNChar());
+            // Temporal
+            sqlTypes.add(new SqlSmallDateTime());
+            sqlTypes.add(new SqlDateTime());
+            sqlTypes.add(new SqlDate());
+            sqlTypes.add(new SqlDateTimeOffset());
+            sqlTypes.add(new SqlTime());
+            sqlTypes.add(new SqlDateTime2());
+            // Binary
+            sqlTypes.add(new SqlVarBinary());
+            sqlTypes.add(new SqlBinary());
+
+            // TODO:
+            // Other types
+        }
+    }
 
     /**
      * 

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBSchema.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBSchema.java
@@ -9,6 +9,7 @@
 package com.microsoft.sqlserver.testframework;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.microsoft.sqlserver.testframework.sqlType.SqlBigInt;
@@ -87,81 +88,17 @@ public class DBSchema {
             // Other types
         }
     }
-    
+
     /**
      * 
      * @param autoGenerateSchema
      * @param alternateSchema
      */
-    DBSchema(boolean autoGenerateSchema, boolean alternateSchema) {
-        sqlTypes = new ArrayList<SqlType>();
-        if (autoGenerateSchema && !alternateSchema) {
-            // Exact Numeric
-            sqlTypes.add(new SqlBigInt());
-            sqlTypes.add(new SqlInt());
-            sqlTypes.add(new SqlSmallInt());
-            sqlTypes.add(new SqlTinyInt());
-            sqlTypes.add(new SqlBit());
-            sqlTypes.add(new SqlDecimal());
-            sqlTypes.add(new SqlNumeric());
-            sqlTypes.add(new SqlMoney());
-            sqlTypes.add(new SqlSmallMoney());
-            // Appx Numeric
-            sqlTypes.add(new SqlFloat());
-            sqlTypes.add(new SqlReal());
-            // Character
-            sqlTypes.add(new SqlChar());
-            sqlTypes.add(new SqlVarChar());
-            // Unicode
-            sqlTypes.add(new SqlNChar());
-            sqlTypes.add(new SqlNVarChar());
-            // Temporal
-            sqlTypes.add(new SqlDateTime());
-            sqlTypes.add(new SqlDate());
-            sqlTypes.add(new SqlTime());
-            sqlTypes.add(new SqlSmallDateTime());
-            sqlTypes.add(new SqlDateTime2());
-            sqlTypes.add(new SqlDateTimeOffset());
-            // Binary
-            sqlTypes.add(new SqlBinary());
-            sqlTypes.add(new SqlVarBinary());
-
-            // TODO:
-            // Other types
-        }
-        if (autoGenerateSchema && alternateSchema) {
-            // Exact Numeric
-            sqlTypes.add(new SqlBigInt());
-            sqlTypes.add(new SqlTinyInt());
-            sqlTypes.add(new SqlInt());
-            sqlTypes.add(new SqlSmallInt());
-            sqlTypes.add(new SqlBit());
-            sqlTypes.add(new SqlSmallMoney());
-            sqlTypes.add(new SqlDecimal());
-            sqlTypes.add(new SqlNumeric());
-            sqlTypes.add(new SqlMoney());
-            // Appx Numeric
-            sqlTypes.add(new SqlReal());
-            sqlTypes.add(new SqlFloat());
-            // Character
-            sqlTypes.add(new SqlVarChar());
-            sqlTypes.add(new SqlChar());
-            // Unicode
-            sqlTypes.add(new SqlNVarChar());
-            sqlTypes.add(new SqlNChar());
-            // Temporal
-            sqlTypes.add(new SqlSmallDateTime());
-            sqlTypes.add(new SqlDateTime());
-            sqlTypes.add(new SqlDate());
-            sqlTypes.add(new SqlDateTimeOffset());
-            sqlTypes.add(new SqlTime());
-            sqlTypes.add(new SqlDateTime2());
-            // Binary
-            sqlTypes.add(new SqlVarBinary());
-            sqlTypes.add(new SqlBinary());
-
-            // TODO:
-            // Other types
+    DBSchema(boolean autoGenerateSchema,
+            boolean alternateSchema) {
+        this(autoGenerateSchema);
+        if (alternateSchema) {
+            Collections.shuffle(this.sqlTypes);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBTable.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBTable.java
@@ -44,63 +44,41 @@ public class DBTable extends AbstractSQLGenerator {
      *            <code>true</code> : generates schema with all available dataTypes in SqlType class
      */
     public DBTable(boolean autoGenerateSchema) {
-
-        this.tableName = RandomUtil.getIdentifier("table");
-        this.escapedTableName = escapeIdentifier(tableName);
-        this.schema = new DBSchema(autoGenerateSchema);
-        if (autoGenerateSchema) {
-            addColumns();
-        }
-        else {
-            this.columns = new ArrayList<DBColumn>();
-        }
-        this.totalColumns = columns.size();
+        this(autoGenerateSchema, false, false);
     }
-    
+
     /**
      * Initializes {@link DBTable} with tableName, schema, and {@link DBColumns}
      * 
      * @param autoGenerateSchema
-     *            <code>true</code>: generates schema with all available
-     *            dataTypes in SqlType class
+     *            <code>true</code>: generates schema with all available dataTypes in SqlType class
      * @param unicode
-     *             <code>true</code>: sets unicode column names if autoGenerateSchema is also set to <code>true</code>
+     *            <code>true</code>: sets unicode column names if autoGenerateSchema is also set to <code>true</code>
      */
-    public DBTable(boolean autoGenerateSchema, boolean unicode) {
-
-        this.tableName = RandomUtil.getIdentifier("table");
-        this.escapedTableName = escapeIdentifier(tableName);
-        this.schema = new DBSchema(autoGenerateSchema);
-        if (autoGenerateSchema) {
-            if(unicode)
-                addColumns(unicode);
-            else
-                addColumns();
-        }
-        else {
-            this.columns = new ArrayList<DBColumn>();
-        }
-        this.totalColumns = columns.size();
+    public DBTable(boolean autoGenerateSchema,
+            boolean unicode) {
+        this(autoGenerateSchema, unicode, false);
     }
-    
+
     /**
      * Initializes {@link DBTable} with tableName, schema, and {@link DBColumns}
      * 
      * @param autoGenerateSchema
-     *            <code>true</code>: generates schema with all available
-     *            dataTypes in SqlType class
+     *            <code>true</code>: generates schema with all available dataTypes in SqlType class
      * @param unicode
-     *             <code>true</code>: sets unicode column names if autoGenerateSchema is also set to <code>true</code>
+     *            <code>true</code>: sets unicode column names if autoGenerateSchema is also set to <code>true</code>
      * @param alternateShcema
-     *             <code>true</code>: creates table with alternate schema
+     *            <code>true</code>: creates table with alternate schema
      */
-    public DBTable(boolean autoGenerateSchema, boolean unicode, boolean alternateSchema) {
+    public DBTable(boolean autoGenerateSchema,
+            boolean unicode,
+            boolean alternateSchema) {
 
         this.tableName = RandomUtil.getIdentifier("table");
         this.escapedTableName = escapeIdentifier(tableName);
         this.schema = new DBSchema(autoGenerateSchema, alternateSchema);
         if (autoGenerateSchema) {
-            if(unicode)
+            if (unicode)
                 addColumns(unicode);
             else
                 addColumns();
@@ -133,11 +111,11 @@ public class DBTable extends AbstractSQLGenerator {
 
         for (int i = 0; i < totalColumns; i++) {
             SqlType sqlType = schema.getSqlType(i);
-            DBColumn column = new DBColumn(RandomUtil.getIdentifier(sqlType.getName()), sqlType); 
+            DBColumn column = new DBColumn(RandomUtil.getIdentifier(sqlType.getName()), sqlType);
             columns.add(column);
         }
     }
-    
+
     /**
      * adds a columns for each SQL type in DBSchema
      */
@@ -148,7 +126,7 @@ public class DBTable extends AbstractSQLGenerator {
         for (int i = 0; i < totalColumns; i++) {
             SqlType sqlType = schema.getSqlType(i);
             DBColumn column;
-            if(unicode)
+            if (unicode)
                 column = new DBColumn(RandomUtil.getIdentifier(sqlType.getName()) + "ĀĂŎՖએДЕЖЗИЙਟਖਞ", sqlType);
             else
                 column = new DBColumn(RandomUtil.getIdentifier(sqlType.getName()), sqlType);

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBTable.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBTable.java
@@ -82,6 +82,34 @@ public class DBTable extends AbstractSQLGenerator {
         }
         this.totalColumns = columns.size();
     }
+    
+    /**
+     * Initializes {@link DBTable} with tableName, schema, and {@link DBColumns}
+     * 
+     * @param autoGenerateSchema
+     *            <code>true</code>: generates schema with all available
+     *            dataTypes in SqlType class
+     * @param unicode
+     *             <code>true</code>: sets unicode column names if autoGenerateSchema is also set to <code>true</code>
+     * @param alternateShcema
+     *             <code>true</code>: creates table with alternate schema
+     */
+    public DBTable(boolean autoGenerateSchema, boolean unicode, boolean alternateSchema) {
+
+        this.tableName = RandomUtil.getIdentifier("table");
+        this.escapedTableName = escapeIdentifier(tableName);
+        this.schema = new DBSchema(autoGenerateSchema, alternateSchema);
+        if (autoGenerateSchema) {
+            if(unicode)
+                addColumns(unicode);
+            else
+                addColumns();
+        }
+        else {
+            this.columns = new ArrayList<DBColumn>();
+        }
+        this.totalColumns = columns.size();
+    }
 
     /**
      * Similar to {@link DBTable#DBTable(boolean)}, but uses existing list of columns Used internally to clone schema


### PR DESCRIPTION
Before, when two random tables are created, there was a small chance that they would have identical schemas. This caused the ImplicitMismatchCM test case to pass when it was expected to fail. Modified creation of destination table to always have a different schema from the source table.