### PR TITLE
Remove final modifier from static methods

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -48,10 +48,10 @@ final class DDC {
      *            the type of stream required.
      * @return the required object.
      */
-    static final Object convertIntegerToObject(int intValue,
-            int valueLength,
-            JDBCType jdbcType,
-            StreamType streamType) {
+    static Object convertIntegerToObject(int intValue,
+                                         int valueLength,
+                                         JDBCType jdbcType,
+                                         StreamType streamType) {
         switch (jdbcType) {
             case INTEGER:
                 return intValue;
@@ -93,10 +93,10 @@ final class DDC {
      *            the stream type.
      * @return the required object.
      */
-    static final Object convertLongToObject(long longVal,
-            JDBCType jdbcType,
-            SSType baseSSType,
-            StreamType streamType) {
+    static Object convertLongToObject(long longVal,
+                                      JDBCType jdbcType,
+                                      SSType baseSSType,
+                                      StreamType streamType) {
         switch (jdbcType) {
             case BIGINT:
                 return longVal;
@@ -188,8 +188,8 @@ final class DDC {
      *            the number of bytes to encode.
      * @return the byte array containing the big-endian encoded value.
      */
-    static final byte[] convertIntToBytes(int intValue,
-            int valueLength) {
+    static byte[] convertIntToBytes(int intValue,
+                                    int valueLength) {
         byte bytes[] = new byte[valueLength];
         for (int i = valueLength; i-- > 0;) {
             bytes[i] = (byte) (intValue & 0xFF);
@@ -209,9 +209,9 @@ final class DDC {
      *            the stream type.
      * @return the required object.
      */
-    static final Object convertFloatToObject(float floatVal,
-            JDBCType jdbcType,
-            StreamType streamType) {
+    static Object convertFloatToObject(float floatVal,
+                                       JDBCType jdbcType,
+                                       StreamType streamType) {
         switch (jdbcType) {
             case REAL:
                 return floatVal;
@@ -247,7 +247,7 @@ final class DDC {
      *            the long value to encode.
      * @return the byte array containing the big-endian encoded value.
      */
-    static final byte[] convertLongToBytes(long longValue) {
+    static byte[] convertLongToBytes(long longValue) {
         byte bytes[] = new byte[8];
         for (int i = 8; i-- > 0;) {
             bytes[i] = (byte) (longValue & 0xFF);
@@ -267,9 +267,9 @@ final class DDC {
      *            the stream type.
      * @return the required object.
      */
-    static final Object convertDoubleToObject(double doubleVal,
-            JDBCType jdbcType,
-            StreamType streamType) {
+    static Object convertDoubleToObject(double doubleVal,
+                                        JDBCType jdbcType,
+                                        StreamType streamType) {
         switch (jdbcType) {
             case FLOAT:
             case DOUBLE:
@@ -298,8 +298,8 @@ final class DDC {
         }
     }
 
-    static final byte[] convertBigDecimalToBytes(BigDecimal bigDecimalVal,
-            int scale) {
+    static byte[] convertBigDecimalToBytes(BigDecimal bigDecimalVal,
+                                           int scale) {
         byte[] valueBytes;
 
         if (bigDecimalVal == null) {
@@ -344,9 +344,9 @@ final class DDC {
      *            the stream type.
      * @return the required object.
      */
-    static final Object convertBigDecimalToObject(BigDecimal bigDecimalVal,
-            JDBCType jdbcType,
-            StreamType streamType) {
+    static Object convertBigDecimalToObject(BigDecimal bigDecimalVal,
+                                            JDBCType jdbcType,
+                                            StreamType streamType) {
         switch (jdbcType) {
             case DECIMAL:
             case NUMERIC:
@@ -388,10 +388,10 @@ final class DDC {
      *            the number of bytes to convert
      * @return the required object.
      */
-    static final Object convertMoneyToObject(BigDecimal bigDecimalVal,
-            JDBCType jdbcType,
-            StreamType streamType,
-            int numberOfBytes) {
+    static Object convertMoneyToObject(BigDecimal bigDecimalVal,
+                                       JDBCType jdbcType,
+                                       StreamType streamType,
+                                       int numberOfBytes) {
         switch (jdbcType) {
             case DECIMAL:
             case NUMERIC:
@@ -458,9 +458,9 @@ final class DDC {
      * @throws SQLServerException
      *             when an error occurs.
      */
-    static final Object convertBytesToObject(byte[] bytesValue,
-            JDBCType jdbcType,
-            TypeInfo baseTypeInfo) throws SQLServerException {
+    static Object convertBytesToObject(byte[] bytesValue,
+                                       JDBCType jdbcType,
+                                       TypeInfo baseTypeInfo) throws SQLServerException {
         switch (jdbcType) {
             case CHAR:
                 String str = Util.bytesToHexString(bytesValue, bytesValue.length);
@@ -505,10 +505,10 @@ final class DDC {
      *            the jdbc type required.
      * @return the required object.
      */
-    static final Object convertStringToObject(String stringVal,
-            Charset charset,
-            JDBCType jdbcType,
-            StreamType streamType) throws UnsupportedEncodingException, IllegalArgumentException {
+    static Object convertStringToObject(String stringVal,
+                                        Charset charset,
+                                        JDBCType jdbcType,
+                                        StreamType streamType) throws UnsupportedEncodingException, IllegalArgumentException {
         switch (jdbcType) {
             // Convert String to Numeric types.
             case DECIMAL:
@@ -576,10 +576,10 @@ final class DDC {
         }
     }
 
-    static final Object convertStreamToObject(BaseInputStream stream,
-            TypeInfo typeInfo,
-            JDBCType jdbcType,
-            InputStreamGetterArgs getterArgs) throws SQLServerException {
+    static Object convertStreamToObject(BaseInputStream stream,
+                                        TypeInfo typeInfo,
+                                        JDBCType jdbcType,
+                                        InputStreamGetterArgs getterArgs) throws SQLServerException {
         // Need to handle the simple case of a null value here, as it is not done
         // outside this function.
         if (null == stream)
@@ -765,12 +765,12 @@ final class DDC {
      *
      * @return a Java object of the desired type.
      */
-    static final Object convertTemporalToObject(JDBCType jdbcType,
-            SSType ssType,
-            Calendar timeZoneCalendar,
-            int daysSinceBaseDate,
-            long ticksSinceMidnight,
-            int fractionalSecondsScale) {
+    static Object convertTemporalToObject(JDBCType jdbcType,
+                                          SSType ssType,
+                                          Calendar timeZoneCalendar,
+                                          int daysSinceBaseDate,
+                                          long ticksSinceMidnight,
+                                          int fractionalSecondsScale) {
         // Determine the local time zone to associate with the value. Use the default VM
         // time zone if no time zone is otherwise specified.
         TimeZone localTimeZone = (null != timeZoneCalendar) ? timeZoneCalendar.getTimeZone() : TimeZone.getDefault();
@@ -1116,7 +1116,7 @@ final class DDC {
 
     // Returns true if input bigDecimalValue exceeds allowable
     // TDS wire format precision or scale for DECIMAL TDS token.
-    static final boolean exceedsMaxRPCDecimalPrecisionOrScale(BigDecimal bigDecimalValue) {
+    static boolean exceedsMaxRPCDecimalPrecisionOrScale(BigDecimal bigDecimalValue) {
         if (null == bigDecimalValue)
             return false;
 
@@ -1380,7 +1380,7 @@ final class InputStreamGetterArgs {
 
     static final InputStreamGetterArgs defaultArgs = new InputStreamGetterArgs(StreamType.NONE, false, false, "");
 
-    static final InputStreamGetterArgs getDefaultArgs() {
+    static InputStreamGetterArgs getDefaultArgs() {
         return defaultArgs;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
@@ -393,8 +393,8 @@ enum SSType
                 conversionMap.get(conversion.from).addAll(conversion.to);
         }
 
-        static final boolean converts(SSType fromSSType,
-                JDBCType toJDBCType) {
+        static boolean converts(SSType fromSSType,
+                                JDBCType toJDBCType) {
             return conversionMap.get(fromSSType.category).contains(toJDBCType.category);
         }
     }
@@ -1640,8 +1640,8 @@ enum JDBCType
 
 final class DataTypes {
     // ResultSet & CallableStatement getXXX conversions (SSType --> JDBCType)
-    static final void throwConversionError(String fromType,
-            String toType) throws SQLServerException {
+    static void throwConversionError(String fromType,
+                                     String toType) throws SQLServerException {
         MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_unsupportedConversionFromTo"));
         Object[] msgArgs = {fromType, toType};
         SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
@@ -1703,10 +1703,10 @@ final class DataTypes {
     static final int UNKNOWN_STREAM_LENGTH = -1;
 
     // Utility methods to check a reported length against the maximums allowed
-    static final long getCheckedLength(SQLServerConnection con,
-            JDBCType jdbcType,
-            long length,
-            boolean allowUnknown) throws SQLServerException {
+    static long getCheckedLength(SQLServerConnection con,
+                                 JDBCType jdbcType,
+                                 long length,
+                                 boolean allowUnknown) throws SQLServerException {
         long maxLength;
 
         switch (jdbcType) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -138,7 +138,7 @@ final class TDS {
     // Sql_variant length
     static final int SQL_VARIANT_LENGTH = 8009;
 
-    static final String getTokenName(int tdsTokenType) {
+    static String getTokenName(int tdsTokenType) {
         switch (tdsTokenType) {
             case TDS_RET_STAT:
                 return "TDS_RET_STAT (0x79)";
@@ -348,7 +348,7 @@ final class TDS {
     static final byte ENCRYPT_REQ = 0x03;
     static final byte ENCRYPT_INVALID = (byte) 0xFF;
 
-    static final String getEncryptionLevel(int level) {
+    static String getEncryptionLevel(int level) {
         switch (level) {
             case ENCRYPT_OFF:
                 return "OFF";

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
@@ -40,7 +40,7 @@ class PLPInputStream extends BaseInputStream {
     /**
      * Non-destructive method for checking whether a PLP value at the current TDSReader location is null.
      */
-    final static boolean isNull(TDSReader tdsReader) throws SQLServerException {
+    static boolean isNull(TDSReader tdsReader) throws SQLServerException {
         TDSReaderMark mark = tdsReader.mark();
         //Temporary stream cannot get closes, since it closes the main stream. 
         try {
@@ -64,13 +64,13 @@ class PLPInputStream extends BaseInputStream {
      * @throws SQLServerException
      *             when an error occurs
      */
-    final static PLPInputStream makeTempStream(TDSReader tdsReader,
+    static PLPInputStream makeTempStream(TDSReader tdsReader,
             boolean discardValue,
             ServerDTVImpl dtv) throws SQLServerException {
         return makeStream(tdsReader, discardValue, discardValue, dtv);
     }
 
-    final static PLPInputStream makeStream(TDSReader tdsReader,
+    static PLPInputStream makeStream(TDSReader tdsReader,
             InputStreamGetterArgs getterArgs,
             ServerDTVImpl dtv) throws SQLServerException {
         PLPInputStream is = makeStream(tdsReader, getterArgs.isAdaptive, getterArgs.isStreaming, dtv);
@@ -423,7 +423,7 @@ final class PLPXMLInputStream extends PLPInputStream {
     private final static byte[] xmlBOM = {(byte) 0xFF, (byte) 0xFE};
     private final ByteArrayInputStream bomStream = new ByteArrayInputStream(xmlBOM);
 
-    final static PLPXMLInputStream makeXMLStream(TDSReader tdsReader,
+    static PLPXMLInputStream makeXMLStream(TDSReader tdsReader,
             InputStreamGetterArgs getterArgs,
             ServerDTVImpl dtv) throws SQLServerException {
         // Read total length of PLP stream.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
@@ -45,7 +45,7 @@ final class SQLCollation implements java.io.Serializable
     final boolean supportsAsciiConversion() { return encoding.supportsAsciiConversion(); }
     final boolean hasAsciiCompatibleSBCS() { return encoding.hasAsciiCompatibleSBCS(); }
 
-    static final int tdsLength() { return 5; } // Length of collation in TDS (in bytes)
+    static int tdsLength() { return 5; } // Length of collation in TDS (in bytes)
 
     /**
      * Returns the collation info

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -673,7 +673,7 @@ public final class SQLServerDriver implements java.sql.Driver {
         return properties;
     }
 
-    static final DriverPropertyInfo[] getPropertyInfoFromProperties(Properties props) {
+    static DriverPropertyInfo[] getPropertyInfoFromProperties(Properties props) {
         DriverPropertyInfo[] properties = new DriverPropertyInfo[DRIVER_PROPERTIES.length];
 
         for (int i = 0; i < DRIVER_PROPERTIES.length; i++)

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc41.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc41.java
@@ -19,13 +19,13 @@ final class DriverJDBCVersion {
     static final int major = 4;
     static final int minor = 1;
 
-    static final void checkSupportsJDBC42() {
+    static void checkSupportsJDBC42() {
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));
     }
 
     // Stub for the new overloaded method in BatchUpdateException in JDBC 4.2
-    static final void throwBatchUpdateException(SQLServerException lastError,
-            long[] updateCounts) {
+    static void throwBatchUpdateException(SQLServerException lastError,
+                                          long[] updateCounts) {
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));
     }
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java
@@ -22,11 +22,11 @@ final class DriverJDBCVersion {
     static final int major = 4;
     static final int minor = 2;
 
-    static final void checkSupportsJDBC42() {
+    static void checkSupportsJDBC42() {
     }
 
-    static final void throwBatchUpdateException(SQLServerException lastError,
-            long[] updateCounts) throws BatchUpdateException {
+    static void throwBatchUpdateException(SQLServerException lastError,
+                                          long[] updateCounts) throws BatchUpdateException {
         throw new BatchUpdateException(lastError.getMessage(), lastError.getSQLState(), lastError.getErrorCode(), updateCounts,
                 new Throwable(lastError.getMessage()));
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement42Helper.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement42Helper.java
@@ -18,10 +18,10 @@ import java.sql.SQLType;
  */
 class SQLServerPreparedStatement42Helper {
 
-    static final void setObject(SQLServerPreparedStatement ps,
-            int index,
-            Object obj,
-            SQLType jdbcType) throws SQLServerException {
+    static void setObject(SQLServerPreparedStatement ps,
+                          int index,
+                          Object obj,
+                          SQLType jdbcType) throws SQLServerException {
         DriverJDBCVersion.checkSupportsJDBC42();
 
         if (SQLServerStatement.loggerExternal.isLoggable(java.util.logging.Level.FINER))
@@ -33,11 +33,11 @@ class SQLServerPreparedStatement42Helper {
         SQLServerStatement.loggerExternal.exiting(ps.getClassNameLogging(), "setObject");
     }
 
-    static final void setObject(SQLServerPreparedStatement ps,
-            int parameterIndex,
-            Object x,
-            SQLType targetSqlType,
-            int scaleOrLength) throws SQLServerException {
+    static void setObject(SQLServerPreparedStatement ps,
+                          int parameterIndex,
+                          Object x,
+                          SQLType targetSqlType,
+                          int scaleOrLength) throws SQLServerException {
         DriverJDBCVersion.checkSupportsJDBC42();
 
         if (SQLServerStatement.loggerExternal.isLoggable(java.util.logging.Level.FINER))
@@ -50,12 +50,12 @@ class SQLServerPreparedStatement42Helper {
         SQLServerStatement.loggerExternal.exiting(ps.getClassNameLogging(), "setObject");
     }
 
-    static final void setObject(SQLServerPreparedStatement ps,
-            int parameterIndex,
-            Object x,
-            SQLType targetSqlType,
-            Integer precision,
-            Integer scale) throws SQLServerException {
+    static void setObject(SQLServerPreparedStatement ps,
+                          int parameterIndex,
+                          Object x,
+                          SQLType targetSqlType,
+                          Integer precision,
+                          Integer scale) throws SQLServerException {
         DriverJDBCVersion.checkSupportsJDBC42();
 
         if (SQLServerStatement.loggerExternal.isLoggable(java.util.logging.Level.FINER))
@@ -68,13 +68,13 @@ class SQLServerPreparedStatement42Helper {
         SQLServerStatement.loggerExternal.exiting(ps.getClassNameLogging(), "setObject");
     }
 
-    static final void setObject(SQLServerPreparedStatement ps,
-            int parameterIndex,
-            Object x,
-            SQLType targetSqlType,
-            Integer precision,
-            Integer scale,
-            boolean forceEncrypt) throws SQLServerException {
+    static void setObject(SQLServerPreparedStatement ps,
+                          int parameterIndex,
+                          Object x,
+                          SQLType targetSqlType,
+                          Integer precision,
+                          Integer scale,
+                          boolean forceEncrypt) throws SQLServerException {
         DriverJDBCVersion.checkSupportsJDBC42();
 
         if (SQLServerStatement.loggerExternal.isLoggable(java.util.logging.Level.FINER))

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -44,7 +44,7 @@ final class Util {
         return SYSTEM_JRE.startsWith("IBM");
     }
 
-    static final Boolean isCharType(int jdbcType) {
+    static Boolean isCharType(int jdbcType) {
         switch (jdbcType) {
             case java.sql.Types.CHAR:
             case java.sql.Types.NCHAR:
@@ -58,7 +58,7 @@ final class Util {
         }
     }
 
-    static final Boolean isCharType(SSType ssType) {
+    static Boolean isCharType(SSType ssType) {
         switch (ssType) {
             case CHAR:
             case NCHAR:
@@ -72,7 +72,7 @@ final class Util {
         }
     }
 
-    static final Boolean isBinaryType(SSType ssType) {
+    static Boolean isBinaryType(SSType ssType) {
         switch (ssType) {
             case BINARY:
             case VARBINARY:
@@ -84,7 +84,7 @@ final class Util {
         }
     }
 
-    static final Boolean isBinaryType(int jdbcType) {
+    static Boolean isBinaryType(int jdbcType) {
         switch (jdbcType) {
             case java.sql.Types.BINARY:
             case java.sql.Types.VARBINARY:
@@ -680,7 +680,7 @@ final class Util {
         return WSIDNotAvailable;
     }
 
-    static final byte[] asGuidByteArray(UUID aId) {
+    static byte[] asGuidByteArray(UUID aId) {
         long msb = aId.getMostSignificantBits();
         long lsb = aId.getLeastSignificantBits();
         byte[] buffer = new byte[16];
@@ -714,7 +714,7 @@ final class Util {
         return buffer;
     }
 
-    static final UUID readGUIDtoUUID(byte[] inputGUID) throws SQLServerException {
+    static UUID readGUIDtoUUID(byte[] inputGUID) throws SQLServerException {
         if (inputGUID.length != 16) {
             throw new SQLServerException("guid length must be 16", null);
         }
@@ -754,7 +754,7 @@ final class Util {
         return new UUID(msb, lsb);
     }
 
-    static final String readGUID(byte[] inputGUID) throws SQLServerException {
+    static String readGUID(byte[] inputGUID) throws SQLServerException {
         String guidTemplate = "NNNNNNNN-NNNN-NNNN-NNNN-NNNNNNNNNNNN";
         byte guid[] = inputGUID;
 


### PR DESCRIPTION
When a static method is overridden in a subclass it can still be accessed via the super class, making a final declaration not very necessary. Declaring a static method final does prevent subclasses from defining a static method with the same signature.