### PR TITLE
Maven | Update Maven Bundle version for newer JDK compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>4.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>


### PR DESCRIPTION
Fixes Manifest entry `osgi.ee;filter:="(osgi.ee=UNKNOWN)"`