### PR TITLE
655 Fix to return correct column type for spatial datatypes

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
@@ -10,7 +10,6 @@ package com.microsoft.sqlserver.jdbc;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Locale;
 
 public class Geography extends SQLServerSpatialDatatype {
     

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Geometry.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Geometry.java
@@ -10,7 +10,6 @@ package com.microsoft.sqlserver.jdbc;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Locale;
 
 public class Geometry extends SQLServerSpatialDatatype {
     

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -121,11 +121,12 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
         }
         
         JDBCType jdbcType = typeInfo.getSSType().getJDBCType();
+        SSType sqlType = typeInfo.getSSType();
         // in bulkcopy for instance, we need to return the real jdbc type which is sql variant and not the default Char one. 
-        if ( SSType.SQL_VARIANT == typeInfo.getSSType()){
+        if ( SSType.SQL_VARIANT == sqlType){
             jdbcType = JDBCType.SQL_VARIANT;
         }
-        if (SSType.UDT == typeInfo.getSSType()) {
+        if (SSType.UDT == sqlType) {
             if (typeInfo.getSSTypeName().equalsIgnoreCase("geometry")) {
                 jdbcType = JDBCType.GEOMETRY;
             }
@@ -135,8 +136,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
         }
         int r = jdbcType.asJavaSqlType();
         if (con.isKatmaiOrLater()) {
-            SSType sqlType = typeInfo.getSSType();
-
             switch (sqlType) {
                 case VARCHARMAX:
                     r = SSType.VARCHAR.getJDBCType().asJavaSqlType();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -125,6 +125,14 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
         if ( SSType.SQL_VARIANT == typeInfo.getSSType()){
             jdbcType = JDBCType.SQL_VARIANT;
         }
+        if (SSType.UDT == typeInfo.getSSType()) {
+            if (typeInfo.getSSTypeName().equalsIgnoreCase("geometry")) {
+                jdbcType = JDBCType.GEOMETRY;
+            }
+            if (typeInfo.getSSTypeName().equalsIgnoreCase("geography")) {
+                jdbcType = JDBCType.GEOGRAPHY;
+            }
+        }
         int r = jdbcType.asJavaSqlType();
         if (con.isKatmaiOrLater()) {
             SSType sqlType = typeInfo.getSSType();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -127,10 +127,10 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
             jdbcType = JDBCType.SQL_VARIANT;
         }
         if (SSType.UDT == sqlType) {
-            if (typeInfo.getSSTypeName().equalsIgnoreCase("geometry")) {
+            if (typeInfo.getSSTypeName().equalsIgnoreCase(SSType.GEOMETRY.name())) {
                 jdbcType = JDBCType.GEOMETRY;
             }
-            if (typeInfo.getSSTypeName().equalsIgnoreCase("geography")) {
+            if (typeInfo.getSSTypeName().equalsIgnoreCase(SSType.GEOGRAPHY.name())) {
                 jdbcType = JDBCType.GEOGRAPHY;
             }
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.sql.DriverManager;
+import java.sql.ParameterMetaData;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -816,6 +818,43 @@ public class SQLServerSpatialDatatypeTest extends AbstractTest  {
         
         assertEquals(geomWKB, geomWKB2);
         assertEquals(geogWKB, geogWKB2);
+    }
+
+    public void testCheckGeomMetaData() throws SQLException {
+        beforeEachSetup();
+                
+        pstmt = (SQLServerPreparedStatement) connection.prepareStatement("INSERT INTO " + geomTableName +" VALUES (?)");
+        ParameterMetaData paramMetaData = pstmt.getParameterMetaData();
+        Geometry g = Geometry.STGeomFromText("POINT (1 2 3 4)", 0);
+        pstmt.setGeometry(1, g);
+        pstmt.execute();
+        
+        int sqlType = paramMetaData.getParameterType(1);
+        String sqlTypeName = paramMetaData.getParameterTypeName(1);
+        assertEquals(sqlType, -157);
+        assertEquals(sqlTypeName, "geometry");
+        SQLServerResultSet rs = (SQLServerResultSet) stmt.executeQuery("select * from " + geomTableName);
+        ResultSetMetaData rsmd = rs.getMetaData();
+        assertEquals(rsmd.getColumnType(1), -157);
+    }
+    
+    @Test
+    public void testCheckGeogMetaData() throws SQLException {
+        beforeEachSetup();
+        
+        pstmt = (SQLServerPreparedStatement) connection.prepareStatement("INSERT INTO " + geogTableName +" VALUES (?)");
+        ParameterMetaData paramMetaData = pstmt.getParameterMetaData();
+        Geography g = Geography.STGeomFromText("POINT (1 2 3 4)", 4326);
+        pstmt.setGeography(1, g);
+        pstmt.execute();
+        
+        int sqlType = paramMetaData.getParameterType(1);
+        String sqlTypeName = paramMetaData.getParameterTypeName(1);
+        assertEquals(sqlType, -158);
+        assertEquals(sqlTypeName, "geography");
+        SQLServerResultSet rs = (SQLServerResultSet) stmt.executeQuery("select * from " + geogTableName);
+        ResultSetMetaData rsmd = rs.getMetaData();
+        assertEquals(rsmd.getColumnType(1), -158);
     }
     
     private void beforeEachSetup() throws SQLException {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
@@ -823,7 +823,7 @@ public class SQLServerSpatialDatatypeTest extends AbstractTest  {
     public void testCheckGeomMetaData() throws SQLException {
         beforeEachSetup();
                 
-        pstmt = (SQLServerPreparedStatement) connection.prepareStatement("INSERT INTO " + geomTableName +" VALUES (?)");
+        pstmt = (SQLServerPreparedStatement) connection.prepareStatement("INSERT INTO " + geomTableName +" (c1) VALUES (?)");
         ParameterMetaData paramMetaData = pstmt.getParameterMetaData();
         Geometry g = Geometry.STGeomFromText("POINT (1 2 3 4)", 0);
         pstmt.setGeometry(1, g);
@@ -842,7 +842,7 @@ public class SQLServerSpatialDatatypeTest extends AbstractTest  {
     public void testCheckGeogMetaData() throws SQLException {
         beforeEachSetup();
         
-        pstmt = (SQLServerPreparedStatement) connection.prepareStatement("INSERT INTO " + geogTableName +" VALUES (?)");
+        pstmt = (SQLServerPreparedStatement) connection.prepareStatement("INSERT INTO " + geogTableName +" (c1) VALUES (?)");
         ParameterMetaData paramMetaData = pstmt.getParameterMetaData();
         Geography g = Geography.STGeomFromText("POINT (1 2 3 4)", 4326);
         pstmt.setGeography(1, g);


### PR DESCRIPTION
Fixes issue #655. Also added test cases for it.

Also removed an unused import from Geometry/Geography classes.