### PR TITLE
add "connectionDateformat" connection parameter

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -356,7 +356,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
      * @throws SQLServerException
      *             If a connection cannot be established.
      */
-    public SQLServerBulkCopy(String connectionUrl) throws SQLServerException {
+    public SQLServerBulkCopy(String connectionUrl) throws SQLServerException, SQLException {
         loggerExternal.entering(loggerClassName, "SQLServerBulkCopy", "connectionUrl not traced.");
         if ((connectionUrl == null) || "".equals(connectionUrl.trim())) {
             throw new SQLServerException(null, SQLServerException.getErrString("R_nullConnection"), null, 0, false);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -213,10 +213,6 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
         return getStringProperty(connectionProps, SQLServerDriverStringProperty.ACCESS_TOKEN.toString(), null);
     }
 
-    // If lastUpdateCount is set to true, the driver will return only the last update
-    // count from all the update counts returned by a batch. The default of false will
-    // return all update counts. If lastUpdateCount is not set, getLastUpdateCount
-    // returns the default value of false.
     /**
      * Enables/disables Always Encrypted functionality for the data source object. The default is Disabled.
      * 
@@ -235,6 +231,29 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
     public String getColumnEncryptionSetting() {
         return getStringProperty(connectionProps, SQLServerDriverStringProperty.COLUMN_ENCRYPTION.toString(),
                 SQLServerDriverStringProperty.COLUMN_ENCRYPTION.getDefaultValue());
+    }
+
+    /**
+     * Sets the connectionDateformat setting for the data source object.
+     * <p>
+     * Corresponds to the {@code SET DATEFORMAT} statement in T-SQL.
+     * <P>
+     * Valid values: "mdy", "dmy", "ymd", "ydm", "myd", "dym"
+     * 
+     * @param connectionDateformatSetting
+     */
+    public void setConnectionDateformatSetting(String connectionDateformatSetting) {
+        setStringProperty(connectionProps, SQLServerDriverStringProperty.CONNECTION_DATEFORMAT.toString(), connectionDateformatSetting);
+    }
+
+    /**
+     * Retrieves the connectionDateformat setting for the data source object.
+     * 
+     * @return the connectionDateformat setting for the data source object.
+     */
+    public String getConnectionDateformatSetting() {
+        return getStringProperty(connectionProps, SQLServerDriverStringProperty.CONNECTION_DATEFORMAT.toString(),
+                SQLServerDriverStringProperty.CONNECTION_DATEFORMAT.getDefaultValue());
     }
 
     /**
@@ -289,10 +308,30 @@ public class SQLServerDataSource implements ISQLServerDataSource, DataSource, ja
                 SQLServerDriverStringProperty.KEY_STORE_LOCATION.getDefaultValue());
     }
 
+    /**
+     * Sets the lastUpdateCount setting for the data source object.
+     * <p>
+     * If lastUpdateCount is set to true, the driver will return only the last update
+     * count from all the update counts returned by a batch. The default of false will
+     * return all update counts.
+     * 
+     * @param keyStoreLocation
+     *            the location including the file name for the Java keystore.
+     */
     public void setLastUpdateCount(boolean lastUpdateCount) {
         setBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString(), lastUpdateCount);
     }
 
+    /**
+     * Retrieves the lastUpdateCount setting for the data source object.
+     * <p>
+     * If lastUpdateCount is not set, getLastUpdateCount
+     * returns the default value of false.
+     * <p>
+     * See {@link #setLastUpdateCount(boolean)} for details.
+     * 
+     * @return the lastUpdateCount setting for the data source object.
+     */
     public boolean getLastUpdateCount() {
         return getBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString(),
                 SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.getDefaultValue());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -12,6 +12,7 @@ import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
 import java.text.MessageFormat;
 import java.util.Enumeration;
 import java.util.Locale;
@@ -264,6 +265,7 @@ enum SQLServerDriverStringProperty
 {
 	APPLICATION_INTENT         ("applicationIntent",       ApplicationIntent.READ_WRITE.toString()),
 	APPLICATION_NAME           ("applicationName",         SQLServerDriver.DEFAULT_APP_NAME),
+	CONNECTION_DATEFORMAT      ("connectionDateformat",    ""),
 	DATABASE_NAME              ("databaseName",            ""),
 	FAILOVER_PARTNER           ("failoverPartner",         ""),
 	HOSTNAME_IN_CERTIFICATE    ("hostNameInCertificate",   ""),
@@ -384,6 +386,7 @@ public final class SQLServerDriver implements java.sql.Driver {
         new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.APPLICATION_INTENT.toString(),    				      SQLServerDriverStringProperty.APPLICATION_INTENT.getDefaultValue(), 									  false,	  new String[]{ApplicationIntent.READ_ONLY.toString(), ApplicationIntent.READ_WRITE.toString()}),            	
         new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.APPLICATION_NAME.toString(),    					      SQLServerDriverStringProperty.APPLICATION_NAME.getDefaultValue(), 									  false,	  null),
         new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.COLUMN_ENCRYPTION.toString(),            			      SQLServerDriverStringProperty.COLUMN_ENCRYPTION.getDefaultValue(),       							      false,      new String[] {ColumnEncryptionSetting.Disabled.toString(), ColumnEncryptionSetting.Enabled.toString()}),
+        new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.CONNECTION_DATEFORMAT.toString(),                       SQLServerDriverStringProperty.CONNECTION_DATEFORMAT.getDefaultValue(),                                      false,      new String[] {ColumnEncryptionSetting.Disabled.toString(), ColumnEncryptionSetting.Enabled.toString()}),
         new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.DATABASE_NAME.toString(),       					      SQLServerDriverStringProperty.DATABASE_NAME.getDefaultValue(),       								      false,      null),                        
         new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.DISABLE_STATEMENT_POOLING.toString(), 			      Boolean.toString(SQLServerDriverBooleanProperty.DISABLE_STATEMENT_POOLING.getDefaultValue()),       	  false,      new String[] {"true"}),
         new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.ENCRYPT.toString(),                      		      Boolean.toString(SQLServerDriverBooleanProperty.ENCRYPT.getDefaultValue()),        					  false,      TRUE_FALSE),
@@ -605,7 +608,7 @@ public final class SQLServerDriver implements java.sql.Driver {
     }
 
     /* L0 */ public java.sql.Connection connect(String Url,
-            Properties suppliedProperties) throws SQLServerException {
+            Properties suppliedProperties) throws SQLServerException, SQLException {
         loggerExternal.entering(getClassNameLogging(), "connect", "Arguments not traced.");
         SQLServerConnection result = null;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -160,6 +160,7 @@ public final class SQLServerResource extends ListResourceBundle {
 				{"R_portNumberPropertyDescription", "The TCP port where an instance of SQL Server is listening."},
 				{"R_serverSpnPropertyDescription", "SQL Server SPN."},
 				{"R_columnEncryptionSettingPropertyDescription", "The column encryption setting."},
+                {"R_connectionDateformatPropertyDescription", "The T-SQL DATEFORMAT setting for this connection."},
 				{"R_serverNameAsACEPropertyDescription", "Translates the serverName from Unicode to ASCII Compatible Encoding (ACE), as defined by the ToASCII operation of RFC 3490."},
 				{"R_sendStringParametersAsUnicodePropertyDescription", "Determines if the string parameters are sent to the server as Unicode or the database's character set."},
 				{"R_multiSubnetFailoverPropertyDescription", "Indicates that the application is connecting to the Availability Group Listener of an Availability Group or Failover Cluster Instance."},

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
@@ -123,7 +123,7 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
     void testInvalidConnection3() {
         assertThrows(SQLServerException.class, new org.junit.jupiter.api.function.Executable() {
             @Override
-            public void execute() throws SQLServerException {
+            public void execute() throws SQLException {
                 String connectionUrl = " ";
                 try(SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(connectionUrl)) {
                 	//do nothing
@@ -140,7 +140,7 @@ public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
     void testInvalidConnection4() {
         assertThrows(SQLServerException.class, new org.junit.jupiter.api.function.Executable() {
             @Override
-            public void execute() throws SQLServerException {
+            public void execute() throws SQLException {
                 String connectionUrl = null;
                 try(SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(connectionUrl)) {
                 	//do nothing

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -196,7 +196,7 @@ public class CallableStatementTest extends AbstractTest {
 
     private static void createInputParamsProcedure(Statement stmt) throws SQLException {
         String sql = 
-                "CREATE PROCEDURE [dbo].[CallableStatementTest_inputParams_SP] " +
+                "CREATE PROCEDURE [dbo].[" + inputParamsProcedureName + "] " +
                 "    @p1 nvarchar(max) = N'parameter1', " +
                 "    @p2 nvarchar(max) = N'parameter2' " +
                 "AS " +

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -549,4 +549,28 @@ public class ConnectionDriverTest extends AbstractTest {
 
         assertTrue(isInterrupted, "Thread's interrupt status is not set.");
     }
+
+    @Test
+    public void testConnectionDateformat() throws SQLException {
+        SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString);
+        String defaultValueForConnection = getDbccUseroptionsValue(conn, "dateformat");
+        conn.close();
+        String overrideValue = defaultValueForConnection.equals("mdy") ? "ymd" : "mdy";
+        conn = (SQLServerConnection) DriverManager.getConnection(connectionString + ";connectionDateformat=" + overrideValue);
+        assertEquals(overrideValue, getDbccUseroptionsValue(conn, "dateformat"));
+        conn.close();
+    }
+    
+    private String getDbccUseroptionsValue(SQLServerConnection conn, String setOption) throws SQLException {
+        String rtn = null;
+        Statement st = conn.createStatement();
+        ResultSet rs = st.executeQuery("DBCC USEROPTIONS");
+        while (rs.next()) {
+            if (rs.getString("Set Option").equals(setOption)) {
+                rtn = rs.getString("Value");
+                break;
+            }
+        }
+        return rtn;
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/NativeMSSQLDataSourceTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/NativeMSSQLDataSourceTest.java
@@ -35,6 +35,14 @@ import com.microsoft.sqlserver.testframework.AbstractTest;
 public class NativeMSSQLDataSourceTest extends AbstractTest {
 
     @Test
+    public void testConnectionDateformatSetting() {
+        final String testValue = "dym";  // an unlikely, but valid, value
+        SQLServerDataSource ds = new SQLServerDataSource();
+        ds.setConnectionDateformatSetting(testValue);
+        assertEquals(testValue, ds.getConnectionDateformatSetting());
+    }
+    
+    @Test
     public void testNativeMSSQLDataSource() throws SQLException {
         SQLServerXADataSource ds = new SQLServerXADataSource();
         ds.setLastUpdateCount(true);


### PR DESCRIPTION
(Prompted by [this Stack Overflow question](https://stackoverflow.com/q/47111591/2144390).)

It is not uncommon for applications to try and be database-agnostic by dealing with date/time values as strings. Sqoop seems to be one of those applications.

Normally, using a string date literal like `'2017-11-05'` is considered safe because the leading year value suggests that the format is `yyyy-mm-dd`. `yyyy-dd-mm` is almost unheard of ...

... except with SQL Server. If the SQL Server instance is installed with "British English" (or perhaps "English (UK)"?) as the default locale then the default DATEFORMAT is "dmy". When it is passed a `yyyy-xx-xx` string literal for a DATETIME value it is interpreted as `yyyy-dd-mm`, not `yyyy-mm-dd`:

```java
connUrl = "jdbc:sqlserver://localhost:49242;databaseName=myDb";
try (Connection conn = DriverManager.getConnection(connUrl, uid, pwd)) {
    String sql = "SELECT MONTH(CONVERT(DATETIME, '2017-11-05')) AS month_num";
    System.out.println(sql);
    try (Statement st = conn.createStatement()) {
        ResultSet rs = st.executeQuery(sql);
        rs.next();
        System.out.printf("month_num is %d%n", rs.getInt("month_num"));
    }
```

result:

```
SELECT MONTH(CONVERT(DATETIME, '2017-11-05')) AS month_num
month_num is 5
```

A [workaround](https://support.microsoft.com/en-us/help/173907/inf-how-to-set-the-day-month-year-date-format-in-sql-server) is to send a `SET DATEFORMAT 'ymd'` statement immediately after opening the connection. Unfortunately, Sqoop has that option for Oracle connections, but apparently not for other JDBC drivers.

This patch adds a "connectionDateformat" parameter for the connection URL and for a SQLServerDataSource. After adding `;connectionDateformat=ymd` ...

```java
connUrl = "jdbc:sqlserver://localhost:49242;databaseName=myDb;connectionDateformat=ymd";
try (Connection conn = DriverManager.getConnection(connUrl, uid, pwd)) {
    String sql = "SELECT MONTH(CONVERT(DATETIME, '2017-11-05')) AS month_num";
    System.out.println(sql);
    try (Statement st = conn.createStatement()) {
        ResultSet rs = st.executeQuery(sql);
        rs.next();
        System.out.printf("month_num is %d%n", rs.getInt("month_num"));
    }
```

... the result is:

```
SELECT MONTH(CONVERT(DATETIME, '2017-11-05')) AS month_num
month_num is 11
```
