### PR TITLE
Improved retry logic for intermittent TLS1.2 issue

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1801,9 +1801,9 @@ final class TDSChannel {
              * message when re-thrown from underlying InputStream.
              */
             String causeErrMsg = null;
-            if (e.getCause() != null) {
-                causeErrMsg = (e.getCause().getLocalizedMessage() != null) ? e.getCause().getLocalizedMessage()
-                                                                           : e.getCause().getMessage();
+            Throwable cause = e.getCause();
+            if (cause != null) {
+                causeErrMsg = (cause.getLocalizedMessage() != null) ? cause.getLocalizedMessage() : cause.getMessage();
             }
 
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_sslFailed"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1795,7 +1795,8 @@ final class TDSChannel {
                         + ((null != ksProvider) ? ("KeyStore provider info: " + ksProvider.getInfo() + "\n") : "")
                         + "java.ext.dirs: " + System.getProperty("java.ext.dirs"));
             // Retrieve the localized error message if possible.
-            String errMsg = (e.getLocalizedMessage() != null) ? e.getLocalizedMessage() : e.getMessage();
+            String localizedMessage = e.getLocalizedMessage();
+            String errMsg = (localizedMessage != null) ? localizedMessage : e.getMessage();
             /*
              * Retrieve the error message of the cause too because actual error message can be wrapped into a different
              * message when re-thrown from underlying InputStream.
@@ -1803,7 +1804,8 @@ final class TDSChannel {
             String causeErrMsg = null;
             Throwable cause = e.getCause();
             if (cause != null) {
-                causeErrMsg = (cause.getLocalizedMessage() != null) ? cause.getLocalizedMessage() : cause.getMessage();
+                String causeLocalizedMessage = cause.getLocalizedMessage();
+                causeErrMsg = (causeLocalizedMessage != null) ? causeLocalizedMessage : cause.getMessage();
             }
 
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_sslFailed"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1799,31 +1799,38 @@ final class TDSChannel {
                                 + tmfDefaultAlgorithm + "\n") : "")
                         + ((null != ksProvider) ? ("KeyStore provider info: " + ksProvider.getInfo() + "\n") : "")
                         + "java.ext.dirs: " + System.getProperty("java.ext.dirs"));
+            // Retrieve the localized error message if possible.
+            String errMsg = (e.getLocalizedMessage() != null) ? e.getLocalizedMessage() : e.getMessage();
+            /*
+             * Retrieve the error message of the cause too because actual error message can be wrapped into a different
+             * message when re-thrown from underlying InputStream.
+             */
+            String causeErrMsg = null;
+            if (e.getCause() != null) {
+                causeErrMsg = (e.getCause().getLocalizedMessage() != null) ? e.getCause().getLocalizedMessage()
+                                                                           : e.getCause().getMessage();
+            }
 
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_sslFailed"));
-            Object[] msgArgs = {e.getMessage()};
+            Object[] msgArgs = {errMsg};
 
-            // It is important to get the localized message here, otherwise error messages won't match for different
-            // locales.
-            String errMsg = e.getLocalizedMessage();
-            // If the message is null replace it with the non-localized message or a dummy string. This can happen if a
-            // custom
-            // TrustManager implementation is specified that does not provide localized messages.
-            if (errMsg == null) {
-                errMsg = e.getMessage();
-            }
-            if (errMsg == null) {
-                errMsg = "";
-            }
-            // The error message may have a connection id appended to it. Extract the message only for comparison.
-            // This client connection id is appended in method checkAndAppendClientConnId().
-            if (errMsg.contains(SQLServerException.LOG_CLIENT_CONNECTION_ID_PREFIX)) {
+            /*
+             * The error message may have a connection id appended to it. Extract the message only for comparison. This
+             * client connection id is appended in method checkAndAppendClientConnId().
+             */
+            if (errMsg != null && errMsg.contains(SQLServerException.LOG_CLIENT_CONNECTION_ID_PREFIX)) {
                 errMsg = errMsg.substring(0, errMsg.indexOf(SQLServerException.LOG_CLIENT_CONNECTION_ID_PREFIX));
+            }
+
+            if (causeErrMsg != null && causeErrMsg.contains(SQLServerException.LOG_CLIENT_CONNECTION_ID_PREFIX)) {
+                causeErrMsg = causeErrMsg.substring(0,
+                        causeErrMsg.indexOf(SQLServerException.LOG_CLIENT_CONNECTION_ID_PREFIX));
             }
 
             // Isolate the TLS1.2 intermittent connection error.
             if (e instanceof IOException && (SSLHandhsakeState.SSL_HANDHSAKE_STARTED == handshakeState)
-                    && (errMsg.equals(SQLServerException.getErrString("R_truncatedServerResponse")))) {
+                    && (SQLServerException.getErrString("R_truncatedServerResponse").equals(errMsg)
+                            || SQLServerException.getErrString("R_truncatedServerResponse").equals(causeErrMsg))) {
                 con.terminate(SQLServerException.DRIVER_ERROR_INTERMITTENT_TLS_FAILED, form.format(msgArgs), e);
             } else {
                 con.terminate(SQLServerException.DRIVER_ERROR_SSL_FAILED, form.format(msgArgs), e);


### PR DESCRIPTION
Intermittent TLS1.2 issue details can be found [here](https://blogs.msdn.microsoft.com/dataaccesstechnologies/2016/11/30/intermittent-jdbc-connectivity-issue-the-driver-could-not-establish-a-secure-connection-to-sql-server-by-using-secure-sockets-layer-ssl-encryption-error-sql-server-returned-an-incomplete-respons/). 

- Based on the discussion on #879 , changed the retry logic to also check for Exception cause because actual error message can be wrapped into a different message when re-thrown from underlying `InputStream`.
- Some minor cleanup.