### PR TITLE
Replace bare literals

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -498,7 +498,7 @@ class GregorianChange {
 
         GregorianCalendar cal = new GregorianCalendar(Locale.US);
         cal.clear();
-        cal.set(1, 1, 577738, 0, 0, 0);// 577738 = 1+577737(no of days since epoch that brings us to oct 15th 1582)
+        cal.set(1, Calendar.FEBRUARY, 577738, 0, 0, 0);// 577738 = 1+577737(no of days since epoch that brings us to oct 15th 1582)
         if (cal.get(Calendar.DAY_OF_MONTH) == 15) {
             // If the date calculation is correct(the above bug is fixed),
             // post the default gregorian cut over date, the pure gregorian date

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy42Helper.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy42Helper.java
@@ -75,7 +75,7 @@ class SQLServerBulkCopy42Helper {
                     return ts;
                 case java.sql.Types.TIME:
                     // Time is returned as Timestamp to preserve nano seconds.
-                    cal.set(connection.baseYear(), 00, 01);
+                    cal.set(connection.baseYear(), Calendar.JANUARY, 01);
                     ts = new java.sql.Timestamp(cal.getTimeInMillis());
                     ts.setNanos(taNano);
                     return new java.sql.Timestamp(ts.getTime());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -788,7 +788,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         }
         catch (SQLException e) {
             SQLServerException.makeFromDriverError(con, stmtParent, e.toString(), null, false);
-            return 0;
+            return ParameterMetaData.parameterModeUnknown;
         }
     }
 
@@ -908,7 +908,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         }
         catch (SQLException e) {
             SQLServerException.makeFromDriverError(con, stmtParent, e.toString(), null, false);
-            return 0;
+            return ParameterMetaData.parameterNoNulls;
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -788,7 +788,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         }
         catch (SQLException e) {
             SQLServerException.makeFromDriverError(con, stmtParent, e.toString(), null, false);
-            return ParameterMetaData.parameterModeUnknown;
+            return parameterModeUnknown;
         }
     }
 
@@ -908,7 +908,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         }
         catch (SQLException e) {
             SQLServerException.makeFromDriverError(con, stmtParent, e.toString(), null, false);
-            return ParameterMetaData.parameterNoNulls;
+            return parameterNoNulls;
         }
     }
 


### PR DESCRIPTION
Replace bare literals with magic constants. For example:

`cal.set(1, 1, 577738, 0, 0, 0);`

becomes

`cal.set(1, Calendar.FEBRUARY, 577738, 0, 0, 0);`