### PR TITLE
Remove unnecessary return statements

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -1338,7 +1338,6 @@ final class AsciiFilteredUnicodeInputStream extends InputStream {
         catch (IOException e) {
             // unfortunately inputstream mark does not throw an exception so we have to eat any exception from the reader here
             // likely to be a bug in the original InputStream spec.
-            return;
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
@@ -171,7 +171,6 @@ class SQLServerSecurityUtility {
         assert null != cipherAlgorithm : "Cipher algorithm cannot be null in DecryptSymmetricKey";
         md.cipherAlgorithm = cipherAlgorithm;
         md.encryptionKeyInfo = encryptionkeyInfoChosen;
-        return;
     }
 
     /*

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamTabName.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamTabName.java
@@ -50,6 +50,5 @@ final class StreamTabName extends StreamPacket {
         }
 
         tdsReader.reset(currentMark);
-        return;
     }
 }


### PR DESCRIPTION
`return;` is unnecessary if it is the last statement in a `void` method