### PR TITLE
Update Samples to be usable with Eclipse directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 			<optional>true</optional>
 		</dependency>
 		
-		<!-- dependency for running tests -->
+		<!-- dependencies for running tests -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -125,14 +125,6 @@
 			<version>2.2.0</version>
 			<scope>test</scope>
 		</dependency>
-  	<!-- 
-	<dependency>
-  		<groupId>org.junit.vintage</groupId>
-		<artifactId>junit-vintage-engine</artifactId>	
-  		<version>4.12.0-M3</version>
-  		<scope>test</scope>
-  	</dependency>	
-  	 -->
 	</dependencies>
 
 	<profiles>

--- a/src/samples/adaptive/pom.xml
+++ b/src/samples/adaptive/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.0.jre8</version>
+			<version>6.4.0.jre9</version>
 		</dependency>
 	</dependencies>
 	
@@ -35,7 +35,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>executeStoredProcedure</mainClass>
+							<mainClass>adaptive.src.main.java.executeStoredProcedure</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -53,7 +53,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>readLargeData</mainClass>
+							<mainClass>adaptive.src.main.java.readLargeData</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -71,7 +71,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>updateLargeData</mainClass>
+							<mainClass>adaptive.src.main.java.updateLargeData</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -85,8 +85,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 

--- a/src/samples/adaptive/src/main/java/executeStoredProcedure.java
+++ b/src/samples/adaptive/src/main/java/executeStoredProcedure.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package adaptive.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/adaptive/src/main/java/readLargeData.java
+++ b/src/samples/adaptive/src/main/java/readLargeData.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package adaptive.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/adaptive/src/main/java/updateLargeData.java
+++ b/src/samples/adaptive/src/main/java/updateLargeData.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package adaptive.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/alwaysencrypted/pom.xml
+++ b/src/samples/alwaysencrypted/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.0.jre8</version>
+			<version>6.4.0.jre9</version>
 		</dependency>
 	</dependencies>
 	
@@ -35,7 +35,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>AlwaysEncrypted</mainClass>
+							<mainClass>alwaysencrypted.src.main.java.AlwaysEncrypted</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -49,8 +49,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 

--- a/src/samples/alwaysencrypted/src/main/java/AlwaysEncrypted.java
+++ b/src/samples/alwaysencrypted/src/main/java/AlwaysEncrypted.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package alwaysencrypted.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/samples/azureactivedirectoryauthentication/pom.xml
+++ b/src/samples/azureactivedirectoryauthentication/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.0.jre8</version>
+			<version>6.4.0.jre9</version>
 		</dependency>
 	</dependencies>
 	
@@ -35,7 +35,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>AzureActiveDirectoryAuthentication</mainClass>
+							<mainClass>azureactivedirectoryauthentication.src.main.java.AzureActiveDirectoryAuthentication</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/src/samples/azureactivedirectoryauthentication/src/main/java/AzureActiveDirectoryAuthentication.java
+++ b/src/samples/azureactivedirectoryauthentication/src/main/java/AzureActiveDirectoryAuthentication.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package azureactivedirectoryauthentication.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/connections/pom.xml
+++ b/src/samples/connections/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.0.jre8</version>
+			<version>6.4.0.jre9</version>
 		</dependency>
 	</dependencies>
 	
@@ -35,7 +35,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>connectURL</mainClass>
+							<mainClass>connections.src.main.java.connectURL</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -53,7 +53,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>connectDS</mainClass>
+							<mainClass>connections.src.main.java.connectDS</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/src/samples/connections/src/main/java/connectDS.java
+++ b/src/samples/connections/src/main/java/connectDS.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package connections.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/connections/src/main/java/connectURL.java
+++ b/src/samples/connections/src/main/java/connectURL.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package connections.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/constrained/pom.xml
+++ b/src/samples/constrained/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>6.1.5.jre8-preview</version>
+            <version>6.4.0.jre9</version>
         </dependency>
     </dependencies>
 
@@ -37,7 +37,7 @@
                         <artifactId>exec-maven-plugin</artifactId>
                         <version>1.6.0</version>
                         <configuration>
-                            <mainClass>ConstrainedSample</mainClass>
+                            <mainClass>constrained.src.main.java.ConstrainedSample</mainClass>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/samples/constrained/src/main/java/ConstrainedSample.java
+++ b/src/samples/constrained/src/main/java/ConstrainedSample.java
@@ -1,3 +1,5 @@
+package constrained.src.main.java;
+
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.sql.Connection;

--- a/src/samples/datatypes/pom.xml
+++ b/src/samples/datatypes/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.0.jre8</version>
+			<version>6.4.0.jre9</version>
 		</dependency>
 	</dependencies>
 	
@@ -35,7 +35,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>basicDT</mainClass>
+							<mainClass>datatypes.src.main.java.basicDT</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -53,7 +53,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>sqlxmlExample</mainClass>
+							<mainClass>datatypes.src.main.java.sqlxmlExample</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -67,8 +67,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 

--- a/src/samples/datatypes/src/main/java/basicDT.java
+++ b/src/samples/datatypes/src/main/java/basicDT.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package datatypes.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/datatypes/src/main/java/sqlxmlExample.java
+++ b/src/samples/datatypes/src/main/java/sqlxmlExample.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package datatypes.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/resultsets/pom.xml
+++ b/src/samples/resultsets/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.0.jre8</version>
+			<version>6.4.0.jre9</version>
 		</dependency>
 	</dependencies>
 	
@@ -35,7 +35,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>cacheRS</mainClass>
+							<mainClass>resultsets.src.main.java.cacheRS</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -53,7 +53,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>retrieveRS</mainClass>
+							<mainClass>resultsets.src.main.java.retrieveRS</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -71,7 +71,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>updateRS</mainClass>
+							<mainClass>resultsets.src.main.java.updateRS</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -85,8 +85,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 

--- a/src/samples/resultsets/src/main/java/cacheRS.java
+++ b/src/samples/resultsets/src/main/java/cacheRS.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package resultsets.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/resultsets/src/main/java/retrieveRS.java
+++ b/src/samples/resultsets/src/main/java/retrieveRS.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package resultsets.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/resultsets/src/main/java/updateRS.java
+++ b/src/samples/resultsets/src/main/java/updateRS.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package resultsets.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/samples/sparse/pom.xml
+++ b/src/samples/sparse/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.0.jre8</version>
+			<version>6.4.0.jre9</version>
 		</dependency>
 	</dependencies>
 	
@@ -35,7 +35,7 @@
 						<artifactId>exec-maven-plugin</artifactId>
 						<version>1.2.1</version>
 						<configuration>
-							<mainClass>SparseColumns</mainClass>
+							<mainClass>sparse.src.main.java.SparseColumns</mainClass>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -49,8 +49,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 

--- a/src/samples/sparse/src/main/java/SparseColumns.java
+++ b/src/samples/sparse/src/main/java/SparseColumns.java
@@ -5,6 +5,7 @@
  * 
  * This program is made available under the terms of the MIT License. See the LICENSE file in the project root for more information.
  */
+package sparse.src.main.java;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;


### PR DESCRIPTION
Updating Sample files to be able to add to Build Path and use directly in Eclipse. 
Makes it easy to manage sample source code to test with upcoming JDKs.
Also updated driver version used to 6.4.0.jre9