### PR TITLE
Fix ActivityID map getting not cleaned up properly

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ActivityCorrelator.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ActivityCorrelator.java
@@ -17,10 +17,8 @@ final class ActivityCorrelator {
 
     private static Map<Long, ActivityId> activityIdTlsMap = new ConcurrentHashMap<>();
 
-    static void cleanupActivityId() {
+    static void cleanupActivityId(long uniqueThreadId) {
         // remove the ActivityId that belongs to this thread.
-        long uniqueThreadId = Thread.currentThread().getId();
-
         if (activityIdTlsMap.containsKey(uniqueThreadId)) {
             activityIdTlsMap.remove(uniqueThreadId);
         }
@@ -33,7 +31,7 @@ final class ActivityCorrelator {
 
         // Since the Id for each thread is unique, this assures that the below if statement is run only once per thread.
         if (!activityIdTlsMap.containsKey(uniqueThreadId)) {
-            activityIdTlsMap.put(uniqueThreadId, new ActivityId());
+            activityIdTlsMap.put(uniqueThreadId, new ActivityId(uniqueThreadId));
         }
 
         return activityIdTlsMap.get(uniqueThreadId);
@@ -65,13 +63,19 @@ final class ActivityCorrelator {
 
 class ActivityId {
     private final UUID id;
+    private final long uniqueThreadId;
     private long sequence;
     private boolean isSentToServer;
 
-    ActivityId() {
+    ActivityId(long uniqueThreadId) {
         id = UUID.randomUUID();
+        this.uniqueThreadId = uniqueThreadId;
         sequence = 0;
         isSentToServer = false;
+    }
+    
+    public long getUniqueThreadId() {
+        return uniqueThreadId;
     }
 
     UUID getId() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ActivityCorrelator.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ActivityCorrelator.java
@@ -74,7 +74,7 @@ class ActivityId {
         isSentToServer = false;
     }
     
-    public long getUniqueThreadId() {
+    long getUniqueThreadId() {
         return uniqueThreadId;
     }
 


### PR DESCRIPTION
As mentioned in PR #465, the ActivityID objects in activityIdTlsMap would not get cleaned up in scenarios where there is a separate thread that manages the pooled connections. This is because the key that is used to look up and remove the entries in the map comes from the current thread's ID, and in a scenario where a separate thread is responsible for cleaning up all the threads, the thread's ID will stay constant throughout the rest of the application's lifetime and the ActivityIDs will not get cleaned up properly.

To solve this issue, instead of relying on recomputing the current thread's ID when we need to clean up the map, we associate each SQLServerConnection object with the thread ID, and use that variable later when we call close() on the connection. This will ensure that the map is getting cleaned up properly in all scenarios.