### PR TITLE
Fix | Mark spatial datatypes as valid

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
@@ -415,6 +415,8 @@ enum JavaType {
     CLOB(Clob.class, JDBCType.CLOB),
     BLOB(Blob.class, JDBCType.BLOB),
     TVP(com.microsoft.sqlserver.jdbc.TVP.class, JDBCType.TVP),
+    GEOMETRY(Geometry.class, JDBCType.GEOMETRY),
+    GEOGRAPHY(Geography.class, JDBCType.GEOGRAPHY),
 
     INPUTSTREAM(InputStream.class, JDBCType.UNKNOWN) {
         // InputStreams are either ASCII or binary
@@ -776,7 +778,11 @@ enum JDBCType {
 
         SQLXML(JDBCType.Category.SQLXML, EnumSet.of(JDBCType.Category.SQLXML)),
 
-        TVP(JDBCType.Category.TVP, EnumSet.of(JDBCType.Category.TVP));
+        TVP(JDBCType.Category.TVP, EnumSet.of(JDBCType.Category.TVP)),
+        
+        GEOMETRY(JDBCType.Category.GEOMETRY, EnumSet.of(JDBCType.Category.GEOMETRY)),
+        
+        GEOGRAPHY(JDBCType.Category.GEOGRAPHY, EnumSet.of(JDBCType.Category.GEOGRAPHY));
 
         private final JDBCType.Category from;
         private final EnumSet<JDBCType.Category> to;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
@@ -27,7 +27,7 @@ public class Geography extends SQLServerSpatialDatatype {
      * @throws SQLServerException
      *         if an exception occurs
      */
-    private Geography(String wkt, int srid) throws SQLServerException {
+    protected Geography(String wkt, int srid) throws SQLServerException {
         if (null == wkt || wkt.length() <= 0) {
             throwIllegalWKT();
         }
@@ -49,7 +49,7 @@ public class Geography extends SQLServerSpatialDatatype {
      * @throws SQLServerException
      *         if an exception occurs
      */
-    private Geography(byte[] wkb) throws SQLServerException {
+    protected Geography(byte[] wkb) throws SQLServerException {
         if (null == wkb || wkb.length <= 0) {
             throwIllegalWKB();
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Geography.java
@@ -15,6 +15,8 @@ import java.nio.ByteOrder;
 
 public class Geography extends SQLServerSpatialDatatype {
 
+    protected Geography() {}
+
     /**
      * Private constructor used for creating a Geography object from WKT and Spatial Reference Identifier.
      * 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Geometry.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Geometry.java
@@ -15,6 +15,8 @@ import java.nio.ByteOrder;
 
 public class Geometry extends SQLServerSpatialDatatype {
 
+    protected Geometry() {}
+
     /**
      * Private constructor used for creating a Geometry object from WKT and Spatial Reference Identifier.
      * 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Geometry.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Geometry.java
@@ -27,7 +27,7 @@ public class Geometry extends SQLServerSpatialDatatype {
      * @throws SQLServerException
      *         if an exception occurs
      */
-    private Geometry(String wkt, int srid) throws SQLServerException {
+    protected Geometry(String wkt, int srid) throws SQLServerException {
         if (null == wkt || wkt.length() <= 0) {
             throwIllegalWKT();
         }
@@ -49,7 +49,7 @@ public class Geometry extends SQLServerSpatialDatatype {
      * @throws SQLServerException
      *         if an exception occurs
      */
-    private Geometry(byte[] wkb) throws SQLServerException {
+    protected Geometry(byte[] wkb) throws SQLServerException {
         if (null == wkb || wkb.length <= 0) {
             throwIllegalWKB();
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSpatialDatatype.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSpatialDatatype.java
@@ -54,7 +54,7 @@ abstract class SQLServerSpatialDatatype {
     // serialization properties
     protected boolean hasZvalues = false;
     protected boolean hasMvalues = false;
-    protected boolean isValid = false;
+    protected boolean isValid = true;
     protected boolean isSinglePoint = false;
     protected boolean isSingleLineSegment = false;
     protected boolean isLargerThanHemisphere = false;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -1699,6 +1699,14 @@ final class DTV {
                 case DATETIMEOFFSET:
                     op.execute(this, (microsoft.sql.DateTimeOffset) value);
                     break;
+                    
+                case GEOMETRY:
+                    op.execute(this, ((Geometry) value).serialize());
+                    break;
+                    
+                case GEOGRAPHY:
+                    op.execute(this, ((Geography) value).serialize());
+                    break;
 
                 case FLOAT:
                     if (null != cryptoMeta) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
@@ -860,6 +860,46 @@ public class SQLServerSpatialDatatypeTest extends AbstractTest {
 
     @Test
     @Tag(Constants.xAzureSQLDW)
+    public void testSetObject() throws SQLException {
+        beforeEachSetup();
+
+        String geoWKT = "POINT(1 2)";
+
+        Geometry geomWKT = Geometry.point(1, 2, 0);
+        Geography geogWKT = Geography.point(2, 1, 4326);
+
+        try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con.prepareStatement(
+                    "insert into " + AbstractSQLGenerator.escapeIdentifier(geomTableName) + " values (?)");) {
+                pstmt.setObject(1, geomWKT);
+                pstmt.execute();
+
+                try (SQLServerResultSet rs = (SQLServerResultSet) stmt
+                        .executeQuery("select c1 from " + AbstractSQLGenerator.escapeIdentifier(geomTableName))) {
+                    rs.next();
+                    assertEquals(rs.getGeometry(1).asTextZM(), geoWKT);
+                    assertEquals(rs.getGeometry(1).getSrid(), 0);
+                }
+            }
+
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con.prepareStatement(
+                    "insert into " + AbstractSQLGenerator.escapeIdentifier(geogTableName) + " values (?)");) {
+                pstmt.setObject(1, geogWKT);
+                pstmt.execute();
+
+                try (SQLServerResultSet rs = (SQLServerResultSet) stmt
+                        .executeQuery("select c1 from " + AbstractSQLGenerator.escapeIdentifier(geogTableName))) {
+                    rs.next();
+                    assertEquals(rs.getGeography(1).asTextZM(), geoWKT);
+                    assertEquals(rs.getGeography(1).getSrid(), 4326);
+                }
+            }
+        }
+    }
+
+    @Test
+    @Tag(Constants.xAzureSQLDW)
     public void testSTAsText() throws SQLException {
         beforeEachSetup();
 


### PR DESCRIPTION
Addresses issue #1031 and #1038.

For #1031, I changed the isValid bit to be set to `true` by default, as it is stated in the CLR specs. Leaving this isValid bit to false makes some of the Spatial Datatype operations on the server's end fail.

For #1038, I've declared the default constructors as protected, to allow extension of Geometry and Geography classes.

I've also noticed that setObject() using Geography/Geometry weren't working as intended, so I'm fixing that as well.