### PR TITLE
Fix | Fix possible Statement Leak in SQLServerConnection.isValid() API

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,6 @@ jobs:
         Target_SQL: 'SQL-2k8R2-SP3-1'
     maxParallel: 2
   steps:
-  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-    clean: true  # whether to fetch clean each time
-    fetchDepth: 1  # the depth of commits to ask Git to fetch
-    lfs: false  # whether to download Git-LFS files
-    persistCredentials: true  # set to 'true' to leave the OAuth token in the Git config after the initial fetch
   - powershell: |
       mkdir AE_Certificates
       cd AE_Certificates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,11 @@ jobs:
         Target_SQL: 'SQL-2k8R2-SP3-1'
     maxParallel: 2
   steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # whether to fetch clean each time
+    fetchDepth: 1  # the depth of commits to ask Git to fetch
+    lfs: false  # whether to download Git-LFS files
+    persistCredentials: true  # set to 'true' to leave the OAuth token in the Git config after the initial fetch
   - powershell: |
       mkdir AE_Certificates
       cd AE_Certificates

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5563,8 +5563,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      */
     @Override
     public boolean isValid(int timeout) throws SQLException {
-        boolean isValid = false;
-
         loggerExternal.entering(getClassNameLogging(), "isValid", timeout);
 
         // Throw an exception if the timeout is invalid
@@ -5578,6 +5576,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (isSessionUnAvailable())
             return false;
 
+        boolean isValid = true;
         try (SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting)) {
 
@@ -5585,18 +5584,19 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             if (0 != timeout)
                 stmt.setQueryTimeout(timeout);
 
-            // Try to execute the query. If this succeeds, then the connection is valid.
-            // If it fails (throws an exception), then the connection is not valid.
-            // If a timeout was provided, execution throws an "query timed out" exception
-            // if the query fails to execute in that time.
-            stmt.execute("SELECT 1");
-            isValid = true;
+            /*
+             * Try to execute the query. If this succeeds, then the connection is valid. If it fails (throws an
+             * exception), then the connection is not valid. If a timeout was provided, execution throws an
+             * "query timed out" exception if the query fails to execute in that time.
+             */
+            stmt.executeQueryInternal("SELECT 1");
         } catch (SQLException e) {
-            // Do not propagate SQLExceptions from query execution or statement closure.
-            // The connection is considered to be invalid if the statement fails to close,
-            // even though query execution succeeded.
-            connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
             isValid = false;
+            /*
+             * Do not propagate SQLExceptions from query execution or statement closure. The connection is considered to
+             * be invalid if the statement fails to close, even though query execution succeeded.
+             */
+            connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
         }
 
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5554,7 +5554,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     @Override
     public boolean isValid(int timeout) throws SQLException {
         boolean isValid = false;
-        System.out.println(1);
         loggerExternal.entering(getClassNameLogging(), "isValid", timeout);
 
         // Throw an exception if the timeout is invalid
@@ -5564,12 +5563,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             SQLServerException.makeFromDriverError(this, this, form.format(msgArgs), null, true);
         }
 
-        System.out.println(2);
         // Return false if the connection is closed
         if (isSessionUnAvailable())
             return false;
 
-        System.out.println(3);
         try (SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting)) {
 
@@ -5577,25 +5574,21 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             if (0 != timeout)
                 stmt.setQueryTimeout(timeout);
 
-            System.out.println(4);
             // Try to execute the query. If this succeeds, then the connection is valid.
             // If it fails (throws an exception), then the connection is not valid.
             // If a timeout was provided, execution throws an "query timed out" exception
             // if the query fails to execute in that time.
             stmt.executeQueryInternal("SELECT 1");
             isValid = true;
-            System.out.println(5);
         } catch (SQLException e) {
             // Do not propagate SQLExceptions from query execution or statement closure.
             // The connection is considered to be invalid if the statement fails to close,
             // even though query execution succeeded.
             connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
-            System.out.println(6);
             return false;
         }
 
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);
-        System.out.println(7);
         return isValid;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5569,25 +5569,25 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         try (SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting)) {
+            try {
+                // If asked, limit the time to wait for the query to complete.
+                if (0 != timeout)
+                    stmt.setQueryTimeout(timeout);
 
-            // If asked, limit the time to wait for the query to complete.
-            if (0 != timeout)
-                stmt.setQueryTimeout(timeout);
-
-            // Try to execute the query. If this succeeds, then the connection is valid.
-            // If it fails (throws an exception), then the connection is not valid.
-            // If a timeout was provided, execution throws an "query timed out" exception
-            // if the query fails to execute in that time.
-            stmt.executeQueryInternal("SELECT 1");
-            isValid = true;
-        } catch (SQLException e) {
-            // Do not propagate SQLExceptions from query execution or statement closure.
-            // The connection is considered to be invalid if the statement fails to close,
-            // even though query execution succeeded.
-            connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
-            return false;
+                // Try to execute the query. If this succeeds, then the connection is valid.
+                // If it fails (throws an exception), then the connection is not valid.
+                // If a timeout was provided, execution throws an "query timed out" exception
+                // if the query fails to execute in that time.
+                stmt.executeQueryInternal("SELECT 1");
+                isValid = true;
+            } catch (SQLException e) {
+                // Do not propagate SQLExceptions from query execution or statement closure.
+                // The connection is considered to be invalid if the statement fails to close,
+                // even though query execution succeeded.
+                connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
+                return false;
+            }
         }
-
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);
         return isValid;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5586,7 +5586,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // The connection is considered to be invalid if the statement fails to close,
             // even though query execution succeeded.
             connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
-            isValid = false;
+            return false;
         }
 
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5554,6 +5554,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     @Override
     public boolean isValid(int timeout) throws SQLException {
         boolean isValid = false;
+
         loggerExternal.entering(getClassNameLogging(), "isValid", timeout);
 
         // Throw an exception if the timeout is invalid
@@ -5567,27 +5568,35 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (isSessionUnAvailable())
             return false;
 
-        try (SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
-                ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting)) {
-            try {
-                // If asked, limit the time to wait for the query to complete.
-                if (0 != timeout)
-                    stmt.setQueryTimeout(timeout);
+        SQLServerStatement stmt = null;
 
-                // Try to execute the query. If this succeeds, then the connection is valid.
-                // If it fails (throws an exception), then the connection is not valid.
-                // If a timeout was provided, execution throws an "query timed out" exception
-                // if the query fails to execute in that time.
-                stmt.executeQueryInternal("SELECT 1");
-                isValid = true;
-            } catch (SQLException e) {
-                // Do not propagate SQLExceptions from query execution or statement closure.
-                // The connection is considered to be invalid if the statement fails to close,
-                // even though query execution succeeded.
-                connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
-                return false;
+        try {
+            stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
+                    SQLServerStatementColumnEncryptionSetting.UseConnectionSetting);
+
+            // If asked, limit the time to wait for the query to complete.
+            if (0 != timeout)
+                stmt.setQueryTimeout(timeout);
+
+            // Try to execute the query. If this succeeds, then the connection is valid.
+            // If it fails (throws an exception), then the connection is not valid.
+            // If a timeout was provided, execution throws an "query timed out" exception
+            // if the query fails to execute in that time.
+            stmt.executeQueryInternal("SELECT 1");
+            stmt.close();
+            isValid = true;
+        } catch (SQLException e) {
+            // Do not propagate SQLExceptions from query execution or statement closure.
+            // The connection is considered to be invalid if the statement fails to close,
+            // even though query execution succeeded.
+            connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
+            return false;
+        } finally {
+            if (null != stmt && !stmt.isClosed()) {
+                stmt.close();
             }
         }
+
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);
         return isValid;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5568,9 +5568,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (isSessionUnAvailable())
             return false;
 
-        try {
-            SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
-                    ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting);
+        try (SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting)) {
 
             // If asked, limit the time to wait for the query to complete.
             if (0 != timeout)
@@ -5581,7 +5580,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // If a timeout was provided, execution throws an "query timed out" exception
             // if the query fails to execute in that time.
             stmt.executeQueryInternal("SELECT 1");
-            stmt.close();
             isValid = true;
         } catch (SQLException e) {
             // Do not propagate SQLExceptions from query execution or statement closure.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5586,6 +5586,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // The connection is considered to be invalid if the statement fails to close,
             // even though query execution succeeded.
             connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
+            isValid = false;
         }
 
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2911,31 +2911,41 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      */
     boolean executeCommand(TDSCommand newCommand) throws SQLServerException {
         synchronized (schedulerLock) {
-            // Detach (buffer) the response from any previously executing
-            // command so that we can execute the new command.
-            //
-            // Note that detaching the response does not process it. Detaching just
-            // buffers the response off of the wire to clear the TDS channel.
+            /*
+             * Detach (buffer) the response from any previously executing command so that we can execute the new
+             * command. Note that detaching the response does not process it. Detaching just buffers the response off of
+             * the wire to clear the TDS channel.
+             */
             if (null != currentCommand) {
-                currentCommand.detach();
-                currentCommand = null;
+                try {
+                    currentCommand.detach();
+                } catch (SQLServerException e) {
+                    /*
+                     * If any exception occurs during detach, need not do anything, simply log it. Our purpose to detach
+                     * the response and empty buffer is done here. If there is anything wrong with the connection
+                     * itself, let the exception pass below to be thrown during 'execute()'.
+                     */
+                    if (connectionlogger.isLoggable(Level.FINE)) {
+                        connectionlogger.fine("Failed to detach current command : " + e.getMessage());
+                    }
+                } finally {
+                    currentCommand = null;
+                }
             }
 
-            // The implementation of this scheduler is pretty simple...
-            // Since only one command at a time may use a connection
-            // (to avoid TDS protocol errors), just synchronize to
-            // serialize command execution.
+            /*
+             * The implementation of this scheduler is pretty simple... Since only one command at a time may use a
+             * connection (to avoid TDS protocol errors), just synchronize to serialize command execution.
+             */
             boolean commandComplete = false;
             try {
                 commandComplete = newCommand.execute(tdsChannel.getWriter(), tdsChannel.getReader(newCommand));
             } finally {
-                // We should never displace an existing currentCommand
-                // assert null == currentCommand;
-
-                // If execution of the new command left response bytes on the wire
-                // (e.g. a large ResultSet or complex response with multiple results)
-                // then remember it as the current command so that any subsequent call
-                // to executeCommand will detach it before executing another new command.
+                /*
+                 * If execution of the new command left response bytes on the wire (e.g. a large ResultSet or complex
+                 * response with multiple results) then remember it as the current command so that any subsequent call
+                 * to executeCommand will detach it before executing another new command.
+                 */
                 if (!commandComplete && !isSessionUnAvailable())
                     currentCommand = newCommand;
             }
@@ -5568,10 +5578,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (isSessionUnAvailable())
             return false;
 
-        SQLServerStatement stmt = null;
-        try {
-            stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
-                    SQLServerStatementColumnEncryptionSetting.UseConnectionSetting);
+        try (SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting)) {
 
             // If asked, limit the time to wait for the query to complete.
             if (0 != timeout)
@@ -5581,18 +5589,14 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // If it fails (throws an exception), then the connection is not valid.
             // If a timeout was provided, execution throws an "query timed out" exception
             // if the query fails to execute in that time.
-            stmt.executeQueryInternal("SELECT 1");
-            stmt.close();
+            stmt.execute("SELECT 1");
             isValid = true;
         } catch (SQLException e) {
             // Do not propagate SQLExceptions from query execution or statement closure.
             // The connection is considered to be invalid if the statement fails to close,
             // even though query execution succeeded.
             connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
-        } finally {
-            if (null != stmt && !stmt.isClosed()) {
-                stmt.close();
-            }
+            isValid = false;
         }
 
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5569,7 +5569,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             return false;
 
         SQLServerStatement stmt = null;
-
         try {
             stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
                     SQLServerStatementColumnEncryptionSetting.UseConnectionSetting);
@@ -5590,7 +5589,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // The connection is considered to be invalid if the statement fails to close,
             // even though query execution succeeded.
             connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
-            return false;
         } finally {
             if (null != stmt && !stmt.isClosed()) {
                 stmt.close();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5554,7 +5554,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     @Override
     public boolean isValid(int timeout) throws SQLException {
         boolean isValid = false;
-
+        System.out.println(1);
         loggerExternal.entering(getClassNameLogging(), "isValid", timeout);
 
         // Throw an exception if the timeout is invalid
@@ -5564,10 +5564,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             SQLServerException.makeFromDriverError(this, this, form.format(msgArgs), null, true);
         }
 
+        System.out.println(2);
         // Return false if the connection is closed
         if (isSessionUnAvailable())
             return false;
 
+        System.out.println(3);
         try (SQLServerStatement stmt = new SQLServerStatement(this, ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_READ_ONLY, SQLServerStatementColumnEncryptionSetting.UseConnectionSetting)) {
 
@@ -5575,21 +5577,25 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             if (0 != timeout)
                 stmt.setQueryTimeout(timeout);
 
+            System.out.println(4);
             // Try to execute the query. If this succeeds, then the connection is valid.
             // If it fails (throws an exception), then the connection is not valid.
             // If a timeout was provided, execution throws an "query timed out" exception
             // if the query fails to execute in that time.
             stmt.executeQueryInternal("SELECT 1");
             isValid = true;
+            System.out.println(5);
         } catch (SQLException e) {
             // Do not propagate SQLExceptions from query execution or statement closure.
             // The connection is considered to be invalid if the statement fails to close,
             // even though query execution succeeded.
             connectionlogger.fine(toString() + " Exception checking connection validity: " + e.getMessage());
+            System.out.println(6);
             return false;
         }
 
         loggerExternal.exiting(getClassNameLogging(), "isValid", isValid);
+        System.out.println(7);
         return isValid;
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -330,7 +330,7 @@ public class ConnectionDriverTest extends AbstractTest {
                 assertEquals(e.getMessage(), TestResource.getResource("R_connectionReset"),
                         TestResource.getResource("R_unknownException"));
             }
-            assertEquals(conn.isValid(5), false, TestResource.getResource("R_deadConnection"));
+            assertEquals(conn.isValid(10), false, TestResource.getResource("R_deadConnection"));
         } catch (Exception e) {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.toString());
         } finally {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -332,7 +332,7 @@ public class ConnectionDriverTest extends AbstractTest {
                 assertEquals(e.getMessage(), TestResource.getResource("R_connectionReset"),
                         TestResource.getResource("R_unknownException"));
             }
-            assertEquals(conn.isValid(5), false, TestResource.getResource("R_deadConnection"));
+            assertEquals(conn.isValid(0), false, TestResource.getResource("R_deadConnection"));
         } catch (Exception e) {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.toString());
         } finally {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -330,7 +330,7 @@ public class ConnectionDriverTest extends AbstractTest {
                 assertEquals(e.getMessage(), TestResource.getResource("R_connectionReset"),
                         TestResource.getResource("R_unknownException"));
             }
-            assertEquals(conn.isValid(10), false, TestResource.getResource("R_deadConnection"));
+            assertEquals(conn.isValid(5), false, TestResource.getResource("R_deadConnection"));
         } catch (Exception e) {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.toString());
         } finally {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -308,7 +308,6 @@ public class ConnectionDriverTest extends AbstractTest {
     @Test
     public void testDeadConnection() throws SQLException {
         assumeFalse(isSqlAzure(), TestResource.getResource("R_skipAzure"));
-        System.out.println("Starting dead connection test");
         String tableName = RandomUtil.getIdentifier("ConnectionTestTable");
         try (SQLServerConnection conn = (SQLServerConnection) DriverManager
                 .getConnection(connectionString + ";responseBuffering=adaptive");
@@ -331,7 +330,7 @@ public class ConnectionDriverTest extends AbstractTest {
                 assertEquals(e.getMessage(), TestResource.getResource("R_connectionReset"),
                         TestResource.getResource("R_unknownException"));
             }
-            assertEquals(conn.isValid(0), false, TestResource.getResource("R_deadConnection"));
+            assertEquals(conn.isValid(10), false, TestResource.getResource("R_deadConnection"));
         } catch (Exception e) {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.toString());
         } finally {
@@ -343,7 +342,6 @@ public class ConnectionDriverTest extends AbstractTest {
                 }
             }
         }
-        System.out.println("Ending dead connection test");
     }
 
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -267,8 +267,7 @@ public class ConnectionDriverTest extends AbstractTest {
             isWrapper = ssconn.isWrapperFor(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerConnection"));
             Object[] msgArgs2 = {"ISQLServerConnection"};
             assertTrue(isWrapper, form.format(msgArgs2));
-            ISQLServerConnection iSql = (ISQLServerConnection) ssconn
-                    .unwrap(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerConnection"));
+            ssconn.unwrap(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerConnection"));
             assertEquals(ISQLServerConnection.TRANSACTION_SNAPSHOT, ISQLServerConnection.TRANSACTION_SNAPSHOT,
                     TestResource.getResource("R_cantAccessSnapshot"));
 
@@ -309,7 +308,7 @@ public class ConnectionDriverTest extends AbstractTest {
     @Test
     public void testDeadConnection() throws SQLException {
         assumeFalse(isSqlAzure(), TestResource.getResource("R_skipAzure"));
-
+        System.out.println("Starting dead connection test");
         String tableName = RandomUtil.getIdentifier("ConnectionTestTable");
         try (SQLServerConnection conn = (SQLServerConnection) DriverManager
                 .getConnection(connectionString + ";responseBuffering=adaptive");
@@ -344,6 +343,7 @@ public class ConnectionDriverTest extends AbstractTest {
                 }
             }
         }
+        System.out.println("Ending dead connection test");
     }
 
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ConnectionDriverTest.java
@@ -308,6 +308,7 @@ public class ConnectionDriverTest extends AbstractTest {
     @Test
     public void testDeadConnection() throws SQLException {
         assumeFalse(isSqlAzure(), TestResource.getResource("R_skipAzure"));
+
         String tableName = RandomUtil.getIdentifier("ConnectionTestTable");
         try (SQLServerConnection conn = (SQLServerConnection) DriverManager
                 .getConnection(connectionString + ";responseBuffering=adaptive");
@@ -330,7 +331,7 @@ public class ConnectionDriverTest extends AbstractTest {
                 assertEquals(e.getMessage(), TestResource.getResource("R_connectionReset"),
                         TestResource.getResource("R_unknownException"));
             }
-            assertEquals(conn.isValid(10), false, TestResource.getResource("R_deadConnection"));
+            assertEquals(conn.isValid(5), false, TestResource.getResource("R_deadConnection"));
         } catch (Exception e) {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.toString());
         } finally {


### PR DESCRIPTION
Fixes #954 
- Create `SQLServerStatement` in try-with-resources block.