### PR TITLE
Refresh Access Token instead of reconnecting on Token Expiry

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
@@ -59,7 +59,6 @@ final class AuthenticationJNI extends SSPIAuthentication {
             enabled = true;
         } catch (UnsatisfiedLinkError e) {
             temp = e;
-            authLogger.warning("Failed to load the sqljdbc_auth.dll cause : " + e.getMessage());
             // This is not re-thrown on purpose - the constructor will terminate the properly with the appropriate error
             // string
         } finally {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
@@ -10,10 +10,12 @@ import java.util.logging.Level;
 
 class FedAuthDllInfo {
     byte[] accessTokenBytes = null;
+    byte[] refreshTokenBytes = null;
     long expiresIn = 0;
 
-    FedAuthDllInfo(byte[] accessTokenBytes, long expiresIn) {
+    FedAuthDllInfo(byte[] accessTokenBytes, long expiresIn, byte[] refreshTokenBytes) {
         this.accessTokenBytes = accessTokenBytes;
+        this.refreshTokenBytes = refreshTokenBytes;
         this.expiresIn = expiresIn;
     }
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
@@ -10,12 +10,10 @@ import java.util.logging.Level;
 
 class FedAuthDllInfo {
     byte[] accessTokenBytes = null;
-    byte[] refreshTokenBytes = null;
     long expiresIn = 0;
 
-    FedAuthDllInfo(byte[] accessTokenBytes, long expiresIn, byte[] refreshTokenBytes) {
+    FedAuthDllInfo(byte[] accessTokenBytes, long expiresIn) {
         this.accessTokenBytes = accessTokenBytes;
-        this.refreshTokenBytes = refreshTokenBytes;
         this.expiresIn = expiresIn;
     }
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/AuthenticationJNI.java
@@ -92,7 +92,7 @@ final class AuthenticationJNI extends SSPIAuthentication {
         outsize[0] = GetMaxSSPIBlobSize();
         pOut = new byte[outsize[0]];
 
-        // assert DNSName cant be null
+        // assert DNSName can't be null
         assert DNSName != null;
 
         int failure = SNISecGenClientContext(sniSec, sniSecLen, pin, pin.length, pOut, outsize, done, DNSName, port,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3859,7 +3859,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     }
 
     final void processFedAuthInfo(TDSReader tdsReader, TDSTokenHandler tdsTokenHandler) throws SQLServerException {
-        SqlFedAuthInfo sqlFedAuthInfo = new SqlFedAuthInfo();
+        sqlFedAuthInfo = new SqlFedAuthInfo();
 
         tdsReader.readUnsignedByte(); // token type, 0xEE
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1058,19 +1058,19 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // Check if access token is about to expire soon
             if (Util.checkIfNeedNewAccessToken(this)) {
                 boolean needsReconnect = false;
-                // Check is no refreshToken was received
-                // Applies to cases where nativeDLL is in use.
+                // Check if no refreshToken was received
+                // Applies to cases where nativeDLL is in use
                 if (null != fedAuthToken.refreshToken) {
-                    // Attempt to refresh access token
+                    // Attempt to refresh access token using refresh token
                     fedAuthToken = SQLServerADAL4JUtils.aquireTokenFromRefreshToken(sqlFedAuthInfo, fedAuthToken,
                             authenticationString);
                     attemptRefreshTokenLocked = false;
-                    // Check if refreshing Access token has failed
+                    // Check if refreshing Access token has failed, would need reconnect
                     if (null == fedAuthToken) {
                         needsReconnect = true;
                     }
                 } else {
-                    // Reconnect is needed is Native DLL is in use by user application.
+                    // Reconnect is needed if Native DLL is in use by user application.
                     needsReconnect = true;
                 }
                 if (needsReconnect) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -534,5 +534,7 @@ public final class SQLServerResource extends ListResourceBundle {
             {"R_unknownUTF8SupportValue", "Unknown value for UTF8 support."},
             {"R_illegalWKT", "Illegal Well-Known text. Please make sure Well-Known text is valid."},
             {"R_illegalTypeForGeometry", "{0} is not supported for Geometry."},
-            {"R_illegalWKTposition", "Illegal character in Well-Known text at position {0}."},};
+            {"R_illegalWKTposition", "Illegal character in Well-Known text at position {0}."},
+            {"R_ADALMissing", "Failed to load ADAL4J Java library for performing {0} authentication."},
+            {"R_DLLandADALMissing", "Failed to load both sqljdbc_auth.dll and ADAL4J Java library for performing {0} authentication. Please install one of them to proceed."}};
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SqlFedAuthToken.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SqlFedAuthToken.java
@@ -9,23 +9,29 @@ import java.util.Date;
 
 
 class SqlFedAuthToken {
-    final Date expiresOn;
-    final String accessToken;
+    Date expiresOn;
+    String accessToken;
+    final String refreshToken;
 
-    SqlFedAuthToken(final String accessToken, final long expiresIn) {
+    SqlFedAuthToken(final String accessToken, final long expiresIn, final String refreshToken) {
         this.accessToken = accessToken;
 
         Date now = new Date();
         now.setTime(now.getTime() + (expiresIn * 1000));
         this.expiresOn = now;
+
+        this.refreshToken = refreshToken;
     }
 
-    SqlFedAuthToken(final String accessToken, final Date expiresOn) {
+    SqlFedAuthToken(final String accessToken, final Date expiresOn, final String refreshToken) {
         this.accessToken = accessToken;
         this.expiresOn = expiresOn;
+        this.refreshToken = refreshToken;
     }
 
-    Date getExpiresOnDate() {
-        return expiresOn;
+    void updateAccessToken(String accessToken, Date expiresOnDate) {
+        this.accessToken = accessToken;
+        this.expiresOn = expiresOnDate;
+
     }
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -937,7 +937,7 @@ final class Util {
     // it.
     // If a thread is already doing the refresh, just use the existing token and proceed.
     static synchronized boolean checkIfNeedNewAccessToken(SQLServerConnection connection) {
-        Date accessTokenExpireDate = connection.getAuthenticationResult().getExpiresOnDate();
+        Date accessTokenExpireDate = connection.getAuthenticationResult().expiresOn;
         Date now = new Date();
 
         // if the token's expiration is within the next 45 mins


### PR DESCRIPTION
Applies to below Authentication modes:

- Active Directory Password
- Active Directory Integrated

Currently driver reconnects when access token is about to expire in 45 mins, leading to a new connection to target Server everytime. With this change, the driver will use Refresh Token received by Azure, to refresh access token in use without the need to reconnect.

>Note: This PR applies only to user applications using ADAL4J library, and *NOT* making use of *sqljdbc_auth.dll* native library to establish Integrated Authentication with Azure databases/warehouses.
