### PR TITLE
Fix for updating datetime value

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -5340,7 +5340,7 @@ final class TDSWriter {
         // Next, figure out the number of milliseconds since midnight of the current day.
         int millisSinceMidnight;
         // Millis into the current second
-        if (con.getServerMajorVersion() >= SQL_SERVER_VERSION_2016 || con.isAzure()) {
+        if (con.getServerMajorVersion() >= SQL_SERVER_VERSION_2016) {
             millisSinceMidnight = getRoundedMilliseconds(subSecondNanos);
         } else {
             millisSinceMidnight = (subSecondNanos + Nanos.PER_MILLISECOND / 2) / Nanos.PER_MILLISECOND;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -3007,6 +3007,7 @@ final class SocketConnector implements Runnable {
 final class TDSWriter {
     private static Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.TDS.Writer");
     private final String traceID;
+    private static final double SQL_SERVER_VERSION_2016 = 13.0;
 
     final public String toString() {
         return traceID;
@@ -5339,7 +5340,7 @@ final class TDSWriter {
         // Next, figure out the number of milliseconds since midnight of the current day.
         int millisSinceMidnight;
         // Millis into the current second
-        if (con.getServerMajorVersion() >= 13.0 || con.isAzure()) {
+        if (con.getServerMajorVersion() >= SQL_SERVER_VERSION_2016 || con.isAzure()) {
             millisSinceMidnight = getRoundedMilliseconds(subSecondNanos);
         } else {
             millisSinceMidnight = (subSecondNanos + Nanos.PER_MILLISECOND / 2) / Nanos.PER_MILLISECOND;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -5337,10 +5337,15 @@ final class TDSWriter {
                 TDS.BASE_YEAR_1900);
 
         // Next, figure out the number of milliseconds since midnight of the current day.
-        int millisSinceMidnight = (subSecondNanos + Nanos.PER_MILLISECOND / 2) / Nanos.PER_MILLISECOND + // Millis into
-                                                                                                         // the current
-                                                                                                         // second
-                1000 * cal.get(Calendar.SECOND) + // Seconds into the current minute
+        int millisSinceMidnight;
+        // Millis into the current second
+        if (con.getServerMajorVersion() >= 13.0) {
+            millisSinceMidnight = getRoundedMilliseconds(subSecondNanos);
+        } else {
+            millisSinceMidnight = (subSecondNanos + Nanos.PER_MILLISECOND / 2) / Nanos.PER_MILLISECOND;
+        }
+
+        millisSinceMidnight = millisSinceMidnight + 1000 * cal.get(Calendar.SECOND) + // Seconds into the current minute
                 60 * 1000 * cal.get(Calendar.MINUTE) + // Minutes into the current hour
                 60 * 60 * 1000 * cal.get(Calendar.HOUR_OF_DAY); // Hours into the current day
 
@@ -5623,6 +5628,37 @@ final class TDSWriter {
         int roundedNanos = ((subSecondNanos + (Nanos.PER_MAX_SCALE_INTERVAL / 2)) / Nanos.PER_MAX_SCALE_INTERVAL)
                 * Nanos.PER_MAX_SCALE_INTERVAL;
         return roundedNanos;
+    }
+    
+    /**
+     * Returns subSecondNanos rounded to a millisecond value for SQL Server compatibility level >= 130 (SQL Server 2016 and after).
+     * The rounding logic below represents the actual rounding logic employed by datetime columns when determining their last millisecond digit.
+     */
+    private int getRoundedMilliseconds(int subSecondNanos) {
+        int fourthDigitOnward = subSecondNanos % 1000000;
+        int millis = subSecondNanos / 1000000;
+        int lastMillisDigit = millis % 10;
+        switch (lastMillisDigit) {
+            case 1:
+                if (fourthDigitOnward >= 666650) {
+                    millis++;
+                }
+                break;
+            case 4:
+                if (fourthDigitOnward >= 999950) {
+                    millis++;
+                }
+                break;
+            case 8:
+                if (fourthDigitOnward >= 333350) {
+                    millis++;
+                }
+                break;
+            default:
+                break;
+        }
+
+        return millis;
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -3007,7 +3007,6 @@ final class SocketConnector implements Runnable {
 final class TDSWriter {
     private static Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.TDS.Writer");
     private final String traceID;
-    private static final double SQL_SERVER_VERSION_2016 = 13.0;
 
     final public String toString() {
         return traceID;
@@ -5337,8 +5336,10 @@ final class TDSWriter {
         int daysSinceSQLBaseDate = DDC.daysSinceBaseDate(cal.get(Calendar.YEAR), cal.get(Calendar.DAY_OF_YEAR),
                 TDS.BASE_YEAR_1900);
 
-        // Millis into the current second
-        int millisSinceMidnight = (subSecondNanos + Nanos.PER_MILLISECOND / 2) / Nanos.PER_MILLISECOND + 
+        // Next, figure out the number of milliseconds since midnight of the current day.
+        int millisSinceMidnight = (subSecondNanos + Nanos.PER_MILLISECOND / 2) / Nanos.PER_MILLISECOND + // Millis into
+                                                                                                         // the current
+                                                                                                         // second
                 1000 * cal.get(Calendar.SECOND) + // Seconds into the current minute
                 60 * 1000 * cal.get(Calendar.MINUTE) + // Minutes into the current hour
                 60 * 60 * 1000 * cal.get(Calendar.HOUR_OF_DAY); // Hours into the current day

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -5339,7 +5339,7 @@ final class TDSWriter {
         // Next, figure out the number of milliseconds since midnight of the current day.
         int millisSinceMidnight;
         // Millis into the current second
-        if (con.getServerMajorVersion() >= 13.0) {
+        if (con.getServerMajorVersion() >= 13.0 || con.isAzure()) {
             millisSinceMidnight = getRoundedMilliseconds(subSecondNanos);
         } else {
             millisSinceMidnight = (subSecondNanos + Nanos.PER_MILLISECOND / 2) / Nanos.PER_MILLISECOND;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -140,7 +140,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     private String originalHostNameInCertificate = null;
 
+    final int ENGINE_EDITION_FOR_SQL_AZURE = 5;
+    final int ENGINE_EDITION_FOR_SQL_AZURE_DW = 6;
+    final int ENGINE_EDITION_FOR_SQL_AZURE_MI = 8;
+    private Boolean isAzure = null;
     private Boolean isAzureDW = null;
+    private Boolean isAzureMI = null;
 
     private SharedTimer sharedTimer;
 
@@ -6223,33 +6228,69 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             }
         }
     }
-
-    boolean isAzureDW() throws SQLServerException, SQLException {
-        if (null == isAzureDW) {
-            try (Statement stmt = this.createStatement();
-                    ResultSet rs = stmt.executeQuery("SELECT CAST(SERVERPROPERTY('EngineEdition') as INT)")) {
-                // SERVERPROPERTY('EngineEdition') can be used to determine whether the db server is SQL Azure.
-                // It should return 6 for SQL Azure DW. This is more reliable than @@version or
-                // serverproperty('edition').
-                // Reference: http://msdn.microsoft.com/en-us/library/ee336261.aspx
-                //
-                // SERVERPROPERTY('EngineEdition') means
-                // Database Engine edition of the instance of SQL Server installed on the server.
-                // 1 = Personal or Desktop Engine (Not available for SQL Server.)
-                // 2 = Standard (This is returned for Standard and Workgroup.)
-                // 3 = Enterprise (This is returned for Enterprise, Enterprise Evaluation, and Developer.)
-                // 4 = Express (This is returned for Express, Express with Advanced Services, and Windows Embedded SQL.)
-                // 5 = SQL Azure
-                // 6 = SQL Azure DW
-                // Base data type: int
-                final int ENGINE_EDITION_FOR_SQL_AZURE_DW = 6;
+    
+    /*
+     * SERVERPROPERTY('EngineEdition') can be used to determine whether the db server is SQL Azure.
+     * It should return 6 for SQL Azure DW. This is more reliable than @@version or
+     * serverproperty('edition').
+     * Reference: http://msdn.microsoft.com/en-us/library/ee336261.aspx
+     * 
+     * SERVERPROPERTY('EngineEdition') means
+     * Database Engine edition of the instance of SQL Server installed on the server.
+     * 1 = Personal or Desktop Engine (Not available for SQL Server.)
+     * 2 = Standard (This is returned for Standard and Workgroup.)
+     * 3 = Enterprise (This is returned for Enterprise, Enterprise Evaluation, and Developer.)
+     * 4 = Express (This is returned for Express, Express with Advanced Services, and Windows Embedded SQL.)
+     * 5 = SQL Azure
+     * 6 = SQL Azure DW
+     * 8 = Managed Instance
+     * Base data type: int
+     */
+    boolean isAzure() {
+        if (null == isAzure) {
+            try (Statement stmt = this.createStatement(); ResultSet rs = stmt.executeQuery("SELECT CAST(SERVERPROPERTY('EngineEdition') as INT)")) {
                 rs.next();
-                isAzureDW = rs.getInt(1) == ENGINE_EDITION_FOR_SQL_AZURE_DW;
+
+                int engineEdition = rs.getInt(1);
+                if (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI) {
+                    isAzure = true;
+                } else {
+                    isAzure = false;
+                }
+
+                if (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW) {
+                    isAzureDW = true;
+                } else {
+                    isAzureDW = false;
+                }
+
+                if (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI) {
+                    isAzureMI = true;
+                } else {
+                    isAzureMI = false;
+                }
+
+            } catch (SQLException e) {
+                if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+                    loggerExternal.log(Level.FINER, this + ": Error retrieving server type", e);
+                isAzure = false;
+                isAzureDW = false;
+                isAzureMI = false;
             }
-            return isAzureDW;
+            return isAzure;
         } else {
-            return isAzureDW;
+            return isAzure;
         }
+    }
+
+    boolean isAzureDW() {
+        isAzure();
+        return isAzureDW;
+    }
+
+    boolean isAzureMI() {
+        isAzure();
+        return isAzureMI;
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6252,23 +6252,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 rs.next();
 
                 int engineEdition = rs.getInt(1);
-                if (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI) {
-                    isAzure = true;
-                } else {
-                    isAzure = false;
-                }
-
-                if (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW) {
-                    isAzureDW = true;
-                } else {
-                    isAzureDW = false;
-                }
-
-                if (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI) {
-                    isAzureMI = true;
-                } else {
-                    isAzureMI = false;
-                }
+                isAzure = (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI);
+                isAzureDW = (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW);
+                isAzureMI = (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI);
 
             } catch (SQLException e) {
                 if (loggerExternal.isLoggable(java.util.logging.Level.FINER))

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -743,10 +743,7 @@ final class DTV {
                         // Default and max fractional precision is 7 digits (100ns)
                         // Send DateTime2 to DateTime columns to let the server handle nanosecond rounding. Also
                         // adjust scale accordingly to avoid rounding on driver's end.
-                        int scale = typeInfo.getScale();
-                        if (typeInfo.getSSType() == SSType.DATETIME) {
-                            scale+=4;
-                        }
+                        int scale = (typeInfo.getSSType() == SSType.DATETIME) ? typeInfo.getScale() + 4 : typeInfo.getScale();
                         tdsWriter.writeRPCDateTime2(name,
                                 timestampNormalizedCalendar(calendar, javaType, conn.baseYear()), subSecondNanos,
                                 scale, isOutParam);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -740,9 +740,10 @@ final class DTV {
                 switch (typeInfo.getSSType()) {
                     case DATETIME:
                     case DATETIME2:
-                        // Default and max fractional precision is 7 digits (100ns)
-                        // Send DateTime2 to DateTime columns to let the server handle nanosecond rounding. Also
-                        // adjust scale accordingly to avoid rounding on driver's end.
+                        /* Default and max fractional precision is 7 digits (100ns)
+                         * Send DateTime2 to DateTime columns to let the server handle nanosecond rounding. Also
+                         * adjust scale accordingly to avoid rounding on driver's end.
+                         */
                         int scale = (typeInfo.getSSType() == SSType.DATETIME) ? typeInfo.getScale() + 4 : typeInfo.getScale();
                         tdsWriter.writeRPCDateTime2(name,
                                 timestampNormalizedCalendar(calendar, javaType, conn.baseYear()), subSecondNanos,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -741,10 +741,15 @@ final class DTV {
                     case DATETIME:
                     case DATETIME2:
                         // Default and max fractional precision is 7 digits (100ns)
-                        // Send DateTime2 to DateTime columns to let the server handle nanosecond rounding.
+                        // Send DateTime2 to DateTime columns to let the server handle nanosecond rounding. Also
+                        // adjust scale accordingly to avoid rounding on driver's end.
+                        int scale = typeInfo.getScale();
+                        if (typeInfo.getSSType() == SSType.DATETIME) {
+                            scale+=4;
+                        }
                         tdsWriter.writeRPCDateTime2(name,
                                 timestampNormalizedCalendar(calendar, javaType, conn.baseYear()), subSecondNanos,
-                                typeInfo.getScale(), isOutParam);
+                                scale, isOutParam);
 
                         break;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -738,8 +738,10 @@ final class DTV {
             if (null != typeInfo) // updater
             {
                 switch (typeInfo.getSSType()) {
+                    case DATETIME:
                     case DATETIME2:
                         // Default and max fractional precision is 7 digits (100ns)
+                        // Send DateTime2 to DateTime columns to let the server handle nanosecond rounding.
                         tdsWriter.writeRPCDateTime2(name,
                                 timestampNormalizedCalendar(calendar, javaType, conn.baseYear()), subSecondNanos,
                                 typeInfo.getScale(), isOutParam);
@@ -773,7 +775,6 @@ final class DTV {
 
                         break;
 
-                    case DATETIME:
                     case SMALLDATETIME:
                         tdsWriter.writeRPCDateTime(name,
                                 timestampNormalizedCalendar(calendar, javaType, conn.baseYear()), subSecondNanos,

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -21,7 +21,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.microsoft.sqlserver.testframework.sqlType.SqlBigInt;
@@ -67,32 +66,61 @@ public class TestUtils {
 
     // private static SqlType types = null;
     private static ArrayList<SqlType> types = null;
+    
+    final static int ENGINE_EDITION_FOR_SQL_AZURE = 5;
+    final static int ENGINE_EDITION_FOR_SQL_AZURE_DW = 6;
+    final static int ENGINE_EDITION_FOR_SQL_AZURE_MI = 8;
+    private static Boolean isAzure = null;
+    private static Boolean isAzureDW = null;
+    private static Boolean isAzureMI = null;
 
-    /**
-     * Returns serverType
+    /*
+     * SERVERPROPERTY('EngineEdition') can be used to determine whether the db server is SQL Azure.
+     * It should return 6 for SQL Azure DW. This is more reliable than @@version or
+     * serverproperty('edition').
+     * Reference: http://msdn.microsoft.com/en-us/library/ee336261.aspx
      * 
-     * @return
+     * SERVERPROPERTY('EngineEdition') means
+     * Database Engine edition of the instance of SQL Server installed on the server.
+     * 1 = Personal or Desktop Engine (Not available for SQL Server.)
+     * 2 = Standard (This is returned for Standard and Workgroup.)
+     * 3 = Enterprise (This is returned for Enterprise, Enterprise Evaluation, and Developer.)
+     * 4 = Express (This is returned for Express, Express with Advanced Services, and Windows Embedded SQL.)
+     * 5 = SQL Azure
+     * 6 = SQL Azure DW
+     * 8 = Managed Instance
+     * Base data type: int
      */
-    public static String getServerType() {
-        String serverType = null;
+    public static boolean isAzure(Connection con) {
+        if (null == isAzure) {
+            try (Statement stmt = con.createStatement(); ResultSet rs = stmt.executeQuery("SELECT CAST(SERVERPROPERTY('EngineEdition') as INT)")) {
+                rs.next();
 
-        String serverTypeProperty = getConfiguredProperty("server.type");
-        if (null == serverTypeProperty) {
-            // default to SQL Server
-            serverType = SERVER_TYPE_SQL_SERVER;
-        } else if (serverTypeProperty.equalsIgnoreCase(SERVER_TYPE_SQL_AZURE)) {
-            serverType = SERVER_TYPE_SQL_AZURE;
-        } else if (serverTypeProperty.equalsIgnoreCase(SERVER_TYPE_SQL_SERVER)) {
-            serverType = SERVER_TYPE_SQL_SERVER;
-        } else {
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Server.type '" + serverTypeProperty + "' is not supported yet. Default to SQL Server");
+                int engineEdition = rs.getInt(1);
+                isAzure = (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW || engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI);
+                isAzureDW = (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_DW);
+                isAzureMI = (engineEdition == ENGINE_EDITION_FOR_SQL_AZURE_MI);
+
+            } catch (SQLException e) {
+                isAzure = false;
+                isAzureDW = false;
+                isAzureMI = false;
             }
-            serverType = SERVER_TYPE_SQL_SERVER;
+            return isAzure;
+        } else {
+            return isAzure;
         }
-        return serverType;
     }
 
+    public static boolean isAzureDW(Connection con) {
+        isAzure(con);
+        return isAzureDW;
+    }
+
+    public static boolean isAzureMI(Connection con) {
+        isAzure(con);
+        return isAzureMI;
+    }
     /**
      * Read variable from property files if found null try to read from env.
      * 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -1732,8 +1732,15 @@ public class DataTypesTest extends AbstractTest {
                 
                 pstmt.executeBatch();
                 
-                Method method = conn.getClass().getSuperclass().getDeclaredMethod("getServerMajorVersion");
-                method.setAccessible(true);
+                Method method;
+                try {
+                    method = conn.getClass().getSuperclass().getDeclaredMethod("getServerMajorVersion");
+                    method.setAccessible(true);
+                } catch (NoSuchMethodException e) {
+                    method = conn.getClass().getDeclaredMethod("getServerMajorVersion");
+                    method.setAccessible(true);
+                }
+
                 int serverVersion = (int) method.invoke(conn);
                 
                 String[] result = new String[6];

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -1673,6 +1673,11 @@ public class DataTypesTest extends AbstractTest {
         }
     }
     
+    /*
+     * SQL Server compatibility level >= 130 (SQL Server 2016 and after) doesn't round up or down equally for
+     * datetime. The rounding logic below represents the actual rounding logic employed by datetime
+     * columns when determining their last millisecond digit.
+     */
     @Test
     public void testDateTimeInsertUpdate() throws Exception {
         assumeTrue(!isSqlAzureDW(), TestResource.getResource("R_cursorAzureDW"));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -1653,10 +1653,10 @@ public class DataTypesTest extends AbstractTest {
                     assertEquals("1970-01-01 23:59:59.0", new Timestamp(rs.getTime(6).getTime()).toString());
 
                     // Update datetime w/expected rounding of nanos to DATETIME's 1/300second resolution
-                    ts = Timestamp.valueOf("6289-04-22 05:13:57.6745106");
+                    ts = Timestamp.valueOf("6289-04-22 05:13:57.6741234");
                     rs.updateTimestamp(2, ts);
                     rs.updateRow();
-                    assertEquals("6289-04-22 05:13:57.677", rs.getTimestamp(2).toString());
+                    assertEquals("6289-04-22 05:13:57.673", rs.getTimestamp(2).toString());
 
                     // Update datetime with rounding-induced overflow from Time (should roll date part to 1/2/1970)
                     ts = Timestamp.valueOf("2010-01-18 23:59:59.999");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -20,6 +21,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.DateFormatSymbols;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.GregorianCalendar;
@@ -1664,6 +1666,124 @@ public class DataTypesTest extends AbstractTest {
                     rs.updateRow();
                     assertEquals("1970-01-02 00:00:00.0", rs.getTimestamp(2).toString());
 
+                } finally {
+                    TestUtils.dropTableIfExists(escapedTableName, stmt);
+                }
+            }
+        }
+    }
+    
+    @Test
+    public void testDateTimeInsertUpdate() throws Exception {
+        assumeTrue(!isSqlAzureDW(), TestResource.getResource("R_cursorAzureDW"));
+        
+        try (SQLServerConnection conn = (SQLServerConnection) DriverManager
+                .getConnection(connectionString)) {
+
+            try (Statement stmt = conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
+                    SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) conn.prepareStatement("INSERT INTO "
+                            + escapedTableName + " VALUES (?)")) {
+                TestUtils.dropTableIfExists(escapedTableName, stmt);
+
+                stmt.executeUpdate("CREATE TABLE " + escapedTableName + " (c1 datetime)");
+
+                String testValue2 = "2012-06-18T10:34:09Z";
+                Instant ist = Instant.parse(testValue2);
+                ist = ist.plusNanos(634999949);
+                DateTimeOffset dto1 = DateTimeOffset.valueOf(Timestamp.from(ist), 0);
+                
+                pstmt.setObject(1, dto1);
+                pstmt.addBatch();
+                
+                ist = Instant.parse(testValue2);
+                ist = ist.plusNanos(634999950);
+                DateTimeOffset dto2 = DateTimeOffset.valueOf(Timestamp.from(ist), 0);
+                
+                pstmt.setObject(1, dto2);
+                pstmt.addBatch();
+                
+                ist = Instant.parse(testValue2);
+                ist = ist.plusNanos(741666649);
+                DateTimeOffset dto3 = DateTimeOffset.valueOf(Timestamp.from(ist), 0);
+                
+                pstmt.setObject(1, dto3);
+                pstmt.addBatch();
+                
+                ist = Instant.parse(testValue2);
+                ist = ist.plusNanos(741666650);
+                DateTimeOffset dto4 = DateTimeOffset.valueOf(Timestamp.from(ist), 0);
+                
+                pstmt.setObject(1, dto4);
+                pstmt.addBatch();
+                
+                ist = Instant.parse(testValue2);
+                ist = ist.plusNanos(788333349);
+                DateTimeOffset dto5 = DateTimeOffset.valueOf(Timestamp.from(ist), 0);
+                
+                pstmt.setObject(1, dto5);
+                pstmt.addBatch();
+                
+                ist = Instant.parse(testValue2);
+                ist = ist.plusNanos(788333350);
+                DateTimeOffset dto6 = DateTimeOffset.valueOf(Timestamp.from(ist), 0);
+                
+                pstmt.setObject(1, dto6);
+                pstmt.addBatch();
+                
+                pstmt.executeBatch();
+                
+                Method method = conn.getClass().getSuperclass().getDeclaredMethod("getServerMajorVersion");
+                method.setAccessible(true);
+                int serverVersion = (int) method.invoke(conn);
+                
+                String[] result = new String[6];
+                result[0] = "2012-06-18 10:34:09.633";
+                result[1] = "2012-06-18 10:34:09.637";
+                result[2] = "2012-06-18 10:34:09.74";
+                result[3] = "2012-06-18 10:34:09.743";
+                result[4] = "2012-06-18 10:34:09.787";
+                result[5] = "2012-06-18 10:34:09.79";
+                
+                String[] resultPre2k16 = new String[6];
+                resultPre2k16[0] = "2012-06-18 10:34:09.637";
+                resultPre2k16[1] = "2012-06-18 10:34:09.637";
+                resultPre2k16[2] = "2012-06-18 10:34:09.743";
+                resultPre2k16[3] = "2012-06-18 10:34:09.743";
+                resultPre2k16[4] = "2012-06-18 10:34:09.787";
+                resultPre2k16[5] = "2012-06-18 10:34:09.787";
+                
+                DateTimeOffset[] dto = new DateTimeOffset[6];
+                dto[0] = dto1;
+                dto[1] = dto2;
+                dto[2] = dto3;
+                dto[3] = dto4;
+                dto[4] = dto5;
+                dto[5] = dto6;
+                
+                try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + escapedTableName + " ORDER BY c1")) {
+                    if (serverVersion >= 13.0 || TestUtils.isAzure(conn)) {
+                        for (int i = 0; i < result.length; i++) {
+                            rs.next();
+                            assertEquals(rs.getObject(1).toString(), result[i]);
+                        }
+                        
+                        for (int i = 0; i < result.length; i++) {
+                            rs.updateObject(1, dto[i]);
+                            rs.updateRow();
+                            assertEquals(rs.getObject(1).toString(), result[i]);
+                        }
+                    } else {
+                        for (int i = 0; i < result.length; i++) {
+                            rs.next();
+                            assertEquals(rs.getObject(1).toString(), resultPre2k16[i]);
+                        }
+                        
+                        for (int i = 0; i < result.length; i++) {
+                            rs.updateObject(1, dto[i]);
+                            rs.updateRow();
+                            assertEquals(rs.getObject(1).toString(), resultPre2k16[i]);
+                        }
+                    }
                 } finally {
                     TestUtils.dropTableIfExists(escapedTableName, stmt);
                 }


### PR DESCRIPTION
Starting from SQL Server 2016, the rounding logic for inserting datetime value has been changed. Instead of uniformly rounding up values normally (<=4 rounds down, >=5 rounds up), the logic present in the getRoundedMilliseconds method shows how the numbers are actually rounded.

The writeRPCDateTime method that gets used during updating a datetimecolumn wasn't correctly reflecting this, and this PR addresses that issue.