### PR TITLE
Use Javadoc for API documentation

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -2346,7 +2346,7 @@ final class JDBCSyntaxTranslator {
      */
     private final static Pattern limitOnlyPattern = Pattern.compile("\\{\\s*[lL][iI][mM][iI][tT]\\s+(((\\(|\\s)*)(\\d*|\\?)((\\)|\\s)*))\\s*\\}");
 
-    /*
+    /**
      * This function translates the LIMIT escape syntax, {LIMIT <row> [OFFSET <offset>]} SQL Server does not support LIMIT syntax, the LIMIT escape
      * syntax is thus translated to use "TOP" syntax The OFFSET clause is not supported, and will throw an exception if used.
      * 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatementColumnEncryptionSetting.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatementColumnEncryptionSetting.java
@@ -14,23 +14,23 @@ package com.microsoft.sqlserver.jdbc;
  * to bypass encryption and gain access to plaintext data.
  */
 public enum SQLServerStatementColumnEncryptionSetting {
-    /*
+    /**
      * if "Column Encryption Setting=Enabled" in the connection string, use Enabled. Otherwise, maps to Disabled.
      */
     UseConnectionSetting,
 
-    /*
+    /**
      * Enables TCE for the command. Overrides the connection level setting for this command.
      */
     Enabled,
 
-    /*
+    /**
      * Parameters will not be encrypted, only the ResultSet will be decrypted. This is an optimization for queries that do not pass any encrypted
      * input parameters. Overrides the connection level setting for this command.
      */
     ResultSetOnly,
 
-    /*
+    /**
      * Disables TCE for the command.Overrides the connection level setting for this command.
      */
     Disabled,

--- a/src/main/java/microsoft/sql/Types.java
+++ b/src/main/java/microsoft/sql/Types.java
@@ -18,37 +18,37 @@ public final class Types extends Object {
         // not reached
     }
 
-    /*
+    /**
      * The constant in the Java programming language, sometimes referred to as a type code, that identifies the Microsoft SQL type DATETIMEOFFSET.
      */
     public static final int DATETIMEOFFSET = -155;
 
-    /*
+    /**
      * The constant in the Java programming language, sometimes referred to as a type code, that identifies the Microsoft SQL type STRUCTURED.
      */
     public static final int STRUCTURED = -153;
 
-    /*
+    /**
      * The constant in the Java programming language, sometimes referred to as a type code, that identifies the Microsoft SQL type DATETIME.
      */
     public static final int DATETIME = -151;
 
-    /*
+    /**
      * The constant in the Java programming language, sometimes referred to as a type code, that identifies the Microsoft SQL type SMALLDATETIME.
      */
     public static final int SMALLDATETIME = -150;
 
-    /*
+    /**
      * The constant in the Java programming language, sometimes referred to as a type code, that identifies the Microsoft SQL type MONEY.
      */
     public static final int MONEY = -148;
 
-    /*
+    /**
      * The constant in the Java programming language, sometimes referred to as a type code, that identifies the Microsoft SQL type SMALLMONEY.
      */
     public static final int SMALLMONEY = -146;
 
-    /*
+    /**
      * The constant in the Java programming language, sometimes referred to as a type code, that identifies the Microsoft SQL type GUID.
      */
     public static final int GUID = -145;


### PR DESCRIPTION
Java offers two kinds of multi line comments /** and /*.
The first is called Javadoc and ends up in generated API documentation
and is displayed by IDEs. The second is a multi line comment that does
not show up.

There are several places there /* instead of /** is used for API
documentation.

 [1] https://stackoverflow.com/questions/29815636/and-in-java-comments
 [2] http://javadude.com/articles/comments.html