### PR TITLE
Added functionality to insert specific column data  in table using writeToServer polymorphic form and Casting fix on Double and Int for nulls 

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2214,9 +2214,8 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
                         if (bulkNullable) {
                             tdsWriter.writeByte((byte) 0x04);
                         }
-        
-                        tdsWriter.writeInt(Integer.parseInt((String )colValue));
-                       }
+                        tdsWriter.writeInt((int) colValue);
+                    }
                     break;
 
                 case java.sql.Types.SMALLINT:
@@ -2278,9 +2277,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable {
                         if (bulkNullable) {
                             tdsWriter.writeByte((byte) 0x08);
                         }
-                       
-                        tdsWriter.writeDouble(Double.parseDouble((String) colValue));
-                        
+                        tdsWriter.writeDouble((double) colValue);
                     }
                     break;
 


### PR DESCRIPTION
Added polymorphic forms  ( write to server used one to one mapping of  the columns earlier , with this a user can insert rows of data with a specific set of columns )

  writeToServer(String  columns)
  getDestinationMetadata(String  columns)

Changed casting of Int and Double .
Were getting  type cast errors when data on that column was null .