### PR TITLE
Fix random bigInt mismatch issue on appveyor.

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTest.java
@@ -17,7 +17,7 @@ import java.sql.SQLException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -466,8 +466,8 @@ public class bvtTest extends bvtTestSetup {
      * 
      * @throws SQLException
      */
-    @AfterAll
-    public static void terminate() throws SQLException {
+    @AfterEach
+    public void terminate() throws SQLException {
 
         try (DBConnection conn = new DBConnection(connectionString);
              DBStatement stmt = conn.createStatement()) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTestSetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bvt/bvtTestSetup.java
@@ -9,7 +9,7 @@ package com.microsoft.sqlserver.jdbc.bvt;
 
 import java.sql.SQLException;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
@@ -25,11 +25,11 @@ import com.microsoft.sqlserver.testframework.DBTable;
 @RunWith(JUnitPlatform.class)
 public class bvtTestSetup extends AbstractTest {
 
-    static DBTable table1;
-    static DBTable table2;
+    DBTable table1;
+    DBTable table2;
 
-    @BeforeAll
-    public static void init() throws SQLException {
+    @BeforeEach
+    public void init() throws SQLException {
         try (DBConnection conn = new DBConnection(connectionString);
              DBStatement stmt = conn.createStatement()) {
             // create tables


### PR DESCRIPTION
I believe the problem was a timing issue associated with declaring the two table names as static. This means that all test cases share the same table name, and if a new test were to start while another test is running, it will change the table names for both test cases. Removing the static modifier and changing the setup method accordingly should fix this issue.