### PR TITLE
Set the loginTimeout to default in case of a zero value - DRIVER_ERROR_INTERMITTENT_TLS_FAILED

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1079,7 +1079,10 @@ public class SQLServerConnection implements ISQLServerConnection {
                                                                                                           // timeout, default is 15 per spec
                         String sPropValue = propsIn.getProperty(SQLServerDriverIntProperty.LOGIN_TIMEOUT.toString());
                         if (null != sPropValue && sPropValue.length() > 0) {
-                            loginTimeoutSeconds = Integer.parseInt(sPropValue);
+                            int sPropValueInt = Integer.parseInt(sPropValue);
+                            if (0 != sPropValueInt) { // Use the default timeout in case of a zero value
+                                loginTimeoutSeconds = sPropValueInt;
+                            }
                         }
                     }
 


### PR DESCRIPTION
The driver has a workaround for intermittent TLSv1.2 failure. The workaround does not check if the passed in `loginTimeout` is `0`. This PR sets the `loginTimeout` to default( 15 seconds ) in case of a zero value, as specified [here](https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties).