### PR TITLE
Query with timer can throw IllegalThreadStateException

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -64,6 +64,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 


### PR DESCRIPTION
Running a query that uses a timer can cause an IllegalThreadStateException if the underlying ThreadGroup has been destroyed.

This error happens when the caller executes a query with a timeout and then doesn't execute another query with a timeout until some time has elapsed. The JVM can destroy the ThreadGroup behind the TimeoutTimer (because it contains no active threads) which causes any new query with a timeout to throw an IllegalThreadStateException.

Once the JDBC driver has entered this state any new query with a timeout will throw the exception. It's especially easy to run into this problem in demanding / multi-threaded applications.

My change makes sure the ThreadGroup is not destroyed before creating a new timer thread. If the ThreadGroup is destroyed, the code will create a new ThreadGroup.