### PR TITLE
Remove Katmai check

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/Column.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Column.java
@@ -311,12 +311,6 @@ final class Column {
             }
         }
 
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if ((JDBCType.DATETIMEOFFSET == jdbcType || JavaType.DATETIMEOFFSET == javaType) && !con.isKatmaiOrLater()) {
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-        }
-
         // sendStringParametersAsUnicode
         // If set to true, this connection property tells the driver to send textual parameters
         // to the server as Unicode rather than MBCS. This is accomplished here by re-tagging

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -5643,9 +5643,6 @@ final class TDSWriter {
      */
     private void writeScaledTemporal(GregorianCalendar cal, int subSecondNanos, int scale,
             SSType ssType) throws SQLServerException {
-
-        assert con.isKatmaiOrLater();
-
         assert SSType.DATE == ssType || SSType.TIME == ssType || SSType.DATETIME2 == ssType
                 || SSType.DATETIMEOFFSET == ssType : "Unexpected SSType: " + ssType;
 
@@ -5777,8 +5774,6 @@ final class TDSWriter {
      */
     byte[] writeEncryptedScaledTemporal(GregorianCalendar cal, int subSecondNanos, int scale, SSType ssType,
             short minutesOffset) throws SQLServerException {
-        assert con.isKatmaiOrLater();
-
         assert SSType.DATE == ssType || SSType.TIME == ssType || SSType.DATETIME2 == ssType
                 || SSType.DATETIMEOFFSET == ssType : "Unexpected SSType: " + ssType;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -100,12 +100,6 @@ final class Parameter {
     // the transport type reflects how the value is sent to the
     // server (e.g. JDBCType.CHAR for GUID parameters).
     void registerForOutput(JDBCType jdbcType, SQLServerConnection con) throws SQLServerException {
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if (JDBCType.DATETIMEOFFSET == jdbcType && !con.isKatmaiOrLater()) {
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-        }
-
         // sendStringParametersAsUnicode
         // If set to true, this connection property tells the driver to send textual parameters
         // to the server as Unicode rather than MBCS. This is accomplished here by re-tagging
@@ -303,12 +297,6 @@ final class Parameter {
             Object[] msgArgs = {parameterIndex, userSQL};
             SQLServerException.makeFromDriverError(con, this, form.format(msgArgs), null, true);
 
-        }
-
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if ((JDBCType.DATETIMEOFFSET == jdbcType || JavaType.DATETIMEOFFSET == javaType) && !con.isKatmaiOrLater()) {
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
         }
 
         if (JavaType.TVP == javaType) {
@@ -588,7 +576,7 @@ final class Parameter {
 
                 case DATE:
                     // Bind DATE values to pre-Katmai servers as DATETIME (which has no DATE-only type).
-                    param.typeDefinition = con.isKatmaiOrLater() ? SSType.DATE.toString() : SSType.DATETIME.toString();
+                    param.typeDefinition = SSType.DATE.toString();
                     break;
 
                 case TIME:
@@ -625,18 +613,12 @@ final class Parameter {
                          * generic type info can be used as before.
                          */
                         if (userProvidesScale) {
-                            param.typeDefinition = con
-                                    .isKatmaiOrLater() ? (SSType.DATETIME2.toString() + "(" + outScale + ")")
-                                                       : (SSType.DATETIME.toString());
+                            param.typeDefinition = SSType.DATETIME2.toString() + "(" + outScale + ")";
                         } else {
-                            param.typeDefinition = con.isKatmaiOrLater()
-                                                                         ? (SSType.DATETIME2.toString() + "("
-                                                                                 + valueLength + ")")
-                                                                         : SSType.DATETIME.toString();
+                            param.typeDefinition = SSType.DATETIME2.toString() + "(" + valueLength + ")";
                         }
                     } else {
-                        param.typeDefinition = con.isKatmaiOrLater() ? SSType.DATETIME2.toString()
-                                                                     : SSType.DATETIME.toString();
+                        param.typeDefinition = SSType.DATETIME2.toString();
                     }
                     break;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -968,12 +968,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getDateTimeOffset", index);
         checkClosed();
-
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if (!connection.isKatmaiOrLater())
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-
         microsoft.sql.DateTimeOffset value = (microsoft.sql.DateTimeOffset) getValue(index, JDBCType.DATETIMEOFFSET);
         loggerExternal.exiting(getClassNameLogging(), "getDateTimeOffset", value);
         return value;
@@ -983,12 +977,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     public microsoft.sql.DateTimeOffset getDateTimeOffset(String parameterName) throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "getDateTimeOffset", parameterName);
         checkClosed();
-
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if (!connection.isKatmaiOrLater())
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-
         microsoft.sql.DateTimeOffset value = (microsoft.sql.DateTimeOffset) getValue(findColumn(parameterName),
                 JDBCType.DATETIMEOFFSET);
         loggerExternal.exiting(getClassNameLogging(), "getDateTimeOffset", value);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -577,7 +577,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     @Override
     public final boolean getSendTimeAsDatetime() {
-        return !isKatmaiOrLater() || sendTimeAsDatetime;
+        return sendTimeAsDatetime;
     }
 
     final int baseYear() {
@@ -975,12 +975,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     private TDSCommand currentCommand = null;
 
     private int tdsVersion = TDS.VER_UNKNOWN;
-
-    final boolean isKatmaiOrLater() {
-        assert TDS.VER_UNKNOWN != tdsVersion;
-        assert tdsVersion >= TDS.VER_YUKON;
-        return tdsVersion >= TDS.VER_KATMAI;
-    }
 
     final boolean isDenaliOrLater() {
         return tdsVersion >= TDS.VER_DENALI;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -639,13 +639,12 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         arguments[1] = schema;
         arguments[2] = catalog;
         arguments[3] = column;
-        arguments[4] = "2"; // give information about everything including
-                            // sparse columns
+        arguments[4] = "2"; // give information about everything including sparse columns
         arguments[5] = "3"; // odbc version
 
-        SQLServerResultSet rs;
-        rs = getResultSetWithProvidedColumnNames(catalog, CallableHandles.SP_COLUMNS, arguments,
+        SQLServerResultSet rs = getResultSetWithProvidedColumnNames(catalog, CallableHandles.SP_COLUMNS, arguments,
                 getColumnsColumnNamesKatmai);
+        
         // Hook in a filter on the DATA_TYPE column of the result set we're
         // going to return that converts the ODBC values from sp_columns
         // into JDBC values.
@@ -1403,8 +1402,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
         checkClosed();
 
-        SQLServerResultSet rs;
-        rs = getResultSetFromInternalQueries(null, "sp_datatype_info_100 @ODBCVer=3");
+        SQLServerResultSet rs = getResultSetFromInternalQueries(null, "sp_datatype_info_100 @ODBCVer=3");
 
         rs.setColumnName(11, "FIXED_PREC_SCALE");
         // Hook in a filter on the DATA_TYPE column of the result set we're

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -563,7 +563,8 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                 String sProc = parseProcIdentifier(st.procedureName);
                 try (SQLServerStatement s = (SQLServerStatement) con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
                         ResultSet.CONCUR_READ_ONLY);
-                        SQLServerResultSet rsProcedureMeta = s.executeQueryInternal("exec sp_sproc_columns_100 " + sProc + ", @ODBCVer=3")) {
+                        SQLServerResultSet rsProcedureMeta = 
+                                s.executeQueryInternal("exec sp_sproc_columns_100 " + sProc + ", @ODBCVer=3")) {
 
                     // if rsProcedureMeta has next row, it means the stored procedure is found
                     if (rsProcedureMeta.next()) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -563,9 +563,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                 String sProc = parseProcIdentifier(st.procedureName);
                 try (SQLServerStatement s = (SQLServerStatement) con.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
                         ResultSet.CONCUR_READ_ONLY);
-                        SQLServerResultSet rsProcedureMeta = s.executeQueryInternal(
-                                con.isKatmaiOrLater() ? "exec sp_sproc_columns_100 " + sProc + ", @ODBCVer=3"
-                                                      : "exec sp_sproc_columns " + sProc + ", @ODBCVer=3")) {
+                        SQLServerResultSet rsProcedureMeta = s.executeQueryInternal("exec sp_sproc_columns_100 " + sProc + ", @ODBCVer=3")) {
 
                     // if rsProcedureMeta has next row, it means the stored procedure is found
                     if (rsProcedureMeta.next()) {
@@ -578,11 +576,9 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
 
                     // Sixth is DATA_TYPE
                     rsProcedureMeta.getColumn(6).setFilter(new DataTypeFilter());
-                    if (con.isKatmaiOrLater()) {
-                        rsProcedureMeta.getColumn(8).setFilter(new ZeroFixupFilter());
-                        rsProcedureMeta.getColumn(9).setFilter(new ZeroFixupFilter());
-                        rsProcedureMeta.getColumn(17).setFilter(new ZeroFixupFilter());
-                    }
+                    rsProcedureMeta.getColumn(8).setFilter(new ZeroFixupFilter());
+                    rsProcedureMeta.getColumn(9).setFilter(new ZeroFixupFilter());
+                    rsProcedureMeta.getColumn(17).setFilter(new ZeroFixupFilter());
 
                     procMetadata = new ArrayList<>();
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2700,12 +2700,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
     public microsoft.sql.DateTimeOffset getDateTimeOffset(int columnIndex) throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "getDateTimeOffset", columnIndex);
         checkClosed();
-
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if (!stmt.connection.isKatmaiOrLater())
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-
         microsoft.sql.DateTimeOffset value = (microsoft.sql.DateTimeOffset) getValue(columnIndex,
                 JDBCType.DATETIMEOFFSET);
         loggerExternal.exiting(getClassNameLogging(), "getDateTimeOffset", value);
@@ -2716,12 +2710,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
     public microsoft.sql.DateTimeOffset getDateTimeOffset(String columnName) throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "getDateTimeOffset", columnName);
         checkClosed();
-
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if (!stmt.connection.isKatmaiOrLater())
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-
         microsoft.sql.DateTimeOffset value = (microsoft.sql.DateTimeOffset) getValue(findColumn(columnName),
                 JDBCType.DATETIMEOFFSET);
         loggerExternal.exiting(getClassNameLogging(), "getDateTimeOffset", value);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSetMetaData.java
@@ -133,32 +133,30 @@ public final class SQLServerResultSetMetaData implements ISQLServerResultSetMeta
             }
         }
         int r = jdbcType.asJavaSqlType();
-        if (con.isKatmaiOrLater()) {
-            switch (sqlType) {
-                case VARCHARMAX:
-                    r = SSType.VARCHAR.getJDBCType().asJavaSqlType();
-                    break;
-                case NVARCHARMAX:
-                    r = SSType.NVARCHAR.getJDBCType().asJavaSqlType();
-                    break;
-                case VARBINARYMAX:
-                    r = SSType.VARBINARY.getJDBCType().asJavaSqlType();
-                    break;
-                case DATETIME:
-                case SMALLDATETIME:
-                    r = SSType.DATETIME2.getJDBCType().asJavaSqlType();
-                    break;
-                case MONEY:
-                case SMALLMONEY:
-                    r = SSType.DECIMAL.getJDBCType().asJavaSqlType();
-                    break;
-                case GUID:
-                    r = SSType.CHAR.getJDBCType().asJavaSqlType();
-                    break;
-                default:
-                    // Do nothing
-                    break;
-            }
+        switch (sqlType) {
+            case VARCHARMAX:
+                r = SSType.VARCHAR.getJDBCType().asJavaSqlType();
+                break;
+            case NVARCHARMAX:
+                r = SSType.NVARCHAR.getJDBCType().asJavaSqlType();
+                break;
+            case VARBINARYMAX:
+                r = SSType.VARBINARY.getJDBCType().asJavaSqlType();
+                break;
+            case DATETIME:
+            case SMALLDATETIME:
+                r = SSType.DATETIME2.getJDBCType().asJavaSqlType();
+                break;
+            case MONEY:
+            case SMALLMONEY:
+                r = SSType.DECIMAL.getJDBCType().asJavaSqlType();
+                break;
+            case GUID:
+                r = SSType.CHAR.getJDBCType().asJavaSqlType();
+                break;
+            default:
+                // Do nothing
+                break;
         }
         return r;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -850,137 +850,118 @@ final class DTV {
                 // as determined by sendTimeAsDatetime setting
                 // - java.sql.Types.DATE, use DATE SQL Server data type
                 // - microsoft.sql.Types.DATETIMEOFFSET, use DATETIMEOFFSET SQL Server data type
-                if (conn.isKatmaiOrLater()) {
-                    if (aeLogger.isLoggable(java.util.logging.Level.FINE) && (null != cryptoMeta)) {
-                        aeLogger.fine("Encrypting temporal data type.");
-                    }
+                if (aeLogger.isLoggable(java.util.logging.Level.FINE) && (null != cryptoMeta)) {
+                    aeLogger.fine("Encrypting temporal data type.");
+                }
 
-                    switch (jdbcType) {
-                        case DATETIME:
-                        case SMALLDATETIME:
-                        case TIMESTAMP:
-                            if (null != cryptoMeta) {
-                                if ((JDBCType.DATETIME == jdbcType) || (JDBCType.SMALLDATETIME == jdbcType)) {
-                                    tdsWriter.writeEncryptedRPCDateTime(name,
-                                            timestampNormalizedCalendar(calendar, javaType, conn.baseYear()),
-                                            subSecondNanos, isOutParam, jdbcType);
-                                } else if (0 == valueLength) {
-                                    tdsWriter.writeEncryptedRPCDateTime2(name,
-                                            timestampNormalizedCalendar(calendar, javaType, conn.baseYear()),
-                                            subSecondNanos, outScale, isOutParam);
-                                } else {
-                                    tdsWriter.writeEncryptedRPCDateTime2(name,
-                                            timestampNormalizedCalendar(calendar, javaType, conn.baseYear()),
-                                            subSecondNanos, (valueLength), isOutParam);
-                                }
-                            } else
-                                tdsWriter.writeRPCDateTime2(name,
+                switch (jdbcType) {
+                    case DATETIME:
+                    case SMALLDATETIME:
+                    case TIMESTAMP:
+                        if (null != cryptoMeta) {
+                            if ((JDBCType.DATETIME == jdbcType) || (JDBCType.SMALLDATETIME == jdbcType)) {
+                                tdsWriter.writeEncryptedRPCDateTime(name,
                                         timestampNormalizedCalendar(calendar, javaType, conn.baseYear()),
-                                        subSecondNanos, TDS.MAX_FRACTIONAL_SECONDS_SCALE, isOutParam);
-
-                            break;
-
-                        case TIME:
-                            // if column is encrypted, always send as TIME
-                            if (null != cryptoMeta) {
-                                if (0 == valueLength) {
-                                    tdsWriter.writeEncryptedRPCTime(name, calendar, subSecondNanos, outScale,
-                                            isOutParam);
-                                } else {
-                                    tdsWriter.writeEncryptedRPCTime(name, calendar, subSecondNanos, valueLength,
-                                            isOutParam);
-                                }
+                                        subSecondNanos, isOutParam, jdbcType);
+                            } else if (0 == valueLength) {
+                                tdsWriter.writeEncryptedRPCDateTime2(name,
+                                        timestampNormalizedCalendar(calendar, javaType, conn.baseYear()),
+                                        subSecondNanos, outScale, isOutParam);
                             } else {
-                                // Send the java.sql.Types.TIME value as TIME or DATETIME SQL Server
-                                // data type, based on sendTimeAsDatetime setting.
-                                if (conn.getSendTimeAsDatetime()) {
-                                    tdsWriter.writeRPCDateTime(name,
-                                            timestampNormalizedCalendar(calendar, JavaType.TIME, TDS.BASE_YEAR_1970),
-                                            subSecondNanos, isOutParam);
-                                } else {
-                                    tdsWriter.writeRPCTime(name, calendar, subSecondNanos,
-                                            TDS.MAX_FRACTIONAL_SECONDS_SCALE, isOutParam);
-                                }
+                                tdsWriter.writeEncryptedRPCDateTime2(name,
+                                        timestampNormalizedCalendar(calendar, javaType, conn.baseYear()),
+                                        subSecondNanos, (valueLength), isOutParam);
                             }
+                        } else
+                            tdsWriter.writeRPCDateTime2(name,
+                                    timestampNormalizedCalendar(calendar, javaType, conn.baseYear()),
+                                    subSecondNanos, TDS.MAX_FRACTIONAL_SECONDS_SCALE, isOutParam);
 
-                            break;
+                        break;
 
-                        case DATE:
-                            if (null != cryptoMeta)
-                                tdsWriter.writeEncryptedRPCDate(name, calendar, isOutParam);
-                            else
-                                tdsWriter.writeRPCDate(name, calendar, isOutParam);
-
-                            break;
-
-                        case TIME_WITH_TIMEZONE:
-                            // When converting from any other temporal Java type to TIME_WITH_TIMEZONE,
-                            // deliberately reinterpret the value as local to UTC. This is to match
-                            // SQL Server behavior for such conversions.
-                            if ((JavaType.OFFSETDATETIME != javaType) && (JavaType.OFFSETTIME != javaType)) {
-                                calendar = timestampNormalizedCalendar(localCalendarAsUTC(calendar), javaType,
-                                        conn.baseYear());
-
-                                minutesOffset = 0; // UTC
+                    case TIME:
+                        // if column is encrypted, always send as TIME
+                        if (null != cryptoMeta) {
+                            if (0 == valueLength) {
+                                tdsWriter.writeEncryptedRPCTime(name, calendar, subSecondNanos, outScale,
+                                        isOutParam);
+                            } else {
+                                tdsWriter.writeEncryptedRPCTime(name, calendar, subSecondNanos, valueLength,
+                                        isOutParam);
                             }
+                        } else {
+                            // Send the java.sql.Types.TIME value as TIME or DATETIME SQL Server
+                            // data type, based on sendTimeAsDatetime setting.
+                            if (conn.getSendTimeAsDatetime()) {
+                                tdsWriter.writeRPCDateTime(name,
+                                        timestampNormalizedCalendar(calendar, JavaType.TIME, TDS.BASE_YEAR_1970),
+                                        subSecondNanos, isOutParam);
+                            } else {
+                                tdsWriter.writeRPCTime(name, calendar, subSecondNanos,
+                                        TDS.MAX_FRACTIONAL_SECONDS_SCALE, isOutParam);
+                            }
+                        }
 
+                        break;
+
+                    case DATE:
+                        if (null != cryptoMeta)
+                            tdsWriter.writeEncryptedRPCDate(name, calendar, isOutParam);
+                        else
+                            tdsWriter.writeRPCDate(name, calendar, isOutParam);
+
+                        break;
+
+                    case TIME_WITH_TIMEZONE:
+                        // When converting from any other temporal Java type to TIME_WITH_TIMEZONE,
+                        // deliberately reinterpret the value as local to UTC. This is to match
+                        // SQL Server behavior for such conversions.
+                        if ((JavaType.OFFSETDATETIME != javaType) && (JavaType.OFFSETTIME != javaType)) {
+                            calendar = timestampNormalizedCalendar(localCalendarAsUTC(calendar), javaType,
+                                    conn.baseYear());
+
+                            minutesOffset = 0; // UTC
+                        }
+
+                        tdsWriter.writeRPCDateTimeOffset(name, calendar, minutesOffset, subSecondNanos,
+                                TDS.MAX_FRACTIONAL_SECONDS_SCALE, isOutParam);
+
+                        break;
+
+                    case TIMESTAMP_WITH_TIMEZONE:
+                    case DATETIMEOFFSET:
+                        // When converting from any other temporal Java type to
+                        // DATETIMEOFFSET/TIMESTAMP_WITH_TIMEZONE,
+                        // deliberately reinterpret the value as local to UTC. This is to match
+                        // SQL Server behavior for such conversions.
+                        if ((JavaType.DATETIMEOFFSET != javaType) && (JavaType.OFFSETDATETIME != javaType)) {
+                            calendar = timestampNormalizedCalendar(localCalendarAsUTC(calendar), javaType,
+                                    conn.baseYear());
+
+                            minutesOffset = 0; // UTC
+                        }
+
+                        if (null != cryptoMeta) {
+                            if (0 == valueLength) {
+                                tdsWriter.writeEncryptedRPCDateTimeOffset(name, calendar, minutesOffset,
+                                        subSecondNanos, outScale, isOutParam);
+                            } else {
+                                tdsWriter.writeEncryptedRPCDateTimeOffset(name, calendar, minutesOffset,
+                                        subSecondNanos,
+                                        (0 == valueLength ? TDS.MAX_FRACTIONAL_SECONDS_SCALE : valueLength),
+                                        isOutParam);
+                            }
+                        } else
                             tdsWriter.writeRPCDateTimeOffset(name, calendar, minutesOffset, subSecondNanos,
                                     TDS.MAX_FRACTIONAL_SECONDS_SCALE, isOutParam);
 
-                            break;
+                        break;
 
-                        case TIMESTAMP_WITH_TIMEZONE:
-                        case DATETIMEOFFSET:
-                            // When converting from any other temporal Java type to
-                            // DATETIMEOFFSET/TIMESTAMP_WITH_TIMEZONE,
-                            // deliberately reinterpret the value as local to UTC. This is to match
-                            // SQL Server behavior for such conversions.
-                            if ((JavaType.DATETIMEOFFSET != javaType) && (JavaType.OFFSETDATETIME != javaType)) {
-                                calendar = timestampNormalizedCalendar(localCalendarAsUTC(calendar), javaType,
-                                        conn.baseYear());
+                    default:
+                        assert false : "Unexpected JDBCType: " + jdbcType;
 
-                                minutesOffset = 0; // UTC
-                            }
-
-                            if (null != cryptoMeta) {
-                                if (0 == valueLength) {
-                                    tdsWriter.writeEncryptedRPCDateTimeOffset(name, calendar, minutesOffset,
-                                            subSecondNanos, outScale, isOutParam);
-                                } else {
-                                    tdsWriter.writeEncryptedRPCDateTimeOffset(name, calendar, minutesOffset,
-                                            subSecondNanos,
-                                            (0 == valueLength ? TDS.MAX_FRACTIONAL_SECONDS_SCALE : valueLength),
-                                            isOutParam);
-                                }
-                            } else
-                                tdsWriter.writeRPCDateTimeOffset(name, calendar, minutesOffset, subSecondNanos,
-                                        TDS.MAX_FRACTIONAL_SECONDS_SCALE, isOutParam);
-
-                            break;
-
-                        default:
-                            assert false : "Unexpected JDBCType: " + jdbcType;
-
-                    }
                 }
-
-                // Yukon and earlier
-                // -----------------
-                //
-                // When sending as...
-                // - java.sql.Types.TIMESTAMP, use DATETIME SQL Server data type (all components)
-                // - java.sql.Types.TIME, use DATETIME SQL Server data type (with date = 1/1/1970)
-                // - java.sql.Types.DATE, use DATETIME SQL Server data type (with time = midnight)
-                // - microsoft.sql.Types.DATETIMEOFFSET (not supported - exception should have been thrown earlier)
-                else {
-                    assert JDBCType.TIME == jdbcType || JDBCType.DATE == jdbcType
-                            || JDBCType.TIMESTAMP == jdbcType : "Unexpected JDBCType: " + jdbcType;
-
-                    tdsWriter.writeRPCDateTime(name,
-                            timestampNormalizedCalendar(calendar, javaType, TDS.BASE_YEAR_1970), subSecondNanos,
-                            isOutParam);
-                }
-            } // setters
+            }
         }
 
         /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/WrapperTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/WrapperTest.java
@@ -23,7 +23,6 @@ import com.microsoft.sqlserver.jdbc.SQLServerCallableStatement;
 import com.microsoft.sqlserver.jdbc.SQLServerStatement;
 import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.testframework.AbstractTest;
-import com.microsoft.sqlserver.testframework.DBConnection;
 
 
 /**
@@ -85,9 +84,7 @@ public class WrapperTest extends AbstractTest {
                     try (ISQLServerPreparedStatement stmt3 = (ISQLServerPreparedStatement) ((SQLServerCallableStatement) cs)
                             .unwrap(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerPreparedStatement"))) {
                         stmt3.setResponseBuffering("adaptive");
-
-                        if (isKatmaiServer())
-                            stmt3.setDateTimeOffset(1, null);
+                        stmt3.setDateTimeOffset(1, null);
 
                         // Try Unwrapping CallableStatement to a callableStatement
                         isWrapper = ((SQLServerCallableStatement) cs)
@@ -98,9 +95,7 @@ public class WrapperTest extends AbstractTest {
                         try (SQLServerCallableStatement stmt4 = (SQLServerCallableStatement) ((SQLServerCallableStatement) cs)
                                 .unwrap(Class.forName("com.microsoft.sqlserver.jdbc.SQLServerCallableStatement"))) {
                             stmt4.setResponseBuffering("adaptive");
-                            if (isKatmaiServer()) {
-                                stmt4.setDateTimeOffset(1, null);
-                            }
+                            stmt4.setDateTimeOffset(1, null);
                         }
                     }
                 }
@@ -136,13 +131,6 @@ public class WrapperTest extends AbstractTest {
                     "isWrapperFor " + TestResource.getResource("R_shouldBeSupported"));
             assertEquals(e.getMessage(), "This operation is not supported.",
                     TestResource.getResource("R_unexpectedExceptionContent"));
-        }
-    }
-
-    private static boolean isKatmaiServer() throws Exception {
-        try (DBConnection conn = new DBConnection(connectionString)) {
-            double version = conn.getServerVersion();
-            return ((version >= 10.0) ? true : false);
         }
     }
 }


### PR DESCRIPTION
Katmai (SQL Server 2008) server check is no longer needed, because our driver no longer supports SQL server versions below 2008.