### PR TITLE
setNetworkTimeout checks for SQLPermission before proceeding

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -210,8 +210,9 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     // Permission targets
-    // currently only callAbort is implemented
     private static final String callAbortPerm = "callAbort";
+    
+    private static final String SET_NETWORK_TIMEOUT_PERM = "setNetworkTimeout";
 
     private boolean sendStringParametersAsUnicode = SQLServerDriverBooleanProperty.SEND_STRING_PARAMETERS_AS_UNICODE.getDefaultValue();        // see
                                                                                                                                                // connection
@@ -4663,6 +4664,20 @@ public class SQLServerConnection implements ISQLServerConnection {
         }
 
         checkClosed();
+        
+        // check for callAbort permission
+        SecurityManager secMgr = System.getSecurityManager();
+        if (secMgr != null) {
+            try {
+                SQLPermission perm = new SQLPermission(SET_NETWORK_TIMEOUT_PERM);
+                secMgr.checkPermission(perm);
+            }
+            catch (SecurityException ex) {
+                MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_permissionDenied"));
+                Object[] msgArgs = {SET_NETWORK_TIMEOUT_PERM};
+                SQLServerException.makeFromDriverError(this, this, form.format(msgArgs), null, true);
+            }
+        }
 
         try {
             tdsChannel.setNetworkTimeout(timeout);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4665,7 +4665,7 @@ public class SQLServerConnection implements ISQLServerConnection {
 
         checkClosed();
         
-        // check for callAbort permission
+        // check for setNetworkTimeout permission
         SecurityManager secMgr = System.getSecurityManager();
         if (secMgr != null) {
             try {


### PR DESCRIPTION
as be mentioned by @mrotteveel as well on this [page](https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#setNetworkTimeout(java.util.concurrent.Executor,%20int)), setNetworkTimeout method needs to check for permission.