### PR TITLE
Process all responses before proceed and fix retry logic for metadata caching

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -6476,23 +6476,13 @@ final class TDSReader {
         payloadOffset = 0;
         return true;
     }
-    
+
     boolean hasNextPacket() throws SQLServerException {
-        if (null == currentPacket.next) {
-            return false;
-        }
-        else {
-            return true;
-        }
+        return (null != currentPacket.next);
     }
 
     boolean endOfCurrentPacket() {
-        if (payloadOffset == currentPacket.payloadLength) {
-            return true;
-        }
-        else {
-            return false;
-        }
+        return (payloadOffset == currentPacket.payloadLength);
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -6445,7 +6445,7 @@ final class TDSReader {
      *
      * @return true if additional data is available to be read false if no more data is available
      */
-    boolean nextPacket() throws SQLServerException {
+    private boolean nextPacket() throws SQLServerException {
         assert null != currentPacket;
 
         // Shouldn't call this function unless we're at the end of the current packet...
@@ -6475,6 +6475,15 @@ final class TDSReader {
         currentPacket = nextPacket;
         payloadOffset = 0;
         return true;
+    }
+    
+    boolean hasNextPacket() throws SQLServerException {
+        if (null == currentPacket.next) {
+            return false;
+        }
+        else {
+            return true;
+        }
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -6445,7 +6445,7 @@ final class TDSReader {
      *
      * @return true if additional data is available to be read false if no more data is available
      */
-    private boolean nextPacket() throws SQLServerException {
+    boolean nextPacket() throws SQLServerException {
         assert null != currentPacket;
 
         // Shouldn't call this function unless we're at the end of the current packet...

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -6486,6 +6486,15 @@ final class TDSReader {
         }
     }
 
+    boolean endOfCurrentPacket() {
+        if (payloadOffset == currentPacket.payloadLength) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
     /**
      * Reads the next packet of the TDS channel.
      *

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -528,7 +528,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     	        getNextResult();
         	}
         	catch(SQLException e) {
-        		if (retryBasedOnFailedReuseOfCachedHandle(e, attempt))
+        		if (retryBasedOnFailedReuseOfCachedHandle(e.getErrorCode(), attempt))
     				continue;
                 else
     				throw e;
@@ -542,13 +542,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         else if (EXECUTE_UPDATE == executeMethod && null != resultSet) {
             SQLServerException.makeFromDriverError(connection, this, SQLServerException.getErrString("R_resultsetGeneratedForUpdate"), null, false);
         }
-    }
-
-    /** Should the execution be retried because the re-used cached handle could not be re-used due to server side state changes? */
-    private boolean retryBasedOnFailedReuseOfCachedHandle(SQLException e,
-            int attempt) {
-        return 1 == attempt && (STATEMENT_HANDLE_NOT_VALID == e.getErrorCode() || STATEMENT_HANDLE_NOT_FOUND == e.getErrorCode()
-                || STATEMENT_HANDLE_ERROR_CODE_FOR_TESTING == e.getErrorCode());
     }
 
     /**
@@ -2646,7 +2639,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                                     throw e;
 
                                 // Retry if invalid handle exception.
-                                if (retryBasedOnFailedReuseOfCachedHandle(e, attempt)) {
+                                if (retryBasedOnFailedReuseOfCachedHandle(e.getErrorCode(), attempt)) {
                                     // reset number of batches prepare
                                     numBatchesPrepared = numBatchesExecuted;
                                     retry = true;
@@ -2677,7 +2670,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     }
                 }
                 catch(SQLException e) {
-                    if (retryBasedOnFailedReuseOfCachedHandle(e, attempt)) {
+                    if (retryBasedOnFailedReuseOfCachedHandle(e.getErrorCode(), attempt)) {
                         // Reset number of batches prepared.
                         numBatchesPrepared = numBatchesExecuted;
                         continue;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -125,6 +125,15 @@ public class SQLServerStatement implements ISQLServerStatement {
      */
     private volatile TDSCommand currentCommand = null;
     private TDSCommand lastStmtExecCmd = null;
+    
+    /**
+     * error codes for retry of Cached Handle
+     */
+    static final int STATEMENT_HANDLE_NOT_VALID = 586; // 586: The prepared statement handle %d is not valid in this context. Please
+                                                       // verify that current database, user default schema, and ANSI_NULLS and
+                                                       // QUOTED_IDENTIFIER set options are not changed since the handle is prepared.
+    static final int STATEMENT_HANDLE_NOT_FOUND = 8179; // 8179: Could not find prepared statement with handle %d.
+    static final int STATEMENT_HANDLE_ERROR_CODE_FOR_TESTING = 99586;// 99586: Error used for testing.
 
     final void discardLastExecutionResults() {
         if (null != lastStmtExecCmd && !bIsClosed) {
@@ -1546,7 +1555,7 @@ public class SQLServerStatement implements ISQLServerStatement {
             TDSParser.parse(rd, nextResult);
 
             // Check for errors first.
-            if (null != nextResult.getDatabaseError()) {
+            if (null != nextResult.getDatabaseError() && (STATEMENT_HANDLE_ERROR_CODE_FOR_TESTING != nextResult.getDatabaseError().getErrorNumber())) {
                 SQLServerException.makeFromDatabaseError(connection, null, nextResult.getDatabaseError().getMessage(), nextResult.getDatabaseError(),
                         false);
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -1575,7 +1575,7 @@ public class SQLServerStatement implements ISQLServerStatement {
                 return true;
             }
         }
-        while (rd.hasNextPacket());
+        while (rd.hasNextPacket() && rd.endOfCurrentPacket());
 
         // None of the above. Last chance here... Going into the parser above, we know
         // moreResults was initially true. If we come out with moreResults false, then

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -1575,7 +1575,7 @@ public class SQLServerStatement implements ISQLServerStatement {
                 return true;
             }
         }
-        while (rd.nextPacket());
+        while (rd.hasNextPacket());
 
         // None of the above. Last chance here... Going into the parser above, we know
         // moreResults was initially true. If we come out with moreResults false, then

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -32,7 +32,6 @@ import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
 import com.microsoft.sqlserver.testframework.AbstractTest;
-import com.microsoft.sqlserver.testframework.util.RandomUtil;
 
 @RunWith(JUnitPlatform.class)
 public class PreparedStatementTest extends AbstractTest { 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -176,8 +176,10 @@ public class PreparedStatementTest extends AbstractTest {
             con.setStatementPoolingCacheSize(10);
 
             // Test with missing handle failures (fake).
+            this.executeSQL(con,
+                    "IF NOT EXISTS (SELECT * FROM sys.messages WHERE message_id = 99586) EXEC sp_addmessage 99586, 16, 'Prepared handle GAH!';");
             this.executeSQL(con, "CREATE TABLE #update1 (col INT);INSERT #update1 VALUES (1);");
-            this.executeSQL(con, "CREATE PROC #updateProc1 AS UPDATE #update1 SET col += 1; IF EXISTS (SELECT * FROM #update1 WHERE col % 5 = 0) THROW 99586, 'Prepared handle GAH!', 1;");
+            this.executeSQL(con, "CREATE PROC #updateProc1 AS UPDATE #update1 SET col += 1; IF EXISTS (SELECT * FROM #update1 WHERE col % 5 = 0) RAISERROR (99586, 16, 1);");
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con.prepareStatement("#updateProc1")) {
                 for (int i = 0; i < 100; ++i) {
                     assertSame(1, pstmt.executeUpdate());
@@ -185,8 +187,10 @@ public class PreparedStatementTest extends AbstractTest {
             }
 
             // Test batching with missing handle failures (fake).
+            this.executeSQL(con,
+                    "IF NOT EXISTS (SELECT * FROM sys.messages WHERE message_id = 99586) EXEC sp_addmessage 99586, 16, 'Prepared handle GAH!';");
             this.executeSQL(con, "CREATE TABLE #update2 (col INT);INSERT #update2 VALUES (1);");
-            this.executeSQL(con, "CREATE PROC #updateProc2 AS UPDATE #update2 SET col += 1; IF EXISTS (SELECT * FROM #update2 WHERE col % 5 = 0) THROW 99586, 'Prepared handle GAH!', 1;");
+            this.executeSQL(con, "CREATE PROC #updateProc2 AS UPDATE #update2 SET col += 1; IF EXISTS (SELECT * FROM #update2 WHERE col % 5 = 0) RAISERROR (99586, 16, 1);");
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con.prepareStatement("#updateProc2")) {
                 for (int i = 0; i < 100; ++i)
                     pstmt.addBatch();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -186,6 +186,12 @@ public class PreparedStatementTest extends AbstractTest {
                 }
             }
 
+            // test value of col, should be 1 + 100 = 101
+            try (ResultSet rs = con.createStatement().executeQuery("select * from #update1")) {
+                rs.next();
+                assertSame(101, rs.getInt(1));
+            }
+
             // Test batching with missing handle failures (fake).
             this.executeSQL(con,
                     "IF NOT EXISTS (SELECT * FROM sys.messages WHERE message_id = 99586) EXEC sp_addmessage 99586, 16, 'Prepared handle GAH!';");
@@ -201,6 +207,12 @@ public class PreparedStatementTest extends AbstractTest {
                 for (int i : updateCounts) {
                     assertSame(1, i);
                 }
+            }
+
+            // test value of col, should be 1 + 100 = 101
+            try (ResultSet rs = con.createStatement().executeQuery("select * from #update2")) {
+                rs.next();
+                assertSame(101, rs.getInt(1));
             }
         }
 


### PR DESCRIPTION
fix 2 issues in the driver related to metadata caching. 

The issues are found by replacing `throw` with `raiserror` in the test, in order to run the test against SQL Server 2008

Repo code for first issue:
[try_issue.txt](https://github.com/Microsoft/mssql-jdbc/files/1210020/try_issue.txt)

Another issue happens when using batching. The data is inserted/updated more times than expected.