### PR TITLE
Fix parameter metadata

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -176,8 +176,13 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
             }
             if (nState == 1) {
                 if (sToken.trim().length() > 0) {
-                    if (sToken.charAt(0) != ',')
+                    if (sToken.charAt(0) != ',') {
                         sLastField = escapeParse(st, sToken);
+
+                        // in case the parameter has braces in its name, e.g. [c2_nvarchar(max)], the original sToken variable just
+                        // contains [c2_nvarchar, sLastField actually has the whole name [c2_nvarchar(max)]
+                        sTokenIndex = sTokenIndex + (sLastField.length() - sToken.length());
+                    }
                 }
             }
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/parametermetadata/ParameterMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/parametermetadata/ParameterMetaDataTest.java
@@ -52,7 +52,6 @@ public class ParameterMetaDataTest extends AbstractTest {
             finally {
                 Utils.dropTableIfExists(tableName, stmt);
             }
-
         }
     }
 
@@ -94,7 +93,6 @@ public class ParameterMetaDataTest extends AbstractTest {
             finally {
                 Utils.dropTableIfExists(tableName, stmt);
             }
-
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/parametermetadata/ParameterMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/parametermetadata/ParameterMetaDataTest.java
@@ -73,4 +73,28 @@ public class ParameterMetaDataTest extends AbstractTest {
                     "SQLServerException should not be wrapped by another SQLServerException.");
         }
     }
+    
+    /**
+     * Test ParameterMetaData when parameter name contains braces
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testNameWithBraces() throws SQLException {
+        try (Connection con = DriverManager.getConnection(connectionString); Statement stmt = con.createStatement()) {
+
+            stmt.executeUpdate("create table " + tableName + " ([c1_varchar(max)] varchar(max))");
+            try {
+                String query = "insert into " + tableName + " ([c1_varchar(max)]) values (?)";
+
+                try (PreparedStatement pstmt = con.prepareStatement(query)) {
+                    pstmt.getParameterMetaData();
+                }
+            }
+            finally {
+                Utils.dropTableIfExists(tableName, stmt);
+            }
+
+        }
+    }
 }


### PR DESCRIPTION
fix an error on parameter metadata with SQL Server 2008 when calling insertion and parameter name contains braces