### PR TITLE
java.time.OffsetDateTime value sent to the server should not be affected by the default time zone.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -678,14 +678,7 @@ final class DTV {
                                                                                                                         * 1000,
                                                                                                                 "");
 
-                        // The behavior is similar to microsoft.sql.DateTimeOffset
-                        // In Timestamp format, only YEAR needs to have 4 digits. The leading zeros for the rest of the
-                        // fields can be omitted.
-                        String offDateTimeStr = String.format("%04d", offsetDateTimeValue.getYear()) + '-'
-                                + offsetDateTimeValue.getMonthValue() + '-' + offsetDateTimeValue.getDayOfMonth() + ' '
-                                + offsetDateTimeValue.getHour() + ':' + offsetDateTimeValue.getMinute() + ':'
-                                + offsetDateTimeValue.getSecond();
-                        utcMillis = Timestamp.valueOf(offDateTimeStr).getTime();
+                        utcMillis = offsetDateTimeValue.toEpochSecond() * 1000;
                         break;
 
                     case DATETIMEOFFSET: {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/SetObjectTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/SetObjectTest.java
@@ -1,0 +1,63 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.preparedStatement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.OffsetDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.jdbc.RandomUtil;
+import com.microsoft.sqlserver.jdbc.TestUtils;
+import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+
+
+@RunWith(JUnitPlatform.class)
+public class SetObjectTest extends AbstractTest {
+    private static final String tableName = RandomUtil.getIdentifier("SetObjectTestTable");
+
+    /**
+     * Tests setObject(n, java.time.OffsetDateTime.class).
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testGetObjectAsOffsetDateTime() throws SQLException {
+        try (Connection con = DriverManager.getConnection(connectionString)) {
+            final String testValue = "2018-01-02T11:22:33.123456700+12:34";
+            try (Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableName)
+                        + " (id INT PRIMARY KEY, dto DATETIMEOFFSET)");
+                try {
+                    try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO "
+                            + AbstractSQLGenerator.escapeIdentifier(tableName) + " (id, dto) VALUES (?, ?)")) {
+                        pstmt.setInt(1, 1);
+                        pstmt.setObject(2, OffsetDateTime.parse(testValue));
+                        pstmt.executeUpdate();
+                    }
+
+                    try (ResultSet rs = stmt
+                            .executeQuery("SELECT COUNT(*) FROM " + AbstractSQLGenerator.escapeIdentifier(tableName)
+                                    + " WHERE id = 1 AND dto = '" + testValue + "'")) {
+                        rs.next();
+                        assertEquals(1, rs.getInt(1));
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName), stmt);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Although `SQLServerPreparedStatement#setObject(int, Object)` supports `java.time.OffsetDateTime`, the driver sends an incorrect temporal data when the parameter has a different time zone than the default time zone.
Please see the attached test case.

`java.sql.Timestamp#getTime()` used in `DTV#sendTemporal()` subsequently invokes `java.util.Date#normalize()` which takes the default TimeZone into account.
