### PR TITLE
Remove redundant String.toString()

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -4828,7 +4828,7 @@ final class TDSWriter {
                 else {
                     if (isSqlVariant) {
                         writeTVPSqlVariantHeader(10, TDSType.FLOAT8.byteValue(), (byte) 0);
-                        writeDouble(Double.valueOf(currentColumnStringValue.toString()));
+                        writeDouble(Double.valueOf(currentColumnStringValue));
                         break;
                     }
                     writeByte((byte) 8); // len of data bytes

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1521,7 +1521,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
         if (it.hasNext()) {
             bulkCmd.append(" with (");
             while (it.hasNext()) {
-                bulkCmd.append(it.next().toString());
+                bulkCmd.append(it.next());
                 if (it.hasNext()) {
                     bulkCmd.append(", ");
                 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1717,7 +1717,7 @@ public class SQLServerConnection implements ISQLServerConnection {
             sPropKey = SQLServerDriverStringProperty.SSL_PROTOCOL.toString();
             sPropValue = activeConnectionProperties.getProperty(sPropKey);
             if (null == sPropValue) {
-                sPropValue = SQLServerDriverStringProperty.SSL_PROTOCOL.getDefaultValue().toString();
+                sPropValue = SQLServerDriverStringProperty.SSL_PROTOCOL.getDefaultValue();
                 activeConnectionProperties.setProperty(sPropKey, sPropValue);
             }
             else {
@@ -5430,7 +5430,7 @@ public class SQLServerConnection implements ISQLServerConnection {
                 browserResult = new String(receiveBuffer, 3, receiveBuffer.length - 3);
                 if (connectionlogger.isLoggable(Level.FINER))
                     connectionlogger.fine(
-                            toString() + " Received SSRP UDP response from IP address: " + udpResponse.getAddress().getHostAddress().toString());
+                            toString() + " Received SSRP UDP response from IP address: " + udpResponse.getAddress().getHostAddress());
             }
             catch (IOException ioException) {
                 // Warn and retry


### PR DESCRIPTION
Calling toString() on a String object is redundant