### PR TITLE
For invalid error message by passing smalldatetime in ISQLBulkRecord

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2634,7 +2634,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
                 validateDataTypeConversions(srcColOrdinal, destColOrdinal);
             }
         }
-        //If we are using ISQLBulckRecord and the data we are passing is char type, we need to check the source and dest precision
+        //If we are using ISQLBulkRecord and the data we are passing is char type, we need to check the source and dest precision
         else if (null != sourceBulkRecord && (null == destCryptoMeta)) {
             validateStringBinaryLengths(colValue, srcColOrdinal, destColOrdinal);
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -309,6 +309,12 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
     }
 
     private BulkTimeoutTimer timeoutTimer = null;
+    
+    /**
+     * The maximum temporal precision we can send when using varchar(precision) in bulkcommand, to send a smalldatetime/datetime 
+     * value.
+     */
+    private static final int sourceBulkRecordTemporalMaxPrecision = 50;
 
     /**
      * Initializes a new instance of the SQLServerBulkCopy class using the specified open instance of SQLServerConnection.
@@ -1240,11 +1246,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
             int destColIndx,
             TDSWriter tdsWriter) throws SQLServerException {
         boolean isStreaming;
-        /**
-         * The maximum temporal precision we can send when using varchar(precision) in bulkcommand, to send a smalldatetime/datetime 
-         * value.
-         */
-        int sourceBulkRecordTemporalMaxPrecision = 50;
+
         SSType destSSType = (null != destColumnMetadata.get(destColIndx).cryptoMeta)
                 ? destColumnMetadata.get(destColIndx).cryptoMeta.baseTypeInfo.getSSType() : destColumnMetadata.get(destColIndx).ssType;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1653,7 +1653,9 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
 
         if ((Util.isCharType(srcJdbcType) && Util.isCharType(destSSType)) || (Util.isBinaryType(srcJdbcType) && Util.isBinaryType(destSSType))) {
             if (colValue instanceof String) {
-                if (Util.isBinaryType(destSSType)) {  // if the dest value is binary and the value is of type string
+                if (Util.isBinaryType(destSSType)) {  
+                    // if the dest value is binary and the value is of type string. 
+                    //Repro in test case: ImpISQLServerBulkRecord_IssuesTest#testSendValidValueforBinaryColumnAsString
                     sourcePrecision = (((String) colValue).getBytes().length) / 2;
                 }
                 else
@@ -2633,7 +2635,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
             }
         }
         //If we are using ISQLBulckRecord and the data we are passing is char type, we need to check the source and dest precision
-        else if (null != sourceBulkRecord) {
+        else if (null != sourceBulkRecord && (null == destCryptoMeta)) {
             validateStringBinaryLengths(colValue, srcColOrdinal, destColOrdinal);
         }
         else if ((null != sourceBulkRecord) && (null != destCryptoMeta)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -3210,6 +3210,6 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
                 }
             }
             row++;
-            }
+        }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
@@ -1,0 +1,405 @@
+/*
+ * Microsoft JDBC Driver for SQL Server
+ * 
+ * Copyright(c) Microsoft Corporation All rights reserved.
+ * 
+ * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.bulkCopy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord;
+import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
+import com.microsoft.sqlserver.jdbc.SQLServerConnection;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.Utils;
+
+@RunWith(JUnitPlatform.class)
+public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
+
+    static Statement stmt = null;
+    static PreparedStatement pStmt = null;
+    static String query;
+    static SQLServerConnection con = null;
+    static String srcTable = "sourceTable";
+    static String destTable = "destTable";
+    String variation;
+
+    /**
+     * Testing that sending a bigger varchar(3) to varchar(2) is thowing the proper error message.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testVarchar() throws Exception {
+        variation = "testVarchar";
+        BulkDat bData = new BulkDat(variation);
+        String value = "aa";
+        query = "CREATE TABLE " + destTable + " (smallDATA varchar(2))";
+        stmt.executeUpdate(query);
+
+        try {
+            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+            bcOperation.setDestinationTableName(destTable);
+            bcOperation.writeToServer(bData);
+            bcOperation.close();
+        }
+        catch (Exception e) {
+            if (e instanceof SQLServerException) {
+                assertTrue(e.getMessage().contains("The given value of type"), "Invalid Error message: " + e.toString());
+            }
+        }
+        ResultSet rs = stmt.executeQuery("select * from " + destTable);
+        while (rs.next()) {
+            assertEquals(rs.getString(1), value);
+        }
+    }
+
+    /**
+     * Testing that setting scale and precision 0 in column meta data for smalldatetime should work
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSmalldatetime() throws Exception {
+        variation = "testSmalldatetime";
+        BulkDat bData = new BulkDat(variation);
+        String value = ("1954-05-22 02:44:00.0").toString();
+        query = "CREATE TABLE " + destTable + " (smallDATA smalldatetime)";
+        stmt.executeUpdate(query);
+
+        SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+        bcOperation.setDestinationTableName(destTable);
+        bcOperation.writeToServer(bData);
+        bcOperation.close();
+
+        ResultSet rs = stmt.executeQuery("select * from " + destTable);
+        while (rs.next()) {
+            assertEquals(rs.getString(1), value);
+        }
+    }
+
+    /**
+     * Testing that setting out of range value for small datetime is throwing the proper message
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSmalldatetimeOutofRange() throws Exception {
+        variation = "testSmalldatetimeOutofRange";
+        BulkDat bData = new BulkDat(variation);
+        String value = ("1954-05-22 02:44:00.0").toString();
+
+        query = "CREATE TABLE " + destTable + " (smallDATA smalldatetime)";
+        stmt.executeUpdate(query);
+
+        try {
+            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+            bcOperation.setDestinationTableName(destTable);
+            bcOperation.writeToServer(bData);
+            bcOperation.close();
+        }
+        catch (Exception e) {
+            if (e instanceof SQLServerException) {
+                assertTrue(e.getMessage().contains("Conversion failed when converting character string to smalldatetime data type"),
+                        "Invalid Error message: " + e.toString());
+            }
+        }
+        ResultSet rs = stmt.executeQuery("select * from " + destTable);
+        while (rs.next()) {
+            assertEquals(rs.getString(1), value);
+        }
+    }
+
+    /**
+     * Test binary out of length (sending length of 6 to binary (5))
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testBinaryColumnAsByte() throws Exception {
+        variation = "testBinaryColumnAsByte";
+        BulkDat bData = new BulkDat(variation);
+        query = "CREATE TABLE " + destTable + " (col1 binary(5))";
+        stmt.executeUpdate(query);
+
+        try {
+            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+            bcOperation.setDestinationTableName(destTable);
+            bcOperation.writeToServer(bData);
+            bcOperation.close();
+        }
+        catch (Exception e) {
+            if (e instanceof SQLServerException) {
+                assertTrue(e.getMessage().contains("The given value of type"), "Invalid Error message: " + e.toString());
+            }
+            else {
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testBinaryColumnAsString() throws Exception {
+        variation = "testBinaryColumnAsString";
+        BulkDat bData = new BulkDat(variation);
+        query = "CREATE TABLE " + destTable + " (col1 binary(5))";
+        stmt.executeUpdate(query);
+
+        try {
+            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+            bcOperation.setDestinationTableName(destTable);
+            bcOperation.writeToServer(bData);
+            bcOperation.close();
+        }
+        catch (Exception e) {
+            if (e instanceof SQLServerException) {
+                assertTrue(e.getMessage().contains("The given value of type"), "Invalid Error message: " + e.toString());
+            }
+            else {
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Prepare test
+     * 
+     * @throws SQLException
+     * @throws SecurityException
+     * @throws IOException
+     */
+    @BeforeAll
+    public static void setupHere() throws SQLException, SecurityException, IOException {
+        con = (SQLServerConnection) DriverManager.getConnection(connectionString);
+        stmt = con.createStatement();
+        Utils.dropTableIfExists(destTable, stmt);
+        Utils.dropTableIfExists(srcTable, stmt);
+    }
+
+    /**
+     * Clean up
+     * 
+     * @throws SQLException
+     */
+    @AfterEach
+    public void afterEachTests() throws SQLException {
+        Utils.dropTableIfExists(destTable, stmt);
+        Utils.dropTableIfExists(srcTable, stmt);
+    }
+
+    @AfterAll
+    public static void afterAllTests() throws SQLException {
+        if (null != stmt) {
+            stmt.close();
+        }
+        if (null != con) {
+            con.close();
+        }
+    }
+
+}
+
+class BulkDat implements ISQLServerBulkRecord {
+    boolean isStringData = false;
+
+    private class ColumnMetadata {
+        String columnName;
+        int columnType;
+        int precision;
+        int scale;
+
+        ColumnMetadata(String name,
+                int type,
+                int precision,
+                int scale) {
+            columnName = name;
+            columnType = type;
+            this.precision = precision;
+            this.scale = scale;
+        }
+    }
+
+    Map<Integer, ColumnMetadata> columnMetadata;
+    ArrayList<Timestamp> dateData;
+    ArrayList<String> stringData;
+    ArrayList<byte[]> byteData;
+
+    int counter = 0;
+    int rowCount = 1;
+
+    BulkDat(String variation) {
+        if (variation.equalsIgnoreCase("testVarchar")) {
+            isStringData = true;
+            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+
+            columnMetadata.put(1, new ColumnMetadata("varchar(2)", java.sql.Types.VARCHAR, 0, 0));
+
+            stringData = new ArrayList<String>();
+            stringData.add(new String("aaa"));
+            rowCount = stringData.size();
+        }
+        else if (variation.equalsIgnoreCase("testSmalldatetime")) {
+            isStringData = false;
+            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+
+            columnMetadata.put(1, new ColumnMetadata("smallDatetime", java.sql.Types.TIMESTAMP, 0, 0));
+
+            dateData = new ArrayList<Timestamp>();
+            dateData.add(Timestamp.valueOf("1954-05-22 02:43:37.123"));
+            rowCount = dateData.size();
+        }
+        else if (variation.equalsIgnoreCase("testSmalldatetimeOutofRange")) {
+            isStringData = false;
+            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+
+            columnMetadata.put(1, new ColumnMetadata("smallDatetime", java.sql.Types.TIMESTAMP, 0, 0));
+
+            dateData = new ArrayList<Timestamp>();
+            dateData.add(Timestamp.valueOf("1954-05-22 02:43:37.1234"));
+            rowCount = dateData.size();
+
+        }
+        else if (variation.equalsIgnoreCase("testBinaryColumnAsByte")) {
+            isStringData = false;
+            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+
+            columnMetadata.put(1, new ColumnMetadata("binary(5)", java.sql.Types.BINARY, 5, 0));
+
+            byteData = new ArrayList<byte[]>();
+            byteData.add("helloo".getBytes());
+            rowCount = byteData.size();
+
+        }
+        else if (variation.equalsIgnoreCase("testBinaryColumnAsString")) {
+            isStringData = true;
+            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+
+            columnMetadata.put(1, new ColumnMetadata("binary(5)", java.sql.Types.BINARY, 5, 0));
+
+            stringData = new ArrayList<String>();
+            stringData.add("616368697412");
+            rowCount = stringData.size();
+
+        }
+        counter = 0;
+
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#getColumnOrdinals()
+     */
+    @Override
+    public Set<Integer> getColumnOrdinals() {
+        return columnMetadata.keySet();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#getColumnName(int)
+     */
+    @Override
+    public String getColumnName(int column) {
+        return columnMetadata.get(column).columnName;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#getColumnType(int)
+     */
+    @Override
+    public int getColumnType(int column) {
+        return columnMetadata.get(column).columnType;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#getPrecision(int)
+     */
+    @Override
+    public int getPrecision(int column) {
+        return columnMetadata.get(column).precision;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#getScale(int)
+     */
+    @Override
+    public int getScale(int column) {
+        return columnMetadata.get(column).scale;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#isAutoIncrement(int)
+     */
+    @Override
+    public boolean isAutoIncrement(int column) {
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#getRowData()
+     */
+    @Override
+    public Object[] getRowData() throws SQLServerException {
+        Object[] dataRow = new Object[columnMetadata.size()];
+        if (isStringData)
+            dataRow[0] = stringData.get(counter);
+        else {
+            if (null != dateData)
+                dataRow[0] = dateData.get(counter);
+            else if (null != byteData)
+                dataRow[0] = byteData.get(counter);
+        }
+        counter++;
+        return dataRow;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord#next()
+     */
+    @Override
+    public boolean next() throws SQLServerException {
+        if (counter < rowCount) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
@@ -183,7 +183,25 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
                 fail(e.getMessage());
             }
         }
-    }
+    }  
+    
+    @Test
+    public void testSendValidValueforBinaryColumnAsString() throws Exception {
+        variation = "testSendValidValueforBinaryColumnAsString";
+        BulkDat bData = new BulkDat(variation);
+        query = "CREATE TABLE " + destTable + " (col1 binary(5))";
+        stmt.executeUpdate(query);
+
+        try {
+            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+            bcOperation.setDestinationTableName(destTable);
+            bcOperation.writeToServer(bData);
+            bcOperation.close();
+        }
+        catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }  
 
     /**
      * Prepare test
@@ -302,6 +320,18 @@ class BulkDat implements ISQLServerBulkRecord {
 
             stringData = new ArrayList<String>();
             stringData.add("616368697412");
+            rowCount = stringData.size();
+
+        }
+        
+        else if (variation.equalsIgnoreCase("testSendValidValueforBinaryColumnAsString")) {
+            isStringData = true;
+            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+
+            columnMetadata.put(1, new ColumnMetadata("binary(5)", java.sql.Types.BINARY, 5, 0));
+
+            stringData = new ArrayList<String>();
+            stringData.add("616345");
             rowCount = stringData.size();
 
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
@@ -66,15 +66,15 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
             bcOperation.close();
+            fail("BulkCopy executed for testVarchar when it it was expected to fail");
         }
         catch (Exception e) {
             if (e instanceof SQLServerException) {
                 assertTrue(e.getMessage().contains("The given value of type"), "Invalid Error message: " + e.toString());
             }
-        }
-        ResultSet rs = stmt.executeQuery("select * from " + destTable);
-        while (rs.next()) {
-            assertEquals(rs.getString(1), value);
+            else {
+                fail(e.getMessage());
+            }
         }
     }
 
@@ -111,8 +111,7 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
     public void testSmalldatetimeOutofRange() throws Exception {
         variation = "testSmalldatetimeOutofRange";
         BulkDat bData = new BulkDat(variation);
-        String value = ("1954-05-22 02:44:00.0").toString();
-
+        
         query = "CREATE TABLE " + destTable + " (smallDATA smalldatetime)";
         stmt.executeUpdate(query);
 
@@ -121,16 +120,16 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
             bcOperation.close();
+            fail("BulkCopy executed for testSmalldatetimeOutofRange when it it was expected to fail");
         }
         catch (Exception e) {
             if (e instanceof SQLServerException) {
                 assertTrue(e.getMessage().contains("Conversion failed when converting character string to smalldatetime data type"),
                         "Invalid Error message: " + e.toString());
             }
-        }
-        ResultSet rs = stmt.executeQuery("select * from " + destTable);
-        while (rs.next()) {
-            assertEquals(rs.getString(1), value);
+            else {
+                fail(e.getMessage());
+            }
         }
     }
 
@@ -151,6 +150,7 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
             bcOperation.close();
+            fail("BulkCopy executed for testBinaryColumnAsByte when it it was expected to fail");
         }
         catch (Exception e) {
             if (e instanceof SQLServerException) {
@@ -162,6 +162,11 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
         }
     }
 
+    /**
+     * Test sending longer value for binary column while data is sent as string format
+     * 
+     * @throws Exception
+     */
     @Test
     public void testBinaryColumnAsString() throws Exception {
         variation = "testBinaryColumnAsString";
@@ -174,6 +179,7 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
             bcOperation.close();
+            fail("BulkCopy executed for testBinaryColumnAsString when it it was expected to fail");
         }
         catch (Exception e) {
             if (e instanceof SQLServerException) {
@@ -183,8 +189,13 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
                 fail(e.getMessage());
             }
         }
-    }  
-    
+    }
+
+    /**
+     * Verify that sending valid value in string format for binary column is successful
+     * 
+     * @throws Exception
+     */
     @Test
     public void testSendValidValueforBinaryColumnAsString() throws Exception {
         variation = "testSendValidValueforBinaryColumnAsString";
@@ -197,11 +208,17 @@ public class ImpISQLServerBulkRecord_IssuesTest extends AbstractTest {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
             bcOperation.close();
+            
+            ResultSet rs = stmt.executeQuery("select * from " + destTable);
+            String value = "0101010000";
+            while (rs.next()) {
+                assertEquals(rs.getString(1), value);
+            }
         }
         catch (Exception e) {
-            fail(e.getMessage());
+           fail(e.getMessage());
         }
-    }  
+    }
 
     /**
      * Prepare test
@@ -323,7 +340,7 @@ class BulkDat implements ISQLServerBulkRecord {
             rowCount = stringData.size();
 
         }
-        
+
         else if (variation.equalsIgnoreCase("testSendValidValueforBinaryColumnAsString")) {
             isStringData = true;
             columnMetadata = new HashMap<Integer, ColumnMetadata>();
@@ -331,7 +348,7 @@ class BulkDat implements ISQLServerBulkRecord {
             columnMetadata.put(1, new ColumnMetadata("binary(5)", java.sql.Types.BINARY, 5, 0));
 
             stringData = new ArrayList<String>();
-            stringData.add("616345");
+            stringData.add("010101");
             rowCount = stringData.size();
 
         }


### PR DESCRIPTION
Fixes #280 
For issue #280 also mentioned here. https://github.com/Microsoft/mssql-jdbc/issues/161#issuecomment-295906312

Passing smalldatetime via ISQLBulkRecord without specifiying precision should work. 
Also sending out of range values for character type and binary type should throw proper error rather than `Received an invalid column length from the bcp client for colid 1`. 