### PR TITLE
Update Maven Dependencies for test suite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<junit.platform.version>1.1.0</junit.platform.version>
-		<junit.jupiter.version>5.1.0</junit.jupiter.version>
+		<junit.platform.version>1.1.1</junit.platform.version>
+		<junit.jupiter.version>5.1.1</junit.jupiter.version>
 	</properties>
 	
 	<dependencies>
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>2.7.8</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Maven Dependencies Updated:

com.zaxxer » HikariCP - **3.0.0**
org.junit.jupiter » junit-jupiter-api - **5.1.1**
org.junit.jupiter » junit-jupiter-engine - **5.1.1**
org.junit.platform » junit-platform-console - **1.1.1**
org.junit.platform » junit-platform-commons - **1.1.1**
org.junit.platform » junit-platform-engine - **1.1.1**
org.junit.platform » junit-platform-launcher - **1.1.1**
org.junit.platform » junit-platform-runner - **1.1.1**
org.junit.platform » junit-platform-surefire-provider - **1.1.1**

