### PR TITLE
Changes to read SQL Warnings after ResultSet is read completely

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -575,7 +575,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
                 ensureExecuteResultsReader(command.startResponse(getIsResponseBufferingAdaptive()));
                 startResults();
-                getNextResult();
+                getNextResult(true);
             } catch (SQLException e) {
                 if (retryBasedOnFailedReuseOfCachedHandle(e, attempt, needsPrepare, false))
                     continue;
@@ -2763,7 +2763,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                                 // Get the first result from the batch. If there is no result for this batch
                                 // then bail, leaving EXECUTE_FAILED in the current and remaining slots of
                                 // the update count array.
-                                if (!getNextResult())
+                                if (!getNextResult(true))
                                     return;
 
                                 // If the result is a ResultSet (rather than an update count) then throw an

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -1056,7 +1056,11 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         // Otherwise, we have reached the end of the result set
         if (UNKNOWN_ROW_COUNT == rowCount)
             rowCount = currentRow;
-
+        
+        //Read warnings at the end of ResultSet
+        stmt.startResults();
+        stmt.getMoreResults();
+        
         currentRow = AFTER_LAST_ROW;
         loggerExternal.exiting(getClassNameLogging(), "next", false);
         return false;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -1056,11 +1056,11 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         // Otherwise, we have reached the end of the result set
         if (UNKNOWN_ROW_COUNT == rowCount)
             rowCount = currentRow;
-        
-        //Read warnings at the end of ResultSet
+
+        // Read warnings at the end of ResultSet
         stmt.startResults();
         stmt.getMoreResults();
-        
+
         currentRow = AFTER_LAST_ROW;
         loggerExternal.exiting(getClassNameLogging(), "next", false);
         return false;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -1057,9 +1057,11 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         if (UNKNOWN_ROW_COUNT == rowCount)
             rowCount = currentRow;
 
-        // Read warnings at the end of ResultSet
-        stmt.startResults();
-        stmt.getMoreResults();
+        // Read SQL Warnings at the end of ResultSet
+        if (stmt.resultsReader().peekTokenType() == TDS.TDS_MSG) {
+            stmt.startResults();
+            stmt.getNextResult(false);
+        }
 
         currentRow = AFTER_LAST_ROW;
         loggerExternal.exiting(getClassNameLogging(), "next", false);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -1366,6 +1366,10 @@ public class SQLServerStatement implements ISQLServerStatement {
     /**
      * Returns the next result in the TDS response token stream, which may be a result set, update count or exception.
      *
+     * @param clearFlag
+     *        Boolean Flag if set to true, clears the last stored results in ResultSet. If set to false, does not clear
+     *        ResultSet and continues processing TDS Stream for more results.
+     * 
      * @return true if another result (ResultSet or update count) was available; false if there were no more results.
      */
     final boolean getNextResult(boolean clearFlag) throws SQLServerException {
@@ -1592,13 +1596,15 @@ public class SQLServerStatement implements ISQLServerStatement {
         }
 
         // Clear out previous results only when clearFlag = true
-        if (clearFlag)
+        if (clearFlag) {
             clearLastResult();
+        }
 
         // If there are no more results, then we're done.
         // All we had to do was to close out the previous results.
-        if (!moreResults)
+        if (!moreResults) {
             return false;
+        }
 
         // Figure out the next result.
         NextResult nextResult = new NextResult();
@@ -1636,8 +1642,9 @@ public class SQLServerStatement implements ISQLServerStatement {
         // there is no update count. That is: we have a successful result (return true),
         // but we have no other information about it (updateCount = -1).
         updateCount = -1;
-        if (!moreResults)
+        if (!moreResults) {
             return true;
+        }
 
         // Only way to get here (moreResults is still true, but no apparent results of any kind)
         // is if the TDSParser didn't actually parse _anything_. That is, we are at EOF in the


### PR DESCRIPTION
As of now JDBC driver does not capture any warnings after ResultSet is fully consumed and the TDS_MSG tokens are not consumed but are left unused in Stream.

Use Case:
Capturing warnings at the end of ResultSet is helpful for PolyBase External Data tables where rows could get rejected due to bad column values. This information is sent by SQL Server after ResultSet data.