### PR TITLE
Add support for OffsetDateTime to be passed as 'type' in ResultSet.getObject()

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2398,6 +2398,13 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                     returnValue = ldt.toLocalTime();
                 }
             }
+        } else if (type == java.time.OffsetDateTime.class) {
+            microsoft.sql.DateTimeOffset dateTimeOffset = getDateTimeOffset(columnIndex);
+            if (dateTimeOffset == null) {
+                returnValue = null;
+            } else {
+                returnValue = dateTimeOffset.getOffsetDateTime();
+            }
         } else if (type == microsoft.sql.DateTimeOffset.class) {
             returnValue = getDateTimeOffset(columnIndex);
         } else if (type == UUID.class) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2405,6 +2405,13 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
             } else {
                 returnValue = dateTimeOffset.getOffsetDateTime();
             }
+        } else if (type == java.time.OffsetTime.class) {
+            microsoft.sql.DateTimeOffset dateTimeOffset = getDateTimeOffset(columnIndex);
+            if (dateTimeOffset == null) {
+                returnValue = null;
+            } else {
+                returnValue = dateTimeOffset.getOffsetDateTime().toOffsetTime();
+            }
         } else if (type == microsoft.sql.DateTimeOffset.class) {
             returnValue = getDateTimeOffset(columnIndex);
         } else if (type == UUID.class) {

--- a/src/main/java/microsoft/sql/DateTimeOffset.java
+++ b/src/main/java/microsoft/sql/DateTimeOffset.java
@@ -222,9 +222,9 @@ public final class DateTimeOffset implements java.io.Serializable, java.lang.Com
      */
     public java.time.OffsetDateTime getOffsetDateTime() {
         java.time.ZoneOffset zoneOffset = java.time.ZoneOffset.ofTotalSeconds(60 * minutesOffset);
-        java.time.LocalDateTime localDaetTime = java.time.LocalDateTime.ofEpochSecond(utcMillis / 1000, nanos,
+        java.time.LocalDateTime localDateTime = java.time.LocalDateTime.ofEpochSecond(utcMillis / 1000, nanos,
                 zoneOffset);
-        return java.time.OffsetDateTime.of(localDaetTime, zoneOffset);
+        return java.time.OffsetDateTime.of(localDateTime, zoneOffset);
     }
 
     /**

--- a/src/main/java/microsoft/sql/DateTimeOffset.java
+++ b/src/main/java/microsoft/sql/DateTimeOffset.java
@@ -216,6 +216,18 @@ public final class DateTimeOffset implements java.io.Serializable, java.lang.Com
     }
 
     /**
+     * Returns OffsetDateTime equivalent to this DateTimeOffset object.
+     *
+     * @return OffsetDateTime equivalent to this DateTimeOffset object.
+     */
+    public java.time.OffsetDateTime getOffsetDateTime() {
+        java.time.ZoneOffset zoneOffset = java.time.ZoneOffset.ofTotalSeconds(60 * minutesOffset);
+        java.time.LocalDateTime localDaetTime = java.time.LocalDateTime.ofEpochSecond(utcMillis / 1000, nanos,
+                zoneOffset);
+        return java.time.OffsetDateTime.of(localDaetTime, zoneOffset);
+    }
+
+    /**
      * Returns this DateTimeOffset object's offset value.
      *
      * @return this DateTimeOffset object's minutes offset from GMT

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -303,21 +304,23 @@ public class ResultSetTest extends AbstractTest {
             final String testValue = "2018-01-02T11:22:33.123456700+12:34";
 
             stmt.executeUpdate("CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableName)
-                    + " (id INT PRIMARY KEY, dto DATETIMEOFFSET)");
+                    + " (id INT PRIMARY KEY, dto DATETIMEOFFSET, dto2 DATETIMEOFFSET)");
             stmt.executeUpdate("INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(tableName)
-                    + " (id, dto) VALUES (1, '" + testValue + "')");
+                    + " (id, dto, dto2) VALUES (1, '" + testValue + "', null)");
 
             try (ResultSet rs = stmt.executeQuery(
-                    "SELECT dto FROM " + AbstractSQLGenerator.escapeIdentifier(tableName) + " WHERE id=1")) {
+                    "SELECT dto, dto2 FROM " + AbstractSQLGenerator.escapeIdentifier(tableName) + " WHERE id=1")) {
                 rs.next();
 
                 OffsetDateTime expected = OffsetDateTime.parse(testValue);
                 OffsetDateTime actual = rs.getObject(1, OffsetDateTime.class);
                 assertEquals(expected, actual);
+                assertNull(rs.getObject(2, OffsetDateTime.class));
 
                 OffsetTime expectedTime = OffsetTime.parse(testValue.split("T")[1]);
                 OffsetTime actualTime = rs.getObject(1, OffsetTime.class);
                 assertEquals(expectedTime, actualTime);
+                assertNull(rs.getObject(2, OffsetTime.class));
             } finally {
                 TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName), stmt);
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -293,7 +293,7 @@ public class ResultSetTest extends AbstractTest {
     }
 
     /**
-     * Tests getObject(n, java.time.OffsetDateTime.class).
+     * Tests getObject(n, java.time.OffsetDateTime.class) and getObject(n, java.time.OffsetTime.class).
      * 
      * @throws SQLException
      */
@@ -314,6 +314,10 @@ public class ResultSetTest extends AbstractTest {
                 OffsetDateTime expected = OffsetDateTime.parse(testValue);
                 OffsetDateTime actual = rs.getObject(1, OffsetDateTime.class);
                 assertEquals(expected, actual);
+
+                OffsetTime expectedTime = OffsetTime.parse(testValue.split("T")[1]);
+                OffsetTime actualTime = rs.getObject(1, OffsetTime.class);
+                assertEquals(expectedTime, actualTime);
             } finally {
                 TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName), stmt);
             }


### PR DESCRIPTION
As `PreparedStatement.setObject(int, Object)` already supports `java.time.OffsetDateTime`, it may make sense.
This was proposed in https://github.com/Microsoft/mssql-jdbc/pull/749#issuecomment-405637052 , but no work has been done, it seems.