### PR TITLE
Fix issue with JUnit test with Unix environment

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -169,5 +169,5 @@ public final class TestResource extends ListResourceBundle {
             {"R_incorrectColumnNumInsertDW",
                     "Column name or number of supplied values does not match table definition."},
             {"R_incorrectSyntaxTable", "Incorrect syntax near the keyword 'table'."},
-            {"R_incorrectSyntaxTableDW", "Parse error at line: 1, column: 106: Incorrect syntax near 'table'."},};
+            {"R_incorrectSyntaxTableDW", "Incorrect syntax near 'table'."},};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -625,7 +625,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             throw new Exception(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (BatchUpdateException e) {
             if (isSqlAzureDW()) {
-                assertEquals(TestResource.getResource("R_incorrectSyntaxTableDW"), e.getMessage());
+                assertEquals(TestResource.getResource("R_incorrectSyntaxTableDW"), e.getMessage().replaceAll("\r", ""));
             } else {
                 assertEquals(TestResource.getResource("R_incorrectSyntaxTable"), e.getMessage());
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -624,13 +624,10 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.executeBatch();
             throw new Exception(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (BatchUpdateException e) {
-            System.out.println("swagger");
-            System.out.println(TestResource.getResource("R_incorrectSyntaxTableDW"));
-            System.out.println(e.getMessage());
             if (isSqlAzureDW()) {
-                assertEquals(TestResource.getResource("R_incorrectSyntaxTableDW"), e.getMessage());
+                assertTrue(e.getMessage().contains(TestResource.getResource("R_incorrectSyntaxTableDW")));
             } else {
-                assertEquals(TestResource.getResource("R_incorrectSyntaxTable"), e.getMessage());
+                assertTrue(e.getMessage().contains(TestResource.getResource("R_incorrectSyntaxTable")));
             }
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -624,8 +624,11 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.executeBatch();
             throw new Exception(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (BatchUpdateException e) {
+            System.out.println("swagger");
+            System.out.println(TestResource.getResource("R_incorrectSyntaxTableDW"));
+            System.out.println(e.getMessage());
             if (isSqlAzureDW()) {
-                assertEquals(TestResource.getResource("R_incorrectSyntaxTableDW"), e.getMessage().replaceAll("\r", ""));
+                assertEquals(TestResource.getResource("R_incorrectSyntaxTableDW"), e.getMessage());
             } else {
                 assertEquals(TestResource.getResource("R_incorrectSyntaxTable"), e.getMessage());
             }


### PR DESCRIPTION
We don't need to rely on the column number to verify the test.