### PR TITLE
Replace explicit types with <> (The diamond operator).

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/AE.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/AE.java
@@ -88,7 +88,7 @@ class CekTableEntry {
         cekId = 0;
         cekVersion = 0;
         cekMdVersion = null;
-        columnEncryptionKeyValues = new ArrayList<EncryptionKeyInfo>();
+        columnEncryptionKeyValues = new ArrayList<>();
     }
 
     int getSize() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
@@ -382,7 +382,7 @@ enum SSType
             this.to = to;
         }
 
-        private static final EnumMap<SSType.Category, EnumSet<JDBCType.Category>> conversionMap = new EnumMap<SSType.Category, EnumSet<JDBCType.Category>>(
+        private static final EnumMap<SSType.Category, EnumSet<JDBCType.Category>> conversionMap = new EnumMap<>(
                 SSType.Category.class);
 
         static {
@@ -776,7 +776,7 @@ enum JavaType
             this.to = to;
         }
 
-        private static final EnumMap<JavaType, EnumSet<JDBCType>> setterConversionAEMap = new EnumMap<JavaType, EnumSet<JDBCType>>(JavaType.class);
+        private static final EnumMap<JavaType, EnumSet<JDBCType>> setterConversionAEMap = new EnumMap<>(JavaType.class);
 
         static {
             for (JavaType javaType : JavaType.values())
@@ -1086,7 +1086,7 @@ enum JDBCType
             this.to = to;
         }
 
-        private static final EnumMap<JDBCType.Category, EnumSet<JDBCType.Category>> conversionMap = new EnumMap<JDBCType.Category, EnumSet<JDBCType.Category>>(
+        private static final EnumMap<JDBCType.Category, EnumSet<JDBCType.Category>> conversionMap = new EnumMap<>(
                 JDBCType.Category.class);
 
         static {
@@ -1305,7 +1305,7 @@ enum JDBCType
             this.to = to;
         }
 
-        private static final EnumMap<JDBCType.Category, EnumSet<SSType.Category>> conversionMap = new EnumMap<JDBCType.Category, EnumSet<SSType.Category>>(
+        private static final EnumMap<JDBCType.Category, EnumSet<SSType.Category>> conversionMap = new EnumMap<>(
                 JDBCType.Category.class);
 
         static {
@@ -1616,7 +1616,7 @@ enum JDBCType
             this.to = to;
         }
 
-        private static final EnumMap<JDBCType, EnumSet<SSType>> normalizationMapAE = new EnumMap<JDBCType, EnumSet<SSType>>(JDBCType.class);
+        private static final EnumMap<JDBCType, EnumSet<SSType>> normalizationMapAE = new EnumMap<>(JDBCType.class);
 
         static {
             for (JDBCType jdbcType : JDBCType.values())

--- a/src/main/java/com/microsoft/sqlserver/jdbc/FailOverMapSingleton.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/FailOverMapSingleton.java
@@ -13,7 +13,7 @@ import java.util.logging.Level;
 
 final class FailoverMapSingleton {
     private static int INITIALHASHMAPSIZE = 5;
-    private static HashMap<String, FailoverInfo> failoverMap = new HashMap<String, FailoverInfo>(INITIALHASHMAPSIZE);
+    private static HashMap<String, FailoverInfo> failoverMap = new HashMap<>(INITIALHASHMAPSIZE);
 
     private FailoverMapSingleton() {
         /* hide the constructor to stop the instantiation of this class. */}

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -2338,8 +2338,8 @@ final class SocketFinder {
                 findSocketUsingJavaNIO(inetAddrs, portNumber, timeoutInMilliSeconds);
             }
             else {
-                LinkedList<Inet4Address> inet4Addrs = new LinkedList<Inet4Address>();
-                LinkedList<Inet6Address> inet6Addrs = new LinkedList<Inet6Address>();
+                LinkedList<Inet4Address> inet4Addrs = new LinkedList<>();
+                LinkedList<Inet6Address> inet6Addrs = new LinkedList<>();
 
                 for (InetAddress inetAddr : inetAddrs) {
                     if (inetAddr instanceof Inet4Address) {
@@ -2467,7 +2467,7 @@ final class SocketFinder {
         assert inetAddrs.length != 0 : "Number of inetAddresses should not be zero in this function";
 
         Selector selector = null;
-        LinkedList<SocketChannel> socketChannels = new LinkedList<SocketChannel>();
+        LinkedList<SocketChannel> socketChannels = new LinkedList<>();
         SocketChannel selectedChannel = null;
 
         try {
@@ -2646,8 +2646,8 @@ final class SocketFinder {
         
         assert inetAddrs.isEmpty() == false : "Number of inetAddresses should not be zero in this function";
 
-        LinkedList<Socket> sockets = new LinkedList<Socket>();
-        LinkedList<SocketConnector> socketConnectors = new LinkedList<SocketConnector>();
+        LinkedList<Socket> sockets = new LinkedList<>();
+        LinkedList<SocketConnector> socketConnectors = new LinkedList<>();
 
         try {
 
@@ -5164,7 +5164,7 @@ final class TDSWriter {
 
         Map<Integer, SQLServerMetaData> columnMetadata = value.getColumnMetadata();
         Iterator<Entry<Integer, SQLServerMetaData>> columnsIterator = columnMetadata.entrySet().iterator();
-        LinkedList<TdsOrderUnique> columnList = new LinkedList<TdsOrderUnique>();
+        LinkedList<TdsOrderUnique> columnList = new LinkedList<>();
 
         while (columnsIterator.hasNext()) {
             byte flags = 0;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/JaasConfiguration.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/JaasConfiguration.java
@@ -23,9 +23,9 @@ public class JaasConfiguration extends Configuration {
 
     private static AppConfigurationEntry[] generateDefaultConfiguration() {
         if (Util.isIBM()) {
-            Map<String, String> confDetailsWithoutPassword = new HashMap<String, String>();
+            Map<String, String> confDetailsWithoutPassword = new HashMap<>();
             confDetailsWithoutPassword.put("useDefaultCcache", "true");
-            Map<String, String> confDetailsWithPassword = new HashMap<String, String>();
+            Map<String, String> confDetailsWithPassword = new HashMap<>();
             // We generated a two configurations fallback that is suitable for password and password-less authentication
             // See https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/jgssDocs/jaas_login_user.html
             final String ibmLoginModule = "com.ibm.security.auth.module.Krb5LoginModule";
@@ -34,7 +34,7 @@ public class JaasConfiguration extends Configuration {
                     new AppConfigurationEntry(ibmLoginModule, AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT, confDetailsWithPassword)};
         }
         else {
-            Map<String, String> confDetails = new HashMap<String, String>();
+            Map<String, String> confDetails = new HashMap<>();
             confDetails.put("useTicketCache", "true");
             return new AppConfigurationEntry[] {new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule",
                     AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, confDetails)};

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
@@ -530,11 +530,11 @@ final class SQLCollation implements java.io.Serializable
     static {
         // Populate the windows locale and sort order indices
 
-        localeIndex = new HashMap<Integer, WindowsLocale>();
+        localeIndex = new HashMap<>();
         for (WindowsLocale locale : EnumSet.allOf(WindowsLocale.class))
             localeIndex.put(locale.langID, locale);
 
-        sortOrderIndex = new HashMap<Integer, SortOrder>();
+        sortOrderIndex = new HashMap<>();
         for (SortOrder sortOrder : EnumSet.allOf(SortOrder.class))
             sortOrderIndex.put(sortOrder.sortId, sortOrder);
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAeadAes256CbcHmac256Factory.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAeadAes256CbcHmac256Factory.java
@@ -21,7 +21,7 @@ import javax.xml.bind.DatatypeConverter;
 class SQLServerAeadAes256CbcHmac256Factory extends SQLServerEncryptionAlgorithmFactory {
     // In future we can have more
     private byte algorithmVersion = 0x1;
-    private ConcurrentHashMap<String, SQLServerAeadAes256CbcHmac256Algorithm> encryptionAlgorithms = new ConcurrentHashMap<String, SQLServerAeadAes256CbcHmac256Algorithm>();
+    private ConcurrentHashMap<String, SQLServerAeadAes256CbcHmac256Algorithm> encryptionAlgorithms = new ConcurrentHashMap<>();
 
     @Override
     SQLServerEncryptionAlgorithm create(SQLServerSymmetricKey columnEncryptionKey,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBlob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBlob.java
@@ -40,7 +40,7 @@ public final class SQLServerBlob implements java.sql.Blob, java.io.Serializable 
     // Initial size of the array is based on an assumption that a Blob object is
     // typically used either for input or output, and then only once. The array size
     // grows automatically if multiple streams are used.
-    ArrayList<Closeable> activeStreams = new ArrayList<Closeable>(1);
+    ArrayList<Closeable> activeStreams = new ArrayList<>(1);
 
     static private final Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerBlob");
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -158,7 +158,7 @@ public class SQLServerBulkCSVFileRecord implements ISQLServerBulkRecord, java.la
         catch (Exception e) {
             throw new SQLServerException(null, e.getMessage(), null, 0, false);
         }
-        columnMetadata = new HashMap<Integer, SQLServerBulkCSVFileRecord.ColumnMetadata>();
+        columnMetadata = new HashMap<>();
 
         loggerExternal.exiting(loggerClassName, "SQLServerBulkCSVFileRecord");
     }
@@ -215,7 +215,7 @@ public class SQLServerBulkCSVFileRecord implements ISQLServerBulkRecord, java.la
         catch (Exception e) {
             throw new SQLServerException(null, e.getMessage(), null, 0, false);
         }
-        columnMetadata = new HashMap<Integer, SQLServerBulkCSVFileRecord.ColumnMetadata>();
+        columnMetadata = new HashMap<>();
 
         loggerExternal.exiting(loggerClassName, "SQLServerBulkCSVFileRecord");
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -675,7 +675,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
      * Initializes the defaults for member variables that require it.
      */
     private void initializeDefaults() {
-        columnMappings = new LinkedList<SQLServerBulkCopy.ColumnMapping>();
+        columnMappings = new LinkedList<>();
         destinationTableName = null;
         sourceBulkRecord = null;
         sourceResultSet = null;
@@ -1471,7 +1471,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
 
     private String createInsertBulkCommand(TDSWriter tdsWriter) throws SQLServerException {
         StringBuilder bulkCmd = new StringBuilder();
-        List<String> bulkOptions = new ArrayList<String>();
+        List<String> bulkOptions = new ArrayList<>();
         String endColumn = " , ";
         bulkCmd.append("INSERT BULK " + destinationTableName + " (");
 
@@ -1747,7 +1747,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
                     .executeQueryInternal("SET FMTONLY ON SELECT * FROM " + destinationTableName + " SET FMTONLY OFF ");
 
             destColumnCount = rs.getMetaData().getColumnCount();
-            destColumnMetadata = new HashMap<Integer, BulkColumnMetaData>();
+            destColumnMetadata = new HashMap<>();
             destCekTable = rs.getCekTable();
 
             if (!connection.getServerSupportsColumnEncryption()) {
@@ -1793,7 +1793,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
      * source metadata from the same place for both ResultSet and File.
      */
     private void getSourceMetadata() throws SQLServerException {
-        srcColumnMetadata = new HashMap<Integer, BulkColumnMetaData>();
+        srcColumnMetadata = new HashMap<>();
         int currentColumn;
         if (null != sourceResultSet) {
             try {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1431,7 +1431,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 }
 
                 ResultSet rs = s.executeQueryInternal(metaQuery.toString());
-                paramNames = new ArrayList<String>();
+                paramNames = new ArrayList<>();
                 while (rs.next()) {
                     String sCol = rs.getString(4);
                     paramNames.add(sCol.trim());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
@@ -88,7 +88,7 @@ abstract class SQLServerClobBase implements Serializable {
     // Initial size of the array is based on an assumption that a Clob/NClob object is
     // typically used either for input or output, and then only once. The array size
     // grows automatically if multiple streams are used.
-    private ArrayList<Closeable> activeStreams = new ArrayList<Closeable>(1);
+    private ArrayList<Closeable> activeStreams = new ArrayList<>(1);
 
     transient SQLServerConnection con;
     private static Logger logger;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -100,7 +100,7 @@ public class SQLServerConnection implements ISQLServerConnection {
     private Boolean enablePrepareOnFirstPreparedStatementCall = null; // Current limit for this particular connection.
 
     // Handle the actual queue of discarded prepared statements.
-    private ConcurrentLinkedQueue<PreparedStatementHandle> discardedPreparedStatementHandles = new ConcurrentLinkedQueue<PreparedStatementHandle>();
+    private ConcurrentLinkedQueue<PreparedStatementHandle> discardedPreparedStatementHandles = new ConcurrentLinkedQueue<>();
     private AtomicInteger discardedPreparedStatementHandleCount = new AtomicInteger(0);
 
     private boolean fedAuthRequiredByUser = false;
@@ -525,7 +525,7 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     static boolean isWindows;
-    static Map<String, SQLServerColumnEncryptionKeyStoreProvider> globalSystemColumnEncryptionKeyStoreProviders = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
+    static Map<String, SQLServerColumnEncryptionKeyStoreProvider> globalSystemColumnEncryptionKeyStoreProviders = new HashMap<>();
     static {
         if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
             isWindows = true;
@@ -538,7 +538,7 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
     static Map<String, SQLServerColumnEncryptionKeyStoreProvider> globalCustomColumnEncryptionKeyStoreProviders = null;
     // This is a per-connection store provider. It can be JKS or AKV.
-    Map<String, SQLServerColumnEncryptionKeyStoreProvider> systemColumnEncryptionKeyStoreProvider = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
+    Map<String, SQLServerColumnEncryptionKeyStoreProvider> systemColumnEncryptionKeyStoreProvider = new HashMap<>();
 
     /**
      * Registers key store providers in the globalCustomColumnEncryptionKeyStoreProviders.
@@ -561,7 +561,7 @@ public class SQLServerConnection implements ISQLServerConnection {
             throw new SQLServerException(null, SQLServerException.getErrString("R_CustomKeyStoreProviderSetOnce"), null, 0, false);
         }
 
-        globalCustomColumnEncryptionKeyStoreProviders = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
+        globalCustomColumnEncryptionKeyStoreProviders = new HashMap<>();
 
         for (Map.Entry<String, SQLServerColumnEncryptionKeyStoreProvider> entry : clientKeyStoreProviders.entrySet()) {
             String providerName = entry.getKey();
@@ -625,7 +625,7 @@ public class SQLServerConnection implements ISQLServerConnection {
     }
 
     private String trustedServerNameAE = null;
-    private static Map<String, List<String>> columnEncryptionTrustedMasterKeyPaths = new HashMap<String, List<String>>();
+    private static Map<String, List<String>> columnEncryptionTrustedMasterKeyPaths = new HashMap<>();
 
     /**
      * Sets Trusted Master Key Paths in the columnEncryptionTrustedMasterKeyPaths.
@@ -691,7 +691,7 @@ public class SQLServerConnection implements ISQLServerConnection {
     public static synchronized Map<String, List<String>> getColumnEncryptionTrustedMasterKeyPaths() {
         loggerExternal.entering(SQLServerConnection.class.getName(), "getColumnEncryptionTrustedMasterKeyPaths", "Getting Trusted Master Key Paths");
 
-        Map<String, List<String>> masterKeyPathCopy = new HashMap<String, List<String>>();
+        Map<String, List<String>> masterKeyPathCopy = new HashMap<>();
 
         for (Map.Entry<String, List<String>> entry : columnEncryptionTrustedMasterKeyPaths.entrySet()) {
             masterKeyPathCopy.put(entry.getKey(), entry.getValue());
@@ -3217,7 +3217,7 @@ public class SQLServerConnection implements ISQLServerConnection {
     public java.util.Map<String, Class<?>> getTypeMap() throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "getTypeMap");
         checkClosed();
-        java.util.Map<String, Class<?>> mp = new java.util.HashMap<String, Class<?>>();
+        java.util.Map<String, Class<?>> mp = new java.util.HashMap<>();
         loggerExternal.exiting(getClassNameLogging(), "getTypeMap", mp);
         return mp;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -36,8 +36,8 @@ public final class SQLServerDataTable {
      */
     // Name used in CREATE TYPE
     public SQLServerDataTable() throws SQLServerException {
-        columnMetadata = new LinkedHashMap<Integer, SQLServerDataColumn>();
-        rows = new HashMap<Integer, Object[]>();
+        columnMetadata = new LinkedHashMap<>();
+        rows = new HashMap<>();
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -89,7 +89,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
     }
 
-    EnumMap<CallableHandles, HandleAssociation> handleMap = new EnumMap<CallableHandles, HandleAssociation>(CallableHandles.class);
+    EnumMap<CallableHandles, HandleAssociation> handleMap = new EnumMap<>(CallableHandles.class);
 
     // Returns unique id for each instance.
     private static int nextInstanceID() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerEncryptionAlgorithmFactoryList.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerEncryptionAlgorithmFactoryList.java
@@ -21,7 +21,7 @@ final class SQLServerEncryptionAlgorithmFactoryList {
     private static final SQLServerEncryptionAlgorithmFactoryList instance = new SQLServerEncryptionAlgorithmFactoryList();
 
     private SQLServerEncryptionAlgorithmFactoryList() {
-        encryptionAlgoFactoryMap = new ConcurrentHashMap<String, SQLServerEncryptionAlgorithmFactory>();
+        encryptionAlgoFactoryMap = new ConcurrentHashMap<>();
         encryptionAlgoFactoryMap.putIfAbsent(SQLServerAeadAes256CbcHmac256Algorithm.algorithmName, new SQLServerAeadAes256CbcHmac256Factory());
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -601,7 +601,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
             // procedure "sp_describe_undeclared_parameters" to retrieve parameter meta data
             // if SQL server version is 2008, then use FMTONLY
             else {
-                queryMetaMap = new HashMap<Integer, QueryMeta>();
+                queryMetaMap = new HashMap<>();
 
                 if (con.getServerMajorVersion() >= SQL_SERVER_2012_VERSION) {
                     // new implementation for SQL verser 2012 and above
@@ -616,7 +616,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                 else {
                     // old implementation for SQL server 2008
                     stringToParse = sProcString;
-                    ArrayList<MetaInfo> metaInfoList = new ArrayList<MetaInfo>();
+                    ArrayList<MetaInfo> metaInfoList = new ArrayList<>();
                     
                     while (stringToParse.length() > 0) {
                         MetaInfo metaInfo = parseStatement(stringToParse);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
@@ -38,7 +38,7 @@ public class SQLServerPooledConnection implements PooledConnection {
     SQLServerPooledConnection(SQLServerDataSource ds,
             String user,
             String password) throws SQLException {
-        listeners = new Vector<ConnectionEventListener>();
+        listeners = new Vector<>();
         // Piggyback SQLServerDataSource logger for now.
         pcLogger = SQLServerDataSource.dsLogger;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -338,7 +338,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         StringBuilder sb = new StringBuilder();
         int nCols = params.length;
         char cParamName[] = new char[10];
-        parameterNames = new ArrayList<String>();
+        parameterNames = new ArrayList<>();
 
         for (int i = 0; i < nCols; i++) {
             if (i > 0)
@@ -795,7 +795,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             return;
         }
 
-        Map<Integer, CekTableEntry> cekList = new HashMap<Integer, CekTableEntry>();
+        Map<Integer, CekTableEntry> cekList = new HashMap<>();
         CekTableEntry cekEntry = null;
         try {
             while (rs.next()) {
@@ -2376,7 +2376,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
         // Create the list of batch parameter values first time through
         if (batchParamValues == null)
-            batchParamValues = new ArrayList<Parameter[]>();
+            batchParamValues = new ArrayList<>();
 
         final int numParams = inOutParam.length;
         Parameter paramValues[] = new Parameter[numParams];
@@ -2538,7 +2538,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
         int numBatchesPrepared = 0;
         int numBatchesExecuted = 0;
-        Vector<CryptoMetadata> cryptoMetaBatch = new Vector<CryptoMetadata>();
+        Vector<CryptoMetadata> cryptoMetaBatch = new Vector<>();
 
         if (isSelect(userSQL)) {
             SQLServerException.makeFromDriverError(connection, this, SQLServerException.getErrString("R_selectNotPermittedinBatch"), null, true);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -429,7 +429,7 @@ public class SQLServerStatement implements ISQLServerStatement {
      * The array of objects in a batched call. Applicable to statements and prepared statements When the iterativeBatching property is turned on.
      */
     /** The buffer that accumulates batchable statements */
-    private final ArrayList<String> batchStatementBuffer = new ArrayList<String>();
+    private final ArrayList<String> batchStatementBuffer = new ArrayList<>();
 
     /** logging init at the construction */
     static final private java.util.logging.Logger stmtlogger = java.util.logging.Logger
@@ -1512,7 +1512,7 @@ public class SQLServerStatement implements ISQLServerStatement {
                         infoToken.msg.getErrorNumber());
 
                 if (sqlWarnings == null) {
-                    sqlWarnings = new Vector<SQLWarning>();
+                    sqlWarnings = new Vector<>();
                 }
                 else {
                     int n = sqlWarnings.size();
@@ -2384,7 +2384,7 @@ final class JDBCSyntaxTranslator {
         Matcher offsetMatcher = limitSyntaxWithOffset.matcher(sql);
 
         int startIndx = indx;
-        Stack<Integer> topPosition = new Stack<Integer>();
+        Stack<Integer> topPosition = new Stack<>();
         State nextState = State.START;
 
         while (indx < sql.length()) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSymmetricKeyCache.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSymmetricKeyCache.java
@@ -68,7 +68,7 @@ final class SQLServerSymmetricKeyCache {
             .getLogger("com.microsoft.sqlserver.jdbc.SQLServerSymmetricKeyCache");
 
     private SQLServerSymmetricKeyCache() {
-        cache = new ConcurrentHashMap<String, SQLServerSymmetricKey>();
+        cache = new ConcurrentHashMap<>();
     }
 
     static SQLServerSymmetricKeyCache getInstance() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
@@ -792,7 +792,7 @@ public final class SQLServerXAResource implements javax.transaction.xa.XAResourc
     /* L0 */ public Xid[] recover(int flags) throws XAException {
         XAReturnValue r = DTC_XA_Interface(XA_RECOVER, null, flags | tightlyCoupled);
         int offset = 0;
-        ArrayList<XidImpl> al = new ArrayList<XidImpl>();
+        ArrayList<XidImpl> al = new ArrayList<>();
 
         // If no XID's found, return zero length XID array (don't return null).
         //

--- a/src/main/java/com/microsoft/sqlserver/jdbc/TVP.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/TVP.java
@@ -62,7 +62,7 @@ class TVP {
     void initTVP(TVPType type,
             String tvpPartName) throws SQLServerException {
         tvpType = type;
-        columnMetadata = new LinkedHashMap<Integer, SQLServerMetaData>();
+        columnMetadata = new LinkedHashMap<>();
         parseTypeName(tvpPartName);
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dns/DNSUtilities.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dns/DNSUtilities.java
@@ -36,13 +36,13 @@ public class DNSUtilities {
      *             if DNS is not available
      */
     public static Set<DNSRecordSRV> findSrvRecords(final String dnsSrvRecordToFind) throws NamingException {
-        Hashtable<Object, Object> env = new Hashtable<Object, Object>();
+        Hashtable<Object, Object> env = new Hashtable<>();
         env.put("java.naming.factory.initial", "com.sun.jndi.dns.DnsContextFactory");
         env.put("java.naming.provider.url", "dns:");
         DirContext ctx = new InitialDirContext(env);
         Attributes attrs = ctx.getAttributes(dnsSrvRecordToFind, new String[] {"SRV"});
         NamingEnumeration<? extends Attribute> allServers = attrs.getAll();
-        TreeSet<DNSRecordSRV> records = new TreeSet<DNSRecordSRV>();
+        TreeSet<DNSRecordSRV> records = new TreeSet<>();
         while (allServers.hasMoreElements()) {
             Attribute a = allServers.nextElement();
             NamingEnumeration<?> srvRecord = a.getAll();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3328,7 +3328,7 @@ final class TypeInfo {
         }
     }
 
-    private static final Map<TDSType, Builder> builderMap = new EnumMap<TDSType, Builder>(TDSType.class);
+    private static final Map<TDSType, Builder> builderMap = new EnumMap<>(TDSType.class);
 
     static {
         for (Builder builder : Builder.values())

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
@@ -161,7 +161,7 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
      */
     List<BulkCopyTestWrapper> createTestData_testBulkCopyConstructor() {
         String testCaseName = "BulkCopyConstructor ";
-        List<BulkCopyTestWrapper> testData = new ArrayList<BulkCopyTestWrapper>();
+        List<BulkCopyTestWrapper> testData = new ArrayList<>();
         BulkCopyTestWrapper bulkWrapper1 = new BulkCopyTestWrapper(connectionString);
         bulkWrapper1.testName = testCaseName;
         bulkWrapper1.setUsingConnection(true);
@@ -182,7 +182,7 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
      */
     private List<BulkCopyTestWrapper> createTestData_testBulkCopyOption() {
         String testCaseName = "BulkCopyOption ";
-        List<BulkCopyTestWrapper> testData = new ArrayList<BulkCopyTestWrapper>();
+        List<BulkCopyTestWrapper> testData = new ArrayList<>();
 
         Class<SQLServerBulkCopyOptions> bulkOptions = SQLServerBulkCopyOptions.class;
         Method[] methods = bulkOptions.getDeclaredMethods();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
@@ -99,7 +99,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
         List<Object[]> data;
 
         BulkData() {
-            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+            columnMetadata = new HashMap<>();
             totalColumn = dstTable.totalColumns();
 
             // add metadata
@@ -116,7 +116,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
 
             // add data
             rowCount = dstTable.getTotalRows();
-            data = new ArrayList<Object[]>(rowCount);
+            data = new ArrayList<>(rowCount);
             for (int i = 0; i < rowCount; i++) {
                 Object[] CurrentRow = new Object[totalColumn];
                 for (int j = 0; j < totalColumn; j++) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTestWrapper.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTestWrapper.java
@@ -35,7 +35,7 @@ class BulkCopyTestWrapper {
      */
     private boolean isUsingColumnMapping = false;
 
-    public LinkedList<ColumnMap> cm = new LinkedList<ColumnMap>();
+    public LinkedList<ColumnMap> cm = new LinkedList<>();
 
     private SQLServerBulkCopyOptions bulkOptions;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ImpISQLServerBulkRecord_IssuesTest.java
@@ -289,53 +289,53 @@ class BulkDat implements ISQLServerBulkRecord {
     BulkDat(String variation) {
         if (variation.equalsIgnoreCase("testVarchar")) {
             isStringData = true;
-            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+            columnMetadata = new HashMap<>();
 
             columnMetadata.put(1, new ColumnMetadata("varchar(2)", java.sql.Types.VARCHAR, 0, 0));
 
-            stringData = new ArrayList<String>();
+            stringData = new ArrayList<>();
             stringData.add(new String("aaa"));
             rowCount = stringData.size();
         }
         else if (variation.equalsIgnoreCase("testSmalldatetime")) {
             isStringData = false;
-            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+            columnMetadata = new HashMap<>();
 
             columnMetadata.put(1, new ColumnMetadata("smallDatetime", java.sql.Types.TIMESTAMP, 0, 0));
 
-            dateData = new ArrayList<Timestamp>();
+            dateData = new ArrayList<>();
             dateData.add(Timestamp.valueOf("1954-05-22 02:43:37.123"));
             rowCount = dateData.size();
         }
         else if (variation.equalsIgnoreCase("testSmalldatetimeOutofRange")) {
             isStringData = false;
-            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+            columnMetadata = new HashMap<>();
 
             columnMetadata.put(1, new ColumnMetadata("smallDatetime", java.sql.Types.TIMESTAMP, 0, 0));
 
-            dateData = new ArrayList<Timestamp>();
+            dateData = new ArrayList<>();
             dateData.add(Timestamp.valueOf("1954-05-22 02:43:37.1234"));
             rowCount = dateData.size();
 
         }
         else if (variation.equalsIgnoreCase("testBinaryColumnAsByte")) {
             isStringData = false;
-            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+            columnMetadata = new HashMap<>();
 
             columnMetadata.put(1, new ColumnMetadata("binary(5)", java.sql.Types.BINARY, 5, 0));
 
-            byteData = new ArrayList<byte[]>();
+            byteData = new ArrayList<>();
             byteData.add("helloo".getBytes());
             rowCount = byteData.size();
 
         }
         else if (variation.equalsIgnoreCase("testBinaryColumnAsString")) {
             isStringData = true;
-            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+            columnMetadata = new HashMap<>();
 
             columnMetadata.put(1, new ColumnMetadata("binary(5)", java.sql.Types.BINARY, 5, 0));
 
-            stringData = new ArrayList<String>();
+            stringData = new ArrayList<>();
             stringData.add("616368697412");
             rowCount = stringData.size();
 
@@ -343,11 +343,11 @@ class BulkDat implements ISQLServerBulkRecord {
 
         else if (variation.equalsIgnoreCase("testSendValidValueforBinaryColumnAsString")) {
             isStringData = true;
-            columnMetadata = new HashMap<Integer, ColumnMetadata>();
+            columnMetadata = new HashMap<>();
 
             columnMetadata.put(1, new ColumnMetadata("binary(5)", java.sql.Types.BINARY, 5, 0));
 
-            stringData = new ArrayList<String>();
+            stringData = new ArrayList<>();
             stringData.add("010101");
             rowCount = stringData.size();
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/LimitEscapeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/LimitEscapeTest.java
@@ -40,7 +40,7 @@ import com.microsoft.sqlserver.testframework.AbstractTest;
 @RunWith(JUnitPlatform.class)
 public class LimitEscapeTest extends AbstractTest {
     public static final Logger log = Logger.getLogger("LimitEscape");
-    private static Vector<String> offsetQuery = new Vector<String>();
+    private static Vector<String> offsetQuery = new Vector<>();
     private static Connection conn = null;
 
     static class Query {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -2097,7 +2097,7 @@ public class StatementTest extends AbstractTest {
 
                 Random r = new Random();
                 // randomly generate columns whose values would be set to a non null value
-                ArrayList<Integer> nonNullColumns = new ArrayList<Integer>();
+                ArrayList<Integer> nonNullColumns = new ArrayList<>();
                 nonNullColumns.add(1);// this is always non-null
 
                 // Add approximately 10 non-null columns. The number should be low

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBCoercions.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBCoercions.java
@@ -19,7 +19,7 @@ public class DBCoercions extends DBItems {
      * constructor
      */
     public DBCoercions() {
-        coercionsList = new ArrayList<DBCoercion>();
+        coercionsList = new ArrayList<>();
     }
 
     public DBCoercions(DBCoercion coercion) {

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBColumn.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBColumn.java
@@ -78,7 +78,7 @@ public class DBColumn {
      *            number of rows
      */
     void populateValues(int rows) {
-        columnValues = new ArrayList<Object>();
+        columnValues = new ArrayList<>();
         for (int i = 0; i < rows; i++)
             columnValues.add(sqlType.createdata());
     }

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBSchema.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBSchema.java
@@ -52,7 +52,7 @@ public class DBSchema {
      * @param autoGenerateSchema
      */
     DBSchema(boolean autoGenerateSchema) {
-        sqlTypes = new ArrayList<SqlType>();
+        sqlTypes = new ArrayList<>();
         if (autoGenerateSchema) {
             // Exact Numeric
             sqlTypes.add(new SqlBigInt());

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBTable.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBTable.java
@@ -85,7 +85,7 @@ public class DBTable extends AbstractSQLGenerator {
                 addColumns();
         }
         else {
-            this.columns = new ArrayList<DBColumn>();
+            this.columns = new ArrayList<>();
         }
         this.totalColumns = columns.size();
     }
@@ -108,7 +108,7 @@ public class DBTable extends AbstractSQLGenerator {
      */
     private void addColumns() {
         totalColumns = schema.getNumberOfSqlTypes();
-        columns = new ArrayList<DBColumn>(totalColumns);
+        columns = new ArrayList<>(totalColumns);
 
         for (int i = 0; i < totalColumns; i++) {
             SqlType sqlType = schema.getSqlType(i);
@@ -122,7 +122,7 @@ public class DBTable extends AbstractSQLGenerator {
      */
     private void addColumns(boolean unicode) {
         totalColumns = schema.getNumberOfSqlTypes();
-        columns = new ArrayList<DBColumn>(totalColumns);
+        columns = new ArrayList<>(totalColumns);
 
         for (int i = 0; i < totalColumns; i++) {
             SqlType sqlType = schema.getSqlType(i);

--- a/src/test/java/com/microsoft/sqlserver/testframework/Utils.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Utils.java
@@ -164,7 +164,7 @@ public class Utils {
      */
     public static ArrayList<SqlType> types() {
         if (null == types) {
-            types = new ArrayList<SqlType>();
+            types = new ArrayList<>();
 
             types.add(new SqlInt());
             types.add(new SqlSmallInt());


### PR DESCRIPTION
This removes duplicated information when instantiating variables, and increases the readability. For example:

```Java
EnumMap<CallableHandles, HandleAssociation> handleMap =
      new EnumMap<CallableHandles, HandleAssociation>(CallableHandles.class);
```

becomes

```Java
EnumMap<CallableHandles, HandleAssociation> handleMap =
            new EnumMap<>(CallableHandles.class);
```

and

```Java
private static final EnumMap<SSType.Category, EnumSet<JDBCType.Category>> conversionMap =
            new EnumMap<SSType.Category, EnumSet<JDBCType.Category>>(SSType.Category.class);
```

becomes

```Java
private static final EnumMap<SSType.Category, EnumSet<JDBCType.Category>> conversionMap =
                new EnumMap<>(SSType.Category.class);
```