### PR TITLE
Set fmtonly on to support complex query

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -629,6 +629,10 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                             sbTablesAndJoins = sbTablesAndJoins.append(metaInfoList.get(i).table);
                         }
                         else {
+                            if (metaInfoList.get(i).table.equals(metaInfoList.get(i - 1).table)
+                                    && metaInfoList.get(i).fields.equals(metaInfoList.get(i - 1).fields)) {
+                                continue;
+                            }
                             sbTablesAndJoins = sbTablesAndJoins
                                     .append(" LEFT JOIN " + metaInfoList.get(i).table + " ON " + metaInfoList.get(i - 1).table + "."
                                             + metaInfoList.get(i - 1).fields + "=" + metaInfoList.get(i).table + "." + metaInfoList.get(i).fields);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
@@ -55,7 +55,7 @@ public class PQImpsTest extends AbstractTest {
     private static String binaryTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("binaryTable_DB"));
     private static String dateAndTimeTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dateAndTimeTable_DB"));
     private static String multipleTypesTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("multipleTypesTable_DB"));
-
+    private static String spaceTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("spaceTable_DB"));
     /**
      * Setup
      * @throws SQLException
@@ -71,6 +71,7 @@ public class PQImpsTest extends AbstractTest {
         createBinaryTable();
         createDateAndTimeTable();
         createTablesForCompexQueries();
+        createSpaceTable();
         populateTablesForCompexQueries();
     }
 
@@ -414,6 +415,12 @@ public class PQImpsTest extends AbstractTest {
 
         stmt.execute("Create table " + charTable + " (" + "c1 char(50) not null," + "c2 varchar(20) not null," + "c3 nchar(30) not null,"
                 + "c4 nvarchar(60) not null," + "c5 text not null," + "c6 ntext not null" + ")");
+    }
+    
+    private static void createSpaceTable() throws SQLException {
+
+        stmt.execute("Create table " + spaceTable + " (" + "[c1*/someStrintg withspace] char(50) not null," + "c2 varchar(20) not null,"
+                + "c3 nchar(30) not null," + "c4 nvarchar(60) not null," + "c5 text not null," + "c6 ntext not null" + ")");
     }
 
     private static void populateCharTable() throws SQLException {
@@ -1311,10 +1318,10 @@ public class PQImpsTest extends AbstractTest {
     /**
      * test getting parameter count with a complex query with multiple table
      * 
-     * @throws SQLException
+     * @throws SQLServerException 
      */
     @Test
-    public void testComplexQueryWithMultipleTables() throws SQLException {
+    public void testComplexQueryWithMultipleTables() throws SQLServerException {
         pstmt = connection.prepareStatement("insert into table1 (c1) select ? where not exists (select * from table2 where c2 = ?)");
 
         try {
@@ -1322,6 +1329,24 @@ public class PQImpsTest extends AbstractTest {
             int parameterCount = pMD.getParameterCount();
 
             assertTrue(2 == parameterCount, "Parameter Count should be 2.");
+        }
+        catch (Exception e) {
+            fail(e.toString());
+        }
+    }
+    
+    
+    /**
+     * test column name with end comment mark and space
+     * 
+     * @throws SQLServerException 
+     */
+    @Test
+    public void testQueryWithSpaceAndEndCommentMarkInColumnName() throws SQLServerException {
+        pstmt = connection.prepareStatement("SELECT [c1*/someStrintg withspace]=? from " + spaceTable);
+
+        try {
+            pstmt.getParameterMetaData();
         }
         catch (Exception e) {
             fail(e.toString());
@@ -1342,6 +1367,7 @@ public class PQImpsTest extends AbstractTest {
         stmt.execute("if object_id('" + binaryTable + "','U') is not null" + " drop table " + binaryTable);
         stmt.execute("if object_id('" + dateAndTimeTable + "','U') is not null" + " drop table " + dateAndTimeTable);
         stmt.execute("if object_id('" + multipleTypesTable + "','U') is not null" + " drop table " + multipleTypesTable);
+        stmt.execute("if object_id('" + spaceTable + "','U') is not null" + " drop table " + spaceTable);
 
         if (null != rs) {
             rs.close();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
@@ -52,6 +52,7 @@ public class PQImpsTest extends AbstractTest {
     private static String mergeNameDesTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("mergeNameDesTable_DB"));
     private static String numericTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("numericTable_DB"));
     private static String charTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("charTable_DB"));
+    private static String charTable2 = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("charTable2_DB"));
     private static String binaryTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("binaryTable_DB"));
     private static String dateAndTimeTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dateAndTimeTable_DB"));
     private static String multipleTypesTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("multipleTypesTable_DB"));
@@ -68,6 +69,7 @@ public class PQImpsTest extends AbstractTest {
         createMultipleTypesTable();
         createNumericTable();
         createCharTable();
+        createChar2Table();
         createBinaryTable();
         createDateAndTimeTable();
         createTablesForCompexQueries();
@@ -415,6 +417,11 @@ public class PQImpsTest extends AbstractTest {
 
         stmt.execute("Create table " + charTable + " (" + "c1 char(50) not null," + "c2 varchar(20) not null," + "c3 nchar(30) not null,"
                 + "c4 nvarchar(60) not null," + "c5 text not null," + "c6 ntext not null" + ")");
+    }
+    
+    private static void createChar2Table() throws SQLException {
+
+        stmt.execute("Create table " + charTable2 + " (" + "table2c1 char(50) not null)");
     }
     
     private static void createSpaceTable() throws SQLException {
@@ -1318,11 +1325,12 @@ public class PQImpsTest extends AbstractTest {
     /**
      * test getting parameter count with a complex query with multiple table
      * 
-     * @throws SQLServerException 
+     * @throws SQLServerException
      */
     @Test
     public void testComplexQueryWithMultipleTables() throws SQLServerException {
-        pstmt = connection.prepareStatement("insert into table1 (c1) select ? where not exists (select * from table2 where c2 = ?)");
+        pstmt = connection.prepareStatement(
+                "insert into " + charTable + " (c1) select ? where not exists (select * from " + charTable2 + " where table2c1 = ?)");
 
         try {
             SQLServerParameterMetaData pMD = (SQLServerParameterMetaData) pstmt.getParameterMetaData();
@@ -1364,6 +1372,7 @@ public class PQImpsTest extends AbstractTest {
         stmt.execute("if object_id('" + mergeNameDesTable + "','U') is not null" + " drop table " + mergeNameDesTable);
         stmt.execute("if object_id('" + numericTable + "','U') is not null" + " drop table " + numericTable);
         stmt.execute("if object_id('" + charTable + "','U') is not null" + " drop table " + charTable);
+        stmt.execute("if object_id('" + charTable2 + "','U') is not null" + " drop table " + charTable2);
         stmt.execute("if object_id('" + binaryTable + "','U') is not null" + " drop table " + binaryTable);
         stmt.execute("if object_id('" + dateAndTimeTable + "','U') is not null" + " drop table " + dateAndTimeTable);
         stmt.execute("if object_id('" + multipleTypesTable + "','U') is not null" + " drop table " + multipleTypesTable);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.jdbc.SQLServerParameterMetaData;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.util.RandomUtil;
@@ -1301,6 +1302,26 @@ public class PQImpsTest extends AbstractTest {
         
         try {
             pstmt.getParameterMetaData();
+        }
+        catch (Exception e) {
+            fail(e.toString());
+        }
+    }
+    
+    /**
+     * test getting parameter count with a complex query with multiple table
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testComplexQueryWithMultipleTables() throws SQLException {
+        pstmt = connection.prepareStatement("insert into table1 (c1) select ? where not exists (select * from table2 where c2 = ?)");
+
+        try {
+            SQLServerParameterMetaData pMD = (SQLServerParameterMetaData) pstmt.getParameterMetaData();
+            int parameterCount = pMD.getParameterCount();
+
+            assertTrue(2 == parameterCount, "Parameter Count should be 2.");
         }
         catch (Exception e) {
             fail(e.toString());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
@@ -1343,7 +1343,7 @@ public class PQImpsTest extends AbstractTest {
      */
     @Test
     public void testQueryWithSpaceAndEndCommentMarkInColumnName() throws SQLServerException {
-        pstmt = connection.prepareStatement("SELECT [c1*/someStrintg withspace]=? from " + spaceTable);
+        pstmt = connection.prepareStatement("SELECT [c1*/someStrintg withspace] from " + spaceTable);
 
         try {
             pstmt.getParameterMetaData();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
@@ -56,7 +56,7 @@ public class PQImpsTest extends AbstractTest {
     private static String binaryTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("binaryTable_DB"));
     private static String dateAndTimeTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dateAndTimeTable_DB"));
     private static String multipleTypesTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("multipleTypesTable_DB"));
-    private static String spaceTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("spaceTable_DB"));
+
     /**
      * Setup
      * @throws SQLException
@@ -73,7 +73,6 @@ public class PQImpsTest extends AbstractTest {
         createBinaryTable();
         createDateAndTimeTable();
         createTablesForCompexQueries();
-        createSpaceTable();
         populateTablesForCompexQueries();
     }
 
@@ -422,12 +421,6 @@ public class PQImpsTest extends AbstractTest {
     private static void createChar2Table() throws SQLException {
 
         stmt.execute("Create table " + charTable2 + " (" + "table2c1 char(50) not null)");
-    }
-    
-    private static void createSpaceTable() throws SQLException {
-
-        stmt.execute("Create table " + spaceTable + " (" + "[c1*/someStrintg withspace] char(50) not null," + "c2 varchar(20) not null,"
-                + "c3 nchar(30) not null," + "c4 nvarchar(60) not null," + "c5 text not null," + "c6 ntext not null" + ")");
     }
 
     private static void populateCharTable() throws SQLException {
@@ -1342,24 +1335,6 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
-    
-    /**
-     * test column name with end comment mark and space
-     * 
-     * @throws SQLServerException 
-     */
-    @Test
-    public void testQueryWithSpaceAndEndCommentMarkInColumnName() throws SQLServerException {
-        pstmt = connection.prepareStatement("SELECT [c1*/someStrintg withspace] from " + spaceTable);
-
-        try {
-            pstmt.getParameterMetaData();
-        }
-        catch (Exception e) {
-            fail(e.toString());
-        }
-    }
 
     /**
      * Cleanup
@@ -1376,7 +1351,6 @@ public class PQImpsTest extends AbstractTest {
         stmt.execute("if object_id('" + binaryTable + "','U') is not null" + " drop table " + binaryTable);
         stmt.execute("if object_id('" + dateAndTimeTable + "','U') is not null" + " drop table " + dateAndTimeTable);
         stmt.execute("if object_id('" + multipleTypesTable + "','U') is not null" + " drop table " + multipleTypesTable);
-        stmt.execute("if object_id('" + spaceTable + "','U') is not null" + " drop table " + spaceTable);
 
         if (null != rs) {
             rs.close();


### PR DESCRIPTION
fix issue #343 

the original way of using `Set fmtonly on` does not work with complex query or multiple tables. This PR uses a workaround by using `LEFT JOIN` query.

What the PR does is, converting the original query to a `LEFT JOIN` query and retrieve parameter metadata.