### PR TITLE
Workaround Bulk Copy for batch insert operation against specific datatypes.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
@@ -160,12 +160,19 @@ public class SQLServerBulkBatchInsertRecord extends SQLServerBulkCommon {
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
             case Types.BLOB: {
-                // Strip off 0x if present.
-                String binData = data.toString().trim();
-                if (binData.startsWith("0x") || binData.startsWith("0X")) {
-                    return binData.substring(2);
+                if (data instanceof byte[]) {
+                    // if the binary data comes in as a byte array through setBytes through Bulk Copy for Batch Insert
+                    // API,
+                    // don't turn the binary array into a string.
+                    return data;
                 } else {
-                    return binData;
+                    // Strip off 0x if present.
+                    String binData = data.toString().trim();
+                    if (binData.startsWith("0x") || binData.startsWith("0X")) {
+                        return binData.substring(2);
+                    } else {
+                        return binData;
+                    }
                 }
             }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -1936,6 +1936,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
         try {
             if (this.useBulkCopyForBatchInsert && connection.isAzureDW() && isInsert(localUserSQL)) {
+                if (batchParamValues == null) {
+                    updateCounts = new int[0];
+                    loggerExternal.exiting(getClassNameLogging(), "executeBatch", updateCounts);
+                    return updateCounts;
+                }
+
                 // From the JDBC spec, section 9.1.4 - Making Batch Updates:
                 // The CallableStatement.executeBatch method (inherited from PreparedStatement) will
                 // throw a BatchUpdateException if the stored procedure returns anything other than an
@@ -1953,12 +1959,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                                     SQLServerException.getErrString("R_outParamsNotPermittedinBatch"), null, 0, null);
                         }
                     }
-                }
-
-                if (batchParamValues == null) {
-                    updateCounts = new int[0];
-                    loggerExternal.exiting(getClassNameLogging(), "executeBatch", updateCounts);
-                    return updateCounts;
                 }
 
                 String tableName = parseUserSQLForTableNameDW(false, false, false, false);
@@ -2093,6 +2093,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
         try {
             if (this.useBulkCopyForBatchInsert && connection.isAzureDW() && isInsert(localUserSQL)) {
+                if (batchParamValues == null) {
+                    updateCounts = new long[0];
+                    loggerExternal.exiting(getClassNameLogging(), "executeLargeBatch", updateCounts);
+                    return updateCounts;
+                }
+
                 // From the JDBC spec, section 9.1.4 - Making Batch Updates:
                 // The CallableStatement.executeBatch method (inherited from PreparedStatement) will
                 // throw a BatchUpdateException if the stored procedure returns anything other than an
@@ -2110,12 +2116,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                                     SQLServerException.getErrString("R_outParamsNotPermittedinBatch"), null, 0, null);
                         }
                     }
-                }
-
-                if (batchParamValues == null) {
-                    updateCounts = new long[0];
-                    loggerExternal.exiting(getClassNameLogging(), "executeLargeBatch", updateCounts);
-                    return updateCounts;
                 }
 
                 String tableName = parseUserSQLForTableNameDW(false, false, false, false);
@@ -2234,8 +2234,19 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     private void checkValidColumns(TypeInfo ti) throws SQLServerException {
         int jdbctype = ti.getSSType().getJDBCType().getIntValue();
-        // currently, we do not support: geometry, geography, datetime and smalldatetime
+        String typeName;
+        MessageFormat form;
         switch (jdbctype) {
+            case microsoft.sql.Types.MONEY:
+            case microsoft.sql.Types.SMALLMONEY:
+            case java.sql.Types.DATE:
+            case microsoft.sql.Types.DATETIME:
+            case microsoft.sql.Types.DATETIMEOFFSET:
+            case microsoft.sql.Types.SMALLDATETIME:
+            case java.sql.Types.TIME:
+                typeName = ti.getSSTypeName();
+                form = new MessageFormat(SQLServerException.getErrString("R_BulkTypeNotSupportedDW"));
+                throw new IllegalArgumentException(form.format(new Object[] {typeName}));
             case java.sql.Types.INTEGER:
             case java.sql.Types.SMALLINT:
             case java.sql.Types.BIGINT:
@@ -2243,8 +2254,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             case java.sql.Types.TINYINT:
             case java.sql.Types.DOUBLE:
             case java.sql.Types.REAL:
-            case microsoft.sql.Types.MONEY:
-            case microsoft.sql.Types.SMALLMONEY:
             case java.sql.Types.DECIMAL:
             case java.sql.Types.NUMERIC:
             case microsoft.sql.Types.GUID:
@@ -2258,21 +2267,18 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             case java.sql.Types.LONGVARBINARY:
             case java.sql.Types.VARBINARY:
                 // Spatial datatypes fall under Varbinary, check if the UDT is geometry/geography.
-                String typeName = ti.getSSTypeName();
+                typeName = ti.getSSTypeName();
                 if (typeName.equalsIgnoreCase("geometry") || typeName.equalsIgnoreCase("geography")) {
-                    MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_BulkTypeNotSupported"));
+                    form = new MessageFormat(SQLServerException.getErrString("R_BulkTypeNotSupported"));
                     throw new IllegalArgumentException(form.format(new Object[] {typeName}));
                 }
             case java.sql.Types.TIMESTAMP:
-            case java.sql.Types.DATE:
-            case java.sql.Types.TIME:
             case 2013: // java.sql.Types.TIME_WITH_TIMEZONE
             case 2014: // java.sql.Types.TIMESTAMP_WITH_TIMEZONE
-            case microsoft.sql.Types.DATETIMEOFFSET:
             case microsoft.sql.Types.SQL_VARIANT:
                 return;
             default: {
-                MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_BulkTypeNotSupported"));
+                form = new MessageFormat(SQLServerException.getErrString("R_BulkTypeNotSupported"));
                 String unsupportedDataType = JDBCType.of(jdbctype).toString();
                 throw new IllegalArgumentException(form.format(new Object[] {unsupportedDataType}));
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -277,6 +277,7 @@ public final class SQLServerResource extends ListResourceBundle {
             {"R_unableRetrieveSourceData", "Unable to retrieve data from the source."},
             {"R_ParsingError", "Failed to parse data for the {0} type."},
             {"R_BulkTypeNotSupported", "Data type {0} is not supported in bulk copy."},
+            {"R_BulkTypeNotSupportedDW", "Data type {0} is not supported in bulk copy against Azure Data Warehouse."},
             {"R_invalidTransactionOption",
                     "UseInternalTransaction option cannot be set to TRUE when used with a Connection object."},
             {"R_invalidNegativeArg", "The {0} argument cannot be negative."},


### PR DESCRIPTION
For now, these datatypes don't seem to work against Azure DW when using bulk copy:
Money/Smallmoney
Temporal data types (Date, Datetime, Datetime2, SmallDateTime, DateTimeOffset, Time).

This PR puts a workaround that makes tables with those columns present fallback to the original batch insert operation.

Also, Binary/Varbinary data types also used to fail, but I fixed that part in this PR as well.