### PR TITLE
Updating multiple Maven Dependency and Plugin versions. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<junit.platform.version>1.1.1</junit.platform.version>
-		<junit.jupiter.version>5.1.1</junit.jupiter.version>
+		<junit.platform.version>1.2.0</junit.platform.version>
+		<junit.jupiter.version>5.2.0</junit.jupiter.version>
 	</properties>
 	
 	<dependencies>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>adal4j</artifactId>
-			<version>1.4.0</version>
+			<version>1.5.0</version>
 			<optional>true</optional>
 		</dependency>
 		
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>3.0.0</version>
+			<version>3.1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -275,7 +275,7 @@
            	<plugin>
            		<groupId>org.apache.felix</groupId>
        			<artifactId>maven-bundle-plugin</artifactId>
-       			<version>3.3.0</version>
+       			<version>3.4.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -297,7 +297,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
  				<artifactId>maven-javadoc-plugin</artifactId>
- 				<version>3.0.0-M1</version>
+ 				<version>3.0.0</version>
  				
  				<configuration>
  					<failOnError>true</failOnError>
@@ -316,7 +316,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version>
+				<version>2.21.0</version>
 
 				<configuration>
 					<properties>


### PR DESCRIPTION
Updates the following Maven dependencies/plugins:

_Feature Dependency:_
com.microsoft.azure » adal4j - **1.5.0** - Tested and Verified
_[Also tested with PR #675 which shall be merged in future]_

_Test Dependencies:_
com.zaxxer » HikariCP - **3.1.0**
org.junit.jupiter » junit-jupiter-api - **5.2.0**
org.junit.jupiter » junit-jupiter-engine - **5.2.0**
org.junit.platform » junit-platform-console - **1.2.0**
org.junit.platform » junit-platform-commons - **1.2.0**
org.junit.platform » junit-platform-engine - **1.2.0**
org.junit.platform » junit-platform-launcher - **1.2.0**
org.junit.platform » junit-platform-runner - **1.2.0**
org.junit.platform » junit-platform-surefire-provider - **1.2.0**

_Maven Plugins:_
org.apache.felix » maven-bundle-plugin - **3.4.0**
org.apache.maven.plugins » maven-javadoc-plugin - **3.0.0**
org.apache.maven.plugins » maven-surefire-plugin - **2.21.0**

