### PR TITLE
Fixed issues in BulkCopy exception handling

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -3132,7 +3132,7 @@ final class TDSWriter {
     // the client MUST send the next packet with both ignore bit (0x02) and EOM bit (0x01)
     // set in the status to cancel the request.
     final boolean ignoreMessage() throws SQLServerException {
-        if (packetNum > 0) {
+        if (packetNum > 0 || this.tdsMessageType == TDS.PKT_BULK) {
             assert !isEOMSent;
 
             if (logger.isLoggable(Level.FINER))

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -3132,7 +3132,7 @@ final class TDSWriter {
     // the client MUST send the next packet with both ignore bit (0x02) and EOM bit (0x01)
     // set in the status to cancel the request.
     final boolean ignoreMessage() throws SQLServerException {
-        if (packetNum > 0 || this.tdsMessageType == TDS.PKT_BULK) {
+        if (packetNum > 0 || TDS.PKT_BULK == this.tdsMessageType) {
             assert !isEOMSent;
 
             if (logger.isLoggable(Level.FINER))

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1559,22 +1559,6 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
             } finally {
                 tdsWriter = command.getTDSWriter();
             }
-        } catch (SQLServerException ex) {
-            if (null == tdsWriter) {
-                tdsWriter = command.getTDSWriter();
-            }
-
-            // Close the TDS packet before handling the exception
-            writePacketDataDone(tdsWriter);
-
-            // Send Attention packet to interrupt a complete request that was already sent to the server
-            command.startRequest(TDS.PKT_CANCEL_REQ);
-
-            TDSParser.parse(command.startResponse(), command.getLogContext());
-            command.interrupt(ex.getMessage());
-            command.onRequestComplete();
-
-            throw ex;
         } finally {
             if (null == tdsWriter) {
                 tdsWriter = command.getTDSWriter();


### PR DESCRIPTION
1. Removing the catch block, because the driver should not blindly send attention **packets**. To cancel a query, attention **packets** should only be sent if the client has already sent a request, which has the last packet with EOM bit (0x01) set in status. If a complete request has not been sent to the server, the driver  MUST send the next packet with **both ignore bit (0x02) and EOM bit (0x01)** set in the status to cancel the request (2.2.1.7 of TDS Technical Documentation). This is already properly handled in `IOBuffer.execute()`, which is the only method that calls `doInsertBulk()`. 
2. Adding `this.tdsMessageType == TDS.PKT_BULK`, because prior to `TDS.PKT_BULK`, the driver has already sent `INSERT BULK` SQL statement to the server, which in case of an exception needs to be cancelled too. 