### PR TITLE
Fix | Removed populating Lobs when calling wasNull()

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -1072,7 +1072,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
     public boolean wasNull() throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "wasNull");
         checkClosed();
-        fillLOBs();
         loggerExternal.exiting(getClassNameLogging(), "wasNull", lastValueWasNull);
         return lastValueWasNull;
     }


### PR DESCRIPTION
wasNull() does not actually move the cursor, and it's unnecessary to populate the active lob objects when it's called. Addresses #867.