### PR TITLE
Adding a new test for beginRequest()/endRequest()

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
@@ -374,7 +374,7 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
     public void testNewMethods() {
         Method[] methods = SQLServerConnection.class.getDeclaredMethods();
         for (Method method : methods) {
-            assertTrue(isVerfied(method),
+            assertTrue(isVerified(method),
                     "A failure is expected if you are adding a new public non-static method to SQLServerConnection."
                             + " See the test for instructions on how to fix the failure. ");
         }
@@ -437,7 +437,7 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
         con.setClientInfo("name", "value");
     }
 
-    private boolean isVerfied(Method method) {
+    private boolean isVerified(Method method) {
         return (!Modifier.isPublic(method.getModifiers()) || Modifier.isStatic(method.getModifiers())
                 || method.getName().startsWith("get") || getVerifiedMethodNames().contains(method.getName()));
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
@@ -361,7 +361,7 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
     }
 
     /**
-     * This is not really a test. The purpose is to make the build fail if there are new public non-static methods in
+     * This is not really a test. The goal is to make the build fail if there are new public non-static methods in
      * SQLServerConnection and notify the developer to decide whether it needs to be handled by
      * beginRequest()/endRequest().
      *
@@ -375,7 +375,7 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
         Method[] methods = SQLServerConnection.class.getDeclaredMethods();
         for (Method method : methods) {
             assertTrue(isVerfied(method),
-                    "This test is expected to fail if you are adding a new public non-static method to SQLServerConnection."
+                    "A failure is expected if you are adding a new public non-static method to SQLServerConnection."
                             + " See the test for instructions on how to fix the failure. ");
         }
     }


### PR DESCRIPTION
The goal is to make the build fail if there are new public non-static methods in SQLServerConnection and notify the developer to decide whether it needs to be handled by beginRequest()/endRequest().