### PR TITLE
Fix for issue when attempting to insert an empty or null value on encrypted column

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -580,7 +580,8 @@ final class Parameter {
                          * specific type info, otherwise generic type info can be used as before.
                          */
                         if (0 == valueLength) {
-                            param.typeDefinition = "varbinary";
+                            param.typeDefinition = "varbinary(1)";
+                            valueLength++;
                         }
                         else {
                             param.typeDefinition = "varbinary(" + valueLength + ")";
@@ -721,7 +722,8 @@ final class Parameter {
                          * specific type info, otherwise generic type info can be used as before.
                          */
                         if (0 == valueLength) {
-                            param.typeDefinition = "varchar";
+                            param.typeDefinition = "varchar(1)";
+                            valueLength++;
                         }
                         else {
                             param.typeDefinition = "varchar(" + valueLength + ")";
@@ -745,7 +747,8 @@ final class Parameter {
                         if ((null != jdbcTypeSetByUser) && ((jdbcTypeSetByUser == JDBCType.VARCHAR) || (jdbcTypeSetByUser == JDBCType.CHAR)
                                 || (jdbcTypeSetByUser == JDBCType.LONGVARCHAR))) {
                             if (0 == valueLength) {
-                                param.typeDefinition = "varchar";
+                                param.typeDefinition = "varchar(1)";
+                                valueLength++;
                             }
                             else if (DataTypes.SHORT_VARTYPE_MAX_BYTES < valueLength) {
                                 param.typeDefinition = VARCHAR_MAX;
@@ -761,7 +764,8 @@ final class Parameter {
                         else if ((null != jdbcTypeSetByUser)
                                 && (jdbcTypeSetByUser == JDBCType.NVARCHAR || jdbcTypeSetByUser == JDBCType.LONGNVARCHAR)) {
                             if (0 == valueLength) {
-                                param.typeDefinition = "nvarchar";
+                                param.typeDefinition = "nvarchar(1)";
+                                valueLength++;
                             }
                             else if (DataTypes.SHORT_VARTYPE_MAX_CHARS < valueLength) {
                                 param.typeDefinition = NVARCHAR_MAX;
@@ -776,7 +780,8 @@ final class Parameter {
                         }
                         else { // used if setNull() is called with java.sql.Types.NCHAR
                             if (0 == valueLength) {
-                                param.typeDefinition = "nvarchar";
+                                param.typeDefinition = "nvarchar(1)";
+                                valueLength++;
                             }
                             else {
                                 param.typeDefinition = "nvarchar(" + valueLength + ")";
@@ -813,7 +818,8 @@ final class Parameter {
                         if ((null != jdbcTypeSetByUser) && ((jdbcTypeSetByUser == JDBCType.VARCHAR) || (jdbcTypeSetByUser == JDBCType.CHAR)
                                 || (JDBCType.LONGVARCHAR == jdbcTypeSetByUser))) {
                             if (0 == valueLength) {
-                                param.typeDefinition = "varchar";
+                                param.typeDefinition = "varchar(1)";
+                                valueLength++;
                             }
                             else {
                                 param.typeDefinition = "varchar(" + valueLength + ")";
@@ -830,7 +836,8 @@ final class Parameter {
                         else if ((null != jdbcTypeSetByUser) && ((jdbcTypeSetByUser == JDBCType.NVARCHAR) || (jdbcTypeSetByUser == JDBCType.NCHAR)
                                 || (JDBCType.LONGNVARCHAR == jdbcTypeSetByUser))) {
                             if (0 == valueLength) {
-                                param.typeDefinition = "nvarchar";
+                                param.typeDefinition = "nvarchar(1)";
+                                valueLength++;
                             }
                             else {
                                 param.typeDefinition = "nvarchar(" + valueLength + ")";
@@ -846,7 +853,8 @@ final class Parameter {
                         }
                         else { // used if setNull() is called with java.sql.Types.NCHAR
                             if (0 == valueLength) {
-                                param.typeDefinition = "nvarchar";
+                                param.typeDefinition = "nvarchar(1)";
+                                valueLength++;
                             }
                             else {
                                 param.typeDefinition = "nvarchar(" + valueLength + ")";

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -364,10 +364,6 @@ final class Parameter {
             // skip it if is (character types or binary type) & is output parameter && value is already set,
             if ((!(jdbcType.isTextual() || jdbcType.isBinary())) || !(this.isOutput()) || (this.valueLength == 0)) {
                 this.valueLength = Util.getValueLengthBaseOnJavaType(value, javaType, precision, scale, jdbcType);
-                // Workaround for the issue when inserting empty string and null into encrypted columns
-                if( this.valueLength == 0 ) {
-                    this.valueLength ++;
-                }
             }
 
             if (null != scale) {
@@ -584,6 +580,7 @@ final class Parameter {
                          * specific type info, otherwise generic type info can be used as before.
                          */
                         if (0 == valueLength) {
+                            // Workaround for the issue when inserting empty string and null into encrypted columns
                             param.typeDefinition = "varbinary(1)";
                             valueLength++;
                         }
@@ -726,6 +723,7 @@ final class Parameter {
                          * specific type info, otherwise generic type info can be used as before.
                          */
                         if (0 == valueLength) {
+                            // Workaround for the issue when inserting empty string and null into encrypted columns
                             param.typeDefinition = "varchar(1)";
                             valueLength++;
                         }
@@ -751,6 +749,7 @@ final class Parameter {
                         if ((null != jdbcTypeSetByUser) && ((jdbcTypeSetByUser == JDBCType.VARCHAR) || (jdbcTypeSetByUser == JDBCType.CHAR)
                                 || (jdbcTypeSetByUser == JDBCType.LONGVARCHAR))) {
                             if (0 == valueLength) {
+                                // Workaround for the issue when inserting empty string and null into encrypted columns
                                 param.typeDefinition = "varchar(1)";
                                 valueLength++;
                             }
@@ -768,6 +767,7 @@ final class Parameter {
                         else if ((null != jdbcTypeSetByUser)
                                 && (jdbcTypeSetByUser == JDBCType.NVARCHAR || jdbcTypeSetByUser == JDBCType.LONGNVARCHAR)) {
                             if (0 == valueLength) {
+                                // Workaround for the issue when inserting empty string and null into encrypted columns
                                 param.typeDefinition = "nvarchar(1)";
                                 valueLength++;
                             }
@@ -784,6 +784,7 @@ final class Parameter {
                         }
                         else { // used if setNull() is called with java.sql.Types.NCHAR
                             if (0 == valueLength) {
+                                // Workaround for the issue when inserting empty string and null into encrypted columns
                                 param.typeDefinition = "nvarchar(1)";
                                 valueLength++;
                             }
@@ -822,6 +823,7 @@ final class Parameter {
                         if ((null != jdbcTypeSetByUser) && ((jdbcTypeSetByUser == JDBCType.VARCHAR) || (jdbcTypeSetByUser == JDBCType.CHAR)
                                 || (JDBCType.LONGVARCHAR == jdbcTypeSetByUser))) {
                             if (0 == valueLength) {
+                                // Workaround for the issue when inserting empty string and null into encrypted columns
                                 param.typeDefinition = "varchar(1)";
                                 valueLength++;
                             }
@@ -840,6 +842,7 @@ final class Parameter {
                         else if ((null != jdbcTypeSetByUser) && ((jdbcTypeSetByUser == JDBCType.NVARCHAR) || (jdbcTypeSetByUser == JDBCType.NCHAR)
                                 || (JDBCType.LONGNVARCHAR == jdbcTypeSetByUser))) {
                             if (0 == valueLength) {
+                                // Workaround for the issue when inserting empty string and null into encrypted columns
                                 param.typeDefinition = "nvarchar(1)";
                                 valueLength++;
                             }
@@ -857,6 +860,7 @@ final class Parameter {
                         }
                         else { // used if setNull() is called with java.sql.Types.NCHAR
                             if (0 == valueLength) {
+                                // Workaround for the issue when inserting empty string and null into encrypted columns
                                 param.typeDefinition = "nvarchar(1)";
                                 valueLength++;
                             }


### PR DESCRIPTION
Workaround for #624.
Currently, when inserting empty string or `null` into encrypted variable-length columns, the driver sets the data length to `0` and the type to `type(0)` (`varchar(0)` for example). The workaround is to set the length to 1 and the type to type(1). 