### PR TITLE
Fix Geometry.point coordinates

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
@@ -140,7 +140,7 @@ public class Geography extends SQLServerSpatialDatatype {
      *         if an exception occurs
      */
     public static Geography point(double lat, double lon, int srid) throws SQLServerException {
-        return new Geography("POINT (" + lat + " " + lon + ")", srid);
+        return new Geography("POINT (" + lon + " " + lat + ")", srid);
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
@@ -812,7 +812,7 @@ public class SQLServerSpatialDatatypeTest extends AbstractTest {
         String geoWKT = "POINT(1 2)";
 
         Geometry geomWKT = Geometry.point(1, 2, 0);
-        Geography geogWKT = Geography.point(1, 2, 4326);
+        Geography geogWKT = Geography.point(2, 1, 4326);
 
         try (Connection con = (SQLServerConnection) DriverManager.getConnection(connectionString);
                 Statement stmt = con.createStatement()) {


### PR DESCRIPTION
Fixes issue #851.

According to [this](https://docs.microsoft.com/en-us/sql/t-sql/spatial-geography/point-geography-data-type?view=sql-server-2017) page, Geography::point method has the coordinates reversed (lat, long instead of the usual long, lat) compared to the other methods of inserting a Geography point. This PR aligns the driver behavior with the expected behavior.