### PR TITLE
Make ResultSetMetaData accessible when ResultSet is closed

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -55,10 +55,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
         }
     }
 
-    private void checkClosed() throws SQLServerException {
-        rs.checkClosed();
-    }
-
     /* ------------------ JDBC API Methods --------------------- */
 
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
@@ -78,20 +74,14 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public String getCatalogName(int column) throws SQLServerException {
-        checkClosed();
         return rs.getColumn(column).getTableName().getDatabaseName();
     }
 
     /* L0 */ public int getColumnCount() throws SQLServerException {
-        checkClosed();
-        if (rs == null)
-            return 0;
         return rs.getColumnCount();
     }
 
     public int getColumnDisplaySize(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().getDisplaySize();
@@ -101,17 +91,14 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public String getColumnLabel(int column) throws SQLServerException {
-        checkClosed();
         return rs.getColumn(column).getColumnName();
     }
 
     public String getColumnName(int column) throws SQLServerException {
-        checkClosed();
         return rs.getColumn(column).getColumnName();
     }
 
     public int getColumnType(int column) throws SQLServerException {
-        checkClosed();
         // under Katmai map the max types to non max to be inline with DBMD.
         TypeInfo typeInfo = rs.getColumn(column).getTypeInfo();
 
@@ -166,8 +153,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public String getColumnTypeName(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().getSSTypeName();
@@ -177,8 +162,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public int getPrecision(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().getPrecision();
@@ -188,8 +171,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public int getScale(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().getScale();
@@ -199,18 +180,14 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public String getSchemaName(int column) throws SQLServerException {
-        checkClosed();
         return rs.getColumn(column).getTableName().getSchemaName();
     }
 
     public String getTableName(int column) throws SQLServerException {
-        checkClosed();
         return rs.getColumn(column).getTableName().getObjectName();
     }
 
     public boolean isAutoIncrement(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().isIdentity();
@@ -220,8 +197,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public boolean isCaseSensitive(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().isCaseSensitive();
@@ -231,7 +206,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public boolean isCurrency(int column) throws SQLServerException {
-        checkClosed();
         SSType ssType = rs.getColumn(column).getTypeInfo().getSSType();
 
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
@@ -243,8 +217,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public boolean isDefinitelyWritable(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return TypeInfo.UPDATABLE_READ_WRITE == cryptoMetadata.getBaseTypeInfo().getUpdatability();
@@ -254,8 +226,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public int isNullable(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().isNullable() ? columnNullable : columnNoNulls;
@@ -265,8 +235,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public boolean isReadOnly(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return TypeInfo.UPDATABLE_READ_ONLY == cryptoMetadata.getBaseTypeInfo().getUpdatability();
@@ -276,8 +244,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public boolean isSearchable(int column) throws SQLServerException {
-        checkClosed();
-
         SSType ssType = null;
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
 
@@ -302,8 +268,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public boolean isSigned(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().getSSType().getJDBCType().isSigned();
@@ -322,8 +286,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
      *             when an error occurs
      */
     public boolean isSparseColumnSet(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().isSparseColumnSet();
@@ -333,8 +295,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public boolean isWritable(int column) throws SQLServerException {
-        checkClosed();
-
         int updatability = -1;
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
@@ -347,8 +307,6 @@ public final class SQLServerResultSetMetaData implements java.sql.ResultSetMetaD
     }
 
     public String getColumnClassName(int column) throws SQLServerException {
-        checkClosed();
-
         CryptoMetadata cryptoMetadata = rs.getColumn(column).getCryptoMetadata();
         if (null != cryptoMetadata) {
             return cryptoMetadata.getBaseTypeInfo().getSSType().getJDBCType().className();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -1827,8 +1827,8 @@ public class StatementTest extends AbstractTest {
         }
 
         /**
-         * Tests the following for isSparseColumnSet api a) An exception is thrown when result set is closed b) An exception is thrown when statement
-         * is closed c) An exception is thrown when connection is closed
+         * Tests the following for isSparseColumnSet api a) Metadata is available when result set is closed b) Metadata is available when statement
+         * is closed c) Metadata is available when connection is closed
          * 
          * @throws Exception
          */
@@ -1859,38 +1859,20 @@ public class StatementTest extends AbstractTest {
             rs.next();
 
             SQLServerResultSetMetaData rsmd = (SQLServerResultSetMetaData) rs.getMetaData();
-            try {
-                // test that an exception is thrown when result set is closed
-                rs.close();
-                rsmd.isSparseColumnSet(1);
-                assertEquals(true, false, "Should not reach here. An exception should have been thrown");
-            }
-            catch (SQLException e) {
-            }
+            rs.close();
+            rsmd.isSparseColumnSet(1);
 
-            // test that an exception is thrown when statement is closed
-            try {
-                rs = stmt.executeQuery(selectQuery);
-                rsmd = (SQLServerResultSetMetaData) rs.getMetaData();
+            rs = stmt.executeQuery(selectQuery);
+            rsmd = (SQLServerResultSetMetaData) rs.getMetaData();
 
-                assertEquals(stmt.isClosed(), true, "testSparseColumnSetForException: statement should be closed since resultset is closed.");
-                stmt.close();
-                rsmd.isSparseColumnSet(1);
-                assertEquals(true, false, "Should not reach here. An exception should have been thrown");
-            }
-            catch (SQLException e) {
-            }
+            assertEquals(stmt.isClosed(), true, "testSparseColumnSetForException: statement should be closed since resultset is closed.");
+            stmt.close();
+            rsmd.isSparseColumnSet(1);
 
-            // test that an exception is thrown when connection is closed
-            try {
-                rs = con.createStatement().executeQuery("SELECT * FROM " + tableName);
-                rsmd = (SQLServerResultSetMetaData) rs.getMetaData();
-                con.close();
-                rsmd.isSparseColumnSet(1);
-                assertEquals(true, false, "Should not reach here. An exception should have been thrown");
-            }
-            catch (SQLException e) {
-            }
+            rs = con.createStatement().executeQuery("SELECT * FROM " + tableName);
+            rsmd = (SQLServerResultSetMetaData) rs.getMetaData();
+            con.close();
+            rsmd.isSparseColumnSet(1);
 
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -1844,28 +1844,15 @@ public class StatementTest extends AbstractTest {
             con = createConnectionAndPopulateData();
             Statement stmt = con.createStatement();
 
-            // enable isCloseOnCompletion
-            try {
-                stmt.closeOnCompletion();
-            }
-            catch (Exception e) {
-
-                throw new SQLException("testSparseColumnSetForException threw exception: ", e);
-
-            }
-
             String selectQuery = "SELECT * FROM " + tableName;
             ResultSet rs = stmt.executeQuery(selectQuery);
             rs.next();
-
             SQLServerResultSetMetaData rsmd = (SQLServerResultSetMetaData) rs.getMetaData();
             rs.close();
             rsmd.isSparseColumnSet(1);
 
             rs = stmt.executeQuery(selectQuery);
             rsmd = (SQLServerResultSetMetaData) rs.getMetaData();
-
-            assertEquals(stmt.isClosed(), true, "testSparseColumnSetForException: statement should be closed since resultset is closed.");
             stmt.close();
             rsmd.isSparseColumnSet(1);
 


### PR DESCRIPTION
According to JDBC specs (15.2.5) - `ResultSetMetaData` instances that were created by a `ResultSet` that has been closed are still accessible. Removing `checkClosed()` from `SQLServerResultSetMetaData`. Fix for #678.