### PR TITLE
Improve performance of readLong function unrolling loop and using bitwise operators instead of additions

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -3629,14 +3629,7 @@ final class TDSWriter {
                     ((Buffer) logBuffer).position(((Buffer) logBuffer).position() + 8);
             }
         } else {
-            valueBytes[0] = (byte) ((value >> 0) & 0xFF);
-            valueBytes[1] = (byte) ((value >> 8) & 0xFF);
-            valueBytes[2] = (byte) ((value >> 16) & 0xFF);
-            valueBytes[3] = (byte) ((value >> 24) & 0xFF);
-            valueBytes[4] = (byte) ((value >> 32) & 0xFF);
-            valueBytes[5] = (byte) ((value >> 40) & 0xFF);
-            valueBytes[6] = (byte) ((value >> 48) & 0xFF);
-            valueBytes[7] = (byte) ((value >> 56) & 0xFF);
+            Util.writeLong(value, valueBytes, 0);
             writeWrappedBytes(valueBytes, 8);
         }
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -208,6 +208,27 @@ final class Util {
     }
 
     /**
+     * Writes a long to byte array.
+     *
+     * @param value
+     *        long value to write.
+     * @param valueBytes
+     *        the byte array.
+     * @param offset
+     *        the offset inside byte array.
+     */
+    public static void writeLong(long value, byte valueBytes[], int offset) {
+        valueBytes[offset++] = (byte) ((value) & 0xFF);
+        valueBytes[offset++] = (byte) ((value >> 8) & 0xFF);
+        valueBytes[offset++] = (byte) ((value >> 16) & 0xFF);
+        valueBytes[offset++] = (byte) ((value >> 24) & 0xFF);
+        valueBytes[offset++] = (byte) ((value >> 32) & 0xFF);
+        valueBytes[offset++] = (byte) ((value >> 40) & 0xFF);
+        valueBytes[offset++] = (byte) ((value >> 48) & 0xFF);
+        valueBytes[offset] = (byte) ((value >> 56) & 0xFF);
+    }
+
+    /**
      * Parse a JDBC URL into a set of properties.
      * 
      * @param url

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -197,12 +197,14 @@ final class Util {
      * @return long value as read from bytes.
      */
     /* L0 */static long readLong(byte data[], int nOffset) {
-        long v = 0;
-        for (int i = 7; i > 0; i--) {
-            v += (long) (data[nOffset + i] & 0xff);
-            v <<= 8;
-        }
-        return v + (long) (data[nOffset] & 0xff);
+		return ((long) (data[nOffset + 7] & 0xff) << 56)
+                | ((long) (data[nOffset + 6] & 0xff) << 48)
+                | ((long) (data[nOffset + 5] & 0xff) << 40)
+                | ((long) (data[nOffset + 4] & 0xff) << 32)
+                | ((long) (data[nOffset + 3] & 0xff) << 24)
+                | ((long) (data[nOffset + 2] & 0xff) << 16)
+                | ((long) (data[nOffset + 1] & 0xff) << 8)
+                | ((long) (data[nOffset] & 0xff));
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -217,7 +217,7 @@ final class Util {
      * @param offset
      *        the offset inside byte array.
      */
-    public static void writeLong(long value, byte valueBytes[], int offset) {
+    static void writeLong(long value, byte valueBytes[], int offset) {
         valueBytes[offset++] = (byte) ((value) & 0xFF);
         valueBytes[offset++] = (byte) ((value >> 8) & 0xFF);
         valueBytes[offset++] = (byte) ((value >> 16) & 0xFF);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -28,4 +28,22 @@ public class UtilTest {
         assertEquals(expected, Util.readGUIDtoUUID(guid));
     }
 
+    @Test
+    public void testLongConversions() {
+        writeAndReadLong(Long.MIN_VALUE);
+        writeAndReadLong(Long.MIN_VALUE / 2);
+        writeAndReadLong(-1);
+        writeAndReadLong(0);
+        writeAndReadLong(1);
+        writeAndReadLong(Long.MAX_VALUE / 2);
+        writeAndReadLong(Long.MAX_VALUE);
+    }
+
+    private void writeAndReadLong(long valueToTest) {
+        byte[] buffer = new byte[8];
+        Util.writeLong(valueToTest, buffer, 0);
+        long newLong = Util.readLong(buffer, 0);
+        assertEquals(valueToTest, newLong);
+    }
+
 }


### PR DESCRIPTION
Hello, I'm using mssql-jdbc driver for long time and profiling my application for 20 minutes I found that TDSChannel.read() is taking around 548297 milliseconds of CPU (I guess it's due to synchronization). However improving readLong method I reduced around 30000 milliseconds of pure CPU usage.

Could you merge this small change, please?