### PR TITLE
Remove redundant if/else statements

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionCertificateStoreProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionCertificateStoreProvider.java
@@ -45,12 +45,7 @@ public final class SQLServerColumnEncryptionCertificateStoreProvider extends SQL
     static final String myCertificateStore = "My";
 
     static {
-        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
-            isWindows = true;
-        }
-        else {
-            isWindows = false;
-        }
+        isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows");
     }
     private Path keyStoreDirectoryPath = null;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1818,10 +1818,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             case ResultSet.TYPE_SCROLL_INSENSITIVE:
                 // case SQLServerResultSet.TYPE_SS_SCROLL_STATIC: sensitive synonym
             case SQLServerResultSet.TYPE_SS_DIRECT_FORWARD_ONLY:
-                if (ResultSet.CONCUR_READ_ONLY == concurrency)
-                    return true;
-                else
-                    return false;
+                return ResultSet.CONCUR_READ_ONLY == concurrency;
         }
         // per spec if we do not know we do not support.
         return false;
@@ -1830,60 +1827,48 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     /* L0 */ public boolean ownUpdatesAreVisible(int type) throws SQLServerException {
         checkClosed();
         checkResultType(type);
-        if (type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
+        return type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
                 || SQLServerResultSet.TYPE_SCROLL_SENSITIVE == type || SQLServerResultSet.TYPE_SS_SCROLL_KEYSET == type
-                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type)
-            return true;
-        return false;
+                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type;
     }
 
     /* L0 */ public boolean ownDeletesAreVisible(int type) throws SQLServerException {
         checkClosed();
         checkResultType(type);
-        if (type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
+        return type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
                 || SQLServerResultSet.TYPE_SCROLL_SENSITIVE == type || SQLServerResultSet.TYPE_SS_SCROLL_KEYSET == type
-                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type)
-            return true;
-        return false;
+                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type;
     }
 
     /* L0 */ public boolean ownInsertsAreVisible(int type) throws SQLServerException {
         checkClosed();
         checkResultType(type);
-        if (type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
+        return type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
                 || SQLServerResultSet.TYPE_SCROLL_SENSITIVE == type || SQLServerResultSet.TYPE_SS_SCROLL_KEYSET == type
-                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type)
-            return true;
-        return false;
+                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type;
     }
 
     /* L0 */ public boolean othersUpdatesAreVisible(int type) throws SQLServerException {
         checkClosed();
         checkResultType(type);
-        if (type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
+        return type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
                 || SQLServerResultSet.TYPE_SCROLL_SENSITIVE == type || SQLServerResultSet.TYPE_SS_SCROLL_KEYSET == type
-                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type)
-            return true;
-        return false;
+                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type;
     }
 
     /* L0 */ public boolean othersDeletesAreVisible(int type) throws SQLServerException {
         checkClosed();
         checkResultType(type);
-        if (type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
+        return type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
                 || SQLServerResultSet.TYPE_SCROLL_SENSITIVE == type || SQLServerResultSet.TYPE_SS_SCROLL_KEYSET == type
-                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type)
-            return true;
-        return false;
+                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type;
     }
 
     /* L0 */ public boolean othersInsertsAreVisible(int type) throws SQLServerException {
         checkClosed();
         checkResultType(type);
-        if (type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
-                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type)
-            return true;
-        return false;
+        return type == SQLServerResultSet.TYPE_SS_SCROLL_DYNAMIC || SQLServerResultSet.TYPE_FORWARD_ONLY == type
+                || SQLServerResultSet.TYPE_SS_SERVER_CURSOR_FORWARD_ONLY == type;
     }
 
     /* L0 */ public boolean updatesAreDetected(int type) throws SQLServerException {
@@ -1895,10 +1880,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     /* L0 */ public boolean deletesAreDetected(int type) throws SQLServerException {
         checkClosed();
         checkResultType(type);
-        if (SQLServerResultSet.TYPE_SS_SCROLL_KEYSET == type)
-            return true;
-        else
-            return false;
+        return SQLServerResultSet.TYPE_SS_SCROLL_KEYSET == type;
     }
 
     // Check the result types to make sure the user does not pass a bad value.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -581,12 +581,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                     rsProcedureMeta = s.executeQueryInternal("exec sp_sproc_columns " + sProc + ", @ODBCVer=3");
                 
                 // if rsProcedureMeta has next row, it means the stored procedure is found
-                if (rsProcedureMeta.next()) {
-                    procedureIsFound = true;
-                }
-                else {
-                    procedureIsFound = false;
-                }
+                procedureIsFound = rsProcedureMeta.next();
                 rsProcedureMeta.beforeFirst();
 
                 // Sixth is DATA_TYPE

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -6280,8 +6280,7 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
                 // Consume the ROW token, leaving tdsReader at the start of
                 // this row's column values.
-                if (TDS.TDS_ROW != tdsReader.readUnsignedByte())
-                    assert false;
+                assert TDS.TDS_ROW == tdsReader.readUnsignedByte();
                 fetchBufferCurrentRowType = RowType.ROW;
                 return false;
             }
@@ -6291,8 +6290,7 @@ public class SQLServerResultSet implements ISQLServerResultSet {
 
                 // Consume the NBCROW token, leaving tdsReader at the start of
                 // nullbitmap.
-                if (TDS.TDS_NBCROW != tdsReader.readUnsignedByte())
-                    assert false;
+                assert TDS.TDS_NBCROW == tdsReader.readUnsignedByte();
 
                 fetchBufferCurrentRowType = RowType.NBCROW;
                 return false;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamColInfo.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamColInfo.java
@@ -21,8 +21,7 @@ final class StreamColInfo extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_COLINFO != tdsReader.readUnsignedByte())
-            assert false : "Not a COLINFO token";
+        assert TDS.TDS_COLINFO == tdsReader.readUnsignedByte() : "Not a COLINFO token";
 
         this.tdsReader = tdsReader;
         int tokenLength = tdsReader.readUnsignedShort();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamColumns.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamColumns.java
@@ -163,8 +163,7 @@ final class StreamColumns extends StreamPacket {
      * @throws SQLServerException
      */
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_COLMETADATA != tdsReader.readUnsignedByte())
-            assert false;
+        assert TDS.TDS_COLMETADATA == tdsReader.readUnsignedByte();
 
         int nTotColumns = tdsReader.readUnsignedShort();
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamError.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamError.java
@@ -47,8 +47,7 @@ final class StreamError extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_ERR != tdsReader.readUnsignedByte())
-            assert false;
+        assert TDS.TDS_ERR == tdsReader.readUnsignedByte();
         setContentsFromTDS(tdsReader);
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamInfo.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamInfo.java
@@ -16,8 +16,7 @@ final class StreamInfo extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_MSG != tdsReader.readUnsignedByte())
-            assert false;
+        assert TDS.TDS_MSG == tdsReader.readUnsignedByte();
         msg.setContentsFromTDS(tdsReader);
     }
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamLoginAck.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamLoginAck.java
@@ -22,8 +22,7 @@ final class StreamLoginAck extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_LOGIN_ACK != tdsReader.readUnsignedByte())
-            assert false;
+        assert TDS.TDS_LOGIN_ACK == tdsReader.readUnsignedByte();
         tdsReader.readUnsignedShort(); // length of this token stream
         tdsReader.readUnsignedByte(); // SQL version accepted by the server
         tdsVersion = tdsReader.readIntBigEndian(); // TDS version accepted by the server

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamRetStatus.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamRetStatus.java
@@ -25,8 +25,7 @@ final class StreamRetStatus extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_RET_STAT != tdsReader.readUnsignedByte())
-            assert false;
+        assert TDS.TDS_RET_STAT == tdsReader.readUnsignedByte();
         status = tdsReader.readInt();
     }
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamRetValue.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamRetValue.java
@@ -33,8 +33,7 @@ final class StreamRetValue extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_RETURN_VALUE != tdsReader.readUnsignedByte())
-            assert false;
+        assert TDS.TDS_RETURN_VALUE == tdsReader.readUnsignedByte();
         ordinalOrLength = tdsReader.readUnsignedShort();
         paramName = tdsReader.readUnicodeString(tdsReader.readUnsignedByte());
         status = tdsReader.readUnsignedByte();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamSSPI.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamSSPI.java
@@ -21,8 +21,7 @@ final class StreamSSPI extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_SSPI != tdsReader.readUnsignedByte())
-            assert false;
+        assert TDS.TDS_SSPI == tdsReader.readUnsignedByte();
         int blobLength = tdsReader.readUnsignedShort();
         sspiBlob = new byte[blobLength];
         tdsReader.readBytes(sspiBlob, 0, blobLength);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamTabName.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamTabName.java
@@ -22,8 +22,7 @@ final class StreamTabName extends StreamPacket {
     }
 
     void setFromTDS(TDSReader tdsReader) throws SQLServerException {
-        if (TDS.TDS_TABNAME != tdsReader.readUnsignedByte())
-            assert false : "Not a TABNAME token";
+        assert TDS.TDS_TABNAME == tdsReader.readUnsignedByte() : "Not a TABNAME token";
 
         this.tdsReader = tdsReader;
         int tokenLength = tdsReader.readUnsignedShort();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -790,10 +790,7 @@ final class Util {
     static boolean IsActivityTraceOn() {
         LogManager lm = LogManager.getLogManager();
         String activityTrace = lm.getProperty(ActivityIdTraceProperty);
-        if ("on".equalsIgnoreCase(activityTrace))
-            return true;
-        else
-            return false;
+        return "on".equalsIgnoreCase(activityTrace);
     }
 
     /**


### PR DESCRIPTION
Removes redundant if/else statements. For example:

```
if (foo()) {
   return true;
} else {
   return false;
}
```

can be simplified to:
```
return foo();
```