### PR TITLE
Change Bulk Copy API for batch insert to respect the timeout value

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2003,6 +2003,11 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     }
 
                     SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connection);
+                    if (queryTimeout > 0) {
+                        SQLServerBulkCopyOptions option = new SQLServerBulkCopyOptions();
+                        option.setBulkCopyTimeout(queryTimeout);
+                        bcOperation.setBulkCopyOptions(option);
+                    }
                     bcOperation.setDestinationTableName(tableName);
                     bcOperation.setStmtColumnEncriptionSetting(this.getStmtColumnEncriptionSetting());
                     bcOperation.setDestinationTableMetadata(rs);
@@ -2157,6 +2162,11 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     }
 
                     SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connection);
+                    if (queryTimeout > 0) {
+                        SQLServerBulkCopyOptions option = new SQLServerBulkCopyOptions();
+                        option.setBulkCopyTimeout(queryTimeout);
+                        bcOperation.setBulkCopyOptions(option);
+                    }
                     bcOperation.setDestinationTableName(tableName);
                     bcOperation.setStmtColumnEncriptionSetting(this.getStmtColumnEncriptionSetting());
                     bcOperation.setDestinationTableMetadata(rs);


### PR DESCRIPTION
Statements  can have timeouts on their query, and currently this isn't being respected by Bulk Copy API for batch insert. This PR fixes that issue.

I've tested this manually and confirmed the queryTimeout value is correctly applied to the Bulk Copy operation.