### PR TITLE
Tnir fix

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1793,6 +1793,12 @@ public class SQLServerConnection implements ISQLServerConnection {
             }
             else if (useTnir) {
                 long timeSlice = timeoutUnitInterval * (1 << (attemptNumber - 1));
+
+                // In case the timeout for the first slice is less than 500 ms then bump it up to 500 ms
+                if ((1 == attemptNumber) && (500 > timeSlice)) {
+                    timeSlice = 500;
+                }
+
                 intervalExpire = System.currentTimeMillis() + timeSlice;
             }
             else

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1785,11 +1785,15 @@ public class SQLServerConnection implements ISQLServerConnection {
             // Update timeout interval (but no more than the point where we're supposed to fail: timerExpire)
             attemptNumber++;
 
-            if (useParallel || useTnir) {
+            if (useParallel) {
                 intervalExpire = System.currentTimeMillis() + (timeoutUnitInterval * (attemptNumber + 1));
             }
             else if (isDBMirroring) {
                 intervalExpire = System.currentTimeMillis() + (timeoutUnitInterval * ((attemptNumber / 2) + 1));
+            }
+            else if (useTnir) {
+                long timeSlice = timeoutUnitInterval * (1 << (attemptNumber - 1));
+                intervalExpire = System.currentTimeMillis() + timeSlice;
             }
             else
                 intervalExpire = timerExpire;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1478,9 +1478,11 @@ public class SQLServerConnection implements ISQLServerConnection {
                         false);
             }
 
-            // transparentNetworkIPResolution is ignored if multiSubnetFailover or DBMirroring is true.
+            // transparentNetworkIPResolution is ignored if multiSubnetFailover or DBMirroring is true and user does not set TNIR explicitly
             if (multiSubnetFailover || (null != failOverPartnerPropertyValue)) {
-                transparentNetworkIPResolution = false;
+                if (!userSetTNIR) {
+                    transparentNetworkIPResolution = false;
+                }
             }
 
             // failoverPartner and applicationIntent=ReadOnly cannot be used together

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1794,7 +1794,7 @@ public class SQLServerConnection implements ISQLServerConnection {
                 intervalExpire = System.currentTimeMillis() + (timeoutUnitInterval * ((attemptNumber / 2) + 1));
             }
             else if (useTnir) {
-                long timeSlice = timeoutUnitInterval * (1 << (attemptNumber - 1));
+                long timeSlice = timeoutUnitInterval * (1 << attemptNumber);
 
                 // In case the timeout for the first slice is less than 500 ms then bump it up to 500 ms
                 if ((1 == attemptNumber) && (500 > timeSlice)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -190,6 +190,7 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     private final static float TIMEOUTSTEP = 0.08F;    // fraction of timeout to use for fast failover connections
+    private final static float TIMEOUTSTEP_TNIR = 0.125F;
     final static int TnirFirstAttemptTimeoutMs = 500;    // fraction of timeout to use for fast failover connections
 
     /*
@@ -1591,8 +1592,11 @@ public class SQLServerConnection implements ISQLServerConnection {
         timerExpire = timerStart + timerTimeout;
 
         // For non-dbmirroring, non-tnir and non-multisubnetfailover scenarios, full time out would be used as time slice.
-        if (isDBMirroring || useParallel || useTnir) {
+        if (isDBMirroring || useParallel) {
             timeoutUnitInterval = (long) (TIMEOUTSTEP * timerTimeout);
+        }
+        else if (useTnir) {
+            timeoutUnitInterval = (long) (TIMEOUTSTEP_TNIR * timerTimeout);
         }
         else {
             timeoutUnitInterval = timerTimeout;


### PR DESCRIPTION
connected to Microsoft/mssql-jdbc#206

Rework on TNIR
1. Turn TNIR off for Fed Auth
2. Change the TNIR multiplier to 0.125 instead of 0.08
3. Change the time slices to a multiple of 2,4,8 instead of 2,3,4
4. In case the timeout for the first slice is less than 500 ms then bump it up to 500 ms
5. Keep TNIR on if the user has explicitly specified it in the connection string.