### PR TITLE
Fix issue with setAutoCommit leaving a transaction behind in Azure DW

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3042,7 +3042,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         }
 
         rolledBackTransaction = false;
-        connectionCommand(commitPendingTransaction + sqlStatementToSetCommit(newAutoCommitMode), "setAutoCommit");
+        connectionCommand(sqlStatementToSetCommit(newAutoCommitMode) + commitPendingTransaction, "setAutoCommit");
         databaseAutoCommitMode = newAutoCommitMode;
         loggerExternal.exiting(getClassNameLogging(), "setAutoCommit");
     }


### PR DESCRIPTION
Fixed issue #872.

Currently, when we call setAutoCommit(), we execute this query:

```
IF @@TRANCOUNT > 0 COMMIT TRAN set implicit_transactions off 
```

This still leaves a transaction open in Azure DW, according to MSDN documents.

To fix this issue, we're going to execute this query instead:

```
set implicit_transactions off IF @@TRANCOUNT > 0 COMMIT TRAN 
```

Which should do the same thing except it fixes the aforementioned issue in Azure DW.