### PR TITLE
fix methods that use sp_fkeys

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -742,10 +742,10 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
         checkClosed();
 
-        String sp_fkeys_Query = " exec sp_fkeys @pktable_name=[" + tab1 + "]"
+        String sp_fkeys_Query = " exec sp_fkeys @pktable_name='" + tab1 + "'"
                 + (null == schem1 ? ", @pktable_owner=null" : ", @pktable_owner='" + schem1 + "'")
                 + (null == cat1 ? ", @pktable_qualifier=null" : ", @pktable_qualifier='" + cat1 + "'")
-                + ", @fktable_name=[" + tab2 + "]"
+                + ", @fktable_name='" + tab2 + "'"
                 + (null == schem2 ? ", @fktable_owner=null" : ", @fktable_owner='" + schem2 + "'")
                 + (null == cat2 ? ", @fktable_qualifier=null" : ", @fktable_qualifier='" + cat2 + "'");
 
@@ -801,7 +801,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
         checkClosed();
 
-        String sp_fkeys_Query = " exec sp_fkeys @pktable_name=[" + table + "]"
+        String sp_fkeys_Query = " exec sp_fkeys @pktable_name='" + table + "'"
                 + (null == schema ? ", @pktable_owner=null" : ", @pktable_owner='" + schema + "'")
                 + (null == cat ? ", @pktable_qualifier=null" : ", @pktable_qualifier='" + cat + "'");
 
@@ -826,7 +826,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
         checkClosed();
 
-        String sp_fkeys_Query = " exec sp_fkeys @fktable_name=[" + table + "]"
+        String sp_fkeys_Query = " exec sp_fkeys @fktable_name='" + table + "'"
                 + (null == schema ? ", @fktable_owner=null" : ", @fktable_owner='" + schema + "'")
                 + (null == cat ? ", @fktable_qualifier=null" : ", @fktable_qualifier='" + cat + "'");
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -742,10 +742,10 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
         checkClosed();
 
-        String sp_fkeys_Query = " exec sp_fkeys @pktable_name=" + tab1
+        String sp_fkeys_Query = " exec sp_fkeys @pktable_name=[" + tab1 + "]"
                 + (null == schem1 ? ", @pktable_owner=null" : ", @pktable_owner='" + schem1 + "'")
                 + (null == cat1 ? ", @pktable_qualifier=null" : ", @pktable_qualifier='" + cat1 + "'")
-                + ", @fktable_name=" + tab2 
+                + ", @fktable_name=[" + tab2 + "]"
                 + (null == schem2 ? ", @fktable_owner=null" : ", @fktable_owner='" + schem2 + "'")
                 + (null == cat2 ? ", @fktable_qualifier=null" : ", @fktable_qualifier='" + cat2 + "'");
 
@@ -801,7 +801,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
         checkClosed();
 
-        String sp_fkeys_Query = " exec sp_fkeys @pktable_name=" + table
+        String sp_fkeys_Query = " exec sp_fkeys @pktable_name=[" + table + "]"
                 + (null == schema ? ", @pktable_owner=null" : ", @pktable_owner='" + schema + "'")
                 + (null == cat ? ", @pktable_qualifier=null" : ", @pktable_qualifier='" + cat + "'");
 
@@ -826,7 +826,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
         checkClosed();
 
-        String sp_fkeys_Query = " exec sp_fkeys @fktable_name=" + table
+        String sp_fkeys_Query = " exec sp_fkeys @fktable_name=[" + table + "]"
                 + (null == schema ? ", @fktable_owner=null" : ", @fktable_owner='" + schema + "'")
                 + (null == cat ? ", @fktable_qualifier=null" : ", @fktable_qualifier='" + cat + "'");
 
@@ -944,7 +944,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
              * the table with the same definition of the resultset return by sp_fkeys (same column definition and same order).
              */
             return stmt.executeQuery(
-                    "select PKTABLE_QUALIFIER,PKTABLE_OWNER,PKTABLE_NAME,PKCOLUMN_NAME,FKTABLE_QUALIFIER,FKTABLE_OWNER,FKTABLE_NAME,FKCOLUMN_NAME,KEY_SEQ,UPDATE_RULE,DELETE_RULE,FK_NAME,PK_NAME,DEFERRABILITY from "
+                    "select PKTABLE_QUALIFIER as 'PKTABLE_CAT',PKTABLE_OWNER as 'PKTABLE_SCHEM',PKTABLE_NAME,PKCOLUMN_NAME,FKTABLE_QUALIFIER as 'FKTABLE_CAT',FKTABLE_OWNER as 'FKTABLE_SCHEM',FKTABLE_NAME,FKCOLUMN_NAME,KEY_SEQ,UPDATE_RULE,DELETE_RULE,FK_NAME,PK_NAME,DEFERRABILITY from "
                             + foreign_keys_combined_tableName + " order by FKTABLE_QUALIFIER, FKTABLE_OWNER, FKTABLE_NAME, KEY_SEQ");
         }
         finally {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -923,12 +923,12 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                 ps.setString(6, fkeysRS.getString(6));
                 ps.setString(7, fkeysRS.getString(7));
                 ps.setString(8, fkeysRS.getString(8));
-                ps.setString(9, fkeysRS.getString(9));
-                ps.setString(10, fkeysRS.getString(10));
-                ps.setString(11, fkeysRS.getString(11));
+                ps.setInt(9, fkeysRS.getInt(9));
+                ps.setInt(10, fkeysRS.getInt(10));
+                ps.setInt(11, fkeysRS.getInt(11));
                 ps.setString(12, fkeysRS.getString(12));
                 ps.setString(13, fkeysRS.getString(13));
-                ps.setString(14, fkeysRS.getString(14));
+                ps.setInt(14, fkeysRS.getInt(14));
                 ps.execute();
             }
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -742,11 +742,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         checkClosed();
 
         String sp_fkeys_Query = " exec sp_fkeys @pktable_name=" + tab1
-                + (null == schem1 || schem1.trim().length() != 0 ? ", @pktable_owner=" + schem1 : "")
-                + (null == cat1 || cat1.trim().length() != 0 ? ", @pktable_qualifier=" + cat1 : "" )
+                + (null == schem1 ? ", @pktable_owner=null" : ", @pktable_owner='" + schem1 + "'")
+                + (null == cat1 ? ", @pktable_qualifier=null" : ", @pktable_qualifier='" + cat1 + "'")
                 + ", @fktable_name=" + tab2 
-                + (null == schem2 || schem2.trim().length() != 0 ? ", @fktable_owner=" + schem2 : "")
-                + (null == cat2 || cat2.trim().length() != 0 ? ", @fktable_qualifier=" + cat2 : "");
+                + (null == schem2 ? ", @fktable_owner=null" : ", @fktable_owner='" + schem2 + "'")
+                + (null == cat2 ? ", @fktable_qualifier=null" : ", @fktable_qualifier='" + cat2 + "'");
 
         return getResultSetForForeignKeyInformation(sp_fkeys_Query, null);
     }
@@ -801,8 +801,8 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         checkClosed();
 
         String sp_fkeys_Query = " exec sp_fkeys @pktable_name=" + table
-                + (null == schema || schema.trim().length() != 0 ? ", @pktable_owner=" + schema : "")
-                + (null == cat || cat.trim().length() != 0 ? ", @pktable_qualifier=" + cat : "");
+                + (null == schema ? ", @pktable_owner=null" : ", @pktable_owner='" + schema + "'")
+                + (null == cat ? ", @pktable_qualifier=null" : ", @pktable_qualifier='" + cat + "'");
 
         return getResultSetForForeignKeyInformation(sp_fkeys_Query, cat);
     }
@@ -826,8 +826,8 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         checkClosed();
 
         String sp_fkeys_Query = " exec sp_fkeys @fktable_name=" + table
-                + (null == schema || schema.trim().length() != 0 ? ", @fktable_owner=" + schema : "")
-                + (null == cat || cat.trim().length() != 0 ? ", @fktable_qualifier=" + cat : "");
+                + (null == schema ? ", @fktable_owner=null" : ", @fktable_owner='" + schema + "'")
+                + (null == cat ? ", @fktable_qualifier=null" : ", @fktable_qualifier='" + cat + "'");
 
         return getResultSetForForeignKeyInformation(sp_fkeys_Query, cat);
     }
@@ -849,8 +849,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         String fkeys_results_tableName = "[#fkeys_results" + uuid + "]";
         String foreign_keys_combined_tableName = "[#foreign_keys_combined_results" + uuid + "]";
         String sys_foreign_keys = "sys.foreign_keys";
-        
-        String orgCat = switchCatalogs(cat);
+
+        String orgCat = null;
+        if (null != cat && cat.trim().length() != 0) {
+            orgCat = switchCatalogs(cat);
+        }
         try {
             // cannot close this statement, otherwise the returned resultset would be closed too.
             SQLServerStatement stmt = (SQLServerStatement) connection.createStatement();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -864,10 +864,6 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         return getResultSetForForeignKeyInformation(fkeysRS, cat);
     }
 
-    private String fkeys_results_column_definition = "PKTABLE_QUALIFIER sysname, PKTABLE_OWNER sysname, PKTABLE_NAME sysname, PKCOLUMN_NAME sysname, FKTABLE_QUALIFIER sysname, FKTABLE_OWNER sysname, FKTABLE_NAME sysname, FKCOLUMN_NAME sysname, KEY_SEQ smallint, UPDATE_RULE smallint, DELETE_RULE smallint, FK_NAME sysname, PK_NAME sysname, DEFERRABILITY smallint";
-    private String foreign_keys_combined_column_definition = "name sysname, delete_referential_action_desc nvarchar(60), update_referential_action_desc nvarchar(60),"
-            + fkeys_results_column_definition;
-
     /**
      * The original sp_fkeys stored procedure does not give the required values from JDBC specification. This method creates 2 temporary tables and
      * uses join and other operations on them to give the correct values.
@@ -881,6 +877,10 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         String fkeys_results_tableName = "[#fkeys_results" + uuid + "]";
         String foreign_keys_combined_tableName = "[#foreign_keys_combined_results" + uuid + "]";
         String sys_foreign_keys = "sys.foreign_keys";
+
+        String fkeys_results_column_definition = "PKTABLE_QUALIFIER sysname, PKTABLE_OWNER sysname, PKTABLE_NAME sysname, PKCOLUMN_NAME sysname, FKTABLE_QUALIFIER sysname, FKTABLE_OWNER sysname, FKTABLE_NAME sysname, FKCOLUMN_NAME sysname, KEY_SEQ smallint, UPDATE_RULE smallint, DELETE_RULE smallint, FK_NAME sysname, PK_NAME sysname, DEFERRABILITY smallint";
+        String foreign_keys_combined_column_definition = "name sysname, delete_referential_action_desc nvarchar(60), update_referential_action_desc nvarchar(60),"
+                + fkeys_results_column_definition;
 
         // cannot close this statement, otherwise the returned resultset would be closed too.
         SQLServerStatement stmt = (SQLServerStatement) connection.createStatement();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -905,8 +905,9 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         /**
          * insert the results of sp_fkeys to the temp table #fkeys_results
          */
-        stmt.execute("insert into " + fkeys_results 
-                + " exec sp_fkeys @fktable_name=" + table + ", @fktable_owner=" + schema + ", @fktable_qualifier=" + cat);
+        stmt.execute("insert into " + fkeys_results + " exec sp_fkeys @fktable_name=" + table
+                + (null == schema || schema.trim().length() != 0 ? ", @fktable_owner=" + schema : "")
+                + (null == cat || cat.trim().length() != 0 ? ", @fktable_qualifier=" + cat : ""));
 
         /**
          * create another temp table that has 3 columns from sys.foreign_keys and the rest of columns are the same as #fkeys_results:

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataForeignKeyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataForeignKeyTest.java
@@ -1,0 +1,134 @@
+/*
+ * Microsoft JDBC Driver for SQL Server
+ * 
+ * Copyright(c) Microsoft Corporation All rights reserved.
+ * 
+ * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.databasemetadata;
+
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.jdbc.SQLServerConnection;
+import com.microsoft.sqlserver.jdbc.SQLServerDatabaseMetaData;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.jdbc.SQLServerResultSet;
+import com.microsoft.sqlserver.jdbc.SQLServerStatement;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.Utils;
+
+/**
+ * Test class for testing DatabaseMetaData with foreign keys.
+ */
+@RunWith(JUnitPlatform.class)
+public class DatabaseMetaDataForeignKeyTest extends AbstractTest {
+    private static SQLServerConnection conn = null;
+    private static SQLServerStatement stmt = null;
+
+    private static String table1 = "DatabaseMetaDataForeignKeyTest_table_1";
+    private static String table2 = "DatabaseMetaDataForeignKeyTest_table_2";
+    private static String table3 = "DatabaseMetaDataForeignKeyTest_table_3";
+    private static String table4 = "DatabaseMetaDataForeignKeyTest_table_4";
+    private static String table5 = "DatabaseMetaDataForeignKeyTest_table_5";
+    
+    private static String schema = null;
+    private static String catalog = null;
+
+    @BeforeAll
+    private static void setupVariation() throws SQLException {
+        conn = (SQLServerConnection) DriverManager.getConnection(connectionString);
+        SQLServerStatement stmt = (SQLServerStatement) conn.createStatement();
+
+        catalog = conn.getCatalog();
+        schema = conn.getSchema();
+
+        connection.createStatement().executeUpdate("if object_id('" + table1 + "','U') is not null drop table " + table1);
+
+        connection.createStatement().executeUpdate("if object_id('" + table2 + "','U') is not null drop table " + table2);
+        stmt.execute("Create table " + table2 + " (c21 int NOT NULL PRIMARY KEY)");
+
+        connection.createStatement().executeUpdate("if object_id('" + table3 + "','U') is not null drop table " + table3);
+        stmt.execute("Create table " + table3 + " (c31 int NOT NULL PRIMARY KEY)");
+
+        connection.createStatement().executeUpdate("if object_id('" + table4 + "','U') is not null drop table " + table4);
+        stmt.execute("Create table " + table4 + " (c41 int NOT NULL PRIMARY KEY)");
+
+        connection.createStatement().executeUpdate("if object_id('" + table5 + "','U') is not null drop table " + table5);
+        stmt.execute("Create table " + table5 + " (c51 int NOT NULL PRIMARY KEY)");
+
+        connection.createStatement().executeUpdate("if object_id('" + table1 + "','U') is not null drop table " + table1);
+        stmt.execute("Create table " + table1 + " (c11 int primary key," 
+                + " c12 int FOREIGN KEY REFERENCES " + table2 + "(c21) ON DELETE no action ON UPDATE set default," 
+                + " c13 int FOREIGN KEY REFERENCES " + table3 + "(c31) ON DELETE cascade ON UPDATE set null," 
+                + " c14 int FOREIGN KEY REFERENCES " + table4 + "(c41) ON DELETE set null ON UPDATE cascade," 
+                + " c15 int FOREIGN KEY REFERENCES " + table5 + "(c51) ON DELETE set default ON UPDATE no action," 
+                + ")");
+    }
+
+    @AfterAll
+    private static void terminateVariation() throws SQLException {
+        conn = (SQLServerConnection) DriverManager.getConnection(connectionString);
+        stmt = (SQLServerStatement) conn.createStatement();
+
+        Utils.dropTableIfExists(table1, stmt);
+        Utils.dropTableIfExists(table2, stmt);
+        Utils.dropTableIfExists(table3, stmt);
+        Utils.dropTableIfExists(table4, stmt);
+        Utils.dropTableIfExists(table5, stmt);
+    }
+
+    @Test
+    public void testGetImportedKeys() throws SQLServerException {
+        SQLServerDatabaseMetaData dmd = (SQLServerDatabaseMetaData) connection.getMetaData();
+
+        SQLServerResultSet rs1 = (SQLServerResultSet) dmd.getImportedKeys(null, null, table1);
+        validateResults(rs1);
+
+//        SQLServerResultSet rs2 = (SQLServerResultSet) dmd.getImportedKeys("", "", table1);
+//        validateResults(rs2);
+
+        SQLServerResultSet rs3 = (SQLServerResultSet) dmd.getImportedKeys("test", "dbo", table1);
+        validateResults(rs3);
+
+    }
+    
+    private void validateResults(SQLServerResultSet rs) throws SQLServerException {
+        int expectedRowCount = 4;
+        int rowCount = 0;
+        
+        rs.next();
+        assertEquals(4, rs.getInt("UPDATE_RULE"));
+        assertEquals(3, rs.getInt("DELETE_RULE"));
+        rowCount++;
+        
+        rs.next();
+        assertEquals(2, rs.getInt("UPDATE_RULE"));
+        assertEquals(0, rs.getInt("DELETE_RULE"));
+        rowCount++;
+        
+        rs.next();
+        assertEquals(0, rs.getInt("UPDATE_RULE"));
+        assertEquals(2, rs.getInt("DELETE_RULE"));
+        rowCount++;
+        
+        rs.next();
+        assertEquals(3, rs.getInt("UPDATE_RULE"));
+        assertEquals(4, rs.getInt("DELETE_RULE"));
+        rowCount++;
+
+        if(expectedRowCount != rowCount) {
+            assertEquals(expectedRowCount, rowCount, "number of foreign key entries is incorrect.");
+        }
+    }
+
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataForeignKeyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataForeignKeyTest.java
@@ -164,24 +164,70 @@ public class DatabaseMetaDataForeignKeyTest extends AbstractTest {
         SQLServerDatabaseMetaData dmd = (SQLServerDatabaseMetaData) connection.getMetaData();
 
         for (int i = 0; i < tableNames.length; i++) {
-            String table = tableNames[i];
-            SQLServerResultSet rs1 = (SQLServerResultSet) dmd.getExportedKeys(null, null, table);
+            String pkTable = tableNames[i];
+            SQLServerResultSet rs1 = (SQLServerResultSet) dmd.getExportedKeys(null, null, pkTable);
             rs1.next();
             assertEquals(values[i][0], rs1.getInt("UPDATE_RULE"));
             assertEquals(values[i][1], rs1.getInt("DELETE_RULE"));
 
-            SQLServerResultSet rs2 = (SQLServerResultSet) dmd.getExportedKeys(catalog, schema, table);
+            SQLServerResultSet rs2 = (SQLServerResultSet) dmd.getExportedKeys(catalog, schema, pkTable);
             rs2.next();
             assertEquals(values[i][0], rs2.getInt("UPDATE_RULE"));
             assertEquals(values[i][1], rs2.getInt("DELETE_RULE"));
 
-            SQLServerResultSet rs3 = (SQLServerResultSet) dmd.getExportedKeys(catalog, "", table);
+            SQLServerResultSet rs3 = (SQLServerResultSet) dmd.getExportedKeys(catalog, "", pkTable);
             rs3.next();
             assertEquals(values[i][0], rs3.getInt("UPDATE_RULE"));
             assertEquals(values[i][1], rs3.getInt("DELETE_RULE"));
 
             try {
-                dmd.getExportedKeys("", schema, table);
+                dmd.getExportedKeys("", schema, pkTable);
+                fail("Exception is not thrown.");
+            }
+            catch (SQLServerException e) {
+                assertEquals(EXPECTED_ERROR_MESSAGE, e.getMessage());
+            }
+        }
+    }
+    
+    /**
+     * test getCrossReference() methods
+     * 
+     * @throws SQLServerException
+     */
+    @Test
+    public void testGetCrossReference() throws SQLServerException {
+        String fkTable = table1;
+        String[] tableNames = {table2, table3, table4, table5};
+        int[][] values = {
+                // expected UPDATE_RULE, expected DELETE_RULE
+                {4, 3}, 
+                {2, 0}, 
+                {0, 2}, 
+                {3, 4}
+                };
+
+        SQLServerDatabaseMetaData dmd = (SQLServerDatabaseMetaData) connection.getMetaData();
+
+        for (int i = 0; i < tableNames.length; i++) {
+            String pkTable = tableNames[i];
+            SQLServerResultSet rs1 = (SQLServerResultSet) dmd.getCrossReference(null, null, pkTable, null, null, fkTable);
+            rs1.next();
+            assertEquals(values[i][0], rs1.getInt("UPDATE_RULE"));
+            assertEquals(values[i][1], rs1.getInt("DELETE_RULE"));
+
+            SQLServerResultSet rs2 = (SQLServerResultSet) dmd.getCrossReference(catalog, schema, pkTable, catalog, schema, fkTable);
+            rs2.next();
+            assertEquals(values[i][0], rs2.getInt("UPDATE_RULE"));
+            assertEquals(values[i][1], rs2.getInt("DELETE_RULE"));
+
+            SQLServerResultSet rs3 = (SQLServerResultSet) dmd.getCrossReference(catalog, "", pkTable, catalog, "", fkTable);
+            rs3.next();
+            assertEquals(values[i][0], rs3.getInt("UPDATE_RULE"));
+            assertEquals(values[i][1], rs3.getInt("DELETE_RULE"));
+
+            try {
+                dmd.getCrossReference("", schema, pkTable, "", schema, fkTable);
                 fail("Exception is not thrown.");
             }
             catch (SQLServerException e) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataForeignKeyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataForeignKeyTest.java
@@ -8,6 +8,7 @@
 package com.microsoft.sqlserver.jdbc.databasemetadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.DriverManager;
@@ -44,8 +45,10 @@ public class DatabaseMetaDataForeignKeyTest extends AbstractTest {
     private static String schema = null;
     private static String catalog = null;
     
-    private static final String EXPECTED_ERROR_MESSAGE = "The database name component of the object qualifier must be the name of the current database.";
+    private static final String EXPECTED_ERROR_MESSAGE = "An object or column name is missing or empty.";
+    private static final String EXPECTED_ERROR_MESSAGE2 = "The database name component of the object qualifier must be the name of the current database.";
 
+    
     @BeforeAll
     private static void setupVariation() throws SQLException {
         conn = (SQLServerConnection) DriverManager.getConnection(connectionString);
@@ -112,7 +115,7 @@ public class DatabaseMetaDataForeignKeyTest extends AbstractTest {
             fail("Exception is not thrown.");
         }
         catch (SQLServerException e) {
-            assertEquals(EXPECTED_ERROR_MESSAGE, e.getMessage());
+            assertTrue(e.getMessage().startsWith(EXPECTED_ERROR_MESSAGE));
         }
     }
 
@@ -185,7 +188,7 @@ public class DatabaseMetaDataForeignKeyTest extends AbstractTest {
                 fail("Exception is not thrown.");
             }
             catch (SQLServerException e) {
-                assertEquals(EXPECTED_ERROR_MESSAGE, e.getMessage());
+                assertTrue(e.getMessage().startsWith(EXPECTED_ERROR_MESSAGE));
             }
         }
     }
@@ -231,7 +234,7 @@ public class DatabaseMetaDataForeignKeyTest extends AbstractTest {
                 fail("Exception is not thrown.");
             }
             catch (SQLServerException e) {
-                assertEquals(EXPECTED_ERROR_MESSAGE, e.getMessage());
+                assertEquals(EXPECTED_ERROR_MESSAGE2, e.getMessage());
             }
         }
     }


### PR DESCRIPTION
fix issue #467

This PR creates 2 temporary tables to store resultsets returned from `sp_fkeys` and `sys.foreign_keys`, then uses ***RIGHT JOIN operation*** and ***UPDATE operation*** to correct and return the values for `DELETE_RULE` and `UPDATE_RULE`.

This is the best solution I can think of in term of performance and memorization. ***Please let me know if you have any better ideas or suggestions***