### PR TITLE
Add support for LocalDate, LocalTime and LocalDateTime to be passed as 'type' in ResultSet.getObject()

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2381,15 +2381,14 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
             if (ts == null) {
                 returnValue = null;
             } else {
+                java.time.LocalDateTime ldt = java.time.LocalDateTime
+                        .ofInstant(ts.toInstant(), java.time.ZoneId.of("UTC")); 
                 if (type == java.time.LocalDateTime.class) {
-                    returnValue = java.time.LocalDateTime.ofInstant(ts.toInstant(), 
-                            java.time.ZoneId.of("UTC"));
+                    returnValue = ldt;
                 } else if (type == java.time.LocalDate.class) {
-                    returnValue = java.time.LocalDate.ofInstant(ts.toInstant(), 
-                            java.time.ZoneId.of("UTC"));
+                    returnValue = ldt.toLocalDate();
                 } else {
-                    returnValue = java.time.LocalTime.ofInstant(ts.toInstant(), 
-                            java.time.ZoneId.of("UTC"));
+                    returnValue = ldt.toLocalTime();
                 }
             }
         } else if (type == microsoft.sql.DateTimeOffset.class) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2373,13 +2373,24 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
             returnValue = getTime(columnIndex);
         } else if (type == java.sql.Timestamp.class) {
             returnValue = getTimestamp(columnIndex);
-        } else if (type == java.time.LocalDateTime.class) {
-            returnValue = null;
+        } else if (type == java.time.LocalDateTime.class 
+                || type == java.time.LocalDate.class 
+                || type == java.time.LocalTime.class) {
             java.sql.Timestamp ts = getTimestamp(columnIndex,
                     Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC")));
-            if (ts != null) {
-                returnValue = java.time.LocalDateTime.ofInstant(ts.toInstant(), 
-                        java.time.ZoneId.of("UTC"));
+            if (ts == null) {
+                returnValue = null;
+            } else {
+                if (type == java.time.LocalDateTime.class) {
+                    returnValue = java.time.LocalDateTime.ofInstant(ts.toInstant(), 
+                            java.time.ZoneId.of("UTC"));
+                } else if (type == java.time.LocalDate.class) {
+                    returnValue = java.time.LocalDate.ofInstant(ts.toInstant(), 
+                            java.time.ZoneId.of("UTC"));
+                } else {
+                    returnValue = java.time.LocalTime.ofInstant(ts.toInstant(), 
+                            java.time.ZoneId.of("UTC"));
+                }
             }
         } else if (type == microsoft.sql.DateTimeOffset.class) {
             returnValue = getDateTimeOffset(columnIndex);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2373,6 +2373,16 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
             returnValue = getTime(columnIndex);
         } else if (type == java.sql.Timestamp.class) {
             returnValue = getTimestamp(columnIndex);
+        } else if (type == java.time.LocalDateTime.class) {
+            returnValue = null;
+            java.sql.Timestamp ts = getTimestamp(columnIndex,
+                    Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC")));
+            if (ts != null) {
+                var dtf = java.time.format.DateTimeFormatter
+                        .ISO_LOCAL_DATE_TIME
+                        .withZone(java.time.ZoneId.of("UTC"));
+                returnValue = java.time.LocalDateTime.parse(dtf.format(ts.toInstant()));
+            }
         } else if (type == microsoft.sql.DateTimeOffset.class) {
             returnValue = getDateTimeOffset(columnIndex);
         } else if (type == UUID.class) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2378,7 +2378,7 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
             java.sql.Timestamp ts = getTimestamp(columnIndex,
                     Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC")));
             if (ts != null) {
-                var dtf = java.time.format.DateTimeFormatter
+                java.time.format.DateTimeFormatter dtf = java.time.format.DateTimeFormatter
                         .ISO_LOCAL_DATE_TIME
                         .withZone(java.time.ZoneId.of("UTC"));
                 returnValue = java.time.LocalDateTime.parse(dtf.format(ts.toInstant()));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2378,10 +2378,8 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
             java.sql.Timestamp ts = getTimestamp(columnIndex,
                     Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC")));
             if (ts != null) {
-                java.time.format.DateTimeFormatter dtf = java.time.format.DateTimeFormatter
-                        .ISO_LOCAL_DATE_TIME
-                        .withZone(java.time.ZoneId.of("UTC"));
-                returnValue = java.time.LocalDateTime.parse(dtf.format(ts.toInstant()));
+                returnValue = java.time.LocalDateTime.ofInstant(ts.toInstant(), 
+                        java.time.ZoneId.of("UTC"));
             }
         } else if (type == microsoft.sql.DateTimeOffset.class) {
             returnValue = getDateTimeOffset(columnIndex);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -21,7 +21,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Statement;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -253,19 +255,30 @@ public class ResultSetTest extends AbstractTest {
             TimeZone prevTimeZone = TimeZone.getDefault();
             TimeZone.setDefault(TimeZone.getTimeZone("America/Edmonton"));
             
-            // a local date/time that does not actually exist because of Daylight Saving Time 
-            final String testValue = "2018-03-11T02:00:00.1234567";
+            // a local date/time that does not actually exist because of Daylight Saving Time
+            final String testValueDate = "2018-03-11";
+            final String testValueTime = "02:00:00.1234567";
+            final String testValueDateTime = testValueDate + "T" + testValueTime;
             
             stmt.executeUpdate(
                     "CREATE TABLE " + tableName + " (id INT PRIMARY KEY, dt2 DATETIME2)");
             stmt.executeUpdate(
-                    "INSERT INTO " + tableName + " (id, dt2) VALUES (1, '" + testValue + "')");
+                    "INSERT INTO " + tableName + " (id, dt2) VALUES (1, '" + testValueDateTime + "')");
 
             try (ResultSet rs = stmt.executeQuery("SELECT dt2 FROM " + tableName + " WHERE id=1")) {
                 rs.next();
-                LocalDateTime actual = rs.getObject(1, LocalDateTime.class);
-                LocalDateTime expected = LocalDateTime.parse(testValue);
-                assertEquals(expected, actual);
+                
+                LocalDateTime expectedLocalDateTime = LocalDateTime.parse(testValueDateTime);
+                LocalDateTime actualLocalDateTime = rs.getObject(1, LocalDateTime.class);
+                assertEquals(expectedLocalDateTime, actualLocalDateTime);
+                
+                LocalDate expectedLocalDate = LocalDate.parse(testValueDate);
+                LocalDate actualLocalDate = rs.getObject(1, LocalDate.class);
+                assertEquals(expectedLocalDate, actualLocalDate);
+                
+                LocalTime expectedLocalTime = LocalTime.parse(testValueTime);
+                LocalTime actualLocalTime = rs.getObject(1, LocalTime.class);
+                assertEquals(expectedLocalTime, actualLocalTime);
             } finally {
                 Utils.dropTableIfExists(tableName, stmt);
                 TimeZone.setDefault(prevTimeZone);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -248,7 +248,7 @@ public class ResultSetTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
-    public void testGetLocalDateTime() throws SQLException {
+    public void testGetObjectAsLocalDateTime() throws SQLException {
         try (Connection con = DriverManager.getConnection(connectionString); Statement stmt = con.createStatement()) {
             TimeZone prevTimeZone = TimeZone.getDefault();
             TimeZone.setDefault(TimeZone.getTimeZone("America/Edmonton"));


### PR DESCRIPTION
Issue #744 - support for rs.getObject(n, java.time.LocalDateTime.class)