### PR TITLE
java.sql.Time Support is still broken

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DateAndTimeTypeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DateAndTimeTypeTest.java
@@ -162,9 +162,7 @@ public class DateAndTimeTypeTest extends AbstractTest {
         try (DBConnection dbc = new DBConnection(connectionString)) {
             assumeTrue(9 <= dbc.getServerVersion(), "Aborting test case as SQL Server version does not support TIME");
         }
-        // To get TIME & setTime working on Servers >= 2008, we must add 'sendTimeAsDatetime=false'
-        // by default to the connection. See issue https://github.com/Microsoft/mssql-jdbc/issues/559
-        connection = DriverManager.getConnection(connectionString + ";sendTimeAsDatetime=false");
+        connection = DriverManager.getConnection(connectionString);
         stmt = (SQLServerStatement) connection.createStatement();
         Utils.dropTableIfExists("dateandtime", stmt);
         String sql1 = "create table dateandtime (id integer not null, my_date date, my_time time, my_timestamp datetime2 constraint pk_esimple primary key (id))";


### PR DESCRIPTION
I expect, that this test will fail now.
In #559 it was mentioned, that the `sendTimeAsDateTime` default value should be changed to false. It seems that this did not happen yet.