### PR TITLE
remove JNI method for ActiveDirectoryPassword Authentication

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
@@ -87,18 +87,6 @@ final class AuthenticationJNI extends SSPIAuthentication {
         return dllInfo;
     }
 
-    static FedAuthDllInfo getAccessToken(String userName,
-            String password,
-            String stsURL,
-            String servicePrincipalName,
-            String clientConnectionId,
-            String clientId,
-            long expirationFileTime) throws DLLException {
-        FedAuthDllInfo dllInfo = ADALGetAccessToken(userName, password, stsURL, servicePrincipalName, clientConnectionId, clientId,
-                expirationFileTime, authLogger);
-        return dllInfo;
-    }
-
     // InitDNSName should be called to initialize the DNSName before calling this function
     byte[] GenerateClientContext(byte[] pin,
             boolean[] done) throws SQLServerException {
@@ -178,15 +166,6 @@ final class AuthenticationJNI extends SSPIAuthentication {
             java.util.logging.Logger log);
 
     private native static FedAuthDllInfo ADALGetAccessTokenForWindowsIntegrated(String stsURL,
-            String servicePrincipalName,
-            String clientConnectionId,
-            String clientId,
-            long expirationFileTime,
-            java.util.logging.Logger log);
-
-    private native static FedAuthDllInfo ADALGetAccessToken(String userName,
-            String password,
-            String stsURL,
             String servicePrincipalName,
             String clientConnectionId,
             String clientId,


### PR DESCRIPTION
remove JNI method for ActiveDirectoryPassword Authentication, since we no longer use DLL for ActiveDirectoryPassword authentication