### PR TITLE
Split out ThreePartNamesParser and cache compiled regex Pattern

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1315,22 +1315,22 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 // if the user can execute the sql, any fragments of it is potentially executed via the meta data call through injection
                 // is not a security issue.
                 SQLServerStatement s = (SQLServerStatement) connection.createStatement();
-                ThreePartName translator = ThreePartName.parse(procedureName);
+                ThreePartName threePartName = ThreePartName.parse(procedureName);
                 StringBuilder metaQuery = new StringBuilder("exec sp_sproc_columns ");
-                if (null != translator.getDatabasePart()) {
+                if (null != threePartName.getDatabasePart()) {
                     metaQuery.append("@procedure_qualifier=");
-                    metaQuery.append(translator.getDatabasePart());
+                    metaQuery.append(threePartName.getDatabasePart());
                     metaQuery.append(", ");
                 }
-                if (null != translator.getOwnerPart()) {
+                if (null != threePartName.getOwnerPart()) {
                     metaQuery.append("@procedure_owner=");
-                    metaQuery.append(translator.getOwnerPart());
+                    metaQuery.append(threePartName.getOwnerPart());
                     metaQuery.append(", ");
                 }
-                if (null != translator.getProcedurePart()) {
+                if (null != threePartName.getProcedurePart()) {
                     // we should always have a procedure name part
                     metaQuery.append("@procedure_name=");
-                    metaQuery.append(translator.getProcedurePart());
+                    metaQuery.append(threePartName.getProcedurePart());
                     metaQuery.append(" , @ODBCVer=3");
                 }
                 else {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -30,8 +30,6 @@ import java.sql.Types;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * CallableStatement implements JDBC callable statements. CallableStatement allows the caller to specify the procedure name to call along with input
@@ -1311,76 +1309,13 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
      * @return the index
      */
     /* L3 */ private int findColumn(String columnName) throws SQLServerException {
-
-        final class ThreePartNamesParser {
-
-            private String procedurePart = null;
-            private String ownerPart = null;
-            private String databasePart = null;
-
-            String getProcedurePart() {
-                return procedurePart;
-            }
-
-            String getOwnerPart() {
-                return ownerPart;
-            }
-
-            String getDatabasePart() {
-                return databasePart;
-            }
-
-            /*
-             * Three part names parsing For metdata calls we parse the procedure name into parts so we can use it in sp_sproc_columns sp_sproc_columns
-             * [[@procedure_name =] 'name'] [,[@procedure_owner =] 'owner'] [,[@procedure_qualifier =] 'qualifier']
-             * 
-             */
-            private final Pattern threePartName = Pattern.compile(JDBCSyntaxTranslator.getSQLIdentifierWithGroups());
-
-            final void parseProcedureNameIntoParts(String theProcName) {
-                Matcher matcher;
-                if (null != theProcName) {
-                    matcher = threePartName.matcher(theProcName);
-                    if (matcher.matches()) {
-                        if (matcher.group(2) != null) {
-                            databasePart = matcher.group(1);
-
-                            // if we have two parts look to see if the last part can be broken even more
-                            matcher = threePartName.matcher(matcher.group(2));
-                            if (matcher.matches()) {
-                                if (null != matcher.group(2)) {
-                                    ownerPart = matcher.group(1);
-                                    procedurePart = matcher.group(2);
-                                }
-                                else {
-                                    ownerPart = databasePart;
-                                    databasePart = null;
-                                    procedurePart = matcher.group(1);
-                                }
-                            }
-
-                        }
-                        else
-                            procedurePart = matcher.group(1);
-
-                    }
-                    else {
-                        procedurePart = theProcName;
-                    }
-                }
-
-            }
-
-        }
-
         if (paramNames == null) {
             try {
                 // Note we are concatenating the information from the passed in sql, not any arguments provided by the user
                 // if the user can execute the sql, any fragments of it is potentially executed via the meta data call through injection
                 // is not a security issue.
                 SQLServerStatement s = (SQLServerStatement) connection.createStatement();
-                ThreePartNamesParser translator = new ThreePartNamesParser();
-                translator.parseProcedureNameIntoParts(procedureName);
+                ThreePartName translator = ThreePartName.parse(procedureName);
                 StringBuilder metaQuery = new StringBuilder("exec sp_sproc_columns ");
                 if (null != translator.getDatabasePart()) {
                     metaQuery.append("@procedure_qualifier=");

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ThreePartName.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ThreePartName.java
@@ -1,0 +1,71 @@
+package com.microsoft.sqlserver.jdbc;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ThreePartName {
+    /*
+     * Three part names parsing For metdata calls we parse the procedure name into parts so we can use it in sp_sproc_columns sp_sproc_columns
+     * [[@procedure_name =] 'name'] [,[@procedure_owner =] 'owner'] [,[@procedure_qualifier =] 'qualifier']
+     *
+     */
+    private static final Pattern THREE_PART_NAME = Pattern.compile(JDBCSyntaxTranslator.getSQLIdentifierWithGroups());
+
+    private final String databasePart;
+    private final String ownerPart;
+    private final String procedurePart;
+
+    private ThreePartName(String databasePart, String ownerPart, String procedurePart) {
+        this.databasePart = databasePart;
+        this.ownerPart = ownerPart;
+        this.procedurePart = procedurePart;
+    }
+
+    public String getDatabasePart() {
+        return databasePart;
+    }
+
+    public String getOwnerPart() {
+        return ownerPart;
+    }
+
+    public String getProcedurePart() {
+        return procedurePart;
+    }
+
+    public static ThreePartName parse(String theProcName) {
+        String procedurePart = null;
+        String ownerPart = null;
+        String databasePart = null;
+        Matcher matcher;
+        if (null != theProcName) {
+            matcher = THREE_PART_NAME.matcher(theProcName);
+            if (matcher.matches()) {
+                if (matcher.group(2) != null) {
+                    databasePart = matcher.group(1);
+
+                    // if we have two parts look to see if the last part can be broken even more
+                    matcher = THREE_PART_NAME.matcher(matcher.group(2));
+                    if (matcher.matches()) {
+                        if (null != matcher.group(2)) {
+                            ownerPart = matcher.group(1);
+                            procedurePart = matcher.group(2);
+                        }
+                        else {
+                            ownerPart = databasePart;
+                            databasePart = null;
+                            procedurePart = matcher.group(1);
+                        }
+                    }
+                }
+                else {
+                    procedurePart = matcher.group(1);
+                }
+            }
+            else {
+                procedurePart = theProcName;
+            }
+        }
+        return new ThreePartName(databasePart, ownerPart, procedurePart);
+    }
+}

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ThreePartName.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ThreePartName.java
@@ -21,19 +21,19 @@ class ThreePartName {
         this.procedurePart = procedurePart;
     }
 
-    public String getDatabasePart() {
+    String getDatabasePart() {
         return databasePart;
     }
 
-    public String getOwnerPart() {
+    String getOwnerPart() {
         return ownerPart;
     }
 
-    public String getProcedurePart() {
+    String getProcedurePart() {
         return procedurePart;
     }
 
-    public static ThreePartName parse(String theProcName) {
+    static ThreePartName parse(String theProcName) {
         String procedurePart = null;
         String ownerPart = null;
         String databasePart = null;


### PR DESCRIPTION
This patch splits out ThreePartNamesParser (inner class of SQLServerCallableStatement) into a separate class. Internally, that new class caches the regex Pattern for parsing procedure identifiers (ex: database.owner.proc).

The old code (that this replaces) compiles the regex for each new statement.

The code for the new class has been mostly copied from the previous inline implementation. The only changes are:

* Reordering the properties to match their logical order (database / owner / procedure)
* Changing the property values of the parsed object to be final
* Renaming the parsing function to be a static function named "parse"

The implementation of `ThreePartName` itself is copied wholesale from the prior code.

The second commit simply renames the `translator` variable (done in two commits for readability).