### PR TITLE
Fixed potential NullPointerException in logException()

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -126,7 +126,7 @@ public final class SQLServerException extends java.sql.SQLException {
                 exLogger.fine(sb.toString());
             }
         }
-        if (errText.equals(SQLServerException.getErrString("R_queryTimedOut"))) {
+        if (SQLServerException.getErrString("R_queryTimedOut").equals(errText)) {
             this.setDriverErrorCode(SQLServerException.ERROR_QUERY_TIMEOUT);
         }
     }


### PR DESCRIPTION
An `Exception` may have a `null` error message.