### PR TITLE
Make SSL certificate validation respect wildcards

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1412,6 +1412,14 @@ final class TDSChannel {
                 return false;
             }
 
+            // Respect wildcard
+            if (nameInCert.startsWith("*")) {
+                String nameInCertWithoutWildCard = nameInCert.substring(1);
+                if (hostName.endsWith(nameInCertWithoutWildCard)) {
+                    return true;
+                }
+            }
+
             // Verify that the name in certificate matches exactly with the host name
             if (!nameInCert.equals(hostName)) {
                 if (logger.isLoggable(Level.FINER))


### PR DESCRIPTION
Fixes issue #816.

Previously, we needed to use hostNameInCertificate when attempting to make SSL connections to Azure servers because the * (wildcard) character in the SSL certificate from Azure was being processed literally. This change make it so that the wildcard is actually respected as "any characters". 