### PR TITLE
Remove explicit extends object

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1340,7 +1340,7 @@ final class TDSChannel {
      * A PermissiveX509TrustManager is used to "verify" the authenticity of the server when the trustServerCertificate connection property is set to
      * true.
      */
-    private final class PermissiveX509TrustManager extends Object implements X509TrustManager {
+    private final class PermissiveX509TrustManager implements X509TrustManager {
         private final TDSChannel tdsChannel;
         private final Logger logger;
         private final String logContext;
@@ -1373,7 +1373,7 @@ final class TDSChannel {
      *
      * This validates the subject name in the certificate with the host name
      */
-    private final class HostNameOverrideX509TrustManager extends Object implements X509TrustManager {
+    private final class HostNameOverrideX509TrustManager implements X509TrustManager {
         private final Logger logger;
         private final String logContext;
         private final X509TrustManager defaultTrustManager;

--- a/src/main/java/microsoft/sql/DateTimeOffset.java
+++ b/src/main/java/microsoft/sql/DateTimeOffset.java
@@ -18,7 +18,7 @@ import java.util.TimeZone;
  * The DateTimeOffset class represents a java.sql.Timestamp, including fractional seconds, plus an integer representing the number of minutes offset
  * from GMT.
  */
-public final class DateTimeOffset extends Object implements java.io.Serializable, java.lang.Comparable<DateTimeOffset> {
+public final class DateTimeOffset implements java.io.Serializable, java.lang.Comparable<DateTimeOffset> {
     private static final long serialVersionUID = 541973748553014280L;
 
     private final long utcMillis;

--- a/src/main/java/microsoft/sql/Types.java
+++ b/src/main/java/microsoft/sql/Types.java
@@ -13,7 +13,7 @@ package microsoft.sql;
  *
  * This class is never instantiated.
  */
-public final class Types extends Object {
+public final class Types {
     private Types() {
         // not reached
     }


### PR DESCRIPTION
All objects in Java implicity extend `java.lang.Object` so `extends Object` is redundant.

Removing it will reduce confusion, and increase code readability.