### PR TITLE
Adding locale fix for turkey locale issue when lowercasing an "i"

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1383,7 +1383,7 @@ final class TDSChannel {
             this.logContext = tdsChannel.toString() + " (HostNameOverrideX509TrustManager):";
             defaultTrustManager = tm;
             // canonical name is in lower case so convert this to lowercase too.
-            this.hostName = hostName.toLowerCase();
+            this.hostName = hostName.toLowerCase(Locale.ENGLISH);
             ;
         }
 
@@ -1506,13 +1506,11 @@ final class TDSChannel {
                                 if (value != null && value instanceof String) {
                                     String dnsNameInSANCert = (String) value;
 
-                                    // convert to upper case and then to lower case in english locale
-                                    // to avoid Turkish i issues.
+                                    // Use English locale to avoid Turkish i issues.
                                     // Note that, this conversion was not necessary for
                                     // cert.getSubjectX500Principal().getName("canonical");
                                     // as the above API already does this by default as per documentation.
-                                    dnsNameInSANCert = dnsNameInSANCert.toUpperCase(Locale.US);
-                                    dnsNameInSANCert = dnsNameInSANCert.toLowerCase(Locale.US);
+                                    dnsNameInSANCert = dnsNameInSANCert.toLowerCase(Locale.ENGLISH);
 
                                     isServerNameValidated = validateServerName(dnsNameInSANCert);
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1483,7 +1483,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
                     .toUpperCase(Locale.ENGLISH);
             if (null != columnCollation && columnCollation.trim().length() > 0) {
                 // we are adding collate in command only for char and varchar
-                if (null != destType && (destType.toLowerCase().trim().startsWith("char") || destType.toLowerCase().trim().startsWith("varchar")))
+                if (null != destType && (destType.toLowerCase(Locale.ENGLISH).trim().startsWith("char") || destType.toLowerCase(Locale.ENGLISH).trim().startsWith("varchar")))
                     addCollate = " COLLATE " + columnCollation;
             }
             bulkCmd.append("[" + colMapping.destinationColumnName + "] " + destType + addCollate + endColumn);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
@@ -17,6 +17,7 @@ import java.nio.ByteOrder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
@@ -263,7 +264,7 @@ public class SQLServerColumnEncryptionAzureKeyVaultProvider extends SQLServerCol
         byte[] version = new byte[] {firstVersion[0]};
 
         // Get the Unicode encoded bytes of cultureinvariant lower case masterKeyPath
-        byte[] masterKeyPathBytes = masterKeyPath.toLowerCase().getBytes(UTF_16LE);
+        byte[] masterKeyPathBytes = masterKeyPath.toLowerCase(Locale.ENGLISH).getBytes(UTF_16LE);
 
         byte[] keyPathLength = new byte[2];
         keyPathLength[0] = (byte) (((short) masterKeyPathBytes.length) & 0xff);
@@ -405,7 +406,7 @@ public class SQLServerColumnEncryptionAzureKeyVaultProvider extends SQLServerCol
 
             // A valid URI.
             // Check if it is pointing to AKV.
-            if (!parsedUri.getHost().toLowerCase().endsWith(azureKeyVaultDomainName)) {
+            if (!parsedUri.getHost().toLowerCase(Locale.ENGLISH).endsWith(azureKeyVaultDomainName)) {
                 // Return an error indicating that the AKV url is invalid.
                 MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_AKVMasterKeyPathInvalid"));
                 Object[] msgArgs = {masterKeyPath};

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1357,7 +1357,7 @@ public class SQLServerConnection implements ISQLServerConnection {
             if (sPropValue == null)
                 sPropValue = SQLServerDriverStringProperty.SELECT_METHOD.getDefaultValue();
             if ("cursor".equalsIgnoreCase(sPropValue) || "direct".equalsIgnoreCase(sPropValue)) {
-                activeConnectionProperties.setProperty(sPropKey, sPropValue.toLowerCase());
+                activeConnectionProperties.setProperty(sPropKey, sPropValue.toLowerCase(Locale.ENGLISH));
             }
             else {
                 MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidselectMethod"));
@@ -1370,7 +1370,7 @@ public class SQLServerConnection implements ISQLServerConnection {
             if (sPropValue == null)
                 sPropValue = SQLServerDriverStringProperty.RESPONSE_BUFFERING.getDefaultValue();
             if ("full".equalsIgnoreCase(sPropValue) || "adaptive".equalsIgnoreCase(sPropValue)) {
-                activeConnectionProperties.setProperty(sPropKey, sPropValue.toLowerCase());
+                activeConnectionProperties.setProperty(sPropKey, sPropValue.toLowerCase(Locale.ENGLISH));
             }
             else {
                 MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidresponseBuffering"));
@@ -1514,7 +1514,7 @@ public class SQLServerConnection implements ISQLServerConnection {
                 throw new SQLServerException(SQLServerException.getErrString("R_AccessTokenWithUserPassword"), null);
             }
 
-            if ((!System.getProperty("os.name").toLowerCase().startsWith("windows"))
+            if ((!System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows"))
                     && (authenticationString.equalsIgnoreCase(SqlAuthentication.ActiveDirectoryIntegrated.toString()))) {
                 throw new SQLServerException(SQLServerException.getErrString("R_AADIntegratedOnNonWindows"), null);
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -390,7 +390,7 @@ final class Util {
                         if (null != name) {
                             if (logger.isLoggable(Level.FINE)) {
                                 if (false == name.equals(SQLServerDriverStringProperty.USER.toString())) {
-                                    if (!name.toLowerCase().contains("password")) {
+                                    if (!name.toLowerCase(Locale.ENGLISH).contains("password")) {
                                         logger.fine("Property:" + name + " Value:" + value);
                                     }
                                     else {


### PR DESCRIPTION
using toLowerCase() without any locale makes it implicitly toLowerCase(Locale.getDefault()). This is fine in most counties but in Turkey, the default locale converts uppercase "I" to a dotless "i", which is not the same as the lowercase "i" in English. Passing Locale.ENGLISH (or Locale.US) in toLowerCase() solves this problem. I have made these changes to all the applicable places in the codebase.