### PR TITLE
Fix | Fix SQLServerConnection.abort() API behavior to clear resources consistently

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3191,9 +3191,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, false);
         } else {
 
-            // Always report the connection as closed for any further use, no matter
-            // what happens when we try to clean up the physical resources associated
-            // with the connection using executor.
+            /*
+             * Always report the connection as closed for any further use, no matter what happens when we try to clean
+             * up the physical resources associated with the connection using executor.
+             */
             setState(State.Closed);
 
             executor.execute(() -> clearConnectionResources());
@@ -3206,9 +3207,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     public void close() throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "close");
 
-        // Always report the connection as closed for any further use, no matter
-        // what happens when we try to clean up the physical resources associated
-        // with the connection.
+        /*
+         * Always report the connection as closed for any further use, no matter what happens when we try to clean up
+         * the physical resources associated with the connection.
+         */
         setState(State.Closed);
 
         clearConnectionResources();
@@ -3222,9 +3224,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             sharedTimer = null;
         }
 
-        // Close the TDS channel. When the channel is closed, the server automatically
-        // rolls back any pending transactions and closes associated resources like
-        // prepared handles.
+        /*
+         * Close the TDS channel. When the channel is closed, the server automatically rolls back any pending
+         * transactions and closes associated resources like prepared handles.
+         */
         if (null != tdsChannel) {
             tdsChannel.close();
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3192,10 +3192,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             }
         }
 
-        setState(State.Closed);
-
-        if (null != tdsChannel && null != executor)
-            executor.execute(() -> tdsChannel.close());
+        executor.execute(() -> closeInternal());
 
         loggerExternal.exiting(getClassNameLogging(), "abort");
     }
@@ -3203,7 +3200,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     @Override
     public void close() throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "close");
+        closeInternal();
+        loggerExternal.exiting(getClassNameLogging(), "close");
+    }
 
+    private void closeInternal() {
         // Always report the connection as closed for any further use, no matter
         // what happens when we try to clean up the physical resources associated
         // with the connection.
@@ -3232,8 +3233,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         cleanupPreparedStatementDiscardActions();
 
         ActivityCorrelator.cleanupActivityId();
-
-        loggerExternal.exiting(getClassNameLogging(), "close");
     }
 
     // This function is used by the proxy for notifying the pool manager that this connection proxy is closed

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3169,15 +3169,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     public void abort(Executor executor) throws SQLException {
         loggerExternal.entering(getClassNameLogging(), "abort", executor);
 
-        // nop if connection is closed
+        // no-op if connection is closed
         if (isClosed())
             return;
-
-        if (null == executor) {
-            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidArgument"));
-            Object[] msgArgs = {"executor"};
-            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, false);
-        }
 
         // check for callAbort permission
         SecurityManager secMgr = System.getSecurityManager();
@@ -3191,13 +3185,19 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 SQLServerException.makeFromDriverError(this, this, form.format(msgArgs), null, true);
             }
         }
+        if (null == executor) {
+            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidArgument"));
+            Object[] msgArgs = {"executor"};
+            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, false);
+        } else {
 
-        // Always report the connection as closed for any further use, no matter
-        // what happens when we try to clean up the physical resources associated
-        // with the connection using executor.
-        setState(State.Closed);
+            // Always report the connection as closed for any further use, no matter
+            // what happens when we try to clean up the physical resources associated
+            // with the connection using executor.
+            setState(State.Closed);
 
-        executor.execute(() -> clearConnectionResources());
+            executor.execute(() -> clearConnectionResources());
+        }
 
         loggerExternal.exiting(getClassNameLogging(), "abort");
     }
@@ -3210,7 +3210,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         // what happens when we try to clean up the physical resources associated
         // with the connection.
         setState(State.Closed);
-        
+
         clearConnectionResources();
 
         loggerExternal.exiting(getClassNameLogging(), "close");


### PR DESCRIPTION
As per [Java Specifications](https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#abort(java.util.concurrent.Executor)), executing `Connection.abort(Executor executor)`, must also release all resources and mark the connection closed as `Connection.close()` would.

The PR fixes the same by managing resource cleanup separately in a common internal method.
