### PR TITLE
Support Connection get/setNetworkTimeout().

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -2154,6 +2154,26 @@ final class TDSChannel {
 
         packetLogger.finest(logMsg.toString());
     }
+
+    /**
+     * Get the current socket SO_TIMEOUT value.
+     *
+     * @return the current socket timeout value
+     * @throws IOException thrown if the socket timeout cannot be read
+     */
+    final int getNetworkTimeout() throws IOException {
+        return tcpSocket.getSoTimeout();
+    }
+
+    /**
+     * Set the socket SO_TIMEOUT value.
+     *
+     * @param timeout the socket timeout in milliseconds
+     * @throws IOException thrown if the socket timeout cannot be set
+     */
+    final void setNetworkTimeout(int timeout) throws IOException {
+        tcpSocket.setSoTimeout(timeout);
+    }
 }
 
 /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4636,14 +4636,42 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     public int getNetworkTimeout() throws SQLException {
-        // this operation is not supported
-        throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+        loggerExternal.entering(getClassNameLogging(), "getNetworkTimeout");
+
+        checkClosed();
+
+        int timeout = 0;
+        try {
+            timeout = tdsChannel.getNetworkTimeout();
+        }
+        catch (IOException ioe) {
+            terminate(SQLServerException.DRIVER_ERROR_IO_FAILED, ioe.getMessage(), ioe);
+        }
+
+        loggerExternal.exiting(getClassNameLogging(), "getNetworkTimeout");
+        return timeout;
     }
 
     public void setNetworkTimeout(Executor executor,
             int timeout) throws SQLException {
-        // this operation is not supported
-        throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+        loggerExternal.entering(getClassNameLogging(), "setNetworkTimeout", timeout);
+
+        if (timeout < 0) {
+            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidSocketTimeout"));
+            Object[] msgArgs = {timeout};
+            SQLServerException.makeFromDriverError(this, this, form.format(msgArgs), null, false);
+        }
+
+        checkClosed();
+
+        try {
+            tdsChannel.setNetworkTimeout(timeout);
+        }
+        catch (IOException ioe) {
+            terminate(SQLServerException.DRIVER_ERROR_IO_FAILED, ioe.getMessage(), ioe);
+        }
+
+        loggerExternal.exiting(getClassNameLogging(), "setNetworkTimeout");
     }
 
     public String getSchema() throws SQLException {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
@@ -554,14 +554,14 @@ class SQLServerConnectionPoolProxy implements ISQLServerConnection {
     }
 
     public int getNetworkTimeout() throws SQLException {
-        // The driver currently does not implement the optional JDBC APIs
-        throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+        checkClosed();
+        return wrappedConnection.getNetworkTimeout();
     }
 
     public void setNetworkTimeout(Executor executor,
             int timeout) throws SQLException {
-        // The driver currently does not implement the optional JDBC APIs
-        throw new SQLFeatureNotSupportedException(SQLServerException.getErrString("R_notSupported"));
+        checkClosed();
+        wrappedConnection.setNetworkTimeout(executor, timeout);
     }
 
     public String getSchema() throws SQLException {


### PR DESCRIPTION
This is essential to minimize the effects of network partition events.

Related to #72 and #85.
