### PR TITLE
update sendTimeAsDateTime default property to false.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -347,7 +347,7 @@ enum SQLServerDriverBooleanProperty
     MULTI_SUBNET_FAILOVER                     ("multiSubnetFailover",                       false),
     SERVER_NAME_AS_ACE                        ("serverNameAsACE",                           false),
     SEND_STRING_PARAMETERS_AS_UNICODE         ("sendStringParametersAsUnicode",             true),
-    SEND_TIME_AS_DATETIME                     ("sendTimeAsDatetime",                        true),
+    SEND_TIME_AS_DATETIME                     ("sendTimeAsDatetime",                        false),
     TRANSPARENT_NETWORK_IP_RESOLUTION         ("TransparentNetworkIPResolution",            true),
     TRUST_SERVER_CERTIFICATE                  ("trustServerCertificate",                    false),
     XOPEN_STATES                              ("xopenStates",                               false),


### PR DESCRIPTION
After merging this pr, the default behavior of the driver would be to send Time as time. 
Reference for the current behavior in [here](https://docs.microsoft.com/en-us/sql/connect/jdbc/configuring-how-java-sql-time-values-are-sent-to-the-server).

Will fix issue #559 