### PR TITLE
Try with resources implementation in JUnit FW - Part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
 before_script:
   - docker pull microsoft/mssql-server-linux:2017-latest
-  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=<YourStrong!Passw0rd>' -p 1433:1433 -d microsoft/mssql-server-linux
+  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=<YourStrong!Passw0rd>' -p 1433:1433 -d microsoft/mssql-server-linux:2017-latest
 
 script: 
   - docker ps -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pbuild42
 
 before_script:
-  - docker pull microsoft/mssql-server-linux
+  - docker pull microsoft/mssql-server-linux:2017-latest
   - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=<YourStrong!Passw0rd>' -p 1433:1433 -d microsoft/mssql-server-linux
 
 script: 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -96,8 +96,8 @@ public class AESetup extends AbstractTest {
         
         try(SQLServerConnection con = (SQLServerConnection) DriverManager.getConnection(AETestConenctionString);
         	SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
-	        dropCEK();
-	        dropCMK();
+	        dropCEK(stmt);
+	        dropCMK(stmt);
         }
         
         keyPath = Utils.getCurrentClassPath() + jksName;
@@ -126,8 +126,8 @@ public class AESetup extends AbstractTest {
     @AfterAll
     private static void dropAll() throws SQLServerException, SQLException {
         dropTables(stmt);
-        dropCEK();
-        dropCMK();
+        dropCEK(stmt);
+        dropCMK(stmt);
         Util.close(null, stmt, con);
     }
 
@@ -2062,7 +2062,7 @@ public class AESetup extends AbstractTest {
      * @throws SQLServerException
      * @throws SQLException
      */
-    private static void dropCEK() throws SQLServerException, SQLException {
+    private static void dropCEK(SQLServerStatement stmt) throws SQLServerException, SQLException {
         String cekSql = " if exists (SELECT name from sys.column_encryption_keys where name='" + cekName + "')" + " begin"
                 + " drop column encryption key " + cekName + " end";
         stmt.execute(cekSql);
@@ -2074,7 +2074,7 @@ public class AESetup extends AbstractTest {
      * @throws SQLServerException
      * @throws SQLException
      */
-    private static void dropCMK() throws SQLServerException, SQLException {
+    private static void dropCMK(SQLServerStatement stmt) throws SQLServerException, SQLException {
         String cekSql = " if exists (SELECT name from sys.column_master_keys where name='" + cmkName + "')" + " begin" + " drop column master key "
                 + cmkName + " end";
         stmt.execute(cekSql);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -80,8 +80,6 @@ public class AESetup extends AbstractTest {
     static SQLServerColumnEncryptionKeyStoreProvider storeProvider = null;
     static SQLServerStatementColumnEncryptionSetting stmtColEncSetting = null;
 
-    private static SQLServerPreparedStatement pstmt = null;
-
     /**
      * Create connection, statement and generate path of resource file
      * 
@@ -94,26 +92,28 @@ public class AESetup extends AbstractTest {
                 "Aborting test case as SQL Server version is not compatible with Always encrypted ");
 
         String AETestConenctionString = connectionString + ";sendTimeAsDateTime=false";
-
         readFromFile(javaKeyStoreInputFile, "Alias name");
-        con = (SQLServerConnection) DriverManager.getConnection(AETestConenctionString);
-        stmt = (SQLServerStatement) con.createStatement();
-        dropCEK();
-        dropCMK();
-        con.close();
-
+        
+        try(SQLServerConnection con = (SQLServerConnection) DriverManager.getConnection(AETestConenctionString);
+        	SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+	        dropCEK();
+	        dropCMK();
+        }
+        
         keyPath = Utils.getCurrentClassPath() + jksName;
         storeProvider = new SQLServerColumnEncryptionJavaKeyStoreProvider(keyPath, secretstrJks.toCharArray());
         stmtColEncSetting = SQLServerStatementColumnEncryptionSetting.Enabled;
+        
         Properties info = new Properties();
         info.setProperty("ColumnEncryptionSetting", "Enabled");
         info.setProperty("keyStoreAuthentication", "JavaKeyStorePassword");
         info.setProperty("keyStoreLocation", keyPath);
         info.setProperty("keyStoreSecret", secretstrJks);
+        
         con = (SQLServerConnection) DriverManager.getConnection(AETestConenctionString, info);
         stmt = (SQLServerStatement) con.createStatement();
         createCMK(keyStoreName, javaKeyAliases);
-        createCEK(storeProvider);
+	    createCEK(storeProvider);
     }
 
     /**
@@ -140,33 +140,26 @@ public class AESetup extends AbstractTest {
      */
     private static void readFromFile(String inputFile,
             String lookupValue) throws IOException {
-        BufferedReader buffer = null;
         filePath = Utils.getCurrentClassPath();
         try {
             File f = new File(filePath + inputFile);
             assumeTrue(f.exists(), "Aborting test case since no java key store and alias name exists!");
-            buffer = new BufferedReader(new FileReader(f));
-            String readLine = "";
-            String[] linecontents;
-
-            while ((readLine = buffer.readLine()) != null) {
-                if (readLine.trim().contains(lookupValue)) {
-                    linecontents = readLine.split(" ");
-                    javaKeyAliases = linecontents[2];
-                    break;
-                }
+            try(BufferedReader buffer = new BufferedReader(new FileReader(f))) {
+	            String readLine = "";
+	            String[] linecontents;
+	
+	            while ((readLine = buffer.readLine()) != null) {
+	                if (readLine.trim().contains(lookupValue)) {
+	                    linecontents = readLine.split(" ");
+	                    javaKeyAliases = linecontents[2];
+	                    break;
+	                }
+	            }
             }
-
         }
         catch (IOException e) {
             fail(e.toString());
         }
-        finally {
-            if (null != buffer) {
-                buffer.close();
-            }
-        }
-
     }
 
     /**
@@ -744,60 +737,60 @@ public class AESetup extends AbstractTest {
     protected static void populateBinaryNormalCase(LinkedList<byte[]> byteValues) throws SQLException {
         String sql = "insert into " + binaryTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // binary20
-        for (int i = 1; i <= 3; i++) {
-            if (null == byteValues) {
-                pstmt.setBytes(i, null);
-            }
-            else {
-                pstmt.setBytes(i, byteValues.get(0));
-            }
+	        // binary20
+	        for (int i = 1; i <= 3; i++) {
+	            if (null == byteValues) {
+	                pstmt.setBytes(i, null);
+	            }
+	            else {
+	                pstmt.setBytes(i, byteValues.get(0));
+	            }
+	        }
+	
+	        // varbinary50
+	        for (int i = 4; i <= 6; i++) {
+	            if (null == byteValues) {
+	                pstmt.setBytes(i, null);
+	            }
+	            else {
+	                pstmt.setBytes(i, byteValues.get(1));
+	            }
+	        }
+	
+	        // varbinary(max)
+	        for (int i = 7; i <= 9; i++) {
+	            if (null == byteValues) {
+	                pstmt.setBytes(i, null);
+	            }
+	            else {
+	                pstmt.setBytes(i, byteValues.get(2));
+	            }
+	        }
+	
+	        // binary(512)
+	        for (int i = 10; i <= 12; i++) {
+	            if (null == byteValues) {
+	                pstmt.setBytes(i, null);
+	            }
+	            else {
+	                pstmt.setBytes(i, byteValues.get(3));
+	            }
+	        }
+	
+	        // varbinary(8000)
+	        for (int i = 13; i <= 15; i++) {
+	            if (null == byteValues) {
+	                pstmt.setBytes(i, null);
+	            }
+	            else {
+	                pstmt.setBytes(i, byteValues.get(4));
+	            }
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varbinary50
-        for (int i = 4; i <= 6; i++) {
-            if (null == byteValues) {
-                pstmt.setBytes(i, null);
-            }
-            else {
-                pstmt.setBytes(i, byteValues.get(1));
-            }
-        }
-
-        // varbinary(max)
-        for (int i = 7; i <= 9; i++) {
-            if (null == byteValues) {
-                pstmt.setBytes(i, null);
-            }
-            else {
-                pstmt.setBytes(i, byteValues.get(2));
-            }
-        }
-
-        // binary(512)
-        for (int i = 10; i <= 12; i++) {
-            if (null == byteValues) {
-                pstmt.setBytes(i, null);
-            }
-            else {
-                pstmt.setBytes(i, byteValues.get(3));
-            }
-        }
-
-        // varbinary(8000)
-        for (int i = 13; i <= 15; i++) {
-            if (null == byteValues) {
-                pstmt.setBytes(i, null);
-            }
-            else {
-                pstmt.setBytes(i, byteValues.get(4));
-            }
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -809,60 +802,60 @@ public class AESetup extends AbstractTest {
     protected static void populateBinarySetObject(LinkedList<byte[]> byteValues) throws SQLException {
         String sql = "insert into " + binaryTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // binary(20)
-        for (int i = 1; i <= 3; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, java.sql.Types.BINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(0));
-            }
+	        // binary(20)
+	        for (int i = 1; i <= 3; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, java.sql.Types.BINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(0));
+	            }
+	        }
+	
+	        // varbinary(50)
+	        for (int i = 4; i <= 6; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, java.sql.Types.BINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(1));
+	            }
+	        }
+	
+	        // varbinary(max)
+	        for (int i = 7; i <= 9; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, java.sql.Types.BINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(2));
+	            }
+	        }
+	
+	        // binary(512)
+	        for (int i = 10; i <= 12; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, java.sql.Types.BINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(3));
+	            }
+	        }
+	
+	        // varbinary(8000)
+	        for (int i = 13; i <= 15; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, java.sql.Types.BINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(4));
+	            }
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varbinary(50)
-        for (int i = 4; i <= 6; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, java.sql.Types.BINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(1));
-            }
-        }
-
-        // varbinary(max)
-        for (int i = 7; i <= 9; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, java.sql.Types.BINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(2));
-            }
-        }
-
-        // binary(512)
-        for (int i = 10; i <= 12; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, java.sql.Types.BINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(3));
-            }
-        }
-
-        // varbinary(8000)
-        for (int i = 13; i <= 15; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, java.sql.Types.BINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(4));
-            }
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -874,60 +867,60 @@ public class AESetup extends AbstractTest {
     protected static void populateBinarySetObjectWithJDBCType(LinkedList<byte[]> byteValues) throws SQLException {
         String sql = "insert into " + binaryTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // binary(20)
-        for (int i = 1; i <= 3; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, JDBCType.BINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(0), JDBCType.BINARY);
-            }
+	        // binary(20)
+	        for (int i = 1; i <= 3; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, JDBCType.BINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(0), JDBCType.BINARY);
+	            }
+	        }
+	
+	        // varbinary(50)
+	        for (int i = 4; i <= 6; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, JDBCType.VARBINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(1), JDBCType.VARBINARY);
+	            }
+	        }
+	
+	        // varbinary(max)
+	        for (int i = 7; i <= 9; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, JDBCType.VARBINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(2), JDBCType.VARBINARY);
+	            }
+	        }
+	
+	        // binary(512)
+	        for (int i = 10; i <= 12; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, JDBCType.BINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(3), JDBCType.BINARY);
+	            }
+	        }
+	
+	        // varbinary(8000)
+	        for (int i = 13; i <= 15; i++) {
+	            if (null == byteValues) {
+	                pstmt.setObject(i, null, JDBCType.VARBINARY);
+	            }
+	            else {
+	                pstmt.setObject(i, byteValues.get(4), JDBCType.VARBINARY);
+	            }
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varbinary(50)
-        for (int i = 4; i <= 6; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, JDBCType.VARBINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(1), JDBCType.VARBINARY);
-            }
-        }
-
-        // varbinary(max)
-        for (int i = 7; i <= 9; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, JDBCType.VARBINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(2), JDBCType.VARBINARY);
-            }
-        }
-
-        // binary(512)
-        for (int i = 10; i <= 12; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, JDBCType.BINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(3), JDBCType.BINARY);
-            }
-        }
-
-        // varbinary(8000)
-        for (int i = 13; i <= 15; i++) {
-            if (null == byteValues) {
-                pstmt.setObject(i, null, JDBCType.VARBINARY);
-            }
-            else {
-                pstmt.setObject(i, byteValues.get(4), JDBCType.VARBINARY);
-            }
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -938,30 +931,30 @@ public class AESetup extends AbstractTest {
     protected static void populateBinaryNullCase() throws SQLException {
         String sql = "insert into " + binaryTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // binary
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setNull(i, java.sql.Types.BINARY);
+	        // binary
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setNull(i, java.sql.Types.BINARY);
+	        }
+	
+	        // varbinary, varbinary(max)
+	        for (int i = 4; i <= 9; i++) {
+	            pstmt.setNull(i, java.sql.Types.VARBINARY);
+	        }
+	
+	        // binary512
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setNull(i, java.sql.Types.BINARY);
+	        }
+	
+	        // varbinary(8000)
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setNull(i, java.sql.Types.VARBINARY);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varbinary, varbinary(max)
-        for (int i = 4; i <= 9; i++) {
-            pstmt.setNull(i, java.sql.Types.VARBINARY);
-        }
-
-        // binary512
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setNull(i, java.sql.Types.BINARY);
-        }
-
-        // varbinary(8000)
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setNull(i, java.sql.Types.VARBINARY);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -974,60 +967,60 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + charTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // char
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setString(i, charValues[0]);
+	        // char
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setString(i, charValues[0]);
+	        }
+	
+	        // varchar
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setString(i, charValues[1]);
+	        }
+	
+	        // varchar(max)
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setString(i, charValues[2]);
+	        }
+	
+	        // nchar
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setNString(i, charValues[3]);
+	        }
+	
+	        // nvarchar
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setNString(i, charValues[4]);
+	        }
+	
+	        // varchar(max)
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setNString(i, charValues[5]);
+	        }
+	
+	        // uniqueidentifier
+	        for (int i = 19; i <= 21; i++) {
+	            if (null == charValues[6]) {
+	                pstmt.setUniqueIdentifier(i, null);
+	            }
+	            else {
+	                pstmt.setUniqueIdentifier(i, uid);
+	            }
+	        }
+	
+	        // varchar8000
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setString(i, charValues[7]);
+	        }
+	
+	        // nvarchar4000
+	        for (int i = 25; i <= 27; i++) {
+	            pstmt.setNString(i, charValues[8]);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varchar
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setString(i, charValues[1]);
-        }
-
-        // varchar(max)
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setString(i, charValues[2]);
-        }
-
-        // nchar
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setNString(i, charValues[3]);
-        }
-
-        // nvarchar
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setNString(i, charValues[4]);
-        }
-
-        // varchar(max)
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setNString(i, charValues[5]);
-        }
-
-        // uniqueidentifier
-        for (int i = 19; i <= 21; i++) {
-            if (null == charValues[6]) {
-                pstmt.setUniqueIdentifier(i, null);
-            }
-            else {
-                pstmt.setUniqueIdentifier(i, uid);
-            }
-        }
-
-        // varchar8000
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setString(i, charValues[7]);
-        }
-
-        // nvarchar4000
-        for (int i = 25; i <= 27; i++) {
-            pstmt.setNString(i, charValues[8]);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1040,55 +1033,55 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + charTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // char
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, charValues[0]);
+	        // char
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, charValues[0]);
+	        }
+	
+	        // varchar
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, charValues[1]);
+	        }
+	
+	        // varchar(max)
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, charValues[2], java.sql.Types.LONGVARCHAR);
+	        }
+	
+	        // nchar
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, charValues[3], java.sql.Types.NCHAR);
+	        }
+	
+	        // nvarchar
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, charValues[4], java.sql.Types.NCHAR);
+	        }
+	
+	        // nvarchar(max)
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, charValues[5], java.sql.Types.LONGNVARCHAR);
+	        }
+	
+	        // uniqueidentifier
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setObject(i, charValues[6], microsoft.sql.Types.GUID);
+	        }
+	
+	        // varchar8000
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setObject(i, charValues[7]);
+	        }
+	
+	        // nvarchar4000
+	        for (int i = 25; i <= 27; i++) {
+	            pstmt.setObject(i, charValues[8], java.sql.Types.NCHAR);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varchar
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, charValues[1]);
-        }
-
-        // varchar(max)
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, charValues[2], java.sql.Types.LONGVARCHAR);
-        }
-
-        // nchar
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, charValues[3], java.sql.Types.NCHAR);
-        }
-
-        // nvarchar
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, charValues[4], java.sql.Types.NCHAR);
-        }
-
-        // nvarchar(max)
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, charValues[5], java.sql.Types.LONGNVARCHAR);
-        }
-
-        // uniqueidentifier
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setObject(i, charValues[6], microsoft.sql.Types.GUID);
-        }
-
-        // varchar8000
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setObject(i, charValues[7]);
-        }
-
-        // nvarchar4000
-        for (int i = 25; i <= 27; i++) {
-            pstmt.setObject(i, charValues[8], java.sql.Types.NCHAR);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1101,55 +1094,55 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + charTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // char
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, charValues[0], JDBCType.CHAR);
+	        // char
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, charValues[0], JDBCType.CHAR);
+	        }
+	
+	        // varchar
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, charValues[1], JDBCType.VARCHAR);
+	        }
+	
+	        // varchar(max)
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, charValues[2], JDBCType.LONGVARCHAR);
+	        }
+	
+	        // nchar
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, charValues[3], JDBCType.NCHAR);
+	        }
+	
+	        // nvarchar
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, charValues[4], JDBCType.NVARCHAR);
+	        }
+	
+	        // nvarchar(max)
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, charValues[5], JDBCType.LONGNVARCHAR);
+	        }
+	
+	        // uniqueidentifier
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setObject(i, charValues[6], microsoft.sql.Types.GUID);
+	        }
+	
+	        // varchar8000
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setObject(i, charValues[7], JDBCType.VARCHAR);
+	        }
+	
+	        // vnarchar4000
+	        for (int i = 25; i <= 27; i++) {
+	            pstmt.setObject(i, charValues[8], JDBCType.NVARCHAR);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varchar
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, charValues[1], JDBCType.VARCHAR);
-        }
-
-        // varchar(max)
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, charValues[2], JDBCType.LONGVARCHAR);
-        }
-
-        // nchar
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, charValues[3], JDBCType.NCHAR);
-        }
-
-        // nvarchar
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, charValues[4], JDBCType.NVARCHAR);
-        }
-
-        // nvarchar(max)
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, charValues[5], JDBCType.LONGNVARCHAR);
-        }
-
-        // uniqueidentifier
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setObject(i, charValues[6], microsoft.sql.Types.GUID);
-        }
-
-        // varchar8000
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setObject(i, charValues[7], JDBCType.VARCHAR);
-        }
-
-        // vnarchar4000
-        for (int i = 25; i <= 27; i++) {
-            pstmt.setObject(i, charValues[8], JDBCType.NVARCHAR);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1161,46 +1154,46 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + charTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // char
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setNull(i, java.sql.Types.CHAR);
+	        // char
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setNull(i, java.sql.Types.CHAR);
+	        }
+	
+	        // varchar, varchar(max)
+	        for (int i = 4; i <= 9; i++) {
+	            pstmt.setNull(i, java.sql.Types.VARCHAR);
+	        }
+	
+	        // nchar
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setNull(i, java.sql.Types.NCHAR);
+	        }
+	
+	        // nvarchar, varchar(max)
+	        for (int i = 13; i <= 18; i++) {
+	            pstmt.setNull(i, java.sql.Types.NVARCHAR);
+	        }
+	
+	        // uniqueidentifier
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setNull(i, microsoft.sql.Types.GUID);
+	
+	        }
+	
+	        // varchar8000
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setNull(i, java.sql.Types.VARCHAR);
+	        }
+	
+	        // nvarchar4000
+	        for (int i = 25; i <= 27; i++) {
+	            pstmt.setNull(i, java.sql.Types.NVARCHAR);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // varchar, varchar(max)
-        for (int i = 4; i <= 9; i++) {
-            pstmt.setNull(i, java.sql.Types.VARCHAR);
-        }
-
-        // nchar
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setNull(i, java.sql.Types.NCHAR);
-        }
-
-        // nvarchar, varchar(max)
-        for (int i = 13; i <= 18; i++) {
-            pstmt.setNull(i, java.sql.Types.NVARCHAR);
-        }
-
-        // uniqueidentifier
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setNull(i, microsoft.sql.Types.GUID);
-
-        }
-
-        // varchar8000
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setNull(i, java.sql.Types.VARCHAR);
-        }
-
-        // nvarchar4000
-        for (int i = 25; i <= 27; i++) {
-            pstmt.setNull(i, java.sql.Types.NVARCHAR);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1212,40 +1205,40 @@ public class AESetup extends AbstractTest {
     protected static void populateDateNormalCase(LinkedList<Object> dateValues) throws SQLException {
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // date
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setDate(i, (Date) dateValues.get(0));
+	        // date
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setDate(i, (Date) dateValues.get(0));
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setTimestamp(i, (Timestamp) dateValues.get(1));
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setDateTimeOffset(i, (DateTimeOffset) dateValues.get(2));
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setTime(i, (Time) dateValues.get(3));
+	        }
+	
+	        // datetime
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setDateTime(i, (Timestamp) dateValues.get(4));
+	        }
+	
+	        // smalldatetime
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setSmallDateTime(i, (Timestamp) dateValues.get(5));
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setTimestamp(i, (Timestamp) dateValues.get(1));
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setDateTimeOffset(i, (DateTimeOffset) dateValues.get(2));
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setTime(i, (Time) dateValues.get(3));
-        }
-
-        // datetime
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setDateTime(i, (Timestamp) dateValues.get(4));
-        }
-
-        // smalldatetime
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setSmallDateTime(i, (Timestamp) dateValues.get(5));
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1257,25 +1250,25 @@ public class AESetup extends AbstractTest {
     protected static void populateDateScaleNormalCase(LinkedList<Object> dateValues) throws SQLException {
         String sql = "insert into " + scaleDateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // datetime2(2)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setTimestamp(i, (Timestamp) dateValues.get(4), 2);
+	        // datetime2(2)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setTimestamp(i, (Timestamp) dateValues.get(4), 2);
+	        }
+	
+	        // time(2)
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setTime(i, (Time) dateValues.get(5), 2);
+	        }
+	
+	        // datetimeoffset(2)
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setDateTimeOffset(i, (DateTimeOffset) dateValues.get(6), 2);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // time(2)
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setTime(i, (Time) dateValues.get(5), 2);
-        }
-
-        // datetimeoffset(2)
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setDateTimeOffset(i, (DateTimeOffset) dateValues.get(6), 2);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1293,60 +1286,60 @@ public class AESetup extends AbstractTest {
 
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // date
-        for (int i = 1; i <= 3; i++) {
-            if (setter.equalsIgnoreCase("setwithJavaType"))
-                pstmt.setObject(i, (Date) dateValues.get(0), java.sql.Types.DATE);
-            else if (setter.equalsIgnoreCase("setwithJDBCType"))
-                pstmt.setObject(i, (Date) dateValues.get(0), JDBCType.DATE);
-            else
-                pstmt.setObject(i, (Date) dateValues.get(0));
+	        // date
+	        for (int i = 1; i <= 3; i++) {
+	            if (setter.equalsIgnoreCase("setwithJavaType"))
+	                pstmt.setObject(i, (Date) dateValues.get(0), java.sql.Types.DATE);
+	            else if (setter.equalsIgnoreCase("setwithJDBCType"))
+	                pstmt.setObject(i, (Date) dateValues.get(0), JDBCType.DATE);
+	            else
+	                pstmt.setObject(i, (Date) dateValues.get(0));
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            if (setter.equalsIgnoreCase("setwithJavaType"))
+	                pstmt.setObject(i, (Timestamp) dateValues.get(1), java.sql.Types.TIMESTAMP);
+	            else if (setter.equalsIgnoreCase("setwithJDBCType"))
+	                pstmt.setObject(i, (Timestamp) dateValues.get(1), JDBCType.TIMESTAMP);
+	            else
+	                pstmt.setObject(i, (Timestamp) dateValues.get(1));
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            if (setter.equalsIgnoreCase("setwithJavaType"))
+	                pstmt.setObject(i, (DateTimeOffset) dateValues.get(2), microsoft.sql.Types.DATETIMEOFFSET);
+	            else if (setter.equalsIgnoreCase("setwithJDBCType"))
+	                pstmt.setObject(i, (DateTimeOffset) dateValues.get(2), microsoft.sql.Types.DATETIMEOFFSET);
+	            else
+	                pstmt.setObject(i, (DateTimeOffset) dateValues.get(2));
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            if (setter.equalsIgnoreCase("setwithJavaType"))
+	                pstmt.setObject(i, (Time) dateValues.get(3), java.sql.Types.TIME);
+	            else if (setter.equalsIgnoreCase("setwithJDBCType"))
+	                pstmt.setObject(i, (Time) dateValues.get(3), JDBCType.TIME);
+	            else
+	                pstmt.setObject(i, (Time) dateValues.get(3));
+	        }
+	
+	        // datetime
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, (Timestamp) dateValues.get(4), microsoft.sql.Types.DATETIME);
+	        }
+	
+	        // smalldatetime
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, (Timestamp) dateValues.get(5), microsoft.sql.Types.SMALLDATETIME);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            if (setter.equalsIgnoreCase("setwithJavaType"))
-                pstmt.setObject(i, (Timestamp) dateValues.get(1), java.sql.Types.TIMESTAMP);
-            else if (setter.equalsIgnoreCase("setwithJDBCType"))
-                pstmt.setObject(i, (Timestamp) dateValues.get(1), JDBCType.TIMESTAMP);
-            else
-                pstmt.setObject(i, (Timestamp) dateValues.get(1));
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            if (setter.equalsIgnoreCase("setwithJavaType"))
-                pstmt.setObject(i, (DateTimeOffset) dateValues.get(2), microsoft.sql.Types.DATETIMEOFFSET);
-            else if (setter.equalsIgnoreCase("setwithJDBCType"))
-                pstmt.setObject(i, (DateTimeOffset) dateValues.get(2), microsoft.sql.Types.DATETIMEOFFSET);
-            else
-                pstmt.setObject(i, (DateTimeOffset) dateValues.get(2));
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            if (setter.equalsIgnoreCase("setwithJavaType"))
-                pstmt.setObject(i, (Time) dateValues.get(3), java.sql.Types.TIME);
-            else if (setter.equalsIgnoreCase("setwithJDBCType"))
-                pstmt.setObject(i, (Time) dateValues.get(3), JDBCType.TIME);
-            else
-                pstmt.setObject(i, (Time) dateValues.get(3));
-        }
-
-        // datetime
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, (Timestamp) dateValues.get(4), microsoft.sql.Types.DATETIME);
-        }
-
-        // smalldatetime
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, (Timestamp) dateValues.get(5), microsoft.sql.Types.SMALLDATETIME);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1357,40 +1350,40 @@ public class AESetup extends AbstractTest {
     protected void populateDateSetObjectNull() throws SQLException {
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // date
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DATE);
+	        // date
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DATE);
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP);
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET);
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.TIME);
+	        }
+	
+	        // datetime
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, null, microsoft.sql.Types.DATETIME);
+	        }
+	
+	        // smalldatetime
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, null, microsoft.sql.Types.SMALLDATETIME);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP);
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET);
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, null, java.sql.Types.TIME);
-        }
-
-        // datetime
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, null, microsoft.sql.Types.DATETIME);
-        }
-
-        // smalldatetime
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, null, microsoft.sql.Types.SMALLDATETIME);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1401,40 +1394,40 @@ public class AESetup extends AbstractTest {
     protected static void populateDateNullCase() throws SQLException {
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // date
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setNull(i, java.sql.Types.DATE);
+	        // date
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setNull(i, java.sql.Types.DATE);
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setNull(i, java.sql.Types.TIMESTAMP);
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setNull(i, microsoft.sql.Types.DATETIMEOFFSET);
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setNull(i, java.sql.Types.TIME);
+	        }
+	
+	        // datetime
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setNull(i, microsoft.sql.Types.DATETIME);
+	        }
+	
+	        // smalldatetime
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setNull(i, microsoft.sql.Types.SMALLDATETIME);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setNull(i, java.sql.Types.TIMESTAMP);
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setNull(i, microsoft.sql.Types.DATETIMEOFFSET);
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setNull(i, java.sql.Types.TIME);
-        }
-
-        // datetime
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setNull(i, microsoft.sql.Types.DATETIME);
-        }
-
-        // smalldatetime
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setNull(i, microsoft.sql.Types.SMALLDATETIME);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1447,101 +1440,101 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + numericTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            if (values[0].equalsIgnoreCase("true")) {
-                pstmt.setBoolean(i, true);
-            }
-            else {
-                pstmt.setBoolean(i, false);
-            }
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            if (values[0].equalsIgnoreCase("true")) {
+	                pstmt.setBoolean(i, true);
+	            }
+	            else {
+	                pstmt.setBoolean(i, false);
+	            }
+	        }
+	
+	        // tinyint
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setShort(i, Short.valueOf(values[1]));
+	        }
+	
+	        // smallint
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setShort(i, Short.valueOf(values[2]));
+	        }
+	
+	        // int
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setInt(i, Integer.valueOf(values[3]));
+	        }
+	
+	        // bigint
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setLong(i, Long.valueOf(values[4]));
+	        }
+	
+	        // float default
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setDouble(i, Double.valueOf(values[5]));
+	        }
+	
+	        // float(30)
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setDouble(i, Double.valueOf(values[6]));
+	        }
+	
+	        // real
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setFloat(i, Float.valueOf(values[7]));
+	        }
+	
+	        // decimal default
+	        for (int i = 25; i <= 27; i++) {
+	            if (values[8].equalsIgnoreCase("0"))
+	                pstmt.setBigDecimal(i, new BigDecimal(values[8]), 18, 0);
+	            else
+	                pstmt.setBigDecimal(i, new BigDecimal(values[8]));
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 28; i <= 30; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(values[9]), 10, 5);
+	        }
+	
+	        // numeric
+	        for (int i = 31; i <= 33; i++) {
+	            if (values[10].equalsIgnoreCase("0"))
+	                pstmt.setBigDecimal(i, new BigDecimal(values[10]), 18, 0);
+	            else
+	                pstmt.setBigDecimal(i, new BigDecimal(values[10]));
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 34; i <= 36; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(values[11]), 8, 2);
+	        }
+	
+	        // small money
+	        for (int i = 37; i <= 39; i++) {
+	            pstmt.setSmallMoney(i, new BigDecimal(values[12]));
+	        }
+	
+	        // money
+	        for (int i = 40; i <= 42; i++) {
+	            pstmt.setMoney(i, new BigDecimal(values[13]));
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 43; i <= 45; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(values[14]), 28, 4);
+	        }
+	
+	        // numeric(28,4)
+	        for (int i = 46; i <= 48; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(values[15]), 28, 4);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // tinyint
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setShort(i, Short.valueOf(values[1]));
-        }
-
-        // smallint
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setShort(i, Short.valueOf(values[2]));
-        }
-
-        // int
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setInt(i, Integer.valueOf(values[3]));
-        }
-
-        // bigint
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setLong(i, Long.valueOf(values[4]));
-        }
-
-        // float default
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setDouble(i, Double.valueOf(values[5]));
-        }
-
-        // float(30)
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setDouble(i, Double.valueOf(values[6]));
-        }
-
-        // real
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setFloat(i, Float.valueOf(values[7]));
-        }
-
-        // decimal default
-        for (int i = 25; i <= 27; i++) {
-            if (values[8].equalsIgnoreCase("0"))
-                pstmt.setBigDecimal(i, new BigDecimal(values[8]), 18, 0);
-            else
-                pstmt.setBigDecimal(i, new BigDecimal(values[8]));
-        }
-
-        // decimal(10,5)
-        for (int i = 28; i <= 30; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(values[9]), 10, 5);
-        }
-
-        // numeric
-        for (int i = 31; i <= 33; i++) {
-            if (values[10].equalsIgnoreCase("0"))
-                pstmt.setBigDecimal(i, new BigDecimal(values[10]), 18, 0);
-            else
-                pstmt.setBigDecimal(i, new BigDecimal(values[10]));
-        }
-
-        // numeric(8,2)
-        for (int i = 34; i <= 36; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(values[11]), 8, 2);
-        }
-
-        // small money
-        for (int i = 37; i <= 39; i++) {
-            pstmt.setSmallMoney(i, new BigDecimal(values[12]));
-        }
-
-        // money
-        for (int i = 40; i <= 42; i++) {
-            pstmt.setMoney(i, new BigDecimal(values[13]));
-        }
-
-        // decimal(28,4)
-        for (int i = 43; i <= 45; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(values[14]), 28, 4);
-        }
-
-        // numeric(28,4)
-        for (int i = 46; i <= 48; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(values[15]), 28, 4);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1554,101 +1547,101 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + numericTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            if (values[0].equalsIgnoreCase("true")) {
-                pstmt.setObject(i, true);
-            }
-            else {
-                pstmt.setObject(i, false);
-            }
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            if (values[0].equalsIgnoreCase("true")) {
+	                pstmt.setObject(i, true);
+	            }
+	            else {
+	                pstmt.setObject(i, false);
+	            }
+	        }
+	
+	        // tinyint
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, Short.valueOf(values[1]));
+	        }
+	
+	        // smallint
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, Short.valueOf(values[2]));
+	        }
+	
+	        // int
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, Integer.valueOf(values[3]));
+	        }
+	
+	        // bigint
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, Long.valueOf(values[4]));
+	        }
+	
+	        // float default
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, Double.valueOf(values[5]));
+	        }
+	
+	        // float(30)
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setObject(i, Double.valueOf(values[6]));
+	        }
+	
+	        // real
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setObject(i, Float.valueOf(values[7]));
+	        }
+	
+	        // decimal default
+	        for (int i = 25; i <= 27; i++) {
+	            if (RandomData.returnZero)
+	                pstmt.setObject(i, new BigDecimal(values[8]), java.sql.Types.DECIMAL, 18, 0);
+	            else
+	                pstmt.setObject(i, new BigDecimal(values[8]));
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 28; i <= 30; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[9]), java.sql.Types.DECIMAL, 10, 5);
+	        }
+	
+	        // numeric
+	        for (int i = 31; i <= 33; i++) {
+	            if (RandomData.returnZero)
+	                pstmt.setObject(i, new BigDecimal(values[10]), java.sql.Types.NUMERIC, 18, 0);
+	            else
+	                pstmt.setObject(i, new BigDecimal(values[10]));
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 34; i <= 36; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[11]), java.sql.Types.NUMERIC, 8, 2);
+	        }
+	
+	        // small money
+	        for (int i = 37; i <= 39; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[12]), microsoft.sql.Types.SMALLMONEY);
+	        }
+	
+	        // money
+	        for (int i = 40; i <= 42; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[13]), microsoft.sql.Types.MONEY);
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 43; i <= 45; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[14]), java.sql.Types.DECIMAL, 28, 4);
+	        }
+	
+	        // numeric
+	        for (int i = 46; i <= 48; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[15]), java.sql.Types.NUMERIC, 28, 4);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // tinyint
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, Short.valueOf(values[1]));
-        }
-
-        // smallint
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, Short.valueOf(values[2]));
-        }
-
-        // int
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, Integer.valueOf(values[3]));
-        }
-
-        // bigint
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, Long.valueOf(values[4]));
-        }
-
-        // float default
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, Double.valueOf(values[5]));
-        }
-
-        // float(30)
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setObject(i, Double.valueOf(values[6]));
-        }
-
-        // real
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setObject(i, Float.valueOf(values[7]));
-        }
-
-        // decimal default
-        for (int i = 25; i <= 27; i++) {
-            if (RandomData.returnZero)
-                pstmt.setObject(i, new BigDecimal(values[8]), java.sql.Types.DECIMAL, 18, 0);
-            else
-                pstmt.setObject(i, new BigDecimal(values[8]));
-        }
-
-        // decimal(10,5)
-        for (int i = 28; i <= 30; i++) {
-            pstmt.setObject(i, new BigDecimal(values[9]), java.sql.Types.DECIMAL, 10, 5);
-        }
-
-        // numeric
-        for (int i = 31; i <= 33; i++) {
-            if (RandomData.returnZero)
-                pstmt.setObject(i, new BigDecimal(values[10]), java.sql.Types.NUMERIC, 18, 0);
-            else
-                pstmt.setObject(i, new BigDecimal(values[10]));
-        }
-
-        // numeric(8,2)
-        for (int i = 34; i <= 36; i++) {
-            pstmt.setObject(i, new BigDecimal(values[11]), java.sql.Types.NUMERIC, 8, 2);
-        }
-
-        // small money
-        for (int i = 37; i <= 39; i++) {
-            pstmt.setObject(i, new BigDecimal(values[12]), microsoft.sql.Types.SMALLMONEY);
-        }
-
-        // money
-        for (int i = 40; i <= 42; i++) {
-            pstmt.setObject(i, new BigDecimal(values[13]), microsoft.sql.Types.MONEY);
-        }
-
-        // decimal(28,4)
-        for (int i = 43; i <= 45; i++) {
-            pstmt.setObject(i, new BigDecimal(values[14]), java.sql.Types.DECIMAL, 28, 4);
-        }
-
-        // numeric
-        for (int i = 46; i <= 48; i++) {
-            pstmt.setObject(i, new BigDecimal(values[15]), java.sql.Types.NUMERIC, 28, 4);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1661,101 +1654,101 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + numericTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            if (values[0].equalsIgnoreCase("true")) {
-                pstmt.setObject(i, true);
-            }
-            else {
-                pstmt.setObject(i, false);
-            }
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            if (values[0].equalsIgnoreCase("true")) {
+	                pstmt.setObject(i, true);
+	            }
+	            else {
+	                pstmt.setObject(i, false);
+	            }
+	        }
+	
+	        // tinyint
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, Short.valueOf(values[1]), JDBCType.TINYINT);
+	        }
+	
+	        // smallint
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, Short.valueOf(values[2]), JDBCType.SMALLINT);
+	        }
+	
+	        // int
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, Integer.valueOf(values[3]), JDBCType.INTEGER);
+	        }
+	
+	        // bigint
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, Long.valueOf(values[4]), JDBCType.BIGINT);
+	        }
+	
+	        // float default
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, Double.valueOf(values[5]), JDBCType.DOUBLE);
+	        }
+	
+	        // float(30)
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setObject(i, Double.valueOf(values[6]), JDBCType.DOUBLE);
+	        }
+	
+	        // real
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setObject(i, Float.valueOf(values[7]), JDBCType.REAL);
+	        }
+	
+	        // decimal default
+	        for (int i = 25; i <= 27; i++) {
+	            if (RandomData.returnZero)
+	                pstmt.setObject(i, new BigDecimal(values[8]), java.sql.Types.DECIMAL, 18, 0);
+	            else
+	                pstmt.setObject(i, new BigDecimal(values[8]));
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 28; i <= 30; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[9]), java.sql.Types.DECIMAL, 10, 5);
+	        }
+	
+	        // numeric
+	        for (int i = 31; i <= 33; i++) {
+	            if (RandomData.returnZero)
+	                pstmt.setObject(i, new BigDecimal(values[10]), java.sql.Types.NUMERIC, 18, 0);
+	            else
+	                pstmt.setObject(i, new BigDecimal(values[10]));
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 34; i <= 36; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[11]), java.sql.Types.NUMERIC, 8, 2);
+	        }
+	
+	        // small money
+	        for (int i = 37; i <= 39; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[12]), microsoft.sql.Types.SMALLMONEY);
+	        }
+	
+	        // money
+	        for (int i = 40; i <= 42; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[13]), microsoft.sql.Types.MONEY);
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 43; i <= 45; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[14]), java.sql.Types.DECIMAL, 28, 4);
+	        }
+	
+	        // numeric
+	        for (int i = 46; i <= 48; i++) {
+	            pstmt.setObject(i, new BigDecimal(values[15]), java.sql.Types.NUMERIC, 28, 4);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // tinyint
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, Short.valueOf(values[1]), JDBCType.TINYINT);
-        }
-
-        // smallint
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, Short.valueOf(values[2]), JDBCType.SMALLINT);
-        }
-
-        // int
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, Integer.valueOf(values[3]), JDBCType.INTEGER);
-        }
-
-        // bigint
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, Long.valueOf(values[4]), JDBCType.BIGINT);
-        }
-
-        // float default
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, Double.valueOf(values[5]), JDBCType.DOUBLE);
-        }
-
-        // float(30)
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setObject(i, Double.valueOf(values[6]), JDBCType.DOUBLE);
-        }
-
-        // real
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setObject(i, Float.valueOf(values[7]), JDBCType.REAL);
-        }
-
-        // decimal default
-        for (int i = 25; i <= 27; i++) {
-            if (RandomData.returnZero)
-                pstmt.setObject(i, new BigDecimal(values[8]), java.sql.Types.DECIMAL, 18, 0);
-            else
-                pstmt.setObject(i, new BigDecimal(values[8]));
-        }
-
-        // decimal(10,5)
-        for (int i = 28; i <= 30; i++) {
-            pstmt.setObject(i, new BigDecimal(values[9]), java.sql.Types.DECIMAL, 10, 5);
-        }
-
-        // numeric
-        for (int i = 31; i <= 33; i++) {
-            if (RandomData.returnZero)
-                pstmt.setObject(i, new BigDecimal(values[10]), java.sql.Types.NUMERIC, 18, 0);
-            else
-                pstmt.setObject(i, new BigDecimal(values[10]));
-        }
-
-        // numeric(8,2)
-        for (int i = 34; i <= 36; i++) {
-            pstmt.setObject(i, new BigDecimal(values[11]), java.sql.Types.NUMERIC, 8, 2);
-        }
-
-        // small money
-        for (int i = 37; i <= 39; i++) {
-            pstmt.setObject(i, new BigDecimal(values[12]), microsoft.sql.Types.SMALLMONEY);
-        }
-
-        // money
-        for (int i = 40; i <= 42; i++) {
-            pstmt.setObject(i, new BigDecimal(values[13]), microsoft.sql.Types.MONEY);
-        }
-
-        // decimal(28,4)
-        for (int i = 43; i <= 45; i++) {
-            pstmt.setObject(i, new BigDecimal(values[14]), java.sql.Types.DECIMAL, 28, 4);
-        }
-
-        // numeric
-        for (int i = 46; i <= 48; i++) {
-            pstmt.setObject(i, new BigDecimal(values[15]), java.sql.Types.NUMERIC, 28, 4);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1767,90 +1760,90 @@ public class AESetup extends AbstractTest {
         String sql = "insert into " + numericTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, null, java.sql.Types.BIT);
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.BIT);
+	        }
+	
+	        // tinyint
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.TINYINT);
+	        }
+	
+	        // smallint
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.SMALLINT);
+	        }
+	
+	        // int
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.INTEGER);
+	        }
+	
+	        // bigint
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.BIGINT);
+	        }
+	
+	        // float default
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DOUBLE);
+	        }
+	
+	        // float(30)
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DOUBLE);
+	        }
+	
+	        // real
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.REAL);
+	        }
+	
+	        // decimal default
+	        for (int i = 25; i <= 27; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DECIMAL);
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 28; i <= 30; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DECIMAL, 10, 5);
+	        }
+	
+	        // numeric
+	        for (int i = 31; i <= 33; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.NUMERIC);
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 34; i <= 36; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.NUMERIC, 8, 2);
+	        }
+	
+	        // small money
+	        for (int i = 37; i <= 39; i++) {
+	            pstmt.setObject(i, null, microsoft.sql.Types.SMALLMONEY);
+	        }
+	
+	        // money
+	        for (int i = 40; i <= 42; i++) {
+	            pstmt.setObject(i, null, microsoft.sql.Types.MONEY);
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 43; i <= 45; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DECIMAL, 28, 4);
+	        }
+	
+	        // numeric
+	        for (int i = 46; i <= 48; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.NUMERIC, 28, 4);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // tinyint
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, null, java.sql.Types.TINYINT);
-        }
-
-        // smallint
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, null, java.sql.Types.SMALLINT);
-        }
-
-        // int
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, null, java.sql.Types.INTEGER);
-        }
-
-        // bigint
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, null, java.sql.Types.BIGINT);
-        }
-
-        // float default
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DOUBLE);
-        }
-
-        // float(30)
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DOUBLE);
-        }
-
-        // real
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setObject(i, null, java.sql.Types.REAL);
-        }
-
-        // decimal default
-        for (int i = 25; i <= 27; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DECIMAL);
-        }
-
-        // decimal(10,5)
-        for (int i = 28; i <= 30; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DECIMAL, 10, 5);
-        }
-
-        // numeric
-        for (int i = 31; i <= 33; i++) {
-            pstmt.setObject(i, null, java.sql.Types.NUMERIC);
-        }
-
-        // numeric(8,2)
-        for (int i = 34; i <= 36; i++) {
-            pstmt.setObject(i, null, java.sql.Types.NUMERIC, 8, 2);
-        }
-
-        // small money
-        for (int i = 37; i <= 39; i++) {
-            pstmt.setObject(i, null, microsoft.sql.Types.SMALLMONEY);
-        }
-
-        // money
-        for (int i = 40; i <= 42; i++) {
-            pstmt.setObject(i, null, microsoft.sql.Types.MONEY);
-        }
-
-        // decimal(28,4)
-        for (int i = 43; i <= 45; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DECIMAL, 28, 4);
-        }
-
-        // numeric
-        for (int i = 46; i <= 48; i++) {
-            pstmt.setObject(i, null, java.sql.Types.NUMERIC, 28, 4);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1865,89 +1858,89 @@ public class AESetup extends AbstractTest {
 
                 + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setNull(i, java.sql.Types.BIT);
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setNull(i, java.sql.Types.BIT);
+	        }
+	
+	        // tinyint
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setNull(i, java.sql.Types.TINYINT);
+	        }
+	
+	        // smallint
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setNull(i, java.sql.Types.SMALLINT);
+	        }
+	
+	        // int
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setNull(i, java.sql.Types.INTEGER);
+	        }
+	
+	        // bigint
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setNull(i, java.sql.Types.BIGINT);
+	        }
+	
+	        // float default
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setNull(i, java.sql.Types.DOUBLE);
+	        }
+	
+	        // float(30)
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setNull(i, java.sql.Types.DOUBLE);
+	        }
+	
+	        // real
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setNull(i, java.sql.Types.REAL);
+	        }
+	
+	        // decimal default
+	        for (int i = 25; i <= 27; i++) {
+	            pstmt.setBigDecimal(i, null);
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 28; i <= 30; i++) {
+	            pstmt.setBigDecimal(i, null, 10, 5);
+	        }
+	
+	        // numeric
+	        for (int i = 31; i <= 33; i++) {
+	            pstmt.setBigDecimal(i, null);
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 34; i <= 36; i++) {
+	            pstmt.setBigDecimal(i, null, 8, 2);
+	        }
+	
+	        // small money
+	        for (int i = 37; i <= 39; i++) {
+	            pstmt.setSmallMoney(i, null);
+	        }
+	
+	        // money
+	        for (int i = 40; i <= 42; i++) {
+	            pstmt.setMoney(i, null);
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 43; i <= 45; i++) {
+	            pstmt.setBigDecimal(i, null, 28, 4);
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 46; i <= 48; i++) {
+	            pstmt.setBigDecimal(i, null, 28, 4);
+	        }
+	        pstmt.execute();
         }
-
-        // tinyint
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setNull(i, java.sql.Types.TINYINT);
-        }
-
-        // smallint
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setNull(i, java.sql.Types.SMALLINT);
-        }
-
-        // int
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setNull(i, java.sql.Types.INTEGER);
-        }
-
-        // bigint
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setNull(i, java.sql.Types.BIGINT);
-        }
-
-        // float default
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setNull(i, java.sql.Types.DOUBLE);
-        }
-
-        // float(30)
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setNull(i, java.sql.Types.DOUBLE);
-        }
-
-        // real
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setNull(i, java.sql.Types.REAL);
-        }
-
-        // decimal default
-        for (int i = 25; i <= 27; i++) {
-            pstmt.setBigDecimal(i, null);
-        }
-
-        // decimal(10,5)
-        for (int i = 28; i <= 30; i++) {
-            pstmt.setBigDecimal(i, null, 10, 5);
-        }
-
-        // numeric
-        for (int i = 31; i <= 33; i++) {
-            pstmt.setBigDecimal(i, null);
-        }
-
-        // numeric(8,2)
-        for (int i = 34; i <= 36; i++) {
-            pstmt.setBigDecimal(i, null, 8, 2);
-        }
-
-        // small money
-        for (int i = 37; i <= 39; i++) {
-            pstmt.setSmallMoney(i, null);
-        }
-
-        // money
-        for (int i = 40; i <= 42; i++) {
-            pstmt.setMoney(i, null);
-        }
-
-        // decimal(28,4)
-        for (int i = 43; i <= 45; i++) {
-            pstmt.setBigDecimal(i, null, 28, 4);
-        }
-
-        // decimal(28,4)
-        for (int i = 46; i <= 48; i++) {
-            pstmt.setBigDecimal(i, null, 28, 4);
-        }
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**
@@ -1962,105 +1955,105 @@ public class AESetup extends AbstractTest {
 
                 + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            if (numericValues[0].equalsIgnoreCase("true")) {
-                pstmt.setBoolean(i, true);
-            }
-            else {
-                pstmt.setBoolean(i, false);
-            }
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            if (numericValues[0].equalsIgnoreCase("true")) {
+	                pstmt.setBoolean(i, true);
+	            }
+	            else {
+	                pstmt.setBoolean(i, false);
+	            }
+	        }
+	
+	        // tinyint
+	        for (int i = 4; i <= 6; i++) {
+	            if (1 == Integer.valueOf(numericValues[1])) {
+	                pstmt.setBoolean(i, true);
+	            }
+	            else {
+	                pstmt.setBoolean(i, false);
+	            }
+	        }
+	
+	        // smallint
+	        for (int i = 7; i <= 9; i++) {
+	            if (numericValues[2].equalsIgnoreCase("255")) {
+	                pstmt.setByte(i, (byte) 255);
+	            }
+	            else {
+	                pstmt.setByte(i, Byte.valueOf(numericValues[2]));
+	            }
+	        }
+	
+	        // int
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setShort(i, Short.valueOf(numericValues[3]));
+	        }
+	
+	        // bigint
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setInt(i, Integer.valueOf(numericValues[4]));
+	        }
+	
+	        // float default
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setDouble(i, Double.valueOf(numericValues[5]));
+	        }
+	
+	        // float(30)
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setDouble(i, Double.valueOf(numericValues[6]));
+	        }
+	
+	        // real
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setFloat(i, Float.valueOf(numericValues[7]));
+	        }
+	
+	        // decimal default
+	        for (int i = 25; i <= 27; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[8]));
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 28; i <= 30; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[9]), 10, 5);
+	        }
+	
+	        // numeric
+	        for (int i = 31; i <= 33; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[10]));
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 34; i <= 36; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[11]), 8, 2);
+	        }
+	
+	        // small money
+	        for (int i = 37; i <= 39; i++) {
+	            pstmt.setSmallMoney(i, new BigDecimal(numericValues[12]));
+	        }
+	
+	        // money
+	        for (int i = 40; i <= 42; i++) {
+	            pstmt.setSmallMoney(i, new BigDecimal(numericValues[13]));
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 43; i <= 45; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[14]), 28, 4);
+	        }
+	
+	        // numeric
+	        for (int i = 46; i <= 48; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[15]), 28, 4);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // tinyint
-        for (int i = 4; i <= 6; i++) {
-            if (1 == Integer.valueOf(numericValues[1])) {
-                pstmt.setBoolean(i, true);
-            }
-            else {
-                pstmt.setBoolean(i, false);
-            }
-        }
-
-        // smallint
-        for (int i = 7; i <= 9; i++) {
-            if (numericValues[2].equalsIgnoreCase("255")) {
-                pstmt.setByte(i, (byte) 255);
-            }
-            else {
-                pstmt.setByte(i, Byte.valueOf(numericValues[2]));
-            }
-        }
-
-        // int
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setShort(i, Short.valueOf(numericValues[3]));
-        }
-
-        // bigint
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setInt(i, Integer.valueOf(numericValues[4]));
-        }
-
-        // float default
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setDouble(i, Double.valueOf(numericValues[5]));
-        }
-
-        // float(30)
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setDouble(i, Double.valueOf(numericValues[6]));
-        }
-
-        // real
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setFloat(i, Float.valueOf(numericValues[7]));
-        }
-
-        // decimal default
-        for (int i = 25; i <= 27; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[8]));
-        }
-
-        // decimal(10,5)
-        for (int i = 28; i <= 30; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[9]), 10, 5);
-        }
-
-        // numeric
-        for (int i = 31; i <= 33; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[10]));
-        }
-
-        // numeric(8,2)
-        for (int i = 34; i <= 36; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[11]), 8, 2);
-        }
-
-        // small money
-        for (int i = 37; i <= 39; i++) {
-            pstmt.setSmallMoney(i, new BigDecimal(numericValues[12]));
-        }
-
-        // money
-        for (int i = 40; i <= 42; i++) {
-            pstmt.setSmallMoney(i, new BigDecimal(numericValues[13]));
-        }
-
-        // decimal(28,4)
-        for (int i = 43; i <= 45; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[14]), 28, 4);
-        }
-
-        // numeric
-        for (int i = 46; i <= 48; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[15]), 28, 4);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -42,9 +42,6 @@ import microsoft.sql.DateTimeOffset;
 @RunWith(JUnitPlatform.class)
 public class CallableStatementTest extends AESetup {
 
-    private static SQLServerPreparedStatement pstmt = null;
-    private static SQLServerCallableStatement callableStatement = null;
-
     private static String multiStatementsProcedure = "multiStatementsProcedure";
 
     private static String inputProcedure = "inputProcedure";
@@ -470,118 +467,120 @@ public class CallableStatementTest extends AESetup {
     private static void populateTable4() throws SQLException {
         String sql = "insert into " + table4 + " values( " + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setInt(i, Integer.parseInt(numericValues[3]));
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setInt(i, Integer.parseInt(numericValues[3]));
+	        }
+	
+	        pstmt.execute();
         }
-
-        pstmt.execute();
     }
 
     private static void populateTable3() throws SQLException {
         String sql = "insert into " + table3 + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
                 + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // bit
-        for (int i = 1; i <= 3; i++) {
-            if (numericValues[0].equalsIgnoreCase("true")) {
-                pstmt.setBoolean(i, true);
-            }
-            else {
-                pstmt.setBoolean(i, false);
-            }
+	        // bit
+	        for (int i = 1; i <= 3; i++) {
+	            if (numericValues[0].equalsIgnoreCase("true")) {
+	                pstmt.setBoolean(i, true);
+	            }
+	            else {
+	                pstmt.setBoolean(i, false);
+	            }
+	        }
+	
+	        // tinyint
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setShort(i, Short.valueOf(numericValues[1]));
+	        }
+	
+	        // smallint
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setShort(i, Short.parseShort(numericValues[2]));
+	        }
+	
+	        // int
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setInt(i, Integer.parseInt(numericValues[3]));
+	        }
+	
+	        // bigint
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setLong(i, Long.parseLong(numericValues[4]));
+	        }
+	
+	        // float default
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setDouble(i, Double.parseDouble(numericValues[5]));
+	        }
+	
+	        // float(30)
+	        for (int i = 19; i <= 21; i++) {
+	            pstmt.setDouble(i, Double.parseDouble(numericValues[6]));
+	        }
+	
+	        // real
+	        for (int i = 22; i <= 24; i++) {
+	            pstmt.setFloat(i, Float.parseFloat(numericValues[7]));
+	        }
+	
+	        // decimal default
+	        for (int i = 25; i <= 27; i++) {
+	            if (numericValues[8].equalsIgnoreCase("0"))
+	                pstmt.setBigDecimal(i, new BigDecimal(numericValues[8]), 18, 0);
+	            else
+	                pstmt.setBigDecimal(i, new BigDecimal(numericValues[8]));
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 28; i <= 30; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[9]), 10, 5);
+	        }
+	
+	        // numeric
+	        for (int i = 31; i <= 33; i++) {
+	            if (numericValues[10].equalsIgnoreCase("0"))
+	                pstmt.setBigDecimal(i, new BigDecimal(numericValues[10]), 18, 0);
+	            else
+	                pstmt.setBigDecimal(i, new BigDecimal(numericValues[10]));
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 34; i <= 36; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[11]), 8, 2);
+	        }
+	
+	        // int2
+	        for (int i = 37; i <= 39; i++) {
+	            pstmt.setInt(i, Integer.parseInt(numericValues[3]));
+	        }
+	        // smallmoney
+	        for (int i = 40; i <= 42; i++) {
+	            pstmt.setSmallMoney(i, new BigDecimal(numericValues[12]));
+	        }
+	
+	        // money
+	        for (int i = 43; i <= 45; i++) {
+	            pstmt.setMoney(i, new BigDecimal(numericValues[13]));
+	        }
+	
+	        // decimal(28,4)
+	        for (int i = 46; i <= 48; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[14]), 28, 4);
+	        }
+	
+	        // numeric(28,4)
+	        for (int i = 49; i <= 51; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numericValues[15]), 28, 4);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // tinyint
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setShort(i, Short.valueOf(numericValues[1]));
-        }
-
-        // smallint
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setShort(i, Short.parseShort(numericValues[2]));
-        }
-
-        // int
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setInt(i, Integer.parseInt(numericValues[3]));
-        }
-
-        // bigint
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setLong(i, Long.parseLong(numericValues[4]));
-        }
-
-        // float default
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setDouble(i, Double.parseDouble(numericValues[5]));
-        }
-
-        // float(30)
-        for (int i = 19; i <= 21; i++) {
-            pstmt.setDouble(i, Double.parseDouble(numericValues[6]));
-        }
-
-        // real
-        for (int i = 22; i <= 24; i++) {
-            pstmt.setFloat(i, Float.parseFloat(numericValues[7]));
-        }
-
-        // decimal default
-        for (int i = 25; i <= 27; i++) {
-            if (numericValues[8].equalsIgnoreCase("0"))
-                pstmt.setBigDecimal(i, new BigDecimal(numericValues[8]), 18, 0);
-            else
-                pstmt.setBigDecimal(i, new BigDecimal(numericValues[8]));
-        }
-
-        // decimal(10,5)
-        for (int i = 28; i <= 30; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[9]), 10, 5);
-        }
-
-        // numeric
-        for (int i = 31; i <= 33; i++) {
-            if (numericValues[10].equalsIgnoreCase("0"))
-                pstmt.setBigDecimal(i, new BigDecimal(numericValues[10]), 18, 0);
-            else
-                pstmt.setBigDecimal(i, new BigDecimal(numericValues[10]));
-        }
-
-        // numeric(8,2)
-        for (int i = 34; i <= 36; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[11]), 8, 2);
-        }
-
-        // int2
-        for (int i = 37; i <= 39; i++) {
-            pstmt.setInt(i, Integer.parseInt(numericValues[3]));
-        }
-        // smallmoney
-        for (int i = 40; i <= 42; i++) {
-            pstmt.setSmallMoney(i, new BigDecimal(numericValues[12]));
-        }
-
-        // money
-        for (int i = 43; i <= 45; i++) {
-            pstmt.setMoney(i, new BigDecimal(numericValues[13]));
-        }
-
-        // decimal(28,4)
-        for (int i = 46; i <= 48; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[14]), 28, 4);
-        }
-
-        // numeric(28,4)
-        for (int i = 49; i <= 51; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numericValues[15]), 28, 4);
-        }
-
-        pstmt.execute();
     }
 
     private void createMultiInsertionSelection() throws SQLException {
@@ -600,43 +599,38 @@ public class CallableStatementTest extends AESetup {
 
         try {
             String sql = "{call " + multiStatementsProcedure + " (?,?,?,?,?,?)}";
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
-            ResultSet rs = null;
-
-            // char, varchar
-            for (int i = 1; i <= 3; i++) {
-                callableStatement.setString(i, charValues[0]);
-            }
-
-            for (int i = 4; i <= 6; i++) {
-                callableStatement.setString(i, charValues[1]);
-            }
-
-            boolean results = callableStatement.execute();
-
-            // skip update count which is given by insertion
-            while (false == results && (-1) != callableStatement.getUpdateCount()) {
-                results = callableStatement.getMoreResults();
-            }
-
-            while (results) {
-                rs = callableStatement.getResultSet();
-                int numberOfColumns = rs.getMetaData().getColumnCount();
-
-                while (rs.next()) {
-                    testGetString(rs, numberOfColumns);
-                }
-                rs.close();
-                results = callableStatement.getMoreResults();
+            try(SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
+	
+	            // char, varchar
+	            for (int i = 1; i <= 3; i++) {
+	                callableStatement.setString(i, charValues[0]);
+	            }
+	
+	            for (int i = 4; i <= 6; i++) {
+	                callableStatement.setString(i, charValues[1]);
+	            }
+	
+	            boolean results = callableStatement.execute();
+	
+	            // skip update count which is given by insertion
+	            while (false == results && (-1) != callableStatement.getUpdateCount()) {
+	                results = callableStatement.getMoreResults();
+	            }
+	
+	            while (results) {
+	                try(ResultSet rs = callableStatement.getResultSet()) {
+		                int numberOfColumns = rs.getMetaData().getColumnCount();
+		
+		                while (rs.next()) {
+		                    testGetString(rs, numberOfColumns);
+		                }
+	                }
+	                results = callableStatement.getMoreResults();
+	            }
             }
         }
         catch (SQLException e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -675,8 +669,7 @@ public class CallableStatementTest extends AESetup {
     private void testInputProcedure(String sql,
             String[] values) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.setInt(1, Integer.parseInt(values[3]));
             if (RandomData.returnZero)
@@ -703,18 +696,13 @@ public class CallableStatementTest extends AESetup {
             callableStatement.setBigDecimal(14, new BigDecimal(values[14]), 28, 4);
             callableStatement.setBigDecimal(15, new BigDecimal(values[15]), 28, 4);
 
-            SQLServerResultSet rs = (SQLServerResultSet) callableStatement.executeQuery();
-            rs.next();
-
-            assertEquals(rs.getString(1), values[3], "" + "Test for input parameter fails.\n");
+            try (SQLServerResultSet rs = (SQLServerResultSet) callableStatement.executeQuery()) {
+            	rs.next();
+            	assertEquals(rs.getString(1), values[3], "" + "Test for input parameter fails.\n");
+            }
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -735,8 +723,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testInputProcedure2(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.setString(1, charValues[1]);
             callableStatement.setUniqueIdentifier(2, charValues[6]);
@@ -747,25 +734,20 @@ public class CallableStatementTest extends AESetup {
             callableStatement.setString(7, charValues[7]);
             callableStatement.setNString(8, charValues[8]);
 
-            SQLServerResultSet rs = (SQLServerResultSet) callableStatement.executeQuery();
-            rs.next();
-
-            assertEquals(rs.getString(1).trim(), charValues[1], "Test for input parameter fails.\n");
-            assertEquals(rs.getUniqueIdentifier(2), charValues[6].toUpperCase(), "Test for input parameter fails.\n");
-            assertEquals(rs.getString(3).trim(), charValues[2], "Test for input parameter fails.\n");
-            assertEquals(rs.getString(4).trim(), charValues[3], "Test for input parameter fails.\n");
-            assertEquals(rs.getString(5).trim(), charValues[4], "Test for input parameter fails.\n");
-            assertEquals(rs.getString(6).trim(), charValues[5], "Test for input parameter fails.\n");
-            assertEquals(rs.getString(7).trim(), charValues[7], "Test for input parameter fails.\n");
-            assertEquals(rs.getString(8).trim(), charValues[8], "Test for input parameter fails.\n");
+            try (SQLServerResultSet rs = (SQLServerResultSet) callableStatement.executeQuery()) {
+	            rs.next();
+	            assertEquals(rs.getString(1).trim(), charValues[1], "Test for input parameter fails.\n");
+	            assertEquals(rs.getUniqueIdentifier(2), charValues[6].toUpperCase(), "Test for input parameter fails.\n");
+	            assertEquals(rs.getString(3).trim(), charValues[2], "Test for input parameter fails.\n");
+	            assertEquals(rs.getString(4).trim(), charValues[3], "Test for input parameter fails.\n");
+	            assertEquals(rs.getString(5).trim(), charValues[4], "Test for input parameter fails.\n");
+	            assertEquals(rs.getString(6).trim(), charValues[5], "Test for input parameter fails.\n");
+	            assertEquals(rs.getString(7).trim(), charValues[7], "Test for input parameter fails.\n");
+	            assertEquals(rs.getString(8).trim(), charValues[8], "Test for input parameter fails.\n");
+            }
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -782,8 +764,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testOutputProcedure3RandomOrder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.INTEGER);
@@ -808,17 +789,11 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testOutputProcedure3Inorder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.INTEGER);
@@ -833,18 +808,12 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
     private void testOutputProcedure3ReverseOrder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.INTEGER);
@@ -859,11 +828,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -885,8 +849,7 @@ public class CallableStatementTest extends AESetup {
     private void testOutputProcedure2RandomOrder(String sql,
             String[] values) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.INTEGER);
@@ -934,18 +897,12 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testOutputProcedure2Inorder(String sql,
             String[] values) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.INTEGER);
@@ -992,19 +949,13 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
     private void testOutputProcedure2ReverseOrder(String sql,
             String[] values) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.INTEGER);
@@ -1052,11 +1003,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -1076,8 +1022,7 @@ public class CallableStatementTest extends AESetup {
     private void testOutputProcedureRandomOrder(String sql,
             String[] values) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.DOUBLE);
@@ -1121,18 +1066,12 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testOutputProcedureInorder(String sql,
             String[] values) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.DOUBLE);
@@ -1168,19 +1107,13 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
     private void testOutputProcedureReverseOrder(String sql,
             String[] values) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.DOUBLE);
@@ -1215,11 +1148,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -1236,8 +1164,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testInOutProcedure(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.setInt(1, Integer.parseInt(numericValues[3]));
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
@@ -1249,11 +1176,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -1271,8 +1193,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testMixedProcedure(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.setInt(2, Integer.parseInt(numericValues[3]));
@@ -1296,11 +1217,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void createMixedProcedure2() throws SQLException {
@@ -1317,8 +1233,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testMixedProcedure2RandomOrder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.FLOAT);
@@ -1348,17 +1263,11 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testMixedProcedure2Inorder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.FLOAT);
@@ -1375,11 +1284,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void createMixedProcedure3() throws SQLException {
@@ -1395,8 +1299,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testMixedProcedure3RandomOrder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.BIGINT);
             callableStatement.registerOutParameter(2, java.sql.Types.FLOAT);
@@ -1426,17 +1329,11 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testMixedProcedure3Inorder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.BIGINT);
             callableStatement.registerOutParameter(2, java.sql.Types.FLOAT);
@@ -1452,18 +1349,12 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
     private void testMixedProcedure3ReverseOrder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.BIGINT);
             callableStatement.registerOutParameter(2, java.sql.Types.FLOAT);
@@ -1479,11 +1370,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -1503,8 +1389,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testMixedProcedureNumericPrcisionScaleInorder(String sql) throws SQLException {
 
-        try {
-            SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.DECIMAL, 18, 0);
             callableStatement.registerOutParameter(2, java.sql.Types.DECIMAL, 10, 5);
@@ -1530,17 +1415,11 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testMixedProcedureNumericPrcisionScaleParameterName(String sql) throws SQLException {
 
-        try {
-            SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter("p1", java.sql.Types.DECIMAL, 18, 0);
             callableStatement.registerOutParameter("p2", java.sql.Types.DECIMAL, 10, 5);
@@ -1566,11 +1445,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void createOutputProcedureChar() throws SQLException {
@@ -1589,7 +1463,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testOutputProcedureCharInorder(String sql) throws SQLException {
 
-        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);) {
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
             callableStatement.registerOutParameter(1, java.sql.Types.CHAR, 20, 0);
             callableStatement.registerOutParameter(2, java.sql.Types.VARCHAR, 50, 0);
             callableStatement.registerOutParameter(3, java.sql.Types.NCHAR, 30, 0);
@@ -1632,16 +1506,11 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testOutputProcedureCharInorderObject(String sql) throws SQLException {
 
-        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);) {
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
             callableStatement.registerOutParameter(1, java.sql.Types.CHAR, 20, 0);
             callableStatement.registerOutParameter(2, java.sql.Types.VARCHAR, 50, 0);
             callableStatement.registerOutParameter(3, java.sql.Types.NCHAR, 30, 0);
@@ -1686,11 +1555,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -1787,11 +1651,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -2009,11 +1868,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private Object createValue(Class coercion,
@@ -2037,7 +1891,6 @@ public class CallableStatementTest extends AESetup {
                 return new BigDecimal(numericValues[index]);
         }
         catch (java.lang.NumberFormatException e) {
-            return null;
         }
         return null;
     }
@@ -2156,11 +2009,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testOutputProcedureBinaryInorderObject(String sql) throws SQLException {
@@ -2199,11 +2047,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testOutputProcedureBinaryInorderString(String sql) throws SQLException {
@@ -2217,37 +2060,30 @@ public class CallableStatementTest extends AESetup {
             callableStatement.execute();
 
             int index = 1;
-            try {
-                for (int i = 0; i < byteValues.size(); i++) {
-                    String stringValue1 = ("" + callableStatement.getString(index)).trim();
+            for (int i = 0; i < byteValues.size(); i++) {
+                String stringValue1 = ("" + callableStatement.getString(index)).trim();
 
-                    StringBuffer expected = new StringBuffer();
-                    String expectedStr = null;
+                StringBuffer expected = new StringBuffer();
+                String expectedStr = null;
 
-                    if (null != byteValues.get(i)) {
-                        for (byte b : byteValues.get(i)) {
-                            expected.append(String.format("%02X", b));
-                        }
-                        expectedStr = "" + expected.toString();
+                if (null != byteValues.get(i)) {
+                    for (byte b : byteValues.get(i)) {
+                        expected.append(String.format("%02X", b));
                     }
-                    else {
-                        expectedStr = "null";
-                    }
-                    try {
-                        assertEquals(stringValue1.startsWith(expectedStr), true,
-                                "\nDecryption failed with getString(): " + stringValue1 + ".\nExpected Value: " + expectedStr);
-                    }
-                    catch (Exception e) {
-                        fail(e.toString());
-                    }
-                    finally {
-                        index++;
-                    }
+                    expectedStr = "" + expected.toString();
                 }
-            }
-            finally {
-                if (null != callableStatement) {
-                    callableStatement.close();
+                else {
+                    expectedStr = "null";
+                }
+                try {
+                    assertEquals(stringValue1.startsWith(expectedStr), true,
+                            "\nDecryption failed with getString(): " + stringValue1 + ".\nExpected Value: " + expectedStr);
+                }
+                catch (Exception e) {
+                    fail(e.toString());
+                }
+                finally {
+                    index++;
                 }
             }
         }
@@ -2419,7 +2255,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testOutputProcedureDateInorder(String sql) throws SQLException {
 
-        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);) {
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
             callableStatement.registerOutParameter(1, java.sql.Types.DATE);
             callableStatement.registerOutParameter(2, java.sql.Types.DATE);
             callableStatement.registerOutParameter(3, java.sql.Types.TIMESTAMP);
@@ -2459,16 +2295,11 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testOutputProcedureDateInorderObject(String sql) throws SQLException {
 
-        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);) {
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
             callableStatement.registerOutParameter(1, java.sql.Types.DATE);
             callableStatement.registerOutParameter(2, java.sql.Types.DATE);
             callableStatement.registerOutParameter(3, java.sql.Types.TIMESTAMP);
@@ -2508,11 +2339,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void createOutputProcedureBatch() throws SQLException {
@@ -2531,8 +2357,7 @@ public class CallableStatementTest extends AESetup {
 
     private void testOutputProcedureBatchInorder(String sql) throws SQLException {
 
-        try {
-            callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting);
+        try (SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) Util.getCallableStmt(con, sql, stmtColEncSetting)) {
 
             callableStatement.registerOutParameter(1, java.sql.Types.INTEGER);
             callableStatement.registerOutParameter(2, java.sql.Types.DOUBLE);
@@ -2554,11 +2379,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 
@@ -2614,11 +2434,6 @@ public class CallableStatementTest extends AESetup {
         catch (Exception e) {
             fail(e.toString());
         }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
-        }
     }
 
     private void testMixedProcedureDateScaleWithParameterName(String sql) throws SQLException {
@@ -2644,11 +2459,6 @@ public class CallableStatementTest extends AESetup {
         }
         catch (Exception e) {
             fail(e.toString());
-        }
-        finally {
-            if (null != callableStatement) {
-                callableStatement.close();
-            }
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
@@ -512,68 +512,46 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
     private void testChar(SQLServerStatement stmt,
             String[] values) throws SQLException {
         String sql = "select * from " + charTable;
-        SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
-        ResultSet rs = null;
-        if (stmt == null) {
-            rs = pstmt.executeQuery();
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
+	        try(ResultSet rs = (stmt == null) ? pstmt.executeQuery() : stmt.executeQuery(sql)) {
+		        int numberOfColumns = rs.getMetaData().getColumnCount();
+		        while (rs.next()) {
+		            testGetString(rs, numberOfColumns, values);
+		            testGetObject(rs, numberOfColumns, values);
+		        }
+	        }
         }
-        else {
-            rs = stmt.executeQuery(sql);
-        }
-        int numberOfColumns = rs.getMetaData().getColumnCount();
-
-        while (rs.next()) {
-            testGetString(rs, numberOfColumns, values);
-            testGetObject(rs, numberOfColumns, values);
-        }
-
-        Util.close(rs, pstmt, null);
     }
 
     private void testBinary(SQLServerStatement stmt,
             LinkedList<byte[]> values) throws SQLException {
         String sql = "select * from " + binaryTable;
-        SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
-        ResultSet rs = null;
-        if (stmt == null) {
-            rs = pstmt.executeQuery();
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
+	        try(ResultSet rs = (stmt == null) ? pstmt.executeQuery() : stmt.executeQuery(sql)) {
+		        int numberOfColumns = rs.getMetaData().getColumnCount();
+		        while (rs.next()) {
+		            testGetStringForBinary(rs, numberOfColumns, values);
+		            testGetBytes(rs, numberOfColumns, values);
+		            testGetObjectForBinary(rs, numberOfColumns, values);
+		        }
+	        }
         }
-        else {
-            rs = stmt.executeQuery(sql);
-        }
-        int numberOfColumns = rs.getMetaData().getColumnCount();
-
-        while (rs.next()) {
-            testGetStringForBinary(rs, numberOfColumns, values);
-            testGetBytes(rs, numberOfColumns, values);
-            testGetObjectForBinary(rs, numberOfColumns, values);
-        }
-
-        Util.close(rs, pstmt, null);
     }
 
     private void testDate(SQLServerStatement stmt,
             LinkedList<Object> values1) throws SQLException {
-
         String sql = "select * from " + dateTable;
-        SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
-        ResultSet rs = null;
-        if (stmt == null) {
-            rs = pstmt.executeQuery();
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
+	        try(ResultSet rs = (stmt == null) ? pstmt.executeQuery() : stmt.executeQuery(sql)) {
+		        int numberOfColumns = rs.getMetaData().getColumnCount();
+		        while (rs.next()) {
+		            // testGetStringForDate(rs, numberOfColumns, values1); //TODO: Disabling, since getString throws verification error for zero temporal
+		            // types
+		            testGetObjectForTemporal(rs, numberOfColumns, values1);
+		            testGetDate(rs, numberOfColumns, values1);
+		        }
+	        }
         }
-        else {
-            rs = stmt.executeQuery(sql);
-        }
-        int numberOfColumns = rs.getMetaData().getColumnCount();
-
-        while (rs.next()) {
-            // testGetStringForDate(rs, numberOfColumns, values1); //TODO: Disabling, since getString throws verification error for zero temporal
-            // types
-            testGetObjectForTemporal(rs, numberOfColumns, values1);
-            testGetDate(rs, numberOfColumns, values1);
-        }
-
-        Util.close(rs, pstmt, null);
     }
 
     private void testGetObject(ResultSet rs,
@@ -948,29 +926,22 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
             String[] numericValues,
             boolean isNull) throws SQLException {
         String sql = "select * from " + numericTable;
-        SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
-        SQLServerResultSet rs = null;
-        if (stmt == null) {
-            rs = (SQLServerResultSet) pstmt.executeQuery();
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
+        	try(SQLServerResultSet rs = (stmt == null) ? (SQLServerResultSet) pstmt.executeQuery() : (SQLServerResultSet) stmt.executeQuery(sql)) {
+		        int numberOfColumns = rs.getMetaData().getColumnCount();
+		        while (rs.next()) {
+		            testGetString(rs, numberOfColumns, numericValues);
+		            testGetObject(rs, numberOfColumns, numericValues);
+		            testGetBigDecimal(rs, numberOfColumns, numericValues);
+		            if (!isNull)
+		                testWithSpecifiedtype(rs, numberOfColumns, numericValues);
+		            else {
+		                String[] nullNumericValues = {"false", "0", "0", "0", "0", "0.0", "0.0", "0.0", null, null, null, null, null, null, null, null};
+		                testWithSpecifiedtype(rs, numberOfColumns, nullNumericValues);
+		            }
+		        }
+        	}
         }
-        else {
-            rs = (SQLServerResultSet) stmt.executeQuery(sql);
-        }
-        int numberOfColumns = rs.getMetaData().getColumnCount();
-
-        while (rs.next()) {
-            testGetString(rs, numberOfColumns, numericValues);
-            testGetObject(rs, numberOfColumns, numericValues);
-            testGetBigDecimal(rs, numberOfColumns, numericValues);
-            if (!isNull)
-                testWithSpecifiedtype(rs, numberOfColumns, numericValues);
-            else {
-                String[] nullNumericValues = {"false", "0", "0", "0", "0", "0.0", "0.0", "0.0", null, null, null, null, null, null, null, null};
-                testWithSpecifiedtype(rs, numberOfColumns, nullNumericValues);
-            }
-        }
-
-        Util.close(rs, pstmt, null);
     }
 
     private void testWithSpecifiedtype(SQLServerResultSet rs,

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -155,38 +155,32 @@ public class PrecisionScaleTest extends AESetup {
 
     private void testNumeric(String[] numeric) throws SQLException {
 
-        ResultSet rs = stmt.executeQuery("select * from " + numericTable);
-        int numberOfColumns = rs.getMetaData().getColumnCount();
-
-        ArrayList<Integer> skipMax = new ArrayList<>();
-
-        while (rs.next()) {
-            testGetString(rs, numberOfColumns, skipMax, numeric);
-            testGetBigDecimal(rs, numberOfColumns, numeric);
-            testGetObject(rs, numberOfColumns, skipMax, numeric);
-        }
-
-        if (null != rs) {
-            rs.close();
+        try(ResultSet rs = stmt.executeQuery("select * from " + numericTable)) {
+	        int numberOfColumns = rs.getMetaData().getColumnCount();
+	
+	        ArrayList<Integer> skipMax = new ArrayList<>();
+	
+	        while (rs.next()) {
+	            testGetString(rs, numberOfColumns, skipMax, numeric);
+	            testGetBigDecimal(rs, numberOfColumns, numeric);
+	            testGetObject(rs, numberOfColumns, skipMax, numeric);
+	        }
         }
     }
 
     private void testDate(String[] dateNormalCase,
             String[] dateSetObject) throws Exception {
 
-        ResultSet rs = stmt.executeQuery("select * from " + dateTable);
-        int numberOfColumns = rs.getMetaData().getColumnCount();
-
-        ArrayList<Integer> skipMax = new ArrayList<>();
-
-        while (rs.next()) {
-            testGetString(rs, numberOfColumns, skipMax, dateNormalCase);
-            testGetObject(rs, numberOfColumns, skipMax, dateSetObject);
-            testGetDate(rs, numberOfColumns, dateSetObject);
-        }
-
-        if (null != rs) {
-            rs.close();
+        try(ResultSet rs = stmt.executeQuery("select * from " + dateTable)) {
+	        int numberOfColumns = rs.getMetaData().getColumnCount();
+	
+	        ArrayList<Integer> skipMax = new ArrayList<>();
+	
+	        while (rs.next()) {
+	            testGetString(rs, numberOfColumns, skipMax, dateNormalCase);
+	            testGetObject(rs, numberOfColumns, skipMax, dateSetObject);
+	            testGetDate(rs, numberOfColumns, dateSetObject);
+	        }
         }
     }
 
@@ -351,79 +345,79 @@ public class PrecisionScaleTest extends AESetup {
     private void populateDateNormalCase(int scale) throws SQLException {
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // datetime2(5)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setTimestamp(i, new Timestamp(date.getTime()), scale);
+	        // datetime2(5)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setTimestamp(i, new Timestamp(date.getTime()), scale);
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setTimestamp(i, new Timestamp(date.getTime()));
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1));
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setTime(i, new Time(date.getTime()));
+	        }
+	
+	        // time(3)
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setTime(i, new Time(date.getTime()), scale);
+	        }
+	
+	        // datetimeoffset(2)
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1), scale);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setTimestamp(i, new Timestamp(date.getTime()));
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1));
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setTime(i, new Time(date.getTime()));
-        }
-
-        // time(3)
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setTime(i, new Time(date.getTime()), scale);
-        }
-
-        // datetimeoffset(2)
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1), scale);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     private void populateDateNormalCaseNull(int scale) throws SQLException {
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // datetime2(5)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setTimestamp(i, null, scale);
+	        // datetime2(5)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setTimestamp(i, null, scale);
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setTimestamp(i, null);
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setDateTimeOffset(i, null);
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setTime(i, null);
+	        }
+	
+	        // time(3)
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setTime(i, null, scale);
+	        }
+	
+	        // datetimeoffset(2)
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setDateTimeOffset(i, null, scale);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setTimestamp(i, null);
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setDateTimeOffset(i, null);
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setTime(i, null);
-        }
-
-        // time(3)
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setTime(i, null, scale);
-        }
-
-        // datetimeoffset(2)
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setDateTimeOffset(i, null, scale);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     private void populateNumericNormalCase(String[] numeric,
@@ -431,25 +425,25 @@ public class PrecisionScaleTest extends AESetup {
             int scale) throws SQLException {
         String sql = "insert into " + numericTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // float(30)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setDouble(i, Double.valueOf(numeric[0]));
+	        // float(30)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setDouble(i, Double.valueOf(numeric[0]));
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numeric[1]), precision, scale);
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setBigDecimal(i, new BigDecimal(numeric[2]), precision, scale);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // decimal(10,5)
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numeric[1]), precision, scale);
-        }
-
-        // numeric(8,2)
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setBigDecimal(i, new BigDecimal(numeric[2]), precision, scale);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     private void populateNumericSetObject(String[] numeric,
@@ -457,129 +451,129 @@ public class PrecisionScaleTest extends AESetup {
             int scale) throws SQLException {
         String sql = "insert into " + numericTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
-
-        // float(30)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, Double.valueOf(numeric[0]));
-
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
+	
+	        // float(30)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, Double.valueOf(numeric[0]));
+	
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, new BigDecimal(numeric[1]), java.sql.Types.DECIMAL, precision, scale);
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, new BigDecimal(numeric[2]), java.sql.Types.NUMERIC, precision, scale);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // decimal(10,5)
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, new BigDecimal(numeric[1]), java.sql.Types.DECIMAL, precision, scale);
-        }
-
-        // numeric(8,2)
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, new BigDecimal(numeric[2]), java.sql.Types.NUMERIC, precision, scale);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     private void populateNumericSetObjectNull(int precision,
             int scale) throws SQLException {
         String sql = "insert into " + numericTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // float(30)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DOUBLE);
-
+	        // float(30)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DOUBLE);
+	
+	        }
+	
+	        // decimal(10,5)
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.DECIMAL, precision, scale);
+	        }
+	
+	        // numeric(8,2)
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.NUMERIC, precision, scale);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // decimal(10,5)
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, null, java.sql.Types.DECIMAL, precision, scale);
-        }
-
-        // numeric(8,2)
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, null, java.sql.Types.NUMERIC, precision, scale);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     private void populateDateSetObject(int scale) throws SQLException {
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // datetime2(5)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP, scale);
+	        // datetime2(5)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP, scale);
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP);
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1), microsoft.sql.Types.DATETIMEOFFSET);
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME);
+	        }
+	
+	        // time(3)
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME, scale);
+	        }
+	
+	        // datetimeoffset(2)
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1), microsoft.sql.Types.DATETIMEOFFSET, scale);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP);
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1), microsoft.sql.Types.DATETIMEOFFSET);
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME);
-        }
-
-        // time(3)
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME, scale);
-        }
-
-        // datetimeoffset(2)
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1), microsoft.sql.Types.DATETIMEOFFSET, scale);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 
     private void populateDateSetObjectNull(int scale) throws SQLException {
         String sql = "insert into " + dateTable + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
-        pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting);
+        try(SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) Util.getPreparedStmt(con, sql, stmtColEncSetting)) {
 
-        // datetime2(5)
-        for (int i = 1; i <= 3; i++) {
-            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP, scale);
+	        // datetime2(5)
+	        for (int i = 1; i <= 3; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP, scale);
+	        }
+	
+	        // datetime2 default
+	        for (int i = 4; i <= 6; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP);
+	        }
+	
+	        // datetimeoffset default
+	        for (int i = 7; i <= 9; i++) {
+	            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET);
+	        }
+	
+	        // time default
+	        for (int i = 10; i <= 12; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.TIME);
+	        }
+	
+	        // time(3)
+	        for (int i = 13; i <= 15; i++) {
+	            pstmt.setObject(i, null, java.sql.Types.TIME, scale);
+	        }
+	
+	        // datetimeoffset(2)
+	        for (int i = 16; i <= 18; i++) {
+	            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET, scale);
+	        }
+	
+	        pstmt.execute();
         }
-
-        // datetime2 default
-        for (int i = 4; i <= 6; i++) {
-            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP);
-        }
-
-        // datetimeoffset default
-        for (int i = 7; i <= 9; i++) {
-            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET);
-        }
-
-        // time default
-        for (int i = 10; i <= 12; i++) {
-            pstmt.setObject(i, null, java.sql.Types.TIME);
-        }
-
-        // time(3)
-        for (int i = 13; i <= 15; i++) {
-            pstmt.setObject(i, null, java.sql.Types.TIME, scale);
-        }
-
-        // datetimeoffset(2)
-        for (int i = 16; i <= 18; i++) {
-            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET, scale);
-        }
-
-        pstmt.execute();
-        Util.close(null, pstmt, null);
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyAllTypes.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyAllTypes.java
@@ -27,9 +27,7 @@ import com.microsoft.sqlserver.testframework.util.ComparisonUtil;
 
 @RunWith(JUnitPlatform.class)
 public class BulkCopyAllTypes extends AbstractTest {
-    private static Connection conn = null;
-    static Statement stmt = null;
-
+	
     private static DBTable tableSrc = null;
     private static DBTable tableDest = null;
 
@@ -53,55 +51,43 @@ public class BulkCopyAllTypes extends AbstractTest {
             Integer resultSetConcurrency) throws SQLException {
         setupVariation();
 
-        Connection connnection = null;
-        if (setSelectMethod) {
-            connnection = DriverManager.getConnection(connectionString + ";selectMethod=cursor;");
-        }
-        else {
-            connnection = DriverManager.getConnection(connectionString);
-        }
+        try(Connection connnection = DriverManager.getConnection(connectionString + (setSelectMethod ? ";selectMethod=cursor;" : ""));
+        	Statement statement = (null != resultSetType || null != resultSetConcurrency) ? 
+        			connnection.createStatement(resultSetType, resultSetConcurrency) : connnection.createStatement()){
 
-        Statement stmtement = null;
-        if (null != resultSetType || null != resultSetConcurrency) {
-            stmtement = connnection.createStatement(resultSetType, resultSetConcurrency);
+	        ResultSet rs = statement.executeQuery("select * from " + tableSrc.getEscapedTableName());
+	
+	        SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connection);
+	        bcOperation.setDestinationTableName(tableDest.getEscapedTableName());
+	        bcOperation.writeToServer(rs);
+	        bcOperation.close();
+	
+	        ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc, tableDest);
         }
-        else {
-            stmtement = connnection.createStatement();
-        }
-
-        ResultSet rs = stmtement.executeQuery("select * from " + tableSrc.getEscapedTableName());
-
-        SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connection);
-        bcOperation.setDestinationTableName(tableDest.getEscapedTableName());
-        bcOperation.writeToServer(rs);
-        bcOperation.close();
-
-        ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc, tableDest);
 
         terminateVariation();
     }
 
     private void setupVariation() throws SQLException {
-        conn = DriverManager.getConnection(connectionString);
-        stmt = conn.createStatement();
+        try(DBConnection dbConnection = new DBConnection(connectionString);
+    	    DBStatement dbStmt = dbConnection.createStatement()) {
 
-        DBConnection dbConnection = new DBConnection(connectionString);
-        DBStatement dbStmt = dbConnection.createStatement();
-
-        tableSrc = new DBTable(true);
-        tableDest = tableSrc.cloneSchema();
-
-        dbStmt.createTable(tableSrc);
-        dbStmt.createTable(tableDest);
-
-        dbStmt.populateTable(tableSrc);
+	        tableSrc = new DBTable(true);
+	        tableDest = tableSrc.cloneSchema();
+	
+	        dbStmt.createTable(tableSrc);
+	        dbStmt.createTable(tableDest);
+	
+	        dbStmt.populateTable(tableSrc);
+        }
     }
 
     private void terminateVariation() throws SQLException {
-        conn = DriverManager.getConnection(connectionString);
-        stmt = conn.createStatement();
+        try(Connection conn = DriverManager.getConnection(connectionString);
+        	Statement stmt = conn.createStatement()) {
 
-        Utils.dropTableIfExists(tableSrc.getEscapedTableName(), stmt);
-        Utils.dropTableIfExists(tableDest.getEscapedTableName(), stmt);
+	        Utils.dropTableIfExists(tableSrc.getEscapedTableName(), stmt);
+	        Utils.dropTableIfExists(tableDest.getEscapedTableName(), stmt);
+        }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnMappingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnMappingTest.java
@@ -332,31 +332,32 @@ public class BulkCopyColumnMappingTest extends BulkCopyTestSetUp {
     private void validateValuesRepetativeCM(DBConnection con,
             DBTable sourceTable,
             DBTable destinationTable) throws SQLException {
-        DBStatement srcStmt = con.createStatement();
-        DBStatement dstStmt = con.createStatement();
-        DBResultSet srcResultSet = srcStmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
-        DBResultSet dstResultSet = dstStmt.executeQuery("SELECT * FROM " + destinationTable.getEscapedTableName() + ";");
-        ResultSetMetaData sourceMeta = ((ResultSet) srcResultSet.product()).getMetaData();
-        int totalColumns = sourceMeta.getColumnCount();
-
-        // verify data from sourceType and resultSet
-        while (srcResultSet.next() && dstResultSet.next())
-            for (int i = 1; i <= totalColumns; i++) {
-                // TODO: check row and column count in both the tables
-
-                Object srcValue, dstValue;
-                srcValue = srcResultSet.getObject(i);
-                dstValue = dstResultSet.getObject(i);
-                ComparisonUtil.compareExpectedAndActual(sourceMeta.getColumnType(i), srcValue, dstValue);
-
-                // compare value of first column of source with extra column in destination
-                if (1 == i) {
-                    Object srcValueFirstCol = srcResultSet.getObject(i);
-                    Object dstValLastCol = dstResultSet.getObject(totalColumns + 1);
-                    ComparisonUtil.compareExpectedAndActual(sourceMeta.getColumnType(i), srcValueFirstCol, dstValLastCol);
-                }
-            }
-
+        try(DBStatement srcStmt = con.createStatement();
+	        DBStatement dstStmt = con.createStatement();
+	        DBResultSet srcResultSet = srcStmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
+	        DBResultSet dstResultSet = dstStmt.executeQuery("SELECT * FROM " + destinationTable.getEscapedTableName() + ";")) {
+	        ResultSetMetaData sourceMeta = ((ResultSet) srcResultSet.product()).getMetaData();
+	        int totalColumns = sourceMeta.getColumnCount();
+	
+	        // verify data from sourceType and resultSet
+	        while (srcResultSet.next() && dstResultSet.next()) {
+	            for (int i = 1; i <= totalColumns; i++) {
+	                // TODO: check row and column count in both the tables
+	
+	                Object srcValue, dstValue;
+	                srcValue = srcResultSet.getObject(i);
+	                dstValue = dstResultSet.getObject(i);
+	                ComparisonUtil.compareExpectedAndActual(sourceMeta.getColumnType(i), srcValue, dstValue);
+	
+	                // compare value of first column of source with extra column in destination
+	                if (1 == i) {
+	                    Object srcValueFirstCol = srcResultSet.getObject(i);
+	                    Object dstValLastCol = dstResultSet.getObject(totalColumns + 1);
+	                    ComparisonUtil.compareExpectedAndActual(sourceMeta.getColumnType(i), srcValueFirstCol, dstValLastCol);
+	                }
+	            }
+	        }
+        }
     }
 
     private void dropTable(String tableName) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -88,9 +89,11 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
     void testInvalidConnection1() {
         assertThrows(SQLServerException.class, new org.junit.jupiter.api.function.Executable() {
             @Override
-            public void execute() throws SQLServerException {
-                Connection con = null;
-                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);
+            public void execute() throws SQLException {
+                try(Connection con = null;
+                	SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con)) {
+        			//do nothing
+                }
             }
         });
     }
@@ -104,8 +107,10 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
         assertThrows(SQLServerException.class, new org.junit.jupiter.api.function.Executable() {
             @Override
             public void execute() throws SQLServerException {
-                SQLServerConnection con = null;
-                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);
+                try(SQLServerConnection con = null;
+                	SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con)) {
+                	//do nothing
+                }
             }
         });
     }
@@ -120,7 +125,9 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
             @Override
             public void execute() throws SQLServerException {
                 String connectionUrl = " ";
-                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(connectionUrl);
+                try(SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(connectionUrl)) {
+                	//do nothing
+                }
             }
         });
     }
@@ -135,7 +142,9 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
             @Override
             public void execute() throws SQLServerException {
                 String connectionUrl = null;
-                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(connectionUrl);
+                try(SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(connectionUrl)) {
+                	//do nothing
+                }
             }
         });
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
@@ -38,39 +38,18 @@ import com.microsoft.sqlserver.testframework.sqlType.SqlType;
 @DisplayName("Test ISQLServerBulkRecord")
 public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
 
-    static DBConnection con = null;
-    static DBStatement stmt = null;
-    static DBTable dstTable = null;
-
-    /**
-     * Create connection and statement
-     */
-    @BeforeAll
-    static void setUpConnection() {
-        con = new DBConnection(connectionString);
-        stmt = con.createStatement();
-    }
-
     @Test
-    void testISQLServerBulkRecord() {
-        dstTable = new DBTable(true);
-        stmt.createTable(dstTable);
-        BulkData Bdata = new BulkData();
-
-        BulkCopyTestWrapper bulkWrapper = new BulkCopyTestWrapper(connectionString);
-        bulkWrapper.setUsingConnection((0 == ThreadLocalRandom.current().nextInt(2)) ? true : false);
-        BulkCopyTestUtil.performBulkCopy(bulkWrapper, Bdata, dstTable);
-    }
-
-    /**
-     * drop source table after testing bulk copy
-     * 
-     * @throws SQLException
-     */
-    @AfterAll
-    static void tearConnection() throws SQLException {
-        stmt.close();
-        con.close();
+    void testISQLServerBulkRecord() throws SQLException {
+        try (DBConnection con = new DBConnection(connectionString);
+        	 DBStatement stmt = con.createStatement()) {
+        	DBTable dstTable = new DBTable(true);
+	        stmt.createTable(dstTable);
+	        BulkData Bdata = new BulkData(dstTable);
+	
+	        BulkCopyTestWrapper bulkWrapper = new BulkCopyTestWrapper(connectionString);
+	        bulkWrapper.setUsingConnection((0 == ThreadLocalRandom.current().nextInt(2)) ? true : false);
+	        BulkCopyTestUtil.performBulkCopy(bulkWrapper, Bdata, dstTable);
+        }
     }
 
     class BulkData implements ISQLServerBulkRecord {
@@ -98,7 +77,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
         Map<Integer, ColumnMetadata> columnMetadata;
         List<Object[]> data;
 
-        BulkData() {
+        BulkData(DBTable dstTable) {
             columnMetadata = new HashMap<>();
             totalColumn = dstTable.totalColumns();
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTestSetUp.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTestSetUp.java
@@ -7,6 +7,8 @@
  */
 package com.microsoft.sqlserver.jdbc.bulkCopy;
 
+import java.sql.SQLException;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.platform.runner.JUnitPlatform;
@@ -28,39 +30,28 @@ public class BulkCopyTestSetUp extends AbstractTest {
 
     /**
      * Create source table needed for testing bulk copy
+     * @throws SQLException 
      */
     @BeforeAll
-    static void setUpSourceTable() {
-        DBConnection con = null;
-        DBStatement stmt = null;
-        try {
-            con = new DBConnection(connectionString);
-            stmt = con.createStatement();
+    static void setUpSourceTable() throws SQLException {
+        try (DBConnection con = new DBConnection(connectionString);
+        	 DBStatement stmt = con.createStatement();
+        	 DBPreparedStatement pstmt = new DBPreparedStatement(con);) {
             sourceTable = new DBTable(true);
             stmt.createTable(sourceTable);
-            DBPreparedStatement pstmt = new DBPreparedStatement(con);
             pstmt.populateTable(sourceTable);
-        }
-        finally {
-            con.close();
         }
     }
 
     /**
      * drop source table after testing bulk copy
+     * @throws SQLException 
      */
     @AfterAll
-    static void dropSourceTable() {
-        DBConnection con = null;
-        DBStatement stmt = null;
-        try {
-            con = new DBConnection(connectionString);
-            stmt = con.createStatement();
+    static void dropSourceTable() throws SQLException {
+        try (DBConnection con = new DBConnection(connectionString);
+        	 DBStatement stmt = con.createStatement()) {
             stmt.dropTable(sourceTable);
         }
-        finally {
-            con.close();
-        }
     }
-
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTestUtil.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTestUtil.java
@@ -7,20 +7,12 @@
  */
 package com.microsoft.sqlserver.jdbc.bulkCopy;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.math.BigDecimal;
 import java.sql.Connection;
-import java.sql.Date;
-import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
-
 import com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
 import com.microsoft.sqlserver.jdbc.bulkCopy.BulkCopyTestWrapper.ColumnMap;
@@ -28,7 +20,6 @@ import com.microsoft.sqlserver.testframework.DBConnection;
 import com.microsoft.sqlserver.testframework.DBResultSet;
 import com.microsoft.sqlserver.testframework.DBStatement;
 import com.microsoft.sqlserver.testframework.DBTable;
-import com.microsoft.sqlserver.testframework.Utils;
 import com.microsoft.sqlserver.testframework.util.ComparisonUtil;
 
 /**
@@ -70,56 +61,52 @@ class BulkCopyTestUtil {
     static void performBulkCopy(BulkCopyTestWrapper wrapper,
             DBTable sourceTable,
             boolean validateResult) {
-        DBConnection con = null;
-        DBStatement stmt = null;
         DBTable destinationTable = null;
-        try {
-            con = new DBConnection(wrapper.getConnectionString());
-            stmt = con.createStatement();
+        try (DBConnection con = new DBConnection(wrapper.getConnectionString());
+        	 DBStatement stmt = con.createStatement()) {
 
             destinationTable = sourceTable.cloneSchema();
             stmt.createTable(destinationTable);
-            DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
-            SQLServerBulkCopy bulkCopy;
-            if (wrapper.isUsingConnection()) {
-                bulkCopy = new SQLServerBulkCopy((Connection) con.product());
+            try (DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
+            	 SQLServerBulkCopy bulkCopy = wrapper.isUsingConnection() ? 
+            			 new SQLServerBulkCopy((Connection) con.product()) : 
+            				 new SQLServerBulkCopy(wrapper.getConnectionString())) {
+	            if (wrapper.isUsingBulkCopyOptions()) {
+	                bulkCopy.setBulkCopyOptions(wrapper.getBulkOptions());
+	            }
+	            bulkCopy.setDestinationTableName(destinationTable.getEscapedTableName());
+	            if (wrapper.isUsingColumnMapping()) {
+	                for (int i = 0; i < wrapper.cm.size(); i++) {
+	                    ColumnMap currentMap = wrapper.cm.get(i);
+	                    if (currentMap.sourceIsInt && currentMap.destIsInt) {
+	                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destInt);
+	                    }
+	                    else if (currentMap.sourceIsInt && (!currentMap.destIsInt)) {
+	                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destString);
+	                    }
+	                    else if ((!currentMap.sourceIsInt) && currentMap.destIsInt) {
+	                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destInt);
+	                    }
+	                    else if ((!currentMap.sourceIsInt) && (!currentMap.destIsInt)) {
+	                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destString);
+	                    }
+	                }
+	            }
+	            bulkCopy.writeToServer((ResultSet) srcResultSet.product());
+	            if (validateResult) {
+	                validateValues(con, sourceTable, destinationTable);
+	            }
             }
-            else {
-                bulkCopy = new SQLServerBulkCopy(wrapper.getConnectionString());
+            catch (SQLException ex) {
+                fail(ex.getMessage());
             }
-            if (wrapper.isUsingBulkCopyOptions()) {
-                bulkCopy.setBulkCopyOptions(wrapper.getBulkOptions());
-            }
-            bulkCopy.setDestinationTableName(destinationTable.getEscapedTableName());
-            if (wrapper.isUsingColumnMapping()) {
-                for (int i = 0; i < wrapper.cm.size(); i++) {
-                    ColumnMap currentMap = wrapper.cm.get(i);
-                    if (currentMap.sourceIsInt && currentMap.destIsInt) {
-                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destInt);
-                    }
-                    else if (currentMap.sourceIsInt && (!currentMap.destIsInt)) {
-                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destString);
-                    }
-                    else if ((!currentMap.sourceIsInt) && currentMap.destIsInt) {
-                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destInt);
-                    }
-                    else if ((!currentMap.sourceIsInt) && (!currentMap.destIsInt)) {
-                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destString);
-                    }
-                }
-            }
-            bulkCopy.writeToServer((ResultSet) srcResultSet.product());
-            bulkCopy.close();
-            if (validateResult) {
-                validateValues(con, sourceTable, destinationTable);
+            finally {
+                stmt.dropTable(destinationTable);
+                con.close();
             }
         }
         catch (SQLException ex) {
             fail(ex.getMessage());
-        }
-        finally {
-            stmt.dropTable(destinationTable);
-            con.close();
         }
     }
 
@@ -135,20 +122,12 @@ class BulkCopyTestUtil {
             DBTable sourceTable,
             DBTable destinationTable,
             boolean validateResult) {
-        DBConnection con = null;
-        DBStatement stmt = null;
-        try {
-            con = new DBConnection(wrapper.getConnectionString());
-            stmt = con.createStatement();
-
-            DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
-            SQLServerBulkCopy bulkCopy;
-            if (wrapper.isUsingConnection()) {
-                bulkCopy = new SQLServerBulkCopy((Connection) con.product());
-            }
-            else {
-                bulkCopy = new SQLServerBulkCopy(wrapper.getConnectionString());
-            }
+        try (DBConnection con = new DBConnection(wrapper.getConnectionString());
+        	 DBStatement stmt = con.createStatement();
+             DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
+             SQLServerBulkCopy bulkCopy = wrapper.isUsingConnection() ? 
+            		 new SQLServerBulkCopy((Connection) con.product()) : 
+            			 new SQLServerBulkCopy(wrapper.getConnectionString())) {
             if (wrapper.isUsingBulkCopyOptions()) {
                 bulkCopy.setBulkCopyOptions(wrapper.getBulkOptions());
             }
@@ -171,17 +150,12 @@ class BulkCopyTestUtil {
                 }
             }
             bulkCopy.writeToServer((ResultSet) srcResultSet.product());
-            bulkCopy.close();
             if (validateResult) {
                 validateValues(con, sourceTable, destinationTable);
             }
-        }
+    	}
         catch (SQLException ex) {
             fail(ex.getMessage());
-        }
-        finally {
-            stmt.dropTable(destinationTable);
-            con.close();
         }
     }
 
@@ -199,58 +173,54 @@ class BulkCopyTestUtil {
             DBTable destinationTable,
             boolean validateResult,
             boolean fail) {
-        DBConnection con = null;
-        DBStatement stmt = null;
-        try {
-            con = new DBConnection(wrapper.getConnectionString());
-            stmt = con.createStatement();
-
-            DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
-            SQLServerBulkCopy bulkCopy;
-            if (wrapper.isUsingConnection()) {
-                bulkCopy = new SQLServerBulkCopy((Connection) con.product());
-            }
-            else {
-                bulkCopy = new SQLServerBulkCopy(wrapper.getConnectionString());
-            }
-            if (wrapper.isUsingBulkCopyOptions()) {
-                bulkCopy.setBulkCopyOptions(wrapper.getBulkOptions());
-            }
-            bulkCopy.setDestinationTableName(destinationTable.getEscapedTableName());
-            if (wrapper.isUsingColumnMapping()) {
-                for (int i = 0; i < wrapper.cm.size(); i++) {
-                    ColumnMap currentMap = wrapper.cm.get(i);
-                    if (currentMap.sourceIsInt && currentMap.destIsInt) {
-                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destInt);
-                    }
-                    else if (currentMap.sourceIsInt && (!currentMap.destIsInt)) {
-                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destString);
-                    }
-                    else if ((!currentMap.sourceIsInt) && currentMap.destIsInt) {
-                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destInt);
-                    }
-                    else if ((!currentMap.sourceIsInt) && (!currentMap.destIsInt)) {
-                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destString);
-                    }
-                }
-            }
-            bulkCopy.writeToServer((ResultSet) srcResultSet.product());
-            if (fail)
-                fail("bulkCopy.writeToServer did not fail when it should have");
-            bulkCopy.close();
-            if (validateResult) {
-                validateValues(con, sourceTable, destinationTable);
-            }
-        }
-        catch (SQLException ex) {
+        try (DBConnection con = new DBConnection(wrapper.getConnectionString());
+        	 DBStatement stmt = con.createStatement();
+             DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
+             SQLServerBulkCopy bulkCopy = wrapper.isUsingConnection() ?
+            		 new SQLServerBulkCopy((Connection) con.product()) :
+            			 new SQLServerBulkCopy(wrapper.getConnectionString())) {
+            try {
+            	if (wrapper.isUsingBulkCopyOptions()) {
+	                bulkCopy.setBulkCopyOptions(wrapper.getBulkOptions());
+	            }
+	            bulkCopy.setDestinationTableName(destinationTable.getEscapedTableName());
+	            if (wrapper.isUsingColumnMapping()) {
+	                for (int i = 0; i < wrapper.cm.size(); i++) {
+	                    ColumnMap currentMap = wrapper.cm.get(i);
+	                    if (currentMap.sourceIsInt && currentMap.destIsInt) {
+	                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destInt);
+	                    }
+	                    else if (currentMap.sourceIsInt && (!currentMap.destIsInt)) {
+	                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destString);
+	                    }
+	                    else if ((!currentMap.sourceIsInt) && currentMap.destIsInt) {
+	                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destInt);
+	                    }
+	                    else if ((!currentMap.sourceIsInt) && (!currentMap.destIsInt)) {
+	                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destString);
+	                    }
+	                }
+	            }
+	            bulkCopy.writeToServer((ResultSet) srcResultSet.product());
+	            if (fail)
+	                fail("bulkCopy.writeToServer did not fail when it should have");
+	            if (validateResult) {
+	                validateValues(con, sourceTable, destinationTable);
+	            }
+	        } catch (SQLException ex) {
+	            if (!fail) {
+	                fail(ex.getMessage());
+	            }
+	        }
+	        finally {
+	            stmt.dropTable(destinationTable);
+	            con.close();
+	        }
+        } catch (SQLException e) {
             if (!fail) {
-                fail(ex.getMessage());
+                fail(e.getMessage());
             }
-        }
-        finally {
-            stmt.dropTable(destinationTable);
-            con.close();
-        }
+		}
     }
 
     /**
@@ -269,59 +239,58 @@ class BulkCopyTestUtil {
             boolean validateResult,
             boolean fail,
             boolean dropDest) {
-        DBConnection con = null;
-        DBStatement stmt = null;
-        try {
-            con = new DBConnection(wrapper.getConnectionString());
-            stmt = con.createStatement();
-
-            DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
-            SQLServerBulkCopy bulkCopy;
-            if (wrapper.isUsingConnection()) {
-                bulkCopy = new SQLServerBulkCopy((Connection) con.product());
-            }
-            else {
-                bulkCopy = new SQLServerBulkCopy(wrapper.getConnectionString());
-            }
-            if (wrapper.isUsingBulkCopyOptions()) {
-                bulkCopy.setBulkCopyOptions(wrapper.getBulkOptions());
-            }
-            bulkCopy.setDestinationTableName(destinationTable.getEscapedTableName());
-            if (wrapper.isUsingColumnMapping()) {
-                for (int i = 0; i < wrapper.cm.size(); i++) {
-                    ColumnMap currentMap = wrapper.cm.get(i);
-                    if (currentMap.sourceIsInt && currentMap.destIsInt) {
-                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destInt);
-                    }
-                    else if (currentMap.sourceIsInt && (!currentMap.destIsInt)) {
-                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destString);
-                    }
-                    else if ((!currentMap.sourceIsInt) && currentMap.destIsInt) {
-                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destInt);
-                    }
-                    else if ((!currentMap.sourceIsInt) && (!currentMap.destIsInt)) {
-                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destString);
-                    }
-                }
-            }
-            bulkCopy.writeToServer((ResultSet) srcResultSet.product());
-            if (fail)
-                fail("bulkCopy.writeToServer did not fail when it should have");
-            bulkCopy.close();
-            if (validateResult) {
-                validateValues(con, sourceTable, destinationTable);
-            }
+        try (DBConnection con = new DBConnection(wrapper.getConnectionString());
+        	 DBStatement stmt = con.createStatement();
+             DBResultSet srcResultSet = stmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
+             SQLServerBulkCopy bulkCopy = wrapper.isUsingConnection() ?
+            		new SQLServerBulkCopy((Connection) con.product()) :
+            			new SQLServerBulkCopy(wrapper.getConnectionString())) {
+            try {
+            	if (wrapper.isUsingBulkCopyOptions()) {
+	                bulkCopy.setBulkCopyOptions(wrapper.getBulkOptions());
+	            }
+	            bulkCopy.setDestinationTableName(destinationTable.getEscapedTableName());
+	            if (wrapper.isUsingColumnMapping()) {
+	                for (int i = 0; i < wrapper.cm.size(); i++) {
+	                    ColumnMap currentMap = wrapper.cm.get(i);
+	                    if (currentMap.sourceIsInt && currentMap.destIsInt) {
+	                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destInt);
+	                    }
+	                    else if (currentMap.sourceIsInt && (!currentMap.destIsInt)) {
+	                        bulkCopy.addColumnMapping(currentMap.srcInt, currentMap.destString);
+	                    }
+	                    else if ((!currentMap.sourceIsInt) && currentMap.destIsInt) {
+	                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destInt);
+	                    }
+	                    else if ((!currentMap.sourceIsInt) && (!currentMap.destIsInt)) {
+	                        bulkCopy.addColumnMapping(currentMap.srcString, currentMap.destString);
+	                    }
+	                }
+	            }
+	            bulkCopy.writeToServer((ResultSet) srcResultSet.product());
+	            if (fail)
+	                fail("bulkCopy.writeToServer did not fail when it should have");
+	            bulkCopy.close();
+	            if (validateResult) {
+	                validateValues(con, sourceTable, destinationTable);
+	            }
+	        }
+	        catch (SQLException ex) {
+	            if (!fail) {
+	                fail(ex.getMessage());
+	            }
+	        }
+	        finally {
+	            if (dropDest) {
+	                stmt.dropTable(destinationTable);
+	            }
+	            con.close();
+	        }
         }
         catch (SQLException ex) {
             if (!fail) {
                 fail(ex.getMessage());
             }
-        }
-        finally {
-            if (dropDest) {
-                stmt.dropTable(destinationTable);
-            }
-            con.close();
         }
     }
 
@@ -336,24 +305,26 @@ class BulkCopyTestUtil {
     static void validateValues(DBConnection con,
             DBTable sourceTable,
             DBTable destinationTable) throws SQLException {
-        DBStatement srcStmt = con.createStatement();
-        DBStatement dstStmt = con.createStatement();
-        DBResultSet srcResultSet = srcStmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
-        DBResultSet dstResultSet = dstStmt.executeQuery("SELECT * FROM " + destinationTable.getEscapedTableName() + ";");
-        ResultSetMetaData destMeta = ((ResultSet) dstResultSet.product()).getMetaData();
-        int totalColumns = destMeta.getColumnCount();
-
-        // verify data from sourceType and resultSet
-        while (srcResultSet.next() && dstResultSet.next())
-            for (int i = 1; i <= totalColumns; i++) {
-                // TODO: check row and column count in both the tables
-
-                Object srcValue, dstValue;
-                srcValue = srcResultSet.getObject(i);
-                dstValue = dstResultSet.getObject(i);
-
-                ComparisonUtil.compareExpectedAndActual(destMeta.getColumnType(i), srcValue, dstValue);
-            }
+        try (DBStatement srcStmt = con.createStatement();
+        	 DBStatement dstStmt = con.createStatement();
+        	 DBResultSet srcResultSet = srcStmt.executeQuery("SELECT * FROM " + sourceTable.getEscapedTableName() + ";");
+        	 DBResultSet dstResultSet = dstStmt.executeQuery("SELECT * FROM " + destinationTable.getEscapedTableName() + ";")) {
+	        ResultSetMetaData destMeta = ((ResultSet) dstResultSet.product()).getMetaData();
+	        int totalColumns = destMeta.getColumnCount();
+	
+	        // verify data from sourceType and resultSet
+	        while (srcResultSet.next() && dstResultSet.next()) {
+	            for (int i = 1; i <= totalColumns; i++) {
+	                // TODO: check row and column count in both the tables
+	
+	                Object srcValue, dstValue;
+	                srcValue = srcResultSet.getObject(i);
+	                dstValue = dstResultSet.getObject(i);
+	
+	                ComparisonUtil.compareExpectedAndActual(destMeta.getColumnType(i), srcValue, dstValue);
+	            }
+	        }
+        }
     }
 
     /**
@@ -365,21 +336,15 @@ class BulkCopyTestUtil {
     static void performBulkCopy(BulkCopyTestWrapper bulkWrapper,
             ISQLServerBulkRecord srcData,
             DBTable dstTable) {
-        SQLServerBulkCopy bc;
-        DBConnection con = new DBConnection(bulkWrapper.getConnectionString());
-        DBStatement stmt = con.createStatement();
-        try {
-            bc = new SQLServerBulkCopy(bulkWrapper.getConnectionString());
+        try (DBConnection con = new DBConnection(bulkWrapper.getConnectionString());
+        	 DBStatement stmt = con.createStatement();
+        	 SQLServerBulkCopy bc = new SQLServerBulkCopy(bulkWrapper.getConnectionString());) {
             bc.setDestinationTableName(dstTable.getEscapedTableName());
             bc.writeToServer(srcData);
-            bc.close();
             validateValues(con, srcData, dstTable);
         }
         catch (Exception e) {
             fail(e.getMessage());
-        }
-        finally {
-            con.close();
         }
     }
     
@@ -395,38 +360,38 @@ class BulkCopyTestUtil {
             ISQLServerBulkRecord srcData,
             DBTable destinationTable) throws Exception {
         
-        DBStatement dstStmt = con.createStatement();
-        DBResultSet dstResultSet = dstStmt.executeQuery("SELECT * FROM " + destinationTable.getEscapedTableName() + ";");
-        ResultSetMetaData destMeta = ((ResultSet) dstResultSet.product()).getMetaData();
-        int totalColumns = destMeta.getColumnCount();
-        
-        // reset the counter in ISQLServerBulkRecord, which was incremented during read by BulkCopy 
-        java.lang.reflect.Method method  = srcData.getClass().getMethod("reset");
-        method.invoke(srcData);
-        
-        
-        // verify data from sourceType and resultSet
-        while (srcData.next() && dstResultSet.next())
-        {
-            Object[] srcValues = srcData.getRowData();
-            for (int i = 1; i <= totalColumns; i++) {
-
-                Object srcValue, dstValue;
-                srcValue = srcValues[i-1];
-                if(srcValue.getClass().getName().equalsIgnoreCase("java.lang.Double")){
-                    // in case of SQL Server type Float (ie java type double), in float(n) if n is <=24 ie precsion is <=7 SQL Server type Real is returned(ie java type float)
-                    if(destMeta.getPrecision(i) <8)
-                        srcValue = new Float(((Double)srcValue));
-                }
-                dstValue = dstResultSet.getObject(i);
-                int dstType = destMeta.getColumnType(i);
-                if(java.sql.Types.TIMESTAMP != dstType
-                        && java.sql.Types.TIME != dstType
-                        && microsoft.sql.Types.DATETIMEOFFSET != dstType){
-                    // skip validation for temporal types due to rounding eg 7986-10-21 09:51:15.114 is rounded as 7986-10-21 09:51:15.113 in server
-                    ComparisonUtil.compareExpectedAndActual(dstType, srcValue, dstValue);
-                }
-            }
+        try (DBStatement dstStmt = con.createStatement();
+        	 DBResultSet dstResultSet = dstStmt.executeQuery("SELECT * FROM " + destinationTable.getEscapedTableName() + ";")) {
+	        ResultSetMetaData destMeta = ((ResultSet) dstResultSet.product()).getMetaData();
+	        int totalColumns = destMeta.getColumnCount();
+	        
+	        // reset the counter in ISQLServerBulkRecord, which was incremented during read by BulkCopy 
+	        java.lang.reflect.Method method  = srcData.getClass().getMethod("reset");
+	        method.invoke(srcData);
+	        
+	        // verify data from sourceType and resultSet
+	        while (srcData.next() && dstResultSet.next())
+	        {
+	            Object[] srcValues = srcData.getRowData();
+	            for (int i = 1; i <= totalColumns; i++) {
+	
+	                Object srcValue, dstValue;
+	                srcValue = srcValues[i-1];
+	                if(srcValue.getClass().getName().equalsIgnoreCase("java.lang.Double")){
+	                    // in case of SQL Server type Float (ie java type double), in float(n) if n is <=24 ie precsion is <=7 SQL Server type Real is returned(ie java type float)
+	                    if(destMeta.getPrecision(i) <8)
+	                        srcValue = new Float(((Double)srcValue));
+	                }
+	                dstValue = dstResultSet.getObject(i);
+	                int dstType = destMeta.getColumnType(i);
+	                if(java.sql.Types.TIMESTAMP != dstType
+	                        && java.sql.Types.TIME != dstType
+	                        && microsoft.sql.Types.DATETIMEOFFSET != dstType){
+	                    // skip validation for temporal types due to rounding eg 7986-10-21 09:51:15.114 is rounded as 7986-10-21 09:51:15.113 in server
+	                    ComparisonUtil.compareExpectedAndActual(dstType, srcValue, dstValue);
+	                }
+	            }
+	        }
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTimeoutTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTimeoutTest.java
@@ -38,13 +38,7 @@ public class BulkCopyTimeoutTest extends BulkCopyTestSetUp {
     @Test
     @DisplayName("BulkCopy:test zero timeout")
     void testZeroTimeOut() throws SQLServerException {
-        BulkCopyTestWrapper bulkWrapper = new BulkCopyTestWrapper(connectionString);
-        bulkWrapper.setUsingConnection((0 == ThreadLocalRandom.current().nextInt(2)) ? true : false);
-        SQLServerBulkCopyOptions option = new SQLServerBulkCopyOptions();
-        option.setBulkCopyTimeout(0);
-        bulkWrapper.useBulkCopyOptions(true);
-        bulkWrapper.setBulkOptions(option);
-        BulkCopyTestUtil.performBulkCopy(bulkWrapper, sourceTable, false);
+        testBulkCopyWithTimeout(0);
     }
 
     /**
@@ -58,14 +52,18 @@ public class BulkCopyTimeoutTest extends BulkCopyTestSetUp {
         assertThrows(SQLServerException.class, new org.junit.jupiter.api.function.Executable() {
             @Override
             public void execute() throws SQLServerException {
-                BulkCopyTestWrapper bulkWrapper = new BulkCopyTestWrapper(connectionString);
-                bulkWrapper.setUsingConnection((0 == ThreadLocalRandom.current().nextInt(2)) ? true : false);
-                SQLServerBulkCopyOptions option = new SQLServerBulkCopyOptions();
-                option.setBulkCopyTimeout(-1);
-                bulkWrapper.useBulkCopyOptions(true);
-                bulkWrapper.setBulkOptions(option);
-                BulkCopyTestUtil.performBulkCopy(bulkWrapper, sourceTable, false);
+                testBulkCopyWithTimeout(-1);
             }
         });
+    }
+    
+    private void testBulkCopyWithTimeout(int timeout) throws SQLServerException {
+    	BulkCopyTestWrapper bulkWrapper = new BulkCopyTestWrapper(connectionString);
+        bulkWrapper.setUsingConnection((0 == ThreadLocalRandom.current().nextInt(2)) ? true : false);
+        SQLServerBulkCopyOptions option = new SQLServerBulkCopyOptions();
+        option.setBulkCopyTimeout(timeout);
+        bulkWrapper.useBulkCopyOptions(true);
+        bulkWrapper.setBulkOptions(option);
+        BulkCopyTestUtil.performBulkCopy(bulkWrapper, sourceTable, false);
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
@@ -56,13 +56,11 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     @Test
     public void testVarchar() throws Exception {
         variation = "testVarchar";
-        BulkDat bData = new BulkDat(variation);
-        String value = "aa";
+        BulkData bData = new BulkData(variation);
         query = "CREATE TABLE " + destTable + " (smallDATA varchar(2))";
         stmt.executeUpdate(query);
 
-        try {
-            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+        try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
             bcOperation.close();
@@ -86,19 +84,20 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     @Test
     public void testSmalldatetime() throws Exception {
         variation = "testSmalldatetime";
-        BulkDat bData = new BulkDat(variation);
+        BulkData bData = new BulkData(variation);
         String value = ("1954-05-22 02:44:00.0").toString();
         query = "CREATE TABLE " + destTable + " (smallDATA smalldatetime)";
         stmt.executeUpdate(query);
 
-        SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
-        bcOperation.setDestinationTableName(destTable);
-        bcOperation.writeToServer(bData);
-        bcOperation.close();
-
-        ResultSet rs = stmt.executeQuery("select * from " + destTable);
-        while (rs.next()) {
-            assertEquals(rs.getString(1), value);
+        try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
+	        bcOperation.setDestinationTableName(destTable);
+	        bcOperation.writeToServer(bData);
+	
+	        try (ResultSet rs = stmt.executeQuery("select * from " + destTable)) {
+		        while (rs.next()) {
+		            assertEquals(rs.getString(1), value);
+		        }
+	        }
         }
     }
 
@@ -110,16 +109,14 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     @Test
     public void testSmalldatetimeOutofRange() throws Exception {
         variation = "testSmalldatetimeOutofRange";
-        BulkDat bData = new BulkDat(variation);
+        BulkData bData = new BulkData(variation);
         
         query = "CREATE TABLE " + destTable + " (smallDATA smalldatetime)";
         stmt.executeUpdate(query);
 
-        try {
-            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+        try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
-            bcOperation.close();
             fail("BulkCopy executed for testSmalldatetimeOutofRange when it it was expected to fail");
         }
         catch (Exception e) {
@@ -141,15 +138,13 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     @Test
     public void testBinaryColumnAsByte() throws Exception {
         variation = "testBinaryColumnAsByte";
-        BulkDat bData = new BulkDat(variation);
+        BulkData bData = new BulkData(variation);
         query = "CREATE TABLE " + destTable + " (col1 binary(5))";
         stmt.executeUpdate(query);
 
-        try {
-            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+        try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
-            bcOperation.close();
             fail("BulkCopy executed for testBinaryColumnAsByte when it it was expected to fail");
         }
         catch (Exception e) {
@@ -170,15 +165,13 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     @Test
     public void testBinaryColumnAsString() throws Exception {
         variation = "testBinaryColumnAsString";
-        BulkDat bData = new BulkDat(variation);
+        BulkData bData = new BulkData(variation);
         query = "CREATE TABLE " + destTable + " (col1 binary(5))";
         stmt.executeUpdate(query);
 
-        try {
-            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+        try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
-            bcOperation.close();
             fail("BulkCopy executed for testBinaryColumnAsString when it it was expected to fail");
         }
         catch (Exception e) {
@@ -199,20 +192,18 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     @Test
     public void testSendValidValueforBinaryColumnAsString() throws Exception {
         variation = "testSendValidValueforBinaryColumnAsString";
-        BulkDat bData = new BulkDat(variation);
+        BulkData bData = new BulkData(variation);
         query = "CREATE TABLE " + destTable + " (col1 binary(5))";
         stmt.executeUpdate(query);
 
-        try {
-            SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString);
+        try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
             bcOperation.setDestinationTableName(destTable);
             bcOperation.writeToServer(bData);
-            bcOperation.close();
             
-            ResultSet rs = stmt.executeQuery("select * from " + destTable);
-            String value = "0101010000";
-            while (rs.next()) {
-                assertEquals(rs.getString(1), value);
+            try (ResultSet rs = stmt.executeQuery("select * from " + destTable)) {
+	            while (rs.next()) {
+	                assertEquals(rs.getString(1), "0101010000");
+	            }
             }
         }
         catch (Exception e) {
@@ -258,7 +249,7 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
 
 }
 
-class BulkDat implements ISQLServerBulkRecord {
+class BulkData implements ISQLServerBulkRecord {
     boolean isStringData = false;
 
     private class ColumnMetadata {
@@ -286,7 +277,7 @@ class BulkDat implements ISQLServerBulkRecord {
     int counter = 0;
     int rowCount = 1;
 
-    BulkDat(String variation) {
+    BulkData(String variation) {
         if (variation.equalsIgnoreCase("testVarchar")) {
             isStringData = true;
             columnMetadata = new HashMap<>();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTest.java
@@ -33,10 +33,6 @@ import com.microsoft.sqlserver.testframework.DBStatement;
 @DisplayName("BVT Test")
 public class bvtTest extends bvtTestSetup {
     private static String driverNamePattern = "Microsoft JDBC Driver \\d.\\d for SQL Server";
-    private static DBResultSet rs = null;
-    private static DBPreparedStatement pstmt = null;
-    private static DBConnection conn = null;
-    private static DBStatement stmt = null;
 
     /**
      * Connect to specified server and close the connection
@@ -46,13 +42,7 @@ public class bvtTest extends bvtTestSetup {
     @Test
     @DisplayName("test connection")
     public void testConnection() throws SQLException {
-        try {
-            conn = new DBConnection(connectionString);
-            conn.close();
-        }
-        finally {
-            terminateVariation();
-        }
+        try (DBConnection conn = new DBConnection(connectionString)) {}
     }
 
     /**
@@ -62,14 +52,10 @@ public class bvtTest extends bvtTestSetup {
      */
     @Test
     public void testConnectionIsClosed() throws SQLException {
-        try {
-            conn = new DBConnection(connectionString);
+        try (DBConnection conn = new DBConnection(connectionString)) {
             assertTrue(!conn.isClosed(), "BVT connection should not be closed");
             conn.close();
             assertTrue(conn.isClosed(), "BVT connection should not be open");
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -80,8 +66,7 @@ public class bvtTest extends bvtTestSetup {
      */
     @Test
     public void testDriverNameAndDriverVersion() throws SQLException {
-        try {
-            conn = new DBConnection(connectionString);
+        try (DBConnection conn = new DBConnection(connectionString)) {
             DatabaseMetaData metaData = conn.getMetaData();
             Pattern p = Pattern.compile(driverNamePattern);
             Matcher m = p.matcher(metaData.getDriverName());
@@ -89,9 +74,6 @@ public class bvtTest extends bvtTestSetup {
             String[] parts = metaData.getDriverVersion().split("\\.");
             if (parts.length != 4)
                 assertTrue(true, "Driver version number should be four parts! ");
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -103,16 +85,12 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testCreateStatement() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement();
-            String query = "SELECT * FROM " + table1.getEscapedTableName() + ";";
-            rs = stmt.executeQuery(query);
+    	String query = "SELECT * FROM " + table1.getEscapedTableName() + ";";
+    	
+        try (DBConnection conn = new DBConnection(connectionString);
+            DBStatement stmt = conn.createStatement();
+            DBResultSet rs = stmt.executeQuery(query)) {
             rs.verify(table1);
-            rs.close();
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -124,13 +102,9 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testCreateStatementWithQueryTimeout() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString + ";querytimeout=10");
-            stmt = conn.createStatement();
+        try (DBConnection conn = new DBConnection(connectionString + ";querytimeout=10");
+            DBStatement stmt = conn.createStatement()) {
             assertEquals(10, stmt.getQueryTimeout());
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -144,11 +118,11 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testStmtForwardOnlyReadOnly() throws SQLException, ClassNotFoundException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement(DBResultSetTypes.TYPE_FORWARD_ONLY_CONCUR_READ_ONLY);
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
+    	String query = "SELECT * FROM " + table1.getEscapedTableName();
+    	
+        try (DBConnection conn = new DBConnection(connectionString);
+            DBStatement stmt = conn.createStatement(DBResultSetTypes.TYPE_FORWARD_ONLY_CONCUR_READ_ONLY);
+            DBResultSet rs = stmt.executeQuery(query)) {
 
             rs.next();
             rs.verifyCurrentRow(table1);
@@ -163,9 +137,6 @@ public class bvtTest extends bvtTestSetup {
                 // expected exception
             }
             rs.verify(table1);
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -178,20 +149,15 @@ public class bvtTest extends bvtTestSetup {
      */
     @Test
     public void testStmtScrollInsensitiveReadOnly() throws SQLException, ClassNotFoundException {
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement(DBResultSetTypes.TYPE_SCROLL_INSENSITIVE_CONCUR_READ_ONLY);
-
-            rs = stmt.selectAll(table1);
+        try (DBConnection conn = new DBConnection(connectionString);
+            DBStatement stmt = conn.createStatement(DBResultSetTypes.TYPE_SCROLL_INSENSITIVE_CONCUR_READ_ONLY);
+        	DBResultSet rs = stmt.selectAll(table1)) {
             rs.next();
             rs.verifyCurrentRow(table1);
             rs.afterLast();
             rs.previous();
             rs.verifyCurrentRow(table1);
             rs.verify(table1);
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -204,12 +170,11 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testStmtScrollSensitiveReadOnly() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement(DBResultSetTypes.TYPE_SCROLL_SENSITIVE_CONCUR_READ_ONLY);
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        
+        try (DBConnection conn = new DBConnection(connectionString);
+            DBStatement stmt = conn.createStatement(DBResultSetTypes.TYPE_SCROLL_SENSITIVE_CONCUR_READ_ONLY);
+            DBResultSet rs = stmt.executeQuery(query)) {
             rs.next();
             rs.next();
             rs.verifyCurrentRow(table1);
@@ -218,9 +183,6 @@ public class bvtTest extends bvtTestSetup {
             rs.absolute(1);
             rs.verify(table1);
 
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -232,13 +194,12 @@ public class bvtTest extends bvtTestSetup {
      */
     @Test
     public void testStmtForwardOnlyUpdateable() throws SQLException {
+        
+    	String query = "SELECT * FROM " + table1.getEscapedTableName();
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement(DBResultSetTypes.TYPE_FORWARD_ONLY_CONCUR_UPDATABLE);
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
+        try (DBConnection conn = new DBConnection(connectionString);
+            DBStatement stmt = conn.createStatement(DBResultSetTypes.TYPE_FORWARD_ONLY_CONCUR_UPDATABLE);
+        	DBResultSet rs = stmt.executeQuery(query)) {
             rs.next();
 
             // Verify resultset behavior
@@ -255,9 +216,6 @@ public class bvtTest extends bvtTestSetup {
             }
             rs.verify(table1);
         }
-        finally {
-            terminateVariation();
-        }
     }
 
     /**
@@ -269,12 +227,11 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testStmtScrollSensitiveUpdatable() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement(DBResultSetTypes.TYPE_SCROLL_SENSITIVE_CONCUR_UPDATABLE);
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
+    	String query = "SELECT * FROM " + table1.getEscapedTableName();
+    	
+        try (DBConnection conn = new DBConnection(connectionString);
+            DBStatement stmt = conn.createStatement(DBResultSetTypes.TYPE_SCROLL_SENSITIVE_CONCUR_UPDATABLE);
+        	DBResultSet rs = stmt.executeQuery(query)) {
 
             // Verify resultset behavior
             rs.next();
@@ -284,9 +241,6 @@ public class bvtTest extends bvtTestSetup {
             rs.verifyCurrentRow(table1);
             rs.absolute(1);
             rs.verify(table1);
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -298,20 +252,15 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testStmtSSScrollDynamicOptimisticCC() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement(DBResultSetTypes.TYPE_DYNAMIC_CONCUR_OPTIMISTIC);
-
-            rs = stmt.selectAll(table1);
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt = conn.createStatement(DBResultSetTypes.TYPE_DYNAMIC_CONCUR_OPTIMISTIC);
+             DBResultSet rs = stmt.selectAll(table1)) {
 
             // Verify resultset behavior
             rs.next();
             rs.afterLast();
             rs.previous();
             rs.verify(table1);
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -323,23 +272,16 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testStmtSserverCursorForwardOnly() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            DBResultSetTypes rsType = DBResultSetTypes.TYPE_FORWARD_ONLY_CONCUR_READ_ONLY;
-            stmt = conn.createStatement(rsType.resultsetCursor, rsType.resultSetConcurrency);
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-
-            rs = stmt.executeQuery(query);
-
+        DBResultSetTypes rsType = DBResultSetTypes.TYPE_FORWARD_ONLY_CONCUR_READ_ONLY;
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        
+        try (DBConnection conn = new DBConnection(connectionString);
+            DBStatement stmt = conn.createStatement(rsType.resultsetCursor, rsType.resultSetConcurrency);
+        	DBResultSet rs = stmt.executeQuery(query)) {
             // Verify resultset behavior
             rs.next();
             rs.verify(table1);
         }
-        finally {
-            terminateVariation();
-        }
-
     }
 
     /**
@@ -350,21 +292,17 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testCreatepreparedStatement() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            String colName = table1.getColumnName(7);
-            String value = table1.getRowData(7, 0).toString();
+        String colName = table1.getColumnName(7);
+        String value = table1.getRowData(7, 0).toString();
+        String query = "SELECT * from " + table1.getEscapedTableName() + " where [" + colName + "] = ? ";
+        
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBPreparedStatement pstmt = conn.prepareStatement(query)) {
 
-            String query = "SELECT * from " + table1.getEscapedTableName() + " where [" + colName + "] = ? ";
-
-            pstmt = conn.prepareStatement(query);
             pstmt.setObject(1, new BigDecimal(value));
-
-            rs = pstmt.executeQuery();
+            DBResultSet rs = pstmt.executeQuery();
             rs.verify(table1);
-        }
-        finally {
-            terminateVariation();
+            rs.close();
         }
     }
 
@@ -376,18 +314,13 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testResultSet() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement();
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
-
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt = conn.createStatement();
+        	 DBResultSet rs = stmt.executeQuery(query)) {
             // verify resultSet
             rs.verify(table1);
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -399,12 +332,11 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testResultSetAndClose() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement();
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt = conn.createStatement();
+             DBResultSet rs = stmt.executeQuery(query)) {
 
             try {
                 if (null != rs)
@@ -413,9 +345,6 @@ public class bvtTest extends bvtTestSetup {
             catch (SQLException e) {
                 fail(e.toString());
             }
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -426,21 +355,15 @@ public class bvtTest extends bvtTestSetup {
      */
     @Test
     public void testTwoResultsetsDifferentStmt() throws SQLException {
+    	
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        String query2 = "SELECT * FROM " + table2.getEscapedTableName();
 
-        DBStatement stmt1 = null;
-        DBStatement stmt2 = null;
-        DBResultSet rs1 = null;
-        DBResultSet rs2 = null;
-        try {
-            conn = new DBConnection(connectionString);
-            stmt1 = conn.createStatement();
-            stmt2 = conn.createStatement();
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs1 = stmt1.executeQuery(query);
-
-            String query2 = "SELECT * FROM " + table2.getEscapedTableName();
-            rs2 = stmt2.executeQuery(query2);
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt1 = conn.createStatement();
+             DBStatement stmt2 = conn.createStatement();
+             DBResultSet rs1 = stmt1.executeQuery(query);
+             DBResultSet rs2 = stmt2.executeQuery(query2)) {
 
             // Interleave resultset calls
             rs1.next();
@@ -450,24 +373,8 @@ public class bvtTest extends bvtTestSetup {
             rs1.next();
             rs1.verifyCurrentRow(table1);
             rs1.verify(table1);
-            rs1.close();
             rs2.next();
             rs2.verify(table2);
-        }
-        finally {
-            if (null != rs1) {
-                rs1.close();
-            }
-            if (null != rs2) {
-                rs2.close();
-            }
-            if (null != stmt1) {
-                stmt1.close();
-            }
-            if (null != stmt2) {
-                stmt2.close();
-            }
-            terminateVariation();
         }
     }
 
@@ -479,17 +386,13 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testTwoResultsetsSameStmt() throws SQLException {
 
-        DBResultSet rs1 = null;
-        DBResultSet rs2 = null;
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement();
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs1 = stmt.executeQuery(query);
-
-            String query2 = "SELECT * FROM " + table2.getEscapedTableName();
-            rs2 = stmt.executeQuery(query2);
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        String query2 = "SELECT * FROM " + table2.getEscapedTableName();
+        
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt = conn.createStatement();
+             DBResultSet rs1 = stmt.executeQuery(query);
+             DBResultSet rs2 = stmt.executeQuery(query2)) {
 
             // Interleave resultset calls. rs is expected to be closed
             try {
@@ -506,18 +409,8 @@ public class bvtTest extends bvtTestSetup {
             catch (SQLException e) {
                 assertEquals(e.toString(), "com.microsoft.sqlserver.jdbc.SQLServerException: The result set is closed.");
             }
-            rs1.close();
             rs2.next();
             rs2.verify(table2);
-        }
-        finally {
-            if (null != rs1) {
-                rs1.close();
-            }
-            if (null != rs2) {
-                rs2.close();
-            }
-            terminateVariation();
         }
     }
 
@@ -528,12 +421,10 @@ public class bvtTest extends bvtTestSetup {
      */
     @Test
     public void testResultSetAndCloseStmt() throws SQLException {
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement();
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt = conn.createStatement();
+             DBResultSet rs = stmt.executeQuery(query)) {
 
             stmt.close(); // this should close the resultSet
             try {
@@ -542,10 +433,7 @@ public class bvtTest extends bvtTestSetup {
             catch (SQLException e) {
                 assertEquals(e.toString(), "com.microsoft.sqlserver.jdbc.SQLServerException: The result set is closed.");
             }
-            assertTrue(true, "Previouse one should have thrown exception!");
-        }
-        finally {
-            terminateVariation();
+            assertTrue(true, "Previous one should have thrown exception!");
         }
     }
 
@@ -557,17 +445,11 @@ public class bvtTest extends bvtTestSetup {
     @Test
     public void testResultSetSelectMethod() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString + ";selectMethod=cursor;");
-            stmt = conn.createStatement();
-
-            String query = "SELECT * FROM " + table1.getEscapedTableName();
-            rs = stmt.executeQuery(query);
-
+        String query = "SELECT * FROM " + table1.getEscapedTableName();
+        try (DBConnection conn = new DBConnection(connectionString + ";selectMethod=cursor;");
+             DBStatement stmt = conn.createStatement();
+             DBResultSet rs = stmt.executeQuery(query)) {
             rs.verify(table1);
-        }
-        finally {
-            terminateVariation();
         }
     }
 
@@ -579,34 +461,10 @@ public class bvtTest extends bvtTestSetup {
     @AfterAll
     public static void terminate() throws SQLException {
 
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement();
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt = conn.createStatement()) {
             stmt.execute("if object_id('" + table1.getEscapedTableName() + "','U') is not null" + " drop table " + table1.getEscapedTableName());
             stmt.execute("if object_id('" + table2.getEscapedTableName() + "','U') is not null" + " drop table " + table2.getEscapedTableName());
         }
-        finally {
-            terminateVariation();
-        }
     }
-
-    /**
-     * cleanup after tests
-     * 
-     * @throws SQLException
-     */
-    public static void terminateVariation() throws SQLException {
-        if (conn != null && !conn.isClosed()) {
-            try {
-                conn.close();
-            }
-            finally {
-                if (null != rs)
-                    rs.close();
-                if (null != stmt)
-                    stmt.close();
-            }
-        }
-    }
-
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTest.java
@@ -361,10 +361,11 @@ public class bvtTest extends bvtTestSetup {
 
         try (DBConnection conn = new DBConnection(connectionString);
              DBStatement stmt1 = conn.createStatement();
-             DBStatement stmt2 = conn.createStatement();
-             DBResultSet rs1 = stmt1.executeQuery(query);
-             DBResultSet rs2 = stmt2.executeQuery(query2)) {
+             DBStatement stmt2 = conn.createStatement()) {
 
+            DBResultSet rs1 = stmt1.executeQuery(query);
+            DBResultSet rs2 = stmt2.executeQuery(query2);
+            
             // Interleave resultset calls
             rs1.next();
             rs1.verifyCurrentRow(table1);
@@ -373,8 +374,10 @@ public class bvtTest extends bvtTestSetup {
             rs1.next();
             rs1.verifyCurrentRow(table1);
             rs1.verify(table1);
+            rs1.close();
             rs2.next();
             rs2.verify(table2);
+            rs2.close();
         }
     }
 
@@ -390,10 +393,10 @@ public class bvtTest extends bvtTestSetup {
         String query2 = "SELECT * FROM " + table2.getEscapedTableName();
         
         try (DBConnection conn = new DBConnection(connectionString);
-             DBStatement stmt = conn.createStatement();
-             DBResultSet rs1 = stmt.executeQuery(query);
-             DBResultSet rs2 = stmt.executeQuery(query2)) {
+             DBStatement stmt = conn.createStatement()) {
 
+            DBResultSet rs1 = stmt.executeQuery(query);
+            DBResultSet rs2 = stmt.executeQuery(query2);
             // Interleave resultset calls. rs is expected to be closed
             try {
                 rs1.next();
@@ -409,8 +412,10 @@ public class bvtTest extends bvtTestSetup {
             catch (SQLException e) {
                 assertEquals(e.toString(), "com.microsoft.sqlserver.jdbc.SQLServerException: The result set is closed.");
             }
+            rs1.close();
             rs2.next();
             rs2.verify(table2);
+            rs2.close();
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTestSetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTestSetup.java
@@ -24,18 +24,14 @@ import com.microsoft.sqlserver.testframework.DBTable;
  */
 @RunWith(JUnitPlatform.class)
 public class bvtTestSetup extends AbstractTest {
-    private static DBConnection conn = null;
-    private static DBStatement stmt = null;
 
     static DBTable table1;
     static DBTable table2;
 
     @BeforeAll
     public static void init() throws SQLException {
-        try {
-            conn = new DBConnection(connectionString);
-            stmt = conn.createStatement();
-
+        try (DBConnection conn = new DBConnection(connectionString);
+             DBStatement stmt = conn.createStatement()) {
             // create tables
             table1 = new DBTable(true);
             stmt.createTable(table1);
@@ -44,14 +40,5 @@ public class bvtTestSetup extends AbstractTest {
             stmt.createTable(table2);
             stmt.populateTable(table2);
         }
-        finally {
-            if (null != stmt) {
-                stmt.close();
-            }
-            if (null != conn && !conn.isClosed()) {
-                conn.close();
-            }
-        }
     }
-
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -123,8 +123,7 @@ public class ConnectionDriverTest extends AbstractTest {
         ds.setEncrypt(true);
         ds.setTrustServerCertificate(true);
         ds.setPacketSize(8192);
-        Connection con = ds.getConnection();
-        con.close();
+        try(Connection con = ds.getConnection()) {}
     }
 
     @Test
@@ -172,25 +171,25 @@ public class ConnectionDriverTest extends AbstractTest {
 
         // Attach the Event listener and listen for connection events.
         MyEventListener myE = new MyEventListener();
-        pooledConnection.addConnectionEventListener(myE);	// ConnectionListener
-                                                         	// implements
-                                                         	// ConnectionEventListener
-        Connection con = pooledConnection.getConnection();
-        Statement stmt = con.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+        pooledConnection.addConnectionEventListener(myE);	// ConnectionListener implements ConnectionEventListener
+        
+        try(Connection con = pooledConnection.getConnection();
+        	Statement stmt = con.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE)) {
 
-        boolean exceptionThrown = false;
-        try {
-            // raise a severe exception and make sure that the connection is not
-            // closed.
-            stmt.executeUpdate("RAISERROR ('foo', 20,1) WITH LOG");
+	        boolean exceptionThrown = false;
+	        try {
+	            // raise a severe exception and make sure that the connection is not
+	            // closed.
+	            stmt.executeUpdate("RAISERROR ('foo', 20,1) WITH LOG");
+	        }
+	        catch (Exception e) {
+	            exceptionThrown = true;
+	        }
+	        assertTrue(exceptionThrown, "Expected exception is not thrown.");
+	
+	        // Check to see if error occurred.
+	        assertTrue(myE.errorOccurred, "Error occurred is not called.");
         }
-        catch (Exception e) {
-            exceptionThrown = true;
-        }
-        assertTrue(exceptionThrown, "Expected exception is not thrown.");
-
-        // Check to see if error occurred.
-        assertTrue(myE.errorOccurred, "Error occurred is not called.");
         // make sure that connection is closed.
     }
 
@@ -204,23 +203,18 @@ public class ConnectionDriverTest extends AbstractTest {
 
         // Attach the Event listener and listen for connection events.
         MyEventListener myE = new MyEventListener();
-        pooledConnection.addConnectionEventListener(myE);	// ConnectionListener
-                                                         	// implements
-                                                         	// ConnectionEventListener
+        pooledConnection.addConnectionEventListener(myE);	// ConnectionListener implements ConnectionEventListener
 
-        Connection con = pooledConnection.getConnection();
-        Statement stmt = con.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
-
-        // raise a non severe exception and make sure that the connection is not
-        // closed.
+    	Connection con = pooledConnection.getConnection();
+    	Statement stmt = con.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
+        // raise a non severe exception and make sure that the connection is not closed.
         stmt.executeUpdate("RAISERROR ('foo', 3,1) WITH LOG");
-
         // not a serious error there should not be any errors.
         assertTrue(!myE.errorOccurred, "Error occurred is called.");
         // check to make sure that connection is not closed.
-        assertTrue(!con.isClosed(), "Connection is closed.");
-
-        con.close();
+	    assertTrue(!con.isClosed(), "Connection is closed.");
+	    stmt.close();
+	    con.close();
         // check to make sure that connection is closed.
         assertTrue(con.isClosed(), "Connection is not closed.");
     }
@@ -242,36 +236,34 @@ public class ConnectionDriverTest extends AbstractTest {
             exceptionThrown = true;
         }
         assertTrue(exceptionThrown, "Expected exception is not thrown.");
-
+        
         // check to make sure that connection is closed.
         assertTrue(con.isClosed(), "Connection is not closed.");
     }
 
     @Test
     public void testIsWrapperFor() throws SQLException, ClassNotFoundException {
-        Connection conn = DriverManager.getConnection(connectionString);
-        SQLServerConnection ssconn = (SQLServerConnection) conn;
-        boolean isWrapper;
-        isWrapper = ssconn.isWrapperFor(ssconn.getClass());
-        assertTrue(isWrapper, "SQLServerConnection supports unwrapping");
-        assertEquals(ssconn.TRANSACTION_SNAPSHOT, ssconn.TRANSACTION_SNAPSHOT, "Cant access the TRANSACTION_SNAPSHOT ");
-
-        isWrapper = ssconn.isWrapperFor(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerConnection"));
-        assertTrue(isWrapper, "ISQLServerConnection supports unwrapping");
-        ISQLServerConnection iSql = (ISQLServerConnection) ssconn.unwrap(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerConnection"));
-        assertEquals(iSql.TRANSACTION_SNAPSHOT, iSql.TRANSACTION_SNAPSHOT, "Cant access the TRANSACTION_SNAPSHOT ");
-
-        ssconn.unwrap(Class.forName("java.sql.Connection"));
-
-        conn.close();
+        try(Connection conn = DriverManager.getConnection(connectionString);
+        		SQLServerConnection ssconn = (SQLServerConnection) conn) {
+	        boolean isWrapper;
+	        isWrapper = ssconn.isWrapperFor(ssconn.getClass());
+	        assertTrue(isWrapper, "SQLServerConnection supports unwrapping");
+	        assertEquals(ssconn.TRANSACTION_SNAPSHOT, ssconn.TRANSACTION_SNAPSHOT, "Cant access the TRANSACTION_SNAPSHOT ");
+	
+	        isWrapper = ssconn.isWrapperFor(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerConnection"));
+	        assertTrue(isWrapper, "ISQLServerConnection supports unwrapping");
+	        ISQLServerConnection iSql = (ISQLServerConnection) ssconn.unwrap(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerConnection"));
+	        assertEquals(iSql.TRANSACTION_SNAPSHOT, iSql.TRANSACTION_SNAPSHOT, "Cant access the TRANSACTION_SNAPSHOT ");
+	
+	        ssconn.unwrap(Class.forName("java.sql.Connection"));
+        }
     }
 
     @Test
     public void testNewConnection() throws SQLException {
-        SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString);
-        assertTrue(conn.isValid(0), "Newly created connection should be valid");
-
-        conn.close();
+        try(SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString)) {
+        	assertTrue(conn.isValid(0), "Newly created connection should be valid");
+        }
     }
 
     @Test
@@ -283,46 +275,46 @@ public class ConnectionDriverTest extends AbstractTest {
 
     @Test
     public void testNegativeTimeout() throws Exception {
-        SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString);
-        try {
-            conn.isValid(-42);
-            throw new Exception("No exception thrown with negative timeout");
+        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString)) {
+	        try {
+	            conn.isValid(-42);
+	            throw new Exception("No exception thrown with negative timeout");
+	        }
+	        catch (SQLException e) {
+	            assertEquals(e.getMessage(), "The query timeout value -42 is not valid.", "Wrong exception message");
+	        }
         }
-        catch (SQLException e) {
-            assertEquals(e.getMessage(), "The query timeout value -42 is not valid.", "Wrong exception message");
-        }
-
-        conn.close();
     }
 
     @Test
     public void testDeadConnection() throws SQLException {
         assumeTrue(!DBConnection.isSqlAzure(DriverManager.getConnection(connectionString)), "Skipping test case on Azure SQL.");
 
-        SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString + ";responseBuffering=adaptive");
-        Statement stmt = null;
-
-        String tableName = RandomUtil.getIdentifier("Table");
-        tableName = DBTable.escapeIdentifier(tableName);
-
-        conn.setAutoCommit(false);
-        stmt = conn.createStatement();
-        stmt.executeUpdate("CREATE TABLE " + tableName + " (col1 int primary key)");
-        for (int i = 0; i < 80; i++) {
-            stmt.executeUpdate("INSERT INTO " + tableName + "(col1) values (" + i + ")");
+        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString + ";responseBuffering=adaptive")) {
+        	
+        	Statement stmt = null;
+	        String tableName = RandomUtil.getIdentifier("Table");
+	        tableName = DBTable.escapeIdentifier(tableName);
+	
+	        conn.setAutoCommit(false);
+	        stmt = conn.createStatement();
+	        stmt.executeUpdate("CREATE TABLE " + tableName + " (col1 int primary key)");
+	        for (int i = 0; i < 80; i++) {
+	            stmt.executeUpdate("INSERT INTO " + tableName + "(col1) values (" + i + ")");
+	        }
+	        conn.commit();
+	        try {
+	            stmt.execute("SELECT x1.col1 as foo, x2.col1 as bar, x1.col1 as eeep FROM " + tableName + " as x1, " + tableName
+	                    + " as x2; RAISERROR ('Oops', 21, 42) WITH LOG");
+	        }
+	        catch (SQLServerException e) {
+	            assertEquals(e.getMessage(), "Connection reset", "Unknown Exception");
+	        }
+	        finally {
+	            DriverManager.getConnection(connectionString).createStatement().execute("drop table " + tableName);
+	        }
+	        assertEquals(conn.isValid(5), false, "Dead connection should be invalid");
         }
-        conn.commit();
-        try {
-            stmt.execute("SELECT x1.col1 as foo, x2.col1 as bar, x1.col1 as eeep FROM " + tableName + " as x1, " + tableName
-                    + " as x2; RAISERROR ('Oops', 21, 42) WITH LOG");
-        }
-        catch (SQLServerException e) {
-            assertEquals(e.getMessage(), "Connection reset", "Unknown Exception");
-        }
-        finally {
-            DriverManager.getConnection(connectionString).createStatement().execute("drop table " + tableName);
-        }
-        assertEquals(conn.isValid(5), false, "Dead connection should be invalid");
     }
 
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/DBMetadataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/DBMetadataTest.java
@@ -11,13 +11,13 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
-import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.DBTable;
 import com.microsoft.sqlserver.testframework.util.RandomUtil;
@@ -32,26 +32,27 @@ public class DBMetadataTest extends AbstractTest {
         SQLServerDataSource ds = new SQLServerDataSource();
         ds.setURL(connectionString);
 
-        Connection con = ds.getConnection();
-
-        // drop function
         String sqlDropFunction = "if exists (select * from dbo.sysobjects where id = object_id(N'[dbo]." + functionName + "')"
                 + "and xtype in (N'FN', N'IF', N'TF'))" + "drop function " + functionName;
-        con.createStatement().execute(sqlDropFunction);
-
-        // create function
         String sqlCreateFunction = "CREATE  FUNCTION " + functionName + " (@text varchar(8000), @delimiter varchar(20) = ' ') RETURNS @Strings TABLE "
                 + "(position int IDENTITY PRIMARY KEY, value varchar(8000)) AS BEGIN INSERT INTO @Strings VALUES ('DDD') RETURN END ";
-        con.createStatement().execute(sqlCreateFunction);
+        
+        try (Connection con = ds.getConnection();
+        	 Statement stmt = con.createStatement()) {
+            // drop function
+        	stmt.execute(sqlDropFunction);
+	        // create function
+	        stmt.execute(sqlCreateFunction);
 
-        DatabaseMetaData md = con.getMetaData();
-        ResultSet arguments = md.getProcedureColumns(null, null, null, "@TABLE_RETURN_VALUE");
-
-        if (arguments.next()) {
-            arguments.getString("COLUMN_NAME");
-            arguments.getString("DATA_TYPE"); // call this function to make sure it does not crash
+	        DatabaseMetaData md = con.getMetaData();
+	        try (ResultSet arguments = md.getProcedureColumns(null, null, null, "@TABLE_RETURN_VALUE")) {
+		
+		        if (arguments.next()) {
+		            arguments.getString("COLUMN_NAME");
+		            arguments.getString("DATA_TYPE"); // call this function to make sure it does not crash
+		        }
+	        }
+	        stmt.execute(sqlDropFunction);
         }
-
-        con.createStatement().execute(sqlDropFunction);
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/PoolingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/PoolingTest.java
@@ -59,17 +59,15 @@ public class PoolingTest extends AbstractTest {
         XADataSource1.setDatabaseName("tempdb");
 
         PooledConnection pc = XADataSource1.getPooledConnection();
-        Connection conn = pc.getConnection();
-
-        // create table in tempdb database
-        conn.createStatement().execute("create table [" + tempTableName + "] (myid int)");
-        conn.createStatement().execute("insert into [" + tempTableName + "] values (1)");
-        conn.close();
-
-        conn = pc.getConnection();
+        try (Connection conn = pc.getConnection()) {
+	
+	        // create table in tempdb database
+	        conn.createStatement().execute("create table [" + tempTableName + "] (myid int)");
+	        conn.createStatement().execute("insert into [" + tempTableName + "] values (1)");
+        }
 
         boolean tempTableFileRemoved = false;
-        try {
+        try (Connection conn = pc.getConnection()) {
             conn.createStatement().executeQuery("select * from [" + tempTableName + "]");
         }
         catch (SQLServerException e) {
@@ -109,12 +107,12 @@ public class PoolingTest extends AbstractTest {
         ds.setURL(connectionString);
 
         PooledConnection pc = ds.getPooledConnection();
-        Connection con = pc.getConnection();
-
-        Statement statement = con.createStatement();
-        statement.execute(sql1);
-        statement.execute(sql2);
-        con.clearWarnings();
+        try (Connection con = pc.getConnection();
+        	 Statement statement = con.createStatement()) {
+	        statement.execute(sql1);
+	        statement.execute(sql2);
+	        con.clearWarnings();
+        }
         pc.close();
     }
 

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBConnection.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBConnection.java
@@ -21,7 +21,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerException;
 /*
  * Wrapper class for SQLServerConnection
  */
-public class DBConnection extends AbstractParentWrapper {
+public class DBConnection extends AbstractParentWrapper implements AutoCloseable {
     private double serverversion = 0;
 
     // TODO: add Isolation Level

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBResultSet.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBResultSet.java
@@ -36,7 +36,7 @@ import com.microsoft.sqlserver.testframework.Utils.DBCharacterStream;
  *
  */
 
-public class DBResultSet extends AbstractParentWrapper {
+public class DBResultSet extends AbstractParentWrapper implements AutoCloseable {
 
     // TODO: add cursors
     // TODO: add resultSet level holdability

--- a/src/test/java/com/microsoft/sqlserver/testframework/DBStatement.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/DBStatement.java
@@ -21,7 +21,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerException;
  * @author Microsoft
  *
  */
-public class DBStatement extends AbstractParentWrapper {
+public class DBStatement extends AbstractParentWrapper implements AutoCloseable{
 
     // TODO: support PreparedStatement and CallableStatement
     // TODO: add stmt level holdability
@@ -120,7 +120,7 @@ public class DBStatement extends AbstractParentWrapper {
         if ((null != dbresultSet) && null != ((ResultSet) dbresultSet.product())) {
             ((ResultSet) dbresultSet.product()).close();
         }
-        statement.close();
+        //statement.close();
     }
 
     /**


### PR DESCRIPTION
**Improvements in JUnit Tests:**

`try-with-resources` is available since Java 7 and must be used for defining closeable class objects eg, Connection, Statement, PreparedStatement, ResultSet, Streams, etc. It not only reduces code length, but ensures closure of objects preventing object leaks and also improves code readability. It doesn't make much impact on performance, but prevents memory leaks. 

- A few class level connection and statement objects have been removed as they were being initialized in all class functions. 
- Statement objects are passed in a few functions instead of using class variables to maintain encapsulation.
- `try-with-resources` is avoided in places where connection and statement objects need not be re-initialized and can be reused in a single class. _(A few existing classes may need to be modified to reuse connection to improve test running speed, but will be implemented as part of separate PR)_

Since lot of files are impacted by this change, it will be pushed in parts.