### PR TITLE
Fix for static logger member in abstract class 'SQLServerClobBase'

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
@@ -35,9 +35,6 @@ import java.util.logging.Logger;
 public class SQLServerClob extends SQLServerClobBase implements Clob {
     private static final long serialVersionUID = 2872035282200133865L;
 
-    // Loggers should be class static to avoid lock contention with multiple threads
-    private static final Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerClob");
-
     /**
      * Create a new CLOB
      *
@@ -50,19 +47,19 @@ public class SQLServerClob extends SQLServerClobBase implements Clob {
     @Deprecated
     public SQLServerClob(SQLServerConnection connection,
             String data) {
-        super(connection, data, (null == connection) ? null : connection.getDatabaseCollation(), logger, null);
+        super(connection, data, (null == connection) ? null : connection.getDatabaseCollation(), null);
 
         if (null == data)
             throw new NullPointerException(SQLServerException.getErrString("R_cantSetNull"));
     }
 
     SQLServerClob(SQLServerConnection connection) {
-        super(connection, "", connection.getDatabaseCollation(), logger, null);
+        super(connection, "", connection.getDatabaseCollation(), null);
     }
 
     SQLServerClob(BaseInputStream stream,
             TypeInfo typeInfo) throws SQLServerException, UnsupportedEncodingException {
-        super(null, stream, typeInfo.getSQLCollation(), logger , typeInfo);
+        super(null, stream, typeInfo.getSQLCollation(), typeInfo);
     }
 
     final JDBCType getJdbcType() {
@@ -91,7 +88,9 @@ abstract class SQLServerClobBase implements Serializable {
     private ArrayList<Closeable> activeStreams = new ArrayList<>(1);
 
     transient SQLServerConnection con;
-    private static Logger logger;
+    
+    private final Logger logger = Logger.getLogger(getClass().getName());
+    
     final private String traceID = getClass().getName().substring(1 + getClass().getName().lastIndexOf('.')) + ":" + nextInstanceID();
 
     final public String toString() {
@@ -129,7 +128,6 @@ abstract class SQLServerClobBase implements Serializable {
     SQLServerClobBase(SQLServerConnection connection,
             Object data,
             SQLCollation collation,
-            Logger logger,
             TypeInfo typeInfo) {
         this.con = connection;
         if (data instanceof BaseInputStream) {
@@ -140,7 +138,6 @@ abstract class SQLServerClobBase implements Serializable {
         }
         this.sqlCollation = collation;
         this.typeInfo = typeInfo;
-        SQLServerClobBase.logger = logger;
 
         if (logger.isLoggable(Level.FINE)) {
             String loggingInfo = (null != connection) ? connection.toString() : "null connection";

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerNClob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerNClob.java
@@ -10,23 +10,22 @@ package com.microsoft.sqlserver.jdbc;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.NClob;
-import java.util.logging.Logger;
 
 /**
  * SQLServerNClob represents a National Character Set LOB object and implements java.sql.NClob.
  */
 
 public final class SQLServerNClob extends SQLServerClobBase implements NClob {
-    // Loggers should be class static to avoid lock contention with multiple threads
-    private static final Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerNClob");
 
-    SQLServerNClob(SQLServerConnection connection) {
-        super(connection, "", connection.getDatabaseCollation(), logger, null);
+	private static final long serialVersionUID = 1L;
+
+	SQLServerNClob(SQLServerConnection connection) {
+        super(connection, "", connection.getDatabaseCollation(), null);
     }
 
     SQLServerNClob(BaseInputStream stream,
             TypeInfo typeInfo) throws SQLServerException, UnsupportedEncodingException {
-        super(null, stream, typeInfo.getSQLCollation(), logger , typeInfo);
+        super(null, stream, typeInfo.getSQLCollation(), typeInfo);
     }
 
     final JDBCType getJdbcType() {


### PR DESCRIPTION
Fixes issue #186.

This change makes logger in abstract class 'SQLServerClobBase' non-static but final such that it is instantiated for every new object, based on subclass been used to create object and is immutable.