### PR TITLE
UTC should be a class

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -517,11 +517,13 @@ class GregorianChange {
     }
 }
 
-// UTC/GMT time zone singleton. The enum type delays initialization until first use.
-enum UTC {
-    INSTANCE;
+final class UTC {
 
+    // UTC/GMT time zone singleton.
     static final TimeZone timeZone = new SimpleTimeZone(0, "UTC");
+
+    private UTC() {
+    }
 }
 
 final class TDSChannel {


### PR DESCRIPTION
UTC is an enum with one constant and a static variable. It has the
following comment

> The enum type delays initialization until first use.

This is demonstrably wrong.

The static variable is initialized when the class is initialized. If we
look at the decompiled static initializer of UTC we see that.

```
  // access flags 0x8
  static <clinit>()V
   L0
    LINENUMBER 522 L0
    NEW com/microsoft/sqlserver/jdbc/UTC
    DUP
    LDC "INSTANCE"
    ICONST_0
    INVOKESPECIAL com/microsoft/sqlserver/jdbc/UTC.<init> (Ljava/lang/String;I)V
    PUTSTATIC com/microsoft/sqlserver/jdbc/UTC.INSTANCE : Lcom/microsoft/sqlserver/jdbc/UTC;
    ICONST_1
    ANEWARRAY com/microsoft/sqlserver/jdbc/UTC
    DUP
    ICONST_0
    GETSTATIC com/microsoft/sqlserver/jdbc/UTC.INSTANCE : Lcom/microsoft/sqlserver/jdbc/UTC;
    AASTORE
    PUTSTATIC com/microsoft/sqlserver/jdbc/UTC.ENUM$VALUES : [Lcom/microsoft/sqlserver/jdbc/UTC;
   L1
    LINENUMBER 524 L1
    NEW java/util/SimpleTimeZone
    DUP
    ICONST_0
    LDC "UTC"
    INVOKESPECIAL java/util/SimpleTimeZone.<init> (ILjava/lang/String;)V
    PUTSTATIC com/microsoft/sqlserver/jdbc/UTC.timeZone : Ljava/util/TimeZone;
    RETURN
    MAXSTACK = 4
    MAXLOCALS = 0
```