### PR TITLE
fixed random assertion error

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7553,12 +7553,12 @@ abstract class TDSCommand {
      * interrupted (0 or more packets sent with no EOM bit).
      */
     final void onRequestComplete() throws SQLServerException {
+        synchronized (interruptLock) {
         assert !requestComplete;
 
         if (logger.isLoggable(Level.FINEST))
             logger.finest(this + ": request complete");
 
-        synchronized (interruptLock) {
             requestComplete = true;
 
             // If this command was interrupted before its request was complete then

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7554,10 +7554,10 @@ abstract class TDSCommand {
      */
     final void onRequestComplete() throws SQLServerException {
         synchronized (interruptLock) {
-        assert !requestComplete;
-
-        if (logger.isLoggable(Level.FINEST))
-            logger.finest(this + ": request complete");
+	        assert !requestComplete;
+	
+	        if (logger.isLoggable(Level.FINEST))
+	            logger.finest(this + ": request complete");
 
             requestComplete = true;
 


### PR DESCRIPTION
race condition where 2 onRequestComplete() executed and the first one set the value to true before the second one evaluated. place tests inside synchronized to fix.