### PR TITLE
Change scope of Connection/Statement in test to prevent random failures

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
@@ -165,7 +165,7 @@ public class TVPAllTypesTest extends AbstractTest {
                 dt.addRow(values);
             }
 
-            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) conn
                     .prepareStatement("INSERT INTO " + tableDest.getEscapedTableName() + " select * from ? ;")) {
                 pstmt.setStructured(1, tvpName, dt);
                 pstmt.execute();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
@@ -36,7 +36,6 @@ public class TVPAllTypesTest extends AbstractTest {
 
     private static String tvpName;
     private static String procedureName;
-
     private static DBTable tableSrc = null;
     private static DBTable tableDest = null;
 
@@ -68,7 +67,6 @@ public class TVPAllTypesTest extends AbstractTest {
         }
 
         try (Connection conn = DriverManager.getConnection(connString)) {
-
             if (null != resultSetType && null != resultSetConcurrency) {
                 stmt = conn.createStatement(resultSetType, resultSetConcurrency);
             } else {
@@ -76,13 +74,11 @@ public class TVPAllTypesTest extends AbstractTest {
             }
 
             setupVariation(setSelectMethod, stmt);
-
             try (ResultSet rs = stmt.executeQuery("select * from " + tableSrc.getEscapedTableName());
                     SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) conn.prepareStatement(
                             "INSERT INTO " + tableDest.getEscapedTableName() + " select * from ? ;")) {
                 pstmt.setStructured(1, tvpName, rs);
                 pstmt.execute();
-
                 ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc,
                         tableDest);
             } catch (Exception e) {
@@ -112,7 +108,6 @@ public class TVPAllTypesTest extends AbstractTest {
 
     private void testTVPStoredProcedureResultSet(boolean setSelectMethod, Integer resultSetType,
             Integer resultSetConcurrency) throws SQLException {
-
         String connString;
         Statement stmt = null;
 
@@ -123,7 +118,6 @@ public class TVPAllTypesTest extends AbstractTest {
         }
 
         try (Connection conn = DriverManager.getConnection(connString)) {
-
             if (null != resultSetType && null != resultSetConcurrency) {
                 stmt = conn.createStatement(resultSetType, resultSetConcurrency);
             } else {
@@ -131,7 +125,6 @@ public class TVPAllTypesTest extends AbstractTest {
             }
 
             setupVariation(setSelectMethod, stmt);
-
             try (ResultSet rs = stmt.executeQuery("select * from " + tableSrc.getEscapedTableName());
                     SQLServerCallableStatement Cstmt = (SQLServerCallableStatement) conn
                             .prepareCall("{call " + AbstractSQLGenerator.escapeIdentifier(procedureName) + "(?)}")) {
@@ -156,13 +149,11 @@ public class TVPAllTypesTest extends AbstractTest {
     public void testTVPDataTable() throws SQLException {
 
         try (Connection conn = DriverManager.getConnection(connectionString); Statement stmt = conn.createStatement()) {
-
             setupVariation(false, stmt);
-
             SQLServerDataTable dt = new SQLServerDataTable();
-
             int numberOfColumns = tableDest.getColumns().size();
             Object[] values = new Object[numberOfColumns];
+
             for (int i = 0; i < numberOfColumns; i++) {
                 SqlType sqlType = tableDest.getColumns().get(i).getSqlType();
                 dt.addColumnMetadata(tableDest.getColumnName(i), sqlType.getJdbctype().getVendorTypeNumber());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
@@ -59,7 +59,7 @@ public class TVPAllTypesTest extends AbstractTest {
             Integer resultSetConcurrency) throws SQLException {
 
         String connString;
-        Statement stmt;
+        Statement stmt = null;
 
         if (setSelectMethod) {
             connString = connectionString + ";selectMethod=cursor;";
@@ -90,6 +90,8 @@ public class TVPAllTypesTest extends AbstractTest {
             } finally {
                 terminateVariation(stmt);
             }
+        } finally {
+            stmt.close();
         }
     }
 
@@ -112,7 +114,7 @@ public class TVPAllTypesTest extends AbstractTest {
             Integer resultSetConcurrency) throws SQLException {
 
         String connString;
-        Statement stmt;
+        Statement stmt = null;
 
         if (setSelectMethod) {
             connString = connectionString + ";selectMethod=cursor;";
@@ -135,13 +137,13 @@ public class TVPAllTypesTest extends AbstractTest {
                             .prepareCall("{call " + AbstractSQLGenerator.escapeIdentifier(procedureName) + "(?)}")) {
                 Cstmt.setStructured(1, tvpName, rs);
                 Cstmt.execute();
-
                 ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc,
                         tableDest);
             } finally {
                 terminateVariation(stmt);
-                stmt.close();
             }
+        } finally {
+            stmt.close();
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
@@ -33,8 +33,6 @@ import com.microsoft.sqlserver.testframework.sqlType.SqlType;
 
 @RunWith(JUnitPlatform.class)
 public class TVPAllTypesTest extends AbstractTest {
-    private static Connection conn = null;
-    static Statement stmt = null;
 
     private static String tvpName;
     private static String procedureName;
@@ -59,20 +57,39 @@ public class TVPAllTypesTest extends AbstractTest {
 
     private void testTVPResultSet(boolean setSelectMethod, Integer resultSetType,
             Integer resultSetConcurrency) throws SQLException {
-        setupVariation(setSelectMethod, resultSetType, resultSetConcurrency);
 
-        try (ResultSet rs = stmt.executeQuery("select * from " + tableSrc.getEscapedTableName());
-                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) conn
-                        .prepareStatement("INSERT INTO " + tableDest.getEscapedTableName() + " select * from ? ;")) {
-            pstmt.setStructured(1, tvpName, rs);
-            pstmt.execute();
+        String connString;
+        Statement stmt;
 
-            ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc,
-                    tableDest);
-        } catch (Exception e) {
-            fail(TestResource.getResource("R_unexpectedErrorMessage") + e.toString());
-        } finally {
-            terminateVariation();
+        if (setSelectMethod) {
+            connString = connectionString + ";selectMethod=cursor;";
+        } else {
+            connString = connectionString;
+        }
+
+        try (Connection conn = DriverManager.getConnection(connString)) {
+
+            if (null != resultSetType && null != resultSetConcurrency) {
+                stmt = conn.createStatement(resultSetType, resultSetConcurrency);
+            } else {
+                stmt = conn.createStatement();
+            }
+
+            setupVariation(setSelectMethod, stmt);
+
+            try (ResultSet rs = stmt.executeQuery("select * from " + tableSrc.getEscapedTableName());
+                    SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) conn.prepareStatement(
+                            "INSERT INTO " + tableDest.getEscapedTableName() + " select * from ? ;")) {
+                pstmt.setStructured(1, tvpName, rs);
+                pstmt.execute();
+
+                ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc,
+                        tableDest);
+            } catch (Exception e) {
+                fail(TestResource.getResource("R_unexpectedErrorMessage") + e.toString());
+            } finally {
+                terminateVariation(stmt);
+            }
         }
     }
 
@@ -93,17 +110,38 @@ public class TVPAllTypesTest extends AbstractTest {
 
     private void testTVPStoredProcedureResultSet(boolean setSelectMethod, Integer resultSetType,
             Integer resultSetConcurrency) throws SQLException {
-        setupVariation(setSelectMethod, resultSetType, resultSetConcurrency);
-        try (ResultSet rs = stmt.executeQuery("select * from " + tableSrc.getEscapedTableName());
-                SQLServerCallableStatement Cstmt = (SQLServerCallableStatement) conn
-                        .prepareCall("{call " + AbstractSQLGenerator.escapeIdentifier(procedureName) + "(?)}")) {
-            Cstmt.setStructured(1, tvpName, rs);
-            Cstmt.execute();
 
-            ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc,
-                    tableDest);
-        } finally {
-            terminateVariation();
+        String connString;
+        Statement stmt;
+
+        if (setSelectMethod) {
+            connString = connectionString + ";selectMethod=cursor;";
+        } else {
+            connString = connectionString;
+        }
+
+        try (Connection conn = DriverManager.getConnection(connString)) {
+
+            if (null != resultSetType && null != resultSetConcurrency) {
+                stmt = conn.createStatement(resultSetType, resultSetConcurrency);
+            } else {
+                stmt = conn.createStatement();
+            }
+
+            setupVariation(setSelectMethod, stmt);
+
+            try (ResultSet rs = stmt.executeQuery("select * from " + tableSrc.getEscapedTableName());
+                    SQLServerCallableStatement Cstmt = (SQLServerCallableStatement) conn
+                            .prepareCall("{call " + AbstractSQLGenerator.escapeIdentifier(procedureName) + "(?)}")) {
+                Cstmt.setStructured(1, tvpName, rs);
+                Cstmt.execute();
+
+                ComparisonUtil.compareSrcTableAndDestTableIgnoreRowOrder(new DBConnection(connectionString), tableSrc,
+                        tableDest);
+            } finally {
+                terminateVariation(stmt);
+                stmt.close();
+            }
         }
     }
 
@@ -114,33 +152,37 @@ public class TVPAllTypesTest extends AbstractTest {
      */
     @Test
     public void testTVPDataTable() throws SQLException {
-        setupVariation(false, null, null);
 
-        SQLServerDataTable dt = new SQLServerDataTable();
+        try (Connection conn = DriverManager.getConnection(connectionString); Statement stmt = conn.createStatement()) {
 
-        int numberOfColumns = tableDest.getColumns().size();
-        Object[] values = new Object[numberOfColumns];
-        for (int i = 0; i < numberOfColumns; i++) {
-            SqlType sqlType = tableDest.getColumns().get(i).getSqlType();
-            dt.addColumnMetadata(tableDest.getColumnName(i), sqlType.getJdbctype().getVendorTypeNumber());
-            values[i] = sqlType.createdata();
-        }
+            setupVariation(false, stmt);
 
-        int numberOfRows = 10;
-        for (int i = 0; i < numberOfRows; i++) {
-            dt.addRow(values);
-        }
+            SQLServerDataTable dt = new SQLServerDataTable();
 
-        try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
-                .prepareStatement("INSERT INTO " + tableDest.getEscapedTableName() + " select * from ? ;")) {
-            pstmt.setStructured(1, tvpName, dt);
-            pstmt.execute();
-        } finally {
-            terminateVariation();
+            int numberOfColumns = tableDest.getColumns().size();
+            Object[] values = new Object[numberOfColumns];
+            for (int i = 0; i < numberOfColumns; i++) {
+                SqlType sqlType = tableDest.getColumns().get(i).getSqlType();
+                dt.addColumnMetadata(tableDest.getColumnName(i), sqlType.getJdbctype().getVendorTypeNumber());
+                values[i] = sqlType.createdata();
+            }
+
+            int numberOfRows = 10;
+            for (int i = 0; i < numberOfRows; i++) {
+                dt.addRow(values);
+            }
+
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + tableDest.getEscapedTableName() + " select * from ? ;")) {
+                pstmt.setStructured(1, tvpName, dt);
+                pstmt.execute();
+            } finally {
+                terminateVariation(stmt);
+            }
         }
     }
 
-    private static void createPreocedure(String procedureName, String destTable) throws SQLException {
+    private static void createPreocedure(String procedureName, String destTable, Statement stmt) throws SQLException {
         String sql = "CREATE PROCEDURE " + AbstractSQLGenerator.escapeIdentifier(procedureName) + " @InputData "
                 + AbstractSQLGenerator.escapeIdentifier(tvpName) + " READONLY " + " AS " + " BEGIN " + " INSERT INTO "
                 + destTable + " SELECT * FROM @InputData" + " END";
@@ -148,29 +190,16 @@ public class TVPAllTypesTest extends AbstractTest {
         stmt.execute(sql);
     }
 
-    private static void createTVPS(String tvpName, String TVPDefinition) throws SQLException {
+    private static void createTVPS(String tvpName, String TVPDefinition, Statement stmt) throws SQLException {
         String TVPCreateCmd = "CREATE TYPE " + AbstractSQLGenerator.escapeIdentifier(tvpName) + " as table ("
                 + TVPDefinition + ");";
         stmt.executeUpdate(TVPCreateCmd);
     }
 
-    private void setupVariation(boolean setSelectMethod, Integer resultSetType,
-            Integer resultSetConcurrency) throws SQLException {
+    private void setupVariation(boolean setSelectMethod, Statement stmt) throws SQLException {
 
         tvpName = RandomUtil.getIdentifier("TVP");
         procedureName = RandomUtil.getIdentifier("TVP");
-
-        if (setSelectMethod) {
-            conn = DriverManager.getConnection(connectionString + ";selectMethod=cursor;");
-        } else {
-            conn = DriverManager.getConnection(connectionString);
-        }
-
-        if (null != resultSetType || null != resultSetConcurrency) {
-            stmt = conn.createStatement(resultSetType, resultSetConcurrency);
-        } else {
-            stmt = conn.createStatement();
-        }
 
         TestUtils.dropProcedureIfExists(AbstractSQLGenerator.escapeIdentifier(procedureName), stmt);
         TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tvpName), stmt);
@@ -184,24 +213,17 @@ public class TVPAllTypesTest extends AbstractTest {
             dbStmt.createTable(tableSrc);
             dbStmt.createTable(tableDest);
 
-            createTVPS(tvpName, tableSrc.getDefinitionOfColumns());
-            createPreocedure(procedureName, tableDest.getEscapedTableName());
+            createTVPS(tvpName, tableSrc.getDefinitionOfColumns(), stmt);
+            createPreocedure(procedureName, tableDest.getEscapedTableName(), stmt);
 
             dbStmt.populateTable(tableSrc);
         }
     }
 
-    private void terminateVariation() throws SQLException {
+    private void terminateVariation(Statement stmt) throws SQLException {
         TestUtils.dropProcedureIfExists(AbstractSQLGenerator.escapeIdentifier(procedureName), stmt);
         TestUtils.dropTableIfExists(tableSrc.getEscapedTableName(), stmt);
         TestUtils.dropTableIfExists(tableDest.getEscapedTableName(), stmt);
         TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tvpName), stmt);
-
-        if (null != stmt) {
-            stmt.close();
-        }
-        if (null != conn) {
-            conn.close();
-        }
     }
 }


### PR DESCRIPTION
Test fails randomly due to shared objects in tests which get closed due to race conditions. 
This PR makes sure Connection and Statement are always dedicated and open while executing a single test.