### PR TITLE
Update JDK to 'oraclejdk11' for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: java
 jdk:
-  - oraclejdk10
+  - oraclejdk11
 
 services:
   - docker


### PR DESCRIPTION
Jdk 10 no longer supported by oracle.