### PR TITLE
Cleaner and tighter.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -8,7 +8,7 @@
 
 package com.microsoft.sqlserver.jdbc;
 
-import static com.microsoft.sqlserver.jdbc.SQLServerConnection.getOrCreateCachedParsedSQLMetadata;
+import static com.microsoft.sqlserver.jdbc.SQLServerConnection.getOrCreateCachedParsedSQL;
 
 import java.sql.BatchUpdateException;
 import java.sql.ResultSet;
@@ -769,7 +769,7 @@ public class SQLServerStatement implements ISQLServerStatement {
             Sha1HashKey cacheKey = new Sha1HashKey(sql);
 
             // Check for cached SQL metadata.
-            ParsedSQLCacheItem cacheItem = getOrCreateCachedParsedSQLMetadata(cacheKey, sql);
+            ParsedSQLCacheItem cacheItem = getOrCreateCachedParsedSQL(cacheKey, sql);
 
             // Retrieve from cache item.
             procedureName = cacheItem.procedureName;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -7,17 +7,24 @@
  */
 package com.microsoft.sqlserver.jdbc.unit.statement;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.DriverManager;
+import java.sql.ParameterMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -52,6 +59,7 @@ public class PreparedStatementTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @SuppressWarnings("resource")
     public void testBatchedUnprepare() throws SQLException {
         SQLServerConnection conOuter = null;
 
@@ -62,12 +70,9 @@ public class PreparedStatementTest extends AbstractTest {
         try (SQLServerConnection con = (SQLServerConnection)DriverManager.getConnection(connectionString)) {
             conOuter = con;
 
-            // Turn off use of prepared statement cache.
-            con.setStatementPoolingCacheSize(0);
-
             // Clean-up proc cache
-            this.executeSQL(con, "DBCC FREEPROCCACHE;"); 
-            
+            this.executeSQL(con, "DBCC FREEPROCCACHE;");
+
             String lookupUniqueifier = UUID.randomUUID().toString();
 
             String queryCacheLookup = String.format("%%/*unpreparetest_%s%%*/SELECT * FROM sys.tables;", lookupUniqueifier);
@@ -81,205 +86,145 @@ public class PreparedStatementTest extends AbstractTest {
             int iterations = 25;
 
             // Verify no prepares for 1 time only uses.
-            for(int i = 0; i < iterations; ++i) {
+            for (int i = 0; i < iterations; ++i) {
                 try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
                     pstmt.execute();
-                } 
-                assertSame(0, con.getDiscardedServerPreparedStatementCount());
+                }
+                assertSame(0, con.getDiscardableServerPreparedStatementCount());
             }
 
             // Verify total cache use.
             assertSame(iterations, executeSQLReturnFirstInt(con, verifyTotalCacheUsesQuery));
 
-            query = String.format("/*unpreparetest_%s, sp_executesql->sp_prepexec->sp_execute- batched sp_unprepare*/SELECT * FROM sys.tables;", lookupUniqueifier);
             int prevDiscardActionCount = 0;
-    
-            // Now verify unprepares are needed.                 
-            for(int i = 0; i < iterations; ++i) {
+
+            // Now verify unprepares are needed.
+            int handle = 0;
+            for (int i = 0; i < iterations; ++i) {
 
                 // Verify current queue depth is expected.
-                assertSame(prevDiscardActionCount, con.getDiscardedServerPreparedStatementCount());
-                
+                assertSame(prevDiscardActionCount, con.getDiscardableServerPreparedStatementCount());
+
+                query = String.format("/*unpreparetest_%s, sp_executesql->sp_prepexec->sp_execute- batched sp_unprepare*/SELECT * FROM sys.tables;", UUID.randomUUID().toString());
                 try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
                     pstmt.execute(); // sp_executesql
-            
+
                     pstmt.execute(); // sp_prepexec
                     ++prevDiscardActionCount;
 
                     pstmt.execute(); // sp_execute
+
+                    if (i > 0)
+                        assertNotSame(handle, pstmt.getPreparedStatementHandle());
+
+                    handle = pstmt.getPreparedStatementHandle();
                 }
 
                 // Verify clean-up is happening as expected.
-                if(prevDiscardActionCount > con.getServerPreparedStatementDiscardThreshold()) {
+                if (prevDiscardActionCount > con.getServerPreparedStatementDiscardThreshold()) {
                     prevDiscardActionCount = 0;
                 }
 
-                assertSame(prevDiscardActionCount, con.getDiscardedServerPreparedStatementCount());
-            }  
+                assertSame(prevDiscardActionCount, con.getDiscardableServerPreparedStatementCount());
+            }
 
             // Skipped for now due to unexpected failures. Not functional so not critical.
-            /*
+
             // Verify total cache use.
-            int expectedCacheHits = iterations * 4;
-            int allowedDiscrepency = 20;
-            // Allow some discrepency in number of cache hits to not fail test (
-            // TODO: Follow up on why there is sometimes a discrepency in number of cache hits (less than expected).
-            assertTrue(expectedCacheHits >= executeSQLReturnFirstInt(con, verifyTotalCacheUsesQuery));              
-            assertTrue(expectedCacheHits - allowedDiscrepency < executeSQLReturnFirstInt(con, verifyTotalCacheUsesQuery));              
-            */
-        } 
+            int expectedCacheHits = iterations;
+            int actualCacheHits = executeSQLReturnFirstInt(con, verifyTotalCacheUsesQuery);
+            assertTrue(expectedCacheHits == actualCacheHits,
+                       String.format("expectedCacheHits not as expected, %d != %d", expectedCacheHits, actualCacheHits));
+        }
+
         // Verify clean-up happened on connection close.
-        assertSame(0, conOuter.getDiscardedServerPreparedStatementCount());        
+        assertSame(0, conOuter.getDiscardableServerPreparedStatementCount());
     }
 
     /**
      * Test handling of statement pooling for prepared statements.
-     * 
+     *
      * @throws SQLException
      */
     @Test
-    public void testStatementPooling() throws SQLException {
+    public void testMetadataCaching() throws SQLException {
         // Make sure correct settings are used.
         SQLServerConnection.setDefaultEnablePrepareOnFirstPreparedStatementCall(SQLServerConnection.getInitialDefaultEnablePrepareOnFirstPreparedStatementCall());
         SQLServerConnection.setDefaultServerPreparedStatementDiscardThreshold(SQLServerConnection.getInitialDefaultServerPreparedStatementDiscardThreshold());
 
+        String lookupUniqueifier = UUID.randomUUID().toString();
+        String query = String.format("/*statementpoolingtest_%s*/SELECT * FROM sys.tables;", lookupUniqueifier);
+
+        ParameterMetaData metadata;
         try (SQLServerConnection con = (SQLServerConnection)DriverManager.getConnection(connectionString)) {
-
-            // Test behvaior with statement pooling.
-            con.setStatementPoolingCacheSize(10);
-
-            String lookupUniqueifier = UUID.randomUUID().toString();
-            String query = String.format("/*statementpoolingtest_%s*/SELECT * FROM sys.tables;", lookupUniqueifier);
-
-            // Execute statement first, should create cache entry WITHOUT handle (since sp_executesql was used).
+            // Execute query first, creates metadata cache entry
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
                 pstmt.execute(); // sp_executesql
-                pstmt.getMoreResults(); // Make sure handle is updated.
 
-                assertSame(0, pstmt.getPreparedStatementHandle());
-            } 
+                metadata = pstmt.getParameterMetaData();  // causes population of parameter metadata cache
+                Assert.assertNotNull(metadata);
+            }
 
-            // Execute statement again, should now create handle.
-            int handle = 0;
+            // Execute query again, should get the same ParameterMetaData instance as above
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
                 pstmt.execute(); // sp_prepexec
-                
-                pstmt.getMoreResults(); // Make sure handle is updated.
 
-                handle = pstmt.getPreparedStatementHandle();
-                assertNotSame(0, handle);
-            } 
+                assertSame(metadata, pstmt.getParameterMetaData());
+            }
 
-            // Execute statement again and verify same handle was used. 
-            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
-                pstmt.execute(); // sp_execute
-                pstmt.getMoreResults(); // Make sure handle is updated.
-
-                assertNotSame(0, pstmt.getPreparedStatementHandle());
-                assertSame(handle, pstmt.getPreparedStatementHandle());
-            } 
-
-            // Execute new statement with different SQL text and verify it does NOT get same handle (should now fall back to using sp_executesql). 
+            // Execute new statement with different SQL text and verify it does NOT get same metadata instance
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query + ";")) {
                 pstmt.execute(); // sp_executesql
-                pstmt.getMoreResults(); // Make sure handle is updated.
 
-                assertSame(0, pstmt.getPreparedStatementHandle());
-                assertNotSame(handle, pstmt.getPreparedStatementHandle());
-            } 
-        } 
+                assertNotSame(metadata, pstmt.getParameterMetaData());
+            }
+        }
     }
 
-    /**
-     * Test handling of eviction from statement pooling for prepared statements.
-     * 
-     * @throws SQLException
-     */
     @Test
-    public void testStatementPoolingEviction() throws SQLException {
+    public void testPrepareRace() throws Exception {
         // Make sure correct settings are used.
-        SQLServerConnection.setDefaultEnablePrepareOnFirstPreparedStatementCall(SQLServerConnection.getInitialDefaultEnablePrepareOnFirstPreparedStatementCall());
-        SQLServerConnection.setDefaultServerPreparedStatementDiscardThreshold(SQLServerConnection.getInitialDefaultServerPreparedStatementDiscardThreshold());
+        SQLServerConnection.setDefaultEnablePrepareOnFirstPreparedStatementCall(true);
+        SQLServerConnection.setDefaultServerPreparedStatementDiscardThreshold(2);
 
-        for (int testNo = 0; testNo < 2; ++testNo) {
-            try (SQLServerConnection con = (SQLServerConnection)DriverManager.getConnection(connectionString)) {
+        String[] queries = new String[3];
+        queries[0] = String.format("SELECT * FROM sys.tables -- %s", UUID.randomUUID());
+        queries[1] = String.format("SELECT * FROM sys.tables -- %s", UUID.randomUUID());
+        queries[2] = String.format("SELECT * FROM sys.tables -- %s", UUID.randomUUID());
 
-                int cacheSize = 10;                
-                int discardedStatementCount = testNo == 0 ? 5 /*batched unprepares*/ : 0 /*regular unprepares*/;
+        ExecutorService threadPool = Executors.newFixedThreadPool(4);
+        AtomicReference<Exception> exception = new AtomicReference<>();
+        try (SQLServerConnection con = (SQLServerConnection)DriverManager.getConnection(connectionString)) {
 
-                con.setStatementPoolingCacheSize(cacheSize);
-                con.setServerPreparedStatementDiscardThreshold(discardedStatementCount);
+            for (int i = 0; i < 4; i++) {
+                threadPool.execute(() -> {
+                    for (int j = 0; j < 500; j++) {
+                        try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con.prepareStatement(queries[j % 3])) {
+                            pstmt.execute(); // sp_executesql
+                        }
+                        catch (SQLException e) {
+                            exception.set(e);
+                            break;
+                        }
+                    }
+                });
+            }
 
-                String lookupUniqueifier = UUID.randomUUID().toString();
-                String query = String.format("/*statementpoolingevictiontest_%s*/SELECT * FROM sys.tables; -- ", lookupUniqueifier);
+            threadPool.shutdown();
+            threadPool.awaitTermination(120, SECONDS);
 
-                // Add new statements to fill up the statement pool.
-                for (int i = 0; i < cacheSize; ++i) {
-                    try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query + new Integer(i).toString())) {
-                        pstmt.execute(); // sp_executesql
-                        pstmt.execute(); // sp_prepexec, actual handle created and cached.
-                    } 
-                    // Make sure no handles in discard queue (still only in statement pool).
-                    assertSame(0, con.getDiscardedServerPreparedStatementCount());
-                }
+            assertNull(exception.get());
 
-                // No discarded handles yet, all in statement pool.
-                assertSame(0, con.getDiscardedServerPreparedStatementCount());
+            // Force un-prepares.
+            con.closeUnreferencedPreparedStatementHandles();
 
-                // Add new statements to fill up the statement discard action queue 
-                // (new statement pushes existing statement from pool into discard 
-                // action queue).
-                for (int i = cacheSize; i < cacheSize + 5; ++i) {
-                    try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query + new Integer(i).toString())) {
-                        pstmt.execute(); // sp_executesql
-                        pstmt.execute(); // sp_prepexec, actual handle created and cached.
-                    } 
-                    // If we use discard queue handles should start going into discard queue.
-                    if(0 == testNo)
-                        assertNotSame(0, con.getDiscardedServerPreparedStatementCount());
-                    else
-                        assertSame(0, con.getDiscardedServerPreparedStatementCount());
-                }
+            // Verify that queue is now empty.
+            assertSame(0, con.getDiscardableServerPreparedStatementCount());
 
-                // If we use it, now discard queue should be "full".
-                if (0 == testNo)
-                    assertSame(discardedStatementCount, con.getDiscardedServerPreparedStatementCount());
-                else
-                    assertSame(0, con.getDiscardedServerPreparedStatementCount());
-
-                // Adding one more statement should cause one more pooled statement to be invalidated and 
-                // discarding actions should be executed (i.e. sp_unprepare batch), clearing out the discard
-                // action queue.
-                try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
-                    pstmt.execute(); // sp_executesql
-                    pstmt.execute(); // sp_prepexec, actual handle created and cached.
-                } 
-
-                // Discard queue should now be empty.
-                assertSame(0, con.getDiscardedServerPreparedStatementCount());
-
-                // Set statement pool size to 0 and verify statements get discarded.
-                int statementsInCache = con.getStatementPoolingCacheEntryCount(); 
-                con.setStatementPoolingCacheSize(0);
-                assertSame(0, con.getStatementPoolingCacheEntryCount());
-
-                if(0 == testNo) 
-                    // Verify statements moved over to discard action queue.
-                    assertSame(statementsInCache, con.getDiscardedServerPreparedStatementCount());
-
-                // Run discard actions (otherwise run on pstmt.close)
-                con.closeDiscardedServerPreparedStatements();
-
-                assertSame(0, con.getDiscardedServerPreparedStatementCount());
-
-                // Verify new statement does not go into cache (since cache is now off)
-                try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
-                    pstmt.execute(); // sp_executesql
-                    pstmt.execute(); // sp_prepexec, actual handle created and cached.
-
-                    assertSame(0, con.getStatementPoolingCacheEntryCount());
-                } 
-            } 
+        }
+        finally {
+            SQLServerConnection.setDefaultEnablePrepareOnFirstPreparedStatementCall(SQLServerConnection.getInitialDefaultEnablePrepareOnFirstPreparedStatementCall());
+            SQLServerConnection.setDefaultServerPreparedStatementDiscardThreshold(SQLServerConnection.getInitialDefaultServerPreparedStatementDiscardThreshold());
         }
     }
 
@@ -377,17 +322,17 @@ public class PreparedStatementTest extends AbstractTest {
 
         // Verify instance settings.
         SQLServerConnection conn1 = (SQLServerConnection)DriverManager.getConnection(connectionString);
-        assertSame(SQLServerConnection.getDefaultServerPreparedStatementDiscardThreshold(), conn1.getServerPreparedStatementDiscardThreshold());        
-        assertSame(SQLServerConnection.getDefaultEnablePrepareOnFirstPreparedStatementCall(), conn1.getEnablePrepareOnFirstPreparedStatementCall());        
+        assertSame(SQLServerConnection.getDefaultServerPreparedStatementDiscardThreshold(), conn1.getServerPreparedStatementDiscardThreshold());
+        assertSame(SQLServerConnection.getDefaultEnablePrepareOnFirstPreparedStatementCall(), conn1.getEnablePrepareOnFirstPreparedStatementCall());
         conn1.setServerPreparedStatementDiscardThreshold(SQLServerConnection.getDefaultServerPreparedStatementDiscardThreshold() + 1);
         conn1.setEnablePrepareOnFirstPreparedStatementCall(!SQLServerConnection.getDefaultEnablePrepareOnFirstPreparedStatementCall());
-        assertNotSame(SQLServerConnection.getDefaultServerPreparedStatementDiscardThreshold(), conn1.getServerPreparedStatementDiscardThreshold());        
-        assertNotSame(SQLServerConnection.getDefaultEnablePrepareOnFirstPreparedStatementCall(), conn1.getEnablePrepareOnFirstPreparedStatementCall());        
-        
+        assertNotSame(SQLServerConnection.getDefaultServerPreparedStatementDiscardThreshold(), conn1.getServerPreparedStatementDiscardThreshold());
+        assertNotSame(SQLServerConnection.getDefaultEnablePrepareOnFirstPreparedStatementCall(), conn1.getEnablePrepareOnFirstPreparedStatementCall());
+
         // Verify new instance not same as changed instance.
         SQLServerConnection conn2 = (SQLServerConnection)DriverManager.getConnection(connectionString);
-        assertNotSame(conn1.getServerPreparedStatementDiscardThreshold(), conn2.getServerPreparedStatementDiscardThreshold());        
-        assertNotSame(conn1.getEnablePrepareOnFirstPreparedStatementCall(), conn2.getEnablePrepareOnFirstPreparedStatementCall());        
+        assertNotSame(conn1.getServerPreparedStatementDiscardThreshold(), conn2.getServerPreparedStatementDiscardThreshold());
+        assertNotSame(conn1.getEnablePrepareOnFirstPreparedStatementCall(), conn2.getEnablePrepareOnFirstPreparedStatementCall());
 
         // Verify instance setting is followed.
         SQLServerConnection.setDefaultServerPreparedStatementDiscardThreshold(SQLServerConnection.getInitialDefaultServerPreparedStatementDiscardThreshold());
@@ -406,22 +351,22 @@ public class PreparedStatementTest extends AbstractTest {
                 pstmt.execute();
             }
             // Verify that the un-prepare action was not handled immediately.
-            assertSame(1, con.getDiscardedServerPreparedStatementCount());
+            assertSame(1, con.getDiscardableServerPreparedStatementCount());
 
             // Force un-prepares.
-            con.closeDiscardedServerPreparedStatements();
+            con.closeUnreferencedPreparedStatementHandles();
 
             // Verify that queue is now empty.
-            assertSame(0, con.getDiscardedServerPreparedStatementCount());
+            assertSame(0, con.getDiscardableServerPreparedStatementCount());
 
             // Set instance setting to serial execution of un-prepare actions.
-            con.setServerPreparedStatementDiscardThreshold(1);                
+            con.setServerPreparedStatementDiscardThreshold(1);
 
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement)con.prepareStatement(query)) {
                 pstmt.execute();
             }
             // Verify that the un-prepare action was handled immediately.
-            assertSame(0, con.getDiscardedServerPreparedStatementCount());
+            assertSame(0, con.getDiscardableServerPreparedStatementCount());
         }
     }
 }


### PR DESCRIPTION
I did rename one or two public methods, but AFAIK they are all still pre-release, so now is the time to get them right.

I tested performance between the before/after and find no difference. I did add a multi-threaded test to try to detect any race conditions (haven't found any in a few hundred runs), and it can also serve as a decent quick test balloon on performance because it is designed to generate maximum contentention.