### PR TITLE
Fix | ThreadPoolExecutor thread preventing JVM from exiting

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SharedTimer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SharedTimer.java
@@ -32,7 +32,11 @@ class SharedTimer implements Serializable {
     private ScheduledThreadPoolExecutor executor;
 
     private SharedTimer() {
-        executor = new ScheduledThreadPoolExecutor(1, task -> new Thread(task, CORE_THREAD_PREFIX + id));
+        executor = new ScheduledThreadPoolExecutor(1, task -> {
+            Thread t = new Thread(task, CORE_THREAD_PREFIX + id);
+            t.setDaemon(true);
+            return t;
+        });
         executor.setRemoveOnCancelPolicy(true);
     }
 


### PR DESCRIPTION
Changed a thread used to initialize `ScheduledThreadPoolExecutor` to daemon so the JVM can exit in specific bulkcopy scenarios.