### PR TITLE
Feature | Introduce Java 12 Support to driver and build additional "jre12" JAR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     displayName: 'Maven build jre12'
     inputs:
       mavenPomFile: 'pom.xml'
-      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre12 -DexcludeGroups=$(Ex_Groups)'
+      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre12 -DexcludedGroups=$(Ex_Groups)'
       testResultsFiles: '**/TEST-*.xml'
       testRunTitle: 'Maven build jre12'
       javaHomeOption: Path
@@ -42,7 +42,7 @@ jobs:
     displayName: 'Maven build jre11'
     inputs:
       mavenPomFile: 'pom.xml'
-      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre11 -DexcludeGroups=$(Ex_Groups)'
+      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre11 -DexcludedGroups=$(Ex_Groups)'
       testResultsFiles: '**/TEST-*.xml'
       testRunTitle: 'Maven build jre11'
       javaHomeOption: Path
@@ -51,7 +51,7 @@ jobs:
     displayName: 'Maven build jre8'
     inputs:
       mavenPomFile: 'pom.xml'
-      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre8 -DexcludeGroups=$(Ex_Groups)'
+      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre8 -DexcludedGroups=$(Ex_Groups)'
       testResultsFiles: '**/TEST-*.xml'
       testRunTitle: 'Maven build jre8'
       javaHomeOption: Path

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,24 +30,29 @@ jobs:
       Remove-Item –path .\JavaKeyStoreBase.txt
     displayName: 'PowerShell Script'
   - task: Maven@3
-    displayName: 'Maven build 43'
+    displayName: 'Maven build jre12'
     inputs:
       mavenPomFile: 'pom.xml'
-      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pbuild43 -DexcludeGroups=$(Ex_Groups)'
+      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre12 -DexcludeGroups=$(Ex_Groups)'
       testResultsFiles: '**/TEST-*.xml'
-      testRunTitle: 'Maven build 43'
+      testRunTitle: 'Maven build jre12'
       javaHomeOption: Path
-      jdkDirectory: $(JDK11)
-      mavenAuthenticateFeed: true
-      checkStyleRunAnalysis: true
-      pmdRunAnalysis: true
+      jdkDirectory: $(JDK12)
   - task: Maven@3
-    displayName: 'Maven build 42'
+    displayName: 'Maven build jre11'
     inputs:
       mavenPomFile: 'pom.xml'
-      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pbuild42 -DexcludeGroups=$(Ex_Groups)'
-      testRunTitle: 'Maven build 42'
+      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre11 -DexcludeGroups=$(Ex_Groups)'
+      testResultsFiles: '**/TEST-*.xml'
+      testRunTitle: 'Maven build jre11'
       javaHomeOption: Path
-      jdkDirectory: $(JDK11)
-      checkStyleRunAnalysis: true
-      pmdRunAnalysis: true
+      jdkDirectory: $(JDK12)
+  - task: Maven@3
+    displayName: 'Maven build jre8'
+    inputs:
+      mavenPomFile: 'pom.xml'
+      goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre8 -DexcludeGroups=$(Ex_Groups)'
+      testResultsFiles: '**/TEST-*.xml'
+      testRunTitle: 'Maven build jre8'
+      javaHomeOption: Path
+      jdkDirectory: $(JDK12)

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,14 @@
  * Gradle Scipt for Building Microsoft JDBC Driver for SQL Server
  ****************************************************************
  * Instruction for Building JDBC Driver:
- * For building jre9 version of the driver,
- * use command 'gradle build' or 'gradle build -PbuildProfile=build43'
- * Whereas, for building jre8 version of the driver,
- * use command 'gradle build -PbuildProfile=build42'
+ * For building particular version of the driver, use commands:
+ * jre12 - - PS> gradle build
+			 PS> gradle build -PbuildProfile=jre12
+ * jre11 - - PS> gradle build -PbuildProfile=jre11
+ * jre8  - - PS> gradle build -PbuildProfile=jre8
+ *
+ * For Excluding Groups in command line:
+ * PS> gradle build -PbuildProfile=jre11 "-PexcludedGroups=['xSQLv15','xGradle']"
  ****************************************************************/
 
 apply plugin: 'java'
@@ -25,7 +29,26 @@ allprojects {
     }
 }
 
-if (!hasProperty('buildProfile') || (hasProperty('buildProfile') && buildProfile == "build43")){
+test {
+    useJUnitPlatform {
+        excludeTags (hasProperty('excludedGroups') ? excludedGroups : 'xSQLv15','xGradle')
+    }
+}
+
+if (!hasProperty('buildProfile') || (hasProperty('buildProfile') && buildProfile == "jre12")){
+	
+	jreVersion = "jre12"
+	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
+	jar {
+		manifest {
+			attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
+		}
+	}
+	sourceCompatibility = 12
+	targetCompatibility = 12
+}
+
+if (hasProperty('buildProfile') && buildProfile == "jre11"){
 	
 	jreVersion = "jre11"
 	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
@@ -38,13 +61,18 @@ if (!hasProperty('buildProfile') || (hasProperty('buildProfile') && buildProfile
 	targetCompatibility = 11
 }
 
-if((hasProperty('buildProfile') && buildProfile == "build42")) {
+if(hasProperty('buildProfile') && buildProfile == "jre8") {
 	
 	jreVersion = "jre8"
 	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc43.java'
 	
 	sourceCompatibility = 1.8
 	targetCompatibility = 1.8
+	test {
+		useJUnitPlatform {
+			excludeTags (hasProperty('excludedGroups') ? excludedGroups : 'xSQLv15','xGradle','xJDBC42')
+		}
+	}
 }
 
 jar.archiveName = "${archivesBaseName}-${version}.${jreVersion}-preview.jar"
@@ -55,7 +83,6 @@ jar {
         'Vendor': 'Microsoft Corporation'
 	}
 }
-
 sourceSets {
     main {
         java {

--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,7 @@ sourceSets {
     }
 	test {
 		resources {
-			srcDirs 'src/test/resources'
-			include '**/*.csv'
+			srcDirs "src/test/resources", "AE_Certificates"
 			output.resourcesDir = testOutputDir
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,11 @@
 
 	<properties>
 		<!-- Allowed values for excluded Groups here - - - - - - - - - - - - - 
+			xJDBC42 - - - - - - For tests not compatible with JDBC 42 Specifications 
+			xGradle - - - - - - For tests not compatible with Gradle Script - - - - - 
 			xSQLv12 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2014 
-			xSQLv14 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2017 
-			xSQLv15 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2019 
+			xSQLv14 - - - - - - For tests not compatible with SQL Server 2016 - 2017 
+			xSQLv15 - - - - - - For tests not compatible with SQL Server 2019 - - - - 
 			xAzureSQLDB - - - - For tests not compatible with Azure SQL Database - - 
 			xAzureSQLDW - - - - For tests not compatible with Azure Data Warehouse - 
 			xAzureSQLMI - - - - For tests not compatible with Azure SQL Managed Instance 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 			xAzureSQLMI - - - - For tests not compatible with Azure SQL Managed Instance 
 			- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 			Default testing enabled with SQL Server 2019 (SQLv14) -->
-		<excludeGroups>xSQLv15</excludeGroups>
+		<excludedGroups>xSQLv15</excludedGroups>
 
 		<!-- Driver Dependencies -->
 		<azure.keyvault.version>1.2.1</azure.keyvault.version>
@@ -181,7 +181,7 @@
 
 	<profiles>
 		<profile>
-			<id>build42</id>
+			<id>jre8</id>
 			<build>
 				<finalName>${project.artifactId}-${project.version}.jre8-preview</finalName>
 				<plugins>
@@ -215,48 +215,19 @@
 						</configuration>
 					</plugin>
 					<plugin>
-						<groupId>org.jacoco</groupId>
-						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.3</version>
-						<executions>
-							<execution>
-								<id>pre-test</id>
-								<goals>
-									<goal>prepare-agent</goal>
-								</goals>
-							</execution>
-							<execution>
-								<id>report</id>
-								<phase>test</phase>
-								<goals>
-									<goal>report</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>3.0.0-M1</version>
 						<configuration>
-							<argLine>
-								${argLine} --illegal-access=permit
-							</argLine>
-							<properties>
-								<excludeTags>${skipTestTag}</excludeTags>
-							</properties>
 							<!-- Exclude [xJDBC42] For tests not compatible with JDBC 4.2 Specifications -->
-							<excludedGroups>${excludeGroups}, xJDBC42</excludedGroups>
+							<excludedGroups>${excludedGroups}, xJDBC42</excludedGroups>
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
 		</profile>
 		<profile>
-			<id>build43</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
+			<id>jre11</id>
 			<build>
 				<finalName>${project.artifactId}-${project.version}.jre11-preview</finalName>
 				<plugins>
@@ -285,39 +256,40 @@
 							</archive>
 						</configuration>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>jre12</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<finalName>${project.artifactId}-${project.version}.jre11-preview</finalName>
+				<plugins>
 					<plugin>
-						<groupId>org.jacoco</groupId>
-						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.3</version>
-						<executions>
-							<execution>
-								<id>pre-test</id>
-								<goals>
-									<goal>prepare-agent</goal>
-								</goals>
-							</execution>
-							<execution>
-								<id>report</id>
-								<phase>test</phase>
-								<goals>
-									<goal>report</goal>
-								</goals>
-							</execution>
-						</executions>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.8.0</version>
+						<configuration>
+							<excludes>
+								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
+							</excludes>
+							<source>12</source>
+							<target>12</target>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0-M1</version>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>3.1.1</version>
 						<configuration>
-							<argLine>
-								${argLine} --illegal-access=permit
-							</argLine>
-							<properties>
-								<excludeTags>${skipTestTag}</excludeTags>
-							</properties>
-							<excludedGroups>
-								${excludeGroups}</excludedGroups>
+							<archive>
+								<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+								<manifestEntries>
+									<Automatic-Module-Name>com.microsoft.sqlserver.jdbc</Automatic-Module-Name>
+								</manifestEntries>
+							</archive>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -380,6 +352,18 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M1</version>
+				<configuration>
+					<argLine>
+						${argLine} --illegal-access=permit
+					</argLine>
+					<excludedGroups>
+						${excludedGroups}</excludedGroups>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -453,6 +437,21 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.3</version>
+				<executions>
+					<execution>
+						<id>pre-test</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
 					<fileSets>
 						<fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<build>
-				<finalName>${project.artifactId}-${project.version}.jre11-preview</finalName>
+				<finalName>${project.artifactId}-${project.version}.jre12-preview</finalName>
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/microsoft/sqlserver/jdbc/JDBC43Test.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/JDBC43Test.java
@@ -16,7 +16,8 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.opentest4j.TestAbortedException;
 
-import com.microsoft.sqlserver.testframework.AbstractTest;;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.Constants;
 
 
 /**
@@ -127,7 +128,7 @@ public class JDBC43Test extends AbstractTest {
      * @since 1.9
      */
     @Test
-    @Tag("xJDBC42")
+    @Tag(Constants.xJDBC42)
     public void setShardingKeyIfValidTest() throws TestAbortedException, SQLException {
         try (SQLServerConnection connection43 = (SQLServerConnection43) getConnection()) {
             try {
@@ -151,7 +152,7 @@ public class JDBC43Test extends AbstractTest {
      * @since 1.9
      */
     @Test
-    @Tag("xJDBC42")
+    @Tag(Constants.xJDBC42)
     public void setShardingKeyTest() throws TestAbortedException, SQLException {
         try (SQLServerConnection connection43 = (SQLServerConnection43) getConnection()) {
             try {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -75,6 +75,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
      *         IOExcption
      */
     @Test
+    @Tag(Constants.xGradle)
     public void testDriverVersion() throws SQLException, IOException {
         String manifestFile = TestUtils.getCurrentClassPath() + "META-INF/MANIFEST.MF";
         manifestFile = manifestFile.replace("test-classes", "classes");

--- a/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
@@ -17,8 +17,8 @@ public class Constants {
      * xJDBC42 - - - - - - For tests not compatible with JDBC 42 Specifications
      * xGradle - - - - - - For tests not compatible with Gradle Script (e.g. Manifest File)
      * xSQLv12 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2014
-     * xSQLv14 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2017
-     * xSQLv15 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2019
+     * xSQLv14 - - - - - - For tests not compatible with SQL Server 2016 - 2017
+     * xSQLv15 - - - - - - For tests not compatible with SQL Server 2019
      * xAzureSQLDB - - - - For tests not compatible with Azure SQL Database
      * xAzureSQLDW - - - - For tests not compatible with Azure Data Warehouse
      * xAzureSQLMI - - - - For tests not compatible with Azure SQL Managed Instance

--- a/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
@@ -14,6 +14,8 @@ public class Constants {
      * Use below tags for tests to exclude them from test group:
      * 
      * <pre>
+     * xJDBC42 - - - - - - For tests not compatible with JDBC 42 Specifications
+     * xGradle - - - - - - For tests not compatible with Gradle Script (e.g. Manifest File)
      * xSQLv12 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2014
      * xSQLv14 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2017
      * xSQLv15 - - - - - - For tests not compatible with SQL Server 2008 R2 - 2019
@@ -22,6 +24,8 @@ public class Constants {
      * xAzureSQLMI - - - - For tests not compatible with Azure SQL Managed Instance
      * </pre>
      */
+    public static final String xJDBC42 = "xJDBC42";
+    public static final String xGradle = "xGradle";
     public static final String xSQLv12 = "xSQLv12";
     public static final String xSQLv14 = "xSQLv14";
     public static final String xSQLv15 = "xSQLv15";


### PR DESCRIPTION
This PR adds support to build `jre12` Jar for the driver along with `jre11` and `jre8` with both Maven and Gradle build scripts.