### PR TITLE
Fix set/getSchema for DataSources - The Driver ignores the setSchema …

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -129,6 +129,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     private Boolean isAzureDW = null;
 
+    private String schema = null;
+
     static class CityHash128Key implements java.io.Serializable {
 
         /**
@@ -5121,12 +5123,27 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         loggerExternal.exiting(getClassNameLogging(), "setNetworkTimeout");
     }
 
+    /**
+     * 
+     * @return If setSchema was used it'll use the value passed into setSchema or else it'll get the schema from Server.
+     * @throws SQLException
+     */
     @Override
     public String getSchema() throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "getSchema");
 
         checkClosed();
 
+        String schema = this.schema;
+        if (schema == null || schema.isBlank()) {
+            schema = getSchemaFromServer();
+        }
+
+        loggerExternal.exiting(getClassNameLogging(), "getSchema");
+        return schema;
+    }
+
+    private String getSchemaFromServer() throws SQLException {
         SQLServerStatement stmt = null;
         SQLServerResultSet resultSet = null;
 
@@ -5155,8 +5172,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 stmt.close();
             }
         }
-
-        loggerExternal.exiting(getClassNameLogging(), "getSchema");
         return null;
     }
 
@@ -5164,8 +5179,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     public void setSchema(String schema) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "setSchema", schema);
         checkClosed();
-        addWarning(SQLServerException.getErrString("R_setSchemaWarning"));
-
+        this.schema = schema;
         loggerExternal.exiting(getClassNameLogging(), "setSchema");
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -261,7 +261,6 @@ public final class SQLServerResource extends ListResourceBundle {
             {"R_integratedAuthenticationFailed", "Integrated authentication failed."},
             {"R_permissionDenied", "Security violation. Permission to target \"{0}\" denied."},
             {"R_getSchemaError", "Error getting default schema name."},
-            {"R_setSchemaWarning", "Warning: setSchema is a no-op in this driver version."},
             {"R_updateCountOutofRange", "The update count value is out of range."},
             {"R_limitOffsetNotSupported", "OFFSET clause in limit escape sequence is not supported."},
             {"R_limitEscapeSyntaxError", "Error in limit escape syntax. Failed to parse query."},


### PR DESCRIPTION
Fix set/getSchema for **DataSources** - The Driver **ignores** the **setSchema** method.

Hello!

I noticed that the **Driver doesn't use the schema defined** when I'm **using DataSource**. The getSchema method **just execute** an 

> "SELECT SCHEMA_NAME()"

and **ignores** the values **passed in the setSchema method**, it´s not compliance with the get/set schema idea of DataSource.

I'm was using a **Spring Boot Application** and setting multiples datasources in the application.yml file. In this case the user has provileges in the schema, but I can't set the default schema in the Sql Server.

My idea is, **if I set the schema programmatically** (e.g. application.yml) the **Driver should use** the value passed in the **setSchema**. If schema is null then the Driver can use the "SELECT SCHEMA_NAME()"

Usually a **DataSource** has the follow **properties**: url, driver-class-name, username and password. Sometime it has the schema property as well.