### PR TITLE
Set fmtonly on to support complex query

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -15,6 +15,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -51,6 +52,9 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
     static private final AtomicInteger baseID = new AtomicInteger(0);	// Unique id generator for each instance (used for logging).
     final private String traceID = " SQLServerParameterMetaData:" + nextInstanceID();
     boolean isTVP = false;
+    
+    private String stringToParse = null;
+    private int indexToBeginParse = -1;
 
     // Returns unique id for each instance.
     private static int nextInstanceID() {
@@ -85,9 +89,12 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         String sLastField = null;
         StringBuilder sb = new StringBuilder();
 
+        int sTokenIndex = 0;
         while (st.hasMoreTokens()) {
 
             String sToken = st.nextToken();
+            sTokenIndex = sTokenIndex + sToken.length();
+            
             if (sToken.equalsIgnoreCase(columnStartToken)) {
                 nState = PARAMNAME;
                 continue;
@@ -120,6 +127,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
             }
         }
 
+        indexToBeginParse = sTokenIndex;
         return sb.toString();
     }
 
@@ -138,8 +146,11 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         String sLastField = null;
         StringBuilder sb = new StringBuilder();
 
+        int sTokenIndex = 0;
         while (st.hasMoreTokens()) {
             String sToken = st.nextToken();
+            sTokenIndex = sTokenIndex + sToken.length();
+            
             if (sToken.equalsIgnoreCase(columnMarker)) {
                 nState = 1;
                 continue;
@@ -169,6 +180,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
             }
         }
 
+        indexToBeginParse = sTokenIndex;
         return sb.toString();
     }
 
@@ -391,12 +403,24 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         }
 
         if (null != metaTable) {
-            if (sTableMarker.equalsIgnoreCase("UPDATE"))
+            if (sTableMarker.equalsIgnoreCase("UPDATE")) {
                 metaFields = parseColumns(sql, "SET"); // Get the set fields
-            else if (sTableMarker.equalsIgnoreCase("INTO")) // insert
+                stringToParse = "";
+            }
+            else if (sTableMarker.equalsIgnoreCase("INTO")) { // insert
                 metaFields = parseInsertColumns(sql, "("); // Get the value fields
-            else
+                stringToParse = sql.substring(indexToBeginParse); // the index of ')'
+
+                // skip VALUES() clause
+                if (stringToParse.trim().toLowerCase().startsWith("values")) {
+                    parseInsertColumns(stringToParse, "(");
+                    stringToParse = stringToParse.substring(indexToBeginParse); // the index of ')'
+                }
+            }
+            else {
                 metaFields = parseColumns(sql, "WHERE"); // Get the where fields
+                stringToParse = "";
+            }
 
             return new MetaInfo(metaTable, metaFields);
         }
@@ -577,20 +601,54 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                 }
                 else {
                     // old implementation for SQL server 2008
-                    MetaInfo metaInfo = parseStatement(sProcString);
-                    if (null == metaInfo) {
-                        MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_cantIdentifyTableMetadata"));
-                        Object[] msgArgs = {sProcString};
-                        SQLServerException.makeFromDriverError(con, stmtParent, form.format(msgArgs), null, false);
+                    stringToParse = sProcString;
+                    ArrayList<MetaInfo> metaInfoList = new ArrayList<MetaInfo>();
+                    
+                    while (stringToParse.length() > 0) {
+                        MetaInfo metaInfo = parseStatement(stringToParse);
+                        if (null == metaInfo) {
+                            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_cantIdentifyTableMetadata"));
+                            Object[] msgArgs = {stringToParse};
+                            SQLServerException.makeFromDriverError(con, stmtParent, form.format(msgArgs), null, false);
+                        }
+
+                        metaInfoList.add(metaInfo);
+                    }
+                    if (metaInfoList.size() <= 0 || metaInfoList.get(0).fields.length() <= 0) {
+                        return;
+                    }
+                    
+                    StringBuilder sbColumns = new StringBuilder();
+
+                    for (MetaInfo mi : metaInfoList) {
+                        sbColumns = sbColumns.append(mi.fields + ",");
+                    }
+                    sbColumns.deleteCharAt(sbColumns.length() - 1);
+
+                    String columns = sbColumns.toString();
+
+                    StringBuilder sbTablesAndJoins = new StringBuilder();
+                    for (int i = 0; i < metaInfoList.size(); i++) {
+                        if (i == 0) {
+                            sbTablesAndJoins = sbTablesAndJoins.append(metaInfoList.get(i).table);
+                        }
+                        else {
+                            if (metaInfoList.get(i).table.equals(metaInfoList.get(i - 1).table)
+                                    && metaInfoList.get(i).fields.equals(metaInfoList.get(i - 1).fields)) {
+                                continue;
+                            }
+                            sbTablesAndJoins = sbTablesAndJoins
+                                    .append(" LEFT JOIN " + metaInfoList.get(i).table + " ON " + metaInfoList.get(i - 1).table + "."
+                                            + metaInfoList.get(i - 1).fields + "=" + metaInfoList.get(i).table + "." + metaInfoList.get(i).fields);
+                        }
                     }
 
-                    if (metaInfo.fields.length() <= 0)
-                        return;
+                    String tablesAndJoins = sbTablesAndJoins.toString();
 
                     Statement stmt = con.createStatement();
-                    String sCom = "sp_executesql N'SET FMTONLY ON SELECT " + metaInfo.fields + " FROM " + metaInfo.table + " WHERE 1 = 2'";
-                    ResultSet rs = stmt.executeQuery(sCom);
+                    String sCom = "sp_executesql N'SET FMTONLY ON SELECT " + columns + " FROM " + tablesAndJoins + " '";
 
+                    ResultSet rs = stmt.executeQuery(sCom);
                     parseQueryMetaFor2008(rs);
                     stmt.close();
                     rs.close();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PQImpsTest.java
@@ -8,8 +8,8 @@
 package com.microsoft.sqlserver.jdbc.unit.statement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.DriverManager;
 import java.sql.ParameterMetaData;
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.jdbc.SQLServerParameterMetaData;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.util.RandomUtil;
@@ -51,13 +52,15 @@ public class PQImpsTest extends AbstractTest {
     private static String mergeNameDesTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("mergeNameDesTable_DB"));
     private static String numericTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("numericTable_DB"));
     private static String charTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("charTable_DB"));
+    private static String charTable2 = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("charTable2_DB"));
     private static String binaryTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("binaryTable_DB"));
     private static String dateAndTimeTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dateAndTimeTable_DB"));
     private static String multipleTypesTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("multipleTypesTable_DB"));
     private static String spaceTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("spaceTable_DB"));
-    
+
     /**
      * Setup
+     * 
      * @throws SQLException
      */
     @BeforeAll
@@ -68,6 +71,7 @@ public class PQImpsTest extends AbstractTest {
         createMultipleTypesTable();
         createNumericTable();
         createCharTable();
+        createChar2Table();
         createBinaryTable();
         createDateAndTimeTable();
         createTablesForCompexQueries();
@@ -77,6 +81,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Numeric types test
+     * 
      * @throws SQLException
      */
     @Test
@@ -104,6 +109,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Char types test
+     * 
      * @throws SQLException
      */
     @Test
@@ -131,6 +137,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Binary types test
+     * 
      * @throws SQLException
      */
     @Test
@@ -159,6 +166,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Temporal types test
+     * 
      * @throws SQLException
      */
     @Test
@@ -187,6 +195,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Multiple Types table
+     * 
      * @throws Exception
      */
     @Test
@@ -416,10 +425,14 @@ public class PQImpsTest extends AbstractTest {
         stmt.execute("Create table " + charTable + " (" + "c1 char(50) not null," + "c2 varchar(20) not null," + "c3 nchar(30) not null,"
                 + "c4 nvarchar(60) not null," + "c5 text not null," + "c6 ntext not null" + ")");
     }
-    
+
     private static void createSpaceTable() throws SQLException {
         stmt.execute("Create table " + spaceTable + " (" + "[c1*/someString withspace] char(50) not null," + "c2 varchar(20) not null,"
                 + "c3 nchar(30) not null," + "c4 nvarchar(60) not null," + "c5 text not null," + "c6 ntext not null" + ")");
+    }
+
+    private static void createChar2Table() throws SQLException {
+        stmt.execute("Create table " + charTable2 + " (" + "table2c1 char(50) not null)");
     }
 
     private static void populateCharTable() throws SQLException {
@@ -714,6 +727,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Test subquery
+     * 
      * @throws SQLException
      */
     @Test
@@ -743,6 +757,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Test join
+     * 
      * @throws SQLException
      */
     @Test
@@ -773,7 +788,8 @@ public class PQImpsTest extends AbstractTest {
     }
 
     /**
-     * Test merge 
+     * Test merge
+     * 
      * @throws SQLException
      */
     @Test
@@ -972,6 +988,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Test Orderby
+     * 
      * @throws SQLException
      */
     @Test
@@ -1001,6 +1018,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Test Groupby
+     * 
      * @throws SQLException
      */
     @Test
@@ -1030,6 +1048,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Test Lower
+     * 
      * @throws SQLException
      */
     @Test
@@ -1058,6 +1077,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * Test Power
+     * 
      * @throws SQLException
      */
     @Test
@@ -1085,6 +1105,7 @@ public class PQImpsTest extends AbstractTest {
 
     /**
      * All in one queries
+     * 
      * @throws SQLException
      */
     @Test
@@ -1115,7 +1136,7 @@ public class PQImpsTest extends AbstractTest {
             compareParameterMetaData(pmd, 3, "java.lang.Integer", 4, "int", 10, 0);
         }
     }
-    
+
     /**
      * test query with simple multiple line comments
      * 
@@ -1154,7 +1175,7 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
+
     /**
      * test insertion query with multiple line comments
      * 
@@ -1163,7 +1184,7 @@ public class PQImpsTest extends AbstractTest {
     @Test
     public void testQueryWithMultipleLineCommentsInsert() throws SQLException {
         pstmt = connection.prepareStatement("/*te\nst*//*test*/insert /*test*/into " + charTable + " (c1) VALUES(?)");
-        
+
         try {
             pstmt.getParameterMetaData();
         }
@@ -1171,7 +1192,7 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
+
     /**
      * test update query with multiple line comments
      * 
@@ -1180,7 +1201,7 @@ public class PQImpsTest extends AbstractTest {
     @Test
     public void testQueryWithMultipleLineCommentsUpdate() throws SQLException {
         pstmt = connection.prepareStatement("/*te\nst*//*test*/update /*test*/" + charTable + " set c1=123 where c1=?");
-        
+
         try {
             pstmt.getParameterMetaData();
         }
@@ -1188,7 +1209,7 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
+
     /**
      * test deletion query with multiple line comments
      * 
@@ -1197,7 +1218,7 @@ public class PQImpsTest extends AbstractTest {
     @Test
     public void testQueryWithMultipleLineCommentsDeletion() throws SQLException {
         pstmt = connection.prepareStatement("/*te\nst*//*test*/delete /*test*/from " + charTable + " where c1=?");
-        
+
         try {
             pstmt.getParameterMetaData();
         }
@@ -1262,7 +1283,7 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
+
     /**
      * test insertion query with single line comments
      * 
@@ -1271,7 +1292,7 @@ public class PQImpsTest extends AbstractTest {
     @Test
     public void testQueryWithSingleLineCommentsInsert() throws SQLException {
         pstmt = connection.prepareStatement("--#test\ninsert /*test*/into " + charTable + " (c1) VALUES(?)");
-        
+
         try {
             pstmt.getParameterMetaData();
         }
@@ -1279,7 +1300,7 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
+
     /**
      * test update query with single line comments
      * 
@@ -1288,7 +1309,7 @@ public class PQImpsTest extends AbstractTest {
     @Test
     public void testQueryWithSingleLineCommentsUpdate() throws SQLException {
         pstmt = connection.prepareStatement("--#test\nupdate /*test*/" + charTable + " set c1=123 where c1=?");
-        
+
         try {
             pstmt.getParameterMetaData();
         }
@@ -1296,7 +1317,7 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
+
     /**
      * test deletion query with single line comments
      * 
@@ -1305,7 +1326,7 @@ public class PQImpsTest extends AbstractTest {
     @Test
     public void testQueryWithSingleLineCommentsDeletion() throws SQLException {
         pstmt = connection.prepareStatement("--#test\ndelete /*test*/from " + charTable + " where c1=?");
-        
+
         try {
             pstmt.getParameterMetaData();
         }
@@ -1313,7 +1334,7 @@ public class PQImpsTest extends AbstractTest {
             fail(e.toString());
         }
     }
-    
+
     /**
      * test column name with end comment mark and space
      * 
@@ -1332,7 +1353,29 @@ public class PQImpsTest extends AbstractTest {
     }
 
     /**
+     * test getting parameter count with a complex query with multiple table
+     * 
+     * @throws SQLServerException
+     */
+    @Test
+    public void testComplexQueryWithMultipleTables() throws SQLServerException {
+        pstmt = connection.prepareStatement(
+                "insert into " + charTable + " (c1) select ? where not exists (select * from " + charTable2 + " where table2c1 = ?)");
+
+        try {
+            SQLServerParameterMetaData pMD = (SQLServerParameterMetaData) pstmt.getParameterMetaData();
+            int parameterCount = pMD.getParameterCount();
+
+            assertTrue(2 == parameterCount, "Parameter Count should be 2.");
+        }
+        catch (Exception e) {
+            fail(e.toString());
+        }
+    }
+
+    /**
      * Cleanup
+     * 
      * @throws SQLException
      */
     @AfterAll
@@ -1342,6 +1385,7 @@ public class PQImpsTest extends AbstractTest {
         stmt.execute("if object_id('" + mergeNameDesTable + "','U') is not null" + " drop table " + mergeNameDesTable);
         stmt.execute("if object_id('" + numericTable + "','U') is not null" + " drop table " + numericTable);
         stmt.execute("if object_id('" + charTable + "','U') is not null" + " drop table " + charTable);
+        stmt.execute("if object_id('" + charTable2 + "','U') is not null" + " drop table " + charTable2);
         stmt.execute("if object_id('" + binaryTable + "','U') is not null" + " drop table " + binaryTable);
         stmt.execute("if object_id('" + dateAndTimeTable + "','U') is not null" + " drop table " + dateAndTimeTable);
         stmt.execute("if object_id('" + multipleTypesTable + "','U') is not null" + " drop table " + multipleTypesTable);


### PR DESCRIPTION
new PR equivalent to #350 which fixes #343

the original way of using Set fmtonly on does not work with complex query or multiple tables. This PR uses a workaround by using LEFT JOIN query.

What the PR does is, converting the original query to a LEFT JOIN query and retrieve parameter metadata.