### PR TITLE
Fix | Fix SharedTimer implementation to use class level lock for thread safety

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SharedTimer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SharedTimer.java
@@ -63,8 +63,7 @@ class SharedTimer implements Serializable {
             if (refCount.get() <= 0) {
                 throw new IllegalStateException("removeRef() called more than actual references");
             }
-            refCount.getAndDecrement();
-            if (refCount.get() == 0) {
+            if (refCount.decrementAndGet() == 0) {
                 // Removed last reference so perform cleanup
                 executor.shutdownNow();
                 executor = null;
@@ -80,15 +79,15 @@ class SharedTimer implements Serializable {
      *
      * When the caller is finished with the SharedTimer it must be released via {@link#removeRef}
      */
-    public static synchronized SharedTimer getTimer() {
+    public static SharedTimer getTimer() {
         synchronized (lock) {
             if (instance == null) {
                 // No shared object exists so create a new one
                 instance = new SharedTimer();
             }
             instance.refCount.getAndIncrement();
+            return instance;
         }
-        return instance;
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SharedTimer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SharedTimer.java
@@ -19,10 +19,9 @@ class SharedTimer implements Serializable {
     private static final long serialVersionUID = -4069361613863955760L;
 
     static final String CORE_THREAD_PREFIX = "mssql-jdbc-shared-timer-core-";
-    private static final AtomicLong CORE_THREAD_COUNTER = new AtomicLong();
-    private static volatile SharedTimer instance;
-    private static Object lock = new Object();
 
+    private static final AtomicLong CORE_THREAD_COUNTER = new AtomicLong();
+    private static final Object lock = new Object();
     /**
      * Unique ID of this SharedTimer
      */
@@ -31,6 +30,8 @@ class SharedTimer implements Serializable {
      * Number of outstanding references to this SharedTimer
      */
     private final AtomicInteger refCount = new AtomicInteger();
+
+    private static volatile SharedTimer instance;
     private ScheduledThreadPoolExecutor executor;
 
     private SharedTimer() {
@@ -49,7 +50,7 @@ class SharedTimer implements Serializable {
     /**
      * @return Whether there is an instance of the SharedTimer currently allocated.
      */
-    static synchronized boolean isRunning() {
+    static boolean isRunning() {
         return instance != null;
     }
 


### PR DESCRIPTION
Fixes #1040 