### PR TITLE
Fix issue with rowDeleted() causing issues with testing

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -974,7 +974,7 @@ public class SQLServerResultSet implements ISQLServerResultSet {
                 } catch (SQLServerException e) {
                     break;
                 }
-            } while (rowDeleted()); // repeat this if the row has been deleted beforehand, for scrollable & updatable resultsets.
+            } while (getDeletedCurrentRow()); // repeat this if the row has been deleted beforehand, for scrollable & updatable resultsets.
             boolean value = hasCurrentRow();
             loggerExternal.exiting(getClassNameLogging(), "next", value);
             return value;


### PR DESCRIPTION
Further addresses issue #477.

the rowDeleted() method calls currentRowDeleted, which checks for the row being deleted outside the cursor. This also involves skipping some columns within the row which results in the resultset state being different than what the test expects and throws an error. Using getDeletedCurrentRow instead (which checks to see if the row has been deleted via deleteRow()) prevents this problem from happening.