### PR TITLE
Fix | Fix SQL Exception Error State length to respect SQLSTATE Standards

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -323,13 +323,13 @@ public final class SQLServerException extends java.sql.SQLException {
      *        the database state
      * @return the state code
      */
-    static String generateStateCode(SQLServerConnection con, int errNum, int databaseState) {
+    static String generateStateCode(SQLServerConnection con, int errNum, Integer databaseState) {
         // Generate a SQL 99 or XOPEN state from a database generated error code
         boolean xopenStates = (con != null && con.xopenStates);
         if (xopenStates) {
             switch (errNum) {
                 case 4060:
-                    return "08001"; // Database name undefined at loging
+                    return "08001"; // Database name undefined at logging
                 case 18456:
                     return "08001"; // username password wrong at login
                 case 2714:
@@ -360,8 +360,19 @@ public final class SQLServerException extends java.sql.SQLException {
                     return "40001"; // deadlock detected
                 case 2627:
                     return "23000"; // DPM 4.04. Primary key violation
-                default:
-                    return "S000" + databaseState;
+                default: {
+                    String dbState = databaseState.toString();
+                    /*
+                     * Length allowed for SQL State is 5 characters as per SQLSTATE specifications. Append trailing
+                     * zeroes as needed based on length of database error State as length of databaseState is either 1
+                     * or 2 characters.
+                     */
+                    StringBuilder trailingZeroes = new StringBuilder("S");
+                    for (int i = 0; i < 4 - dbState.length(); i++) {
+                        trailingZeroes.append("0");
+                    }
+                    return trailingZeroes.append(dbState).toString();
+                }
             }
         }
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -364,8 +364,8 @@ public final class SQLServerException extends java.sql.SQLException {
                     String dbState = databaseState.toString();
                     /*
                      * Length allowed for SQL State is 5 characters as per SQLSTATE specifications. Append trailing
-                     * zeroes as needed based on length of database error State as length of databaseState is either 1
-                     * or 2 characters.
+                     * zeroes as needed based on length of database error State as length of databaseState is between 1
+                     * to 3 digits.
                      */
                     StringBuilder trailingZeroes = new StringBuilder("S");
                     for (int i = 0; i < 4 - dbState.length(); i++) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/exception/ErrorStateTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/exception/ErrorStateTest.java
@@ -1,0 +1,60 @@
+package com.microsoft.sqlserver.jdbc.exception;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.PrepUtil;
+
+
+@RunWith(JUnitPlatform.class)
+public class ErrorStateTest extends AbstractTest {
+
+    @Test
+    public void testSQLStateNegative() throws Exception {
+        int state = -1; // Negative error raised converts to positive SQL State (1)
+        try (Connection con = PrepUtil.getConnection(connectionString); Statement stmt = con.createStatement()) {
+            stmt.execute("RAISERROR (13002, -1, " + state + ", N'Testing error');");
+        } catch (SQLException e) {
+            assert (e.getSQLState().length() == 5);
+            assert (e.getSQLState().equalsIgnoreCase("S0001"));
+        }
+    }
+
+    @Test
+    public void testSQLStateLength1() throws Exception {
+        try (Connection con = PrepUtil.getConnection(connectionString); Statement stmt = con.createStatement()) {
+            stmt.execute("SELECT 1/0;");
+        } catch (SQLException e) {
+            assert (e.getSQLState().length() == 5);
+            assert (e.getSQLState().equalsIgnoreCase("S0001"));
+        }
+    }
+
+    @Test
+    public void testSQLStateLength2() throws Exception {
+        int state = 31;
+        try (Connection con = PrepUtil.getConnection(connectionString); Statement stmt = con.createStatement()) {
+            stmt.execute("RAISERROR (13002, -1, " + state + ", N'Testing error');");
+        } catch (SQLException e) {
+            assert (e.getSQLState().length() == 5);
+            assert (e.getSQLState().equalsIgnoreCase("S00" + state));
+        }
+    }
+
+    @Test
+    public void testSQLStateLength3() throws Exception {
+        int state = 255; // Max Value of SQL State
+        try (Connection con = PrepUtil.getConnection(connectionString); Statement stmt = con.createStatement()) {
+            stmt.execute("RAISERROR (13003, -1, " + state + ", N'Testing error');");
+        } catch (SQLException e) {
+            assert (e.getSQLState().length() == 5);
+            assert (e.getSQLState().equalsIgnoreCase("S0" + state));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #956 

Calling `SQLException.getErrorState()` would result in SQL State of length more than 5 characters allowed as per [SQL State Specifications](https://en.wikipedia.org/wiki/SQLSTATE). This fix restricts length of SQLException Error State and appends zeroes (0) as needed to Error State received from SQL Server.

As per SQL Server specifications, the values of [ERROR_STATE](https://docs.microsoft.com/en-us/sql/t-sql/functions/error-state-transact-sql?view=sql-server-2017#return-value) ranges from 0 - 255 as one can raise an error with custom Error State using [RAISEERROR](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/raiserror-transact-sql?view=sql-server-2017) as well. Accordingly, we must adjust trailing zeroes to the SQLException Error State.
