### PR TITLE
Remove obsolete methods from DriverJDBCVersion

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBlob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBlob.java
@@ -106,8 +106,6 @@ public final class SQLServerBlob implements java.sql.Blob, java.io.Serializable 
      * multiple times, the subsequent calls to free are treated as a no-op.
      */
     public void free() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         if (!isClosed) {
             // Close active streams, ignoring any errors, since nothing can be done with them after that point anyway.
             if (null != activeStreams) {
@@ -147,8 +145,6 @@ public final class SQLServerBlob implements java.sql.Blob, java.io.Serializable 
 
     public InputStream getBinaryStream(long pos,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented - partial materialization
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -487,8 +487,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public final String getNString(int parameterIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         loggerExternal.entering(getClassNameLogging(), "getNString", parameterIndex);
         checkClosed();
         String value = (String) getValue(parameterIndex, JDBCType.NCHAR);
@@ -497,8 +495,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public final String getNString(String parameterName) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         loggerExternal.entering(getClassNameLogging(), "getNString", parameterName);
         checkClosed();
         String value = (String) getValue(findColumn(parameterName), JDBCType.NCHAR);
@@ -680,8 +676,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public <T> T getObject(int index,
             Class<T> type) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // The driver currently does not implement the optional JDBC APIs
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
@@ -698,8 +692,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public <T> T getObject(String sCol,
             Class<T> type) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // The driver currently does not implement the optional JDBC APIs
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
@@ -1206,8 +1198,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public final java.io.Reader getCharacterStream(String parameterName) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         loggerExternal.entering(getClassNameLogging(), "getCharacterStream", parameterName);
         checkClosed();
         Reader reader = (Reader) getStream(findColumn(parameterName), StreamType.CHARACTER);
@@ -1216,7 +1206,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public final java.io.Reader getNCharacterStream(int parameterIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getNCharacterStream", parameterIndex);
         checkClosed();
         Reader reader = (Reader) getStream(parameterIndex, StreamType.NCHARACTER);
@@ -1225,8 +1214,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public final java.io.Reader getNCharacterStream(String parameterName) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         loggerExternal.entering(getClassNameLogging(), "getNCharacterStream", parameterName);
         checkClosed();
         Reader reader = (Reader) getStream(findColumn(parameterName), StreamType.NCHARACTER);
@@ -1265,7 +1252,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public NClob getNClob(int parameterIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getNClob", parameterIndex);
         checkClosed();
         NClob nClob = (NClob) getValue(parameterIndex, JDBCType.NCLOB);
@@ -1274,7 +1260,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public NClob getNClob(String parameterName) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getNClob", parameterName);
         checkClosed();
         NClob nClob = (NClob) getValue(findColumn(parameterName), JDBCType.NCLOB);
@@ -1609,7 +1594,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setCharacterStream(String parameterName,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setCharacterStream", new Object[] {parameterName, reader});
         checkClosed();
@@ -1631,7 +1615,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             Reader reader,
             long length) throws SQLException {
 
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setCharacterStream", new Object[] {parameterName, reader, length});
         checkClosed();
@@ -1641,7 +1624,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setNCharacterStream(String parameterName,
             Reader value) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNCharacterStream", new Object[] {parameterName, value});
         checkClosed();
@@ -1652,7 +1634,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public final void setNCharacterStream(String parameterName,
             Reader value,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNCharacterStream", new Object[] {parameterName, value, length});
         checkClosed();
@@ -1662,7 +1643,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setClob(String parameterName,
             Clob x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterName, x});
         checkClosed();
@@ -1672,7 +1652,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setClob(String parameterName,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterName, reader});
         checkClosed();
@@ -1683,7 +1662,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public final void setClob(String parameterName,
             Reader value,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterName, value, length});
         checkClosed();
@@ -1693,7 +1671,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setNClob(String parameterName,
             NClob value) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterName, value});
         checkClosed();
@@ -1703,7 +1680,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setNClob(String parameterName,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterName, reader});
         checkClosed();
@@ -1714,7 +1690,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public final void setNClob(String parameterName,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterName, reader, length});
         checkClosed();
@@ -1724,7 +1699,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setNString(String parameterName,
             String value) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNString", new Object[] {parameterName, value});
         checkClosed();
@@ -1752,7 +1726,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public final void setNString(String parameterName,
             String value,
             boolean forceEncrypt) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNString", new Object[] {parameterName, value, forceEncrypt});
         checkClosed();
@@ -1904,7 +1877,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             InputStream x) throws SQLException {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setAsciiStream", new Object[] {parameterName, x});
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         setStream(findColumn(parameterName), StreamType.ASCII, x, JavaType.INPUTSTREAM, DataTypes.UNKNOWN_STREAM_LENGTH);
         loggerExternal.exiting(getClassNameLogging(), "setAsciiStream");
@@ -1925,7 +1897,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             long length) throws SQLException {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setAsciiStream", new Object[] {parameterName, x, length});
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         setStream(findColumn(parameterName), StreamType.ASCII, x, JavaType.INPUTSTREAM, length);
         loggerExternal.exiting(getClassNameLogging(), "setAsciiStream");
@@ -1934,7 +1905,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public final void setBinaryStream(String parameterName,
             InputStream x) throws SQLException {
 
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBinaryStream", new Object[] {parameterName, x});
         checkClosed();
@@ -1955,7 +1925,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public final void setBinaryStream(String parameterName,
             InputStream x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBinaryStream", new Object[] {parameterName, x, length});
         checkClosed();
@@ -1965,7 +1934,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setBlob(String parameterName,
             Blob inputStream) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob", new Object[] {parameterName, inputStream});
         checkClosed();
@@ -1975,7 +1943,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setBlob(String parameterName,
             InputStream value) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
 
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob", new Object[] {parameterName, value});
@@ -1987,7 +1954,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public final void setBlob(String parameterName,
             InputStream inputStream,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob", new Object[] {parameterName, inputStream, length});
         checkClosed();
@@ -2919,7 +2885,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setSQLXML(String parameterName,
             SQLXML xmlObject) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setSQLXML", new Object[] {parameterName, xmlObject});
         checkClosed();
@@ -2928,7 +2893,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public final SQLXML getSQLXML(int parameterIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getSQLXML", parameterIndex);
         checkClosed();
         SQLServerSQLXML value = (SQLServerSQLXML) getSQLXMLInternal(parameterIndex);
@@ -2937,7 +2901,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     public final SQLXML getSQLXML(String parameterName) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getSQLXML", parameterName);
         checkClosed();
         SQLServerSQLXML value = (SQLServerSQLXML) getSQLXMLInternal(findColumn(parameterName));
@@ -2947,21 +2910,18 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     public final void setRowId(String parameterName,
             RowId x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
 
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public final RowId getRowId(int parameterIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
 
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public final RowId getRowId(String parameterName) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
 
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
@@ -144,8 +144,6 @@ abstract class SQLServerClobBase implements Serializable {
      *             when an error occurs
      */
     public void free() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         if (!isClosed) {
             // Close active streams, ignoring any errors, since nothing can be done with them after that point anyway.
             if (null != activeStreams) {
@@ -225,8 +223,6 @@ abstract class SQLServerClobBase implements Serializable {
      */
     public Reader getCharacterStream(long pos,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2580,8 +2580,6 @@ public class SQLServerConnection implements ISQLServerConnection {
     public void abort(Executor executor) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "abort", executor);
 
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // nop if connection is closed
         if (isClosed())
             return;
@@ -4593,24 +4591,18 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     public int getNetworkTimeout() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // this operation is not supported
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public void setNetworkTimeout(Executor executor,
             int timeout) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // this operation is not supported
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public String getSchema() throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "getSchema");
-
-        DriverJDBCVersion.checkSupportsJDBC41();
 
         checkClosed();
 
@@ -4650,8 +4642,6 @@ public class SQLServerConnection implements ISQLServerConnection {
 
     public void setSchema(String schema) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "setSchema", schema);
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         checkClosed();
         addWarning(SQLServerException.getErrString("R_setSchemaWarning"));
 
@@ -4675,33 +4665,27 @@ public class SQLServerConnection implements ISQLServerConnection {
 
     public java.sql.Array createArrayOf(String typeName,
             Object[] elements) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public Blob createBlob() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         return new SQLServerBlob(this);
     }
 
     public Clob createClob() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         return new SQLServerClob(this);
     }
 
     public NClob createNClob() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         return new SQLServerNClob(this);
     }
 
     public SQLXML createSQLXML() throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "createSQLXML");
-        DriverJDBCVersion.checkSupportsJDBC4();
         SQLXML sqlxml = null;
         sqlxml = new SQLServerSQLXML(this);
 
@@ -4712,8 +4696,6 @@ public class SQLServerConnection implements ISQLServerConnection {
 
     public Struct createStruct(String typeName,
             Object[] attributes) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
@@ -4723,7 +4705,6 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     public Properties getClientInfo() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getClientInfo");
         checkClosed();
         Properties p = new Properties();
@@ -4732,7 +4713,6 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     public String getClientInfo(String name) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getClientInfo", name);
         checkClosed();
         loggerExternal.exiting(getClassNameLogging(), "getClientInfo", null);
@@ -4740,7 +4720,6 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     public void setClientInfo(Properties properties) throws SQLClientInfoException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "setClientInfo", properties);
         // This function is only marked as throwing only SQLClientInfoException so the conversion is necessary
         try {
@@ -4765,7 +4744,6 @@ public class SQLServerConnection implements ISQLServerConnection {
 
     public void setClientInfo(String name,
             String value) throws SQLClientInfoException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "setClientInfo", new Object[] {name, value});
         // This function is only marked as throwing only SQLClientInfoException so the conversion is necessary
         try {
@@ -4804,8 +4782,6 @@ public class SQLServerConnection implements ISQLServerConnection {
         boolean isValid = false;
 
         loggerExternal.entering(getClassNameLogging(), "isValid", timeout);
-
-        DriverJDBCVersion.checkSupportsJDBC4();
 
         // Throw an exception if the timeout is invalid
         if (timeout < 0) {
@@ -4847,7 +4823,6 @@ public class SQLServerConnection implements ISQLServerConnection {
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "isWrapperFor", iface);
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         loggerExternal.exiting(getClassNameLogging(), "isWrapperFor", Boolean.valueOf(f));
         return f;
@@ -4855,7 +4830,6 @@ public class SQLServerConnection implements ISQLServerConnection {
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "unwrap", iface);
-        DriverJDBCVersion.checkSupportsJDBC4();
         T t;
         try {
             t = iface.cast(this);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
@@ -125,8 +125,6 @@ class SQLServerConnectionPoolProxy implements ISQLServerConnection, java.io.Seri
     }
 
     public void abort(Executor executor) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         if (!bIsOpen || (null == wrappedConnection))
             return;
 
@@ -557,117 +555,86 @@ class SQLServerConnectionPoolProxy implements ISQLServerConnection, java.io.Seri
     }
 
     public int getNetworkTimeout() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // The driver currently does not implement the optional JDBC APIs
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public void setNetworkTimeout(Executor executor,
             int timeout) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // The driver currently does not implement the optional JDBC APIs
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public String getSchema() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         checkClosed();
         return wrappedConnection.getSchema();
     }
 
     public void setSchema(String schema) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         checkClosed();
         wrappedConnection.setSchema(schema);
     }
 
     public java.sql.Array createArrayOf(String typeName,
             Object[] elements) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.createArrayOf(typeName, elements);
     }
 
     public Blob createBlob() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.createBlob();
     }
 
     public Clob createClob() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.createClob();
     }
 
     public NClob createNClob() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.createNClob();
     }
 
     public SQLXML createSQLXML() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.createSQLXML();
     }
 
     public Struct createStruct(String typeName,
             Object[] attributes) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.createStruct(typeName, attributes);
     }
 
     public Properties getClientInfo() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.getClientInfo();
     }
 
     public String getClientInfo(String name) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.getClientInfo(name);
     }
 
     public void setClientInfo(Properties properties) throws SQLClientInfoException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // No checkClosed() call since we can only throw SQLClientInfoException from here
         wrappedConnection.setClientInfo(properties);
     }
 
     public void setClientInfo(String name,
             String value) throws SQLClientInfoException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // No checkClosed() call since we can only throw SQLClientInfoException from here
         wrappedConnection.setClientInfo(name, value);
     }
 
     public boolean isValid(int timeout) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         checkClosed();
         return wrappedConnection.isValid(timeout);
     }
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         wrappedConnection.getConnectionLogger().entering(toString(), "isWrapperFor", iface);
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         wrappedConnection.getConnectionLogger().exiting(toString(), "isWrapperFor", f);
         return f;
@@ -675,8 +642,6 @@ class SQLServerConnectionPoolProxy implements ISQLServerConnection, java.io.Seri
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
         wrappedConnection.getConnectionLogger().entering(toString(), "unwrap", iface);
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         T t;
         try {
             t = iface.cast(this);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -111,8 +111,6 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
     }
 
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         return parentLogger;
     }
 
@@ -954,7 +952,6 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "isWrapperFor", iface);
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         loggerExternal.exiting(getClassNameLogging(), "isWrapperFor", Boolean.valueOf(f));
         return f;
@@ -962,8 +959,6 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "unwrap", iface);
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         T t;
         try {
             t = iface.cast(this);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -120,13 +120,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         return f;
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         T t;
         try {
             t = iface.cast(this);
@@ -358,7 +356,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         return false;
     }
@@ -379,7 +376,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     public boolean generatedKeyAlwaysReturned() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
         checkClosed();
 
         // driver supports retrieving generated keys
@@ -617,7 +613,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     public java.sql.ResultSet getFunctions(String catalog,
             String schemaPattern,
             String functionNamePattern) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
 
         /*
@@ -647,7 +642,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             String schemaPattern,
             String functionNamePattern,
             String columnNamePattern) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         /*
          * sp_sproc_columns [[@procedure_name =] 'name'] [,[@procedure_owner =] 'owner'] [,[@procedure_qualifier =] 'qualifier'] [,[@column_name =]
@@ -688,7 +682,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     public java.sql.ResultSet getClientInfoProperties() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         return getResultSetFromInternalQueries(null, "SELECT" +
         /* 1 */ " cast(NULL as char(1)) as NAME," +
@@ -1109,8 +1102,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             String schemaPattern,
             String tableNamePattern,
             String columnNamePattern) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         if (loggerExternal.isLoggable(Level.FINER) && Util.IsActivityTraceOn()) {
             loggerExternal.finer(toString() + " ActivityId: " + ActivityCorrelator.getNext().toString());
         }
@@ -1217,7 +1208,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         if (loggerExternal.isLoggable(Level.FINER) && Util.IsActivityTraceOn()) {
             loggerExternal.finer(toString() + " ActivityId: " + ActivityCorrelator.getNext().toString());
         }
-        DriverJDBCVersion.checkSupportsJDBC4();
         return getSchemasInternal(catalog, schemaPattern);
     }
 
@@ -2036,7 +2026,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     public RowIdLifetime getRowIdLifetime() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         return RowIdLifetime.ROWID_UNSUPPORTED;
     }
@@ -2141,7 +2130,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         return true;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -639,8 +639,6 @@ public final class SQLServerDriver implements java.sql.Driver {
     }
 
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         return parentLogger;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc41.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc41.java
@@ -19,12 +19,6 @@ final class DriverJDBCVersion {
     static final int major = 4;
     static final int minor = 1;
 
-    static final void checkSupportsJDBC4() {
-    }
-
-    static final void checkSupportsJDBC41() {
-    }
-
     static final void checkSupportsJDBC42() {
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java
@@ -22,12 +22,6 @@ final class DriverJDBCVersion {
     static final int major = 4;
     static final int minor = 2;
 
-    static final void checkSupportsJDBC4() {
-    }
-
-    static final void checkSupportsJDBC41() {
-    }
-
     static final void checkSupportsJDBC42() {
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -584,13 +584,11 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
     }
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         return f;
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         T t;
         try {
             t = iface.cast(this);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
@@ -198,15 +198,11 @@ public class SQLServerPooledConnection implements PooledConnection {
     }
 
     public void addStatementEventListener(StatementEventListener listener) {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public void removeStatementEventListener(StatementEventListener listener) {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -913,7 +913,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setAsciiStream(int parameterIndex,
             InputStream x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setAsciiStream", new Object[] {parameterIndex, x});
         checkClosed();
@@ -934,7 +933,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setAsciiStream(int parameterIndex,
             InputStream x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setAsciiStream", new Object[] {parameterIndex, x, length});
         checkClosed();
@@ -1110,7 +1108,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setBinaryStream(int parameterIndex,
             InputStream x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBinaryStreaml", new Object[] {parameterIndex, x});
         checkClosed();
@@ -1131,7 +1128,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setBinaryStream(int parameterIndex,
             InputStream x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBinaryStream", new Object[] {parameterIndex, x, length});
         checkClosed();
@@ -1750,7 +1746,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setNString(int parameterIndex,
             String value) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNString", new Object[] {parameterIndex, value});
         checkClosed();
@@ -1777,7 +1772,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setNString(int parameterIndex,
             String value,
             boolean forceEncrypt) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNString", new Object[] {parameterIndex, value, forceEncrypt});
         checkClosed();
@@ -2453,7 +2447,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setCharacterStream(int parameterIndex,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setCharacterStream", new Object[] {parameterIndex, reader});
         checkClosed();
@@ -2474,7 +2467,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setCharacterStream(int parameterIndex,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setCharacterStream", new Object[] {parameterIndex, reader, length});
         checkClosed();
@@ -2484,7 +2476,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setNCharacterStream(int parameterIndex,
             Reader value) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNCharacterStream", new Object[] {parameterIndex, value});
         checkClosed();
@@ -2495,7 +2486,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setNCharacterStream(int parameterIndex,
             Reader value,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNCharacterStream", new Object[] {parameterIndex, value, length});
         checkClosed();
@@ -2519,7 +2509,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setBlob(int parameterIndex,
             InputStream inputStream) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob", new Object[] {parameterIndex, inputStream});
         checkClosed();
@@ -2530,7 +2519,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setBlob(int parameterIndex,
             InputStream inputStream,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob", new Object[] {parameterIndex, inputStream, length});
         checkClosed();
@@ -2549,7 +2537,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setClob(int parameterIndex,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterIndex, reader});
         checkClosed();
@@ -2560,7 +2547,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setClob(int parameterIndex,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterIndex, reader, length});
         checkClosed();
@@ -2570,7 +2556,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setNClob(int parameterIndex,
             NClob value) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterIndex, value});
         checkClosed();
@@ -2580,7 +2565,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setNClob(int parameterIndex,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterIndex, reader});
         checkClosed();
@@ -2591,7 +2575,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     public final void setNClob(int parameterIndex,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterIndex, reader, length});
         checkClosed();
@@ -2752,15 +2735,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     public final void setRowId(int parameterIndex,
             RowId x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public final void setSQLXML(int parameterIndex,
             SQLXML xmlObject) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setSQLXML", new Object[] {parameterIndex, xmlObject});
         checkClosed();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -386,7 +386,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "isWrapperFor");
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         loggerExternal.exiting(getClassNameLogging(), "isWrapperFor", Boolean.valueOf(f));
         return f;
@@ -394,7 +393,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "unwrap");
-        DriverJDBCVersion.checkSupportsJDBC4();
         T t;
         try {
             t = iface.cast(this);
@@ -429,8 +427,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     }
 
     public boolean isClosed() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         loggerExternal.entering(getClassNameLogging(), "isClosed");
         boolean result = isClosed || stmt.isClosed();
         loggerExternal.exiting(getClassNameLogging(), "isClosed", result);
@@ -2166,8 +2162,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public <T> T getObject(int columnIndex,
             Class<T> type) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // The driver currently does not implement the optional JDBC APIs
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
@@ -2182,8 +2176,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public <T> T getObject(String columnName,
             Class<T> type) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         // The driver currently does not implement the optional JDBC APIs
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
@@ -2232,7 +2224,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public String getNString(int columnIndex) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "getNString", columnIndex);
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         String value = (String) getValue(columnIndex, JDBCType.NCHAR);
         loggerExternal.exiting(getClassNameLogging(), "getNString", value);
@@ -2241,7 +2232,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public String getNString(String columnLabel) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "getNString", columnLabel);
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         String value = (String) getValue(findColumn(columnLabel), JDBCType.NCHAR);
         loggerExternal.exiting(getClassNameLogging(), "getNString", value);
@@ -2606,7 +2596,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     }
 
     public NClob getNClob(int columnIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getNClob", columnIndex);
         checkClosed();
         NClob value = (NClob) getValue(columnIndex, JDBCType.NCLOB);
@@ -2615,7 +2604,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     }
 
     public NClob getNClob(String columnLabel) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getNClob", columnLabel);
         checkClosed();
         NClob value = (NClob) getValue(findColumn(columnLabel), JDBCType.NCLOB);
@@ -2668,7 +2656,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     }
 
     public Reader getNCharacterStream(int columnIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getNCharacterStream", columnIndex);
         checkClosed();
         Reader value = (Reader) getStream(columnIndex, StreamType.NCHARACTER);
@@ -2677,7 +2664,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     }
 
     public Reader getNCharacterStream(String columnLabel) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getNCharacterStream", columnLabel);
         checkClosed();
         Reader value = (Reader) getStream(findColumn(columnLabel), StreamType.NCHARACTER);
@@ -2770,21 +2756,17 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     }
 
     public RowId getRowId(int columnIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public RowId getRowId(String columnLabel) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
 
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public SQLXML getSQLXML(int columnIndex) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getSQLXML", columnIndex);
         SQLXML xml = getSQLXMLInternal(columnIndex);
         loggerExternal.exiting(getClassNameLogging(), "getSQLXML", xml);
@@ -2792,7 +2774,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     }
 
     public SQLXML getSQLXML(String columnLabel) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "getSQLXML", columnLabel);
         SQLXML xml = getSQLXMLInternal(findColumn(columnLabel));
         loggerExternal.exiting(getClassNameLogging(), "getSQLXML", xml);
@@ -3537,7 +3518,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNString", new Object[] {columnIndex, nString});
 
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         updateValue(columnIndex, JDBCType.NVARCHAR, nString, JavaType.STRING, false);
 
@@ -3567,7 +3547,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNString", new Object[] {columnIndex, nString, forceEncrypt});
 
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         updateValue(columnIndex, JDBCType.NVARCHAR, nString, JavaType.STRING, forceEncrypt);
 
@@ -3579,7 +3558,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNString", new Object[] {columnLabel, nString});
 
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         updateValue(findColumn(columnLabel), JDBCType.NVARCHAR, nString, JavaType.STRING, false);
 
@@ -3610,7 +3588,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNString", new Object[] {columnLabel, nString, forceEncrypt});
 
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
         updateValue(findColumn(columnLabel), JDBCType.NVARCHAR, nString, JavaType.STRING, forceEncrypt);
 
@@ -4108,7 +4085,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateAsciiStream(int columnIndex,
             InputStream x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateAsciiStream", new Object[] {columnIndex, x});
 
@@ -4133,7 +4109,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateAsciiStream(int columnIndex,
             InputStream x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "updateAsciiStream", new Object[] {columnIndex, x, length});
 
         checkClosed();
@@ -4144,7 +4119,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateAsciiStream(String columnLabel,
             InputStream x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateAsciiStream", new Object[] {columnLabel, x});
 
@@ -4169,7 +4143,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateAsciiStream(String columnName,
             InputStream streamValue,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateAsciiStream", new Object[] {columnName, streamValue, length});
 
@@ -4181,7 +4154,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateBinaryStream(int columnIndex,
             InputStream x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBinaryStream", new Object[] {columnIndex, x});
 
@@ -4206,7 +4178,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateBinaryStream(int columnIndex,
             InputStream x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBinaryStream", new Object[] {columnIndex, x, length});
 
@@ -4218,7 +4189,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateBinaryStream(String columnLabel,
             InputStream x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBinaryStream", new Object[] {columnLabel, x});
 
@@ -4243,7 +4213,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateBinaryStream(String columnLabel,
             InputStream x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBinaryStream", new Object[] {columnLabel, x, length});
 
@@ -4255,7 +4224,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateCharacterStream(int columnIndex,
             Reader x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateCharacterStream", new Object[] {columnIndex, x});
 
@@ -4280,7 +4248,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateCharacterStream(int columnIndex,
             Reader x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateCharacterStream", new Object[] {columnIndex, x, length});
 
@@ -4292,7 +4259,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateCharacterStream(String columnLabel,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateCharacterStream", new Object[] {columnLabel, reader});
 
@@ -4317,7 +4283,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateCharacterStream(String columnLabel,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateCharacterStream", new Object[] {columnLabel, reader, length});
 
@@ -4329,7 +4294,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateNCharacterStream(int columnIndex,
             Reader x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNCharacterStream", new Object[] {columnIndex, x});
 
@@ -4342,7 +4306,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateNCharacterStream(int columnIndex,
             Reader x,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNCharacterStream", new Object[] {columnIndex, x, length});
 
@@ -4354,7 +4317,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateNCharacterStream(String columnLabel,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNCharacterStream", new Object[] {columnLabel, reader});
 
@@ -4367,7 +4329,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateNCharacterStream(String columnLabel,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNCharacterStream", new Object[] {columnLabel, reader, length});
 
@@ -5529,23 +5490,18 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateRowId(int columnIndex,
             RowId x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public void updateRowId(String columnLabel,
             RowId x) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         // Not implemented
         throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
     }
 
     public void updateSQLXML(int columnIndex,
             SQLXML xmlObject) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateSQLXML", new Object[] {columnIndex, xmlObject});
         updateSQLXMLInternal(columnIndex, xmlObject);
@@ -5556,7 +5512,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
             SQLXML x) throws SQLException {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateSQLXML", new Object[] {columnLabel, x});
-        DriverJDBCVersion.checkSupportsJDBC4();
         updateSQLXMLInternal(findColumn(columnLabel), x);
         loggerExternal.exiting(getClassNameLogging(), "updateSQLXML");
     }
@@ -5564,7 +5519,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public int getHoldability() throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "getHoldability");
 
-        DriverJDBCVersion.checkSupportsJDBC4();
         checkClosed();
 
         int holdability =
@@ -5976,7 +5930,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateClob(int columnIndex,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateClob", new Object[] {columnIndex, reader});
 
@@ -5989,7 +5942,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateClob(int columnIndex,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateClob", new Object[] {columnIndex, reader, length});
 
@@ -6012,7 +5964,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateClob(String columnLabel,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateClob", new Object[] {columnLabel, reader});
 
@@ -6025,7 +5976,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateClob(String columnLabel,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateClob", new Object[] {columnLabel, reader, length});
 
@@ -6037,7 +5987,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateNClob(int columnIndex,
             NClob nClob) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateClob", new Object[] {columnIndex, nClob});
 
@@ -6049,7 +5998,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateNClob(int columnIndex,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNClob", new Object[] {columnIndex, reader});
 
@@ -6062,7 +6010,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateNClob(int columnIndex,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNClob", new Object[] {columnIndex, reader, length});
 
@@ -6074,7 +6021,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateNClob(String columnLabel,
             NClob nClob) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNClob", new Object[] {columnLabel, nClob});
 
@@ -6086,7 +6032,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateNClob(String columnLabel,
             Reader reader) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNClob", new Object[] {columnLabel, reader});
 
@@ -6099,7 +6044,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateNClob(String columnLabel,
             Reader reader,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateNClob", new Object[] {columnLabel, reader, length});
 
@@ -6122,7 +6066,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateBlob(int columnIndex,
             InputStream inputStream) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBlob", new Object[] {columnIndex, inputStream});
 
@@ -6135,7 +6078,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateBlob(int columnIndex,
             InputStream inputStream,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBlob", new Object[] {columnIndex, inputStream, length});
 
@@ -6158,7 +6100,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
     public void updateBlob(String columnLabel,
             InputStream inputStream) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBlob", new Object[] {columnLabel, inputStream});
 
@@ -6171,7 +6112,6 @@ public class SQLServerResultSet implements ISQLServerResultSet {
     public void updateBlob(String columnLabel,
             InputStream inputStream,
             long length) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateBlob", new Object[] {columnLabel, inputStream, length});
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -63,13 +63,11 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     /* ------------------ JDBC API Methods --------------------- */
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         return f;
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         T t;
         try {
             t = iface.cast(this);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -626,8 +626,6 @@ public class SQLServerStatement implements ISQLServerStatement {
     }
 
     public void closeOnCompletion() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         loggerExternal.entering(getClassNameLogging(), "closeOnCompletion");
 
         checkClosed();
@@ -2143,8 +2141,6 @@ public class SQLServerStatement implements ISQLServerStatement {
     }
 
     public boolean isClosed() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
-
         loggerExternal.entering(getClassNameLogging(), "isClosed");
         boolean result = bIsClosed || connection.isSessionUnAvailable();
         loggerExternal.exiting(getClassNameLogging(), "isClosed", result);
@@ -2152,8 +2148,6 @@ public class SQLServerStatement implements ISQLServerStatement {
     }
 
     public boolean isCloseOnCompletion() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC41();
-
         loggerExternal.entering(getClassNameLogging(), "isCloseOnCompletion");
         checkClosed();
         loggerExternal.exiting(getClassNameLogging(), "isCloseOnCompletion", isCloseOnCompletion);
@@ -2161,7 +2155,6 @@ public class SQLServerStatement implements ISQLServerStatement {
     }
 
     public boolean isPoolable() throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "isPoolable");
         checkClosed();
         loggerExternal.exiting(getClassNameLogging(), "isPoolable", stmtPoolable);
@@ -2169,7 +2162,6 @@ public class SQLServerStatement implements ISQLServerStatement {
     }
 
     public void setPoolable(boolean poolable) throws SQLException {
-        DriverJDBCVersion.checkSupportsJDBC4();
         loggerExternal.entering(getClassNameLogging(), "setPoolable", poolable);
         checkClosed();
         stmtPoolable = poolable;
@@ -2178,7 +2170,6 @@ public class SQLServerStatement implements ISQLServerStatement {
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "isWrapperFor");
-        DriverJDBCVersion.checkSupportsJDBC4();
         boolean f = iface.isInstance(this);
         loggerExternal.exiting(getClassNameLogging(), "isWrapperFor", Boolean.valueOf(f));
         return f;
@@ -2186,7 +2177,6 @@ public class SQLServerStatement implements ISQLServerStatement {
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "unwrap");
-        DriverJDBCVersion.checkSupportsJDBC4();
         T t;
         try {
             t = iface.cast(this);


### PR DESCRIPTION
The current codebase supports JDBC 4.1 and JDBC 4.2 specifications.
This means that there is no need to check if the driver supports JDBC
4.1 and lower since 4.1 is the earliest JDBC version implemented by the
driver. Therefore the methods in DriverJDBCVersion checkSupportsJDBC4
and checkSupportsJDBC41 are obsolete and can safely be removed.

Closes #61