### PR TITLE
Maven | Exclude non-exported packages from Javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,7 @@
 				<version>3.0.0</version>
 				<configuration>
 					<failOnError>true</failOnError>
+					<excludePackageNames>mssql.googlecode.*</excludePackageNames>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/main/java/mssql/googlecode/concurrentlinkedhashmap/Linked.java
+++ b/src/main/java/mssql/googlecode/concurrentlinkedhashmap/Linked.java
@@ -1,0 +1,27 @@
+package mssql.googlecode.concurrentlinkedhashmap;
+
+import java.util.Deque;
+
+/**
+ * An element that is linked on the {@link Deque}.
+ */
+interface Linked<T extends Linked<T>> {
+
+  /**
+   * Retrieves the previous element or <tt>null</tt> if either the element is
+   * unlinked or the first element on the deque.
+   */
+  T getPrevious();
+
+  /** Sets the previous element or <tt>null</tt> if there is no link. */
+  void setPrevious(T prev);
+
+  /**
+   * Retrieves the next element or <tt>null</tt> if either the element is
+   * unlinked or the last element on the deque.
+   */
+  T getNext();
+
+  /** Sets the next element or <tt>null</tt> if there is no link. */
+  void setNext(T next);
+}

--- a/src/main/java/mssql/googlecode/concurrentlinkedhashmap/LinkedDeque.java
+++ b/src/main/java/mssql/googlecode/concurrentlinkedhashmap/LinkedDeque.java
@@ -434,27 +434,3 @@ final class LinkedDeque<E extends Linked<E>> extends AbstractCollection<E> imple
     abstract E computeNext();
   }
 }
-
-/**
- * An element that is linked on the {@link Deque}.
- */
-interface Linked<T extends Linked<T>> {
-
-  /**
-   * Retrieves the previous element or <tt>null</tt> if either the element is
-   * unlinked or the first element on the deque.
-   */
-  T getPrevious();
-
-  /** Sets the previous element or <tt>null</tt> if there is no link. */
-  void setPrevious(T prev);
-
-  /**
-   * Retrieves the next element or <tt>null</tt> if either the element is
-   * unlinked or the last element on the deque.
-   */
-  T getNext();
-
-  /** Sets the next element or <tt>null</tt> if there is no link. */
-  void setNext(T next);
-}


### PR DESCRIPTION
This PR changes the way we generate Javadocs for the driver.

It now excludes generating Javadocs for `mssql.googlecode` packages as they are not exported with driver Jars. Javadocs for future versions will look as under:

![image](https://user-images.githubusercontent.com/13396919/54314284-7e6e1580-4598-11e9-8d3e-f11dce3ec925.png)
