### PR TITLE
 Test | Fix DB Metadata tests + fix maven warnings + clean all objects

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1090,6 +1090,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns if Federated Authentication is in use or is about to expire soon
+     * 
+     * @return true/false
+     * @throws SQLServerException
+     *         if an error occurs.
      */
     protected boolean needsReconnect() throws SQLServerException {
         return (null != fedAuthToken && Util.checkIfNeedNewAccessToken(this, fedAuthToken.expiresOn));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -46,6 +46,7 @@ public final class TestResource extends ListResourceBundle {
             {"R_createDropViewFailed", "Create/drop view with preparedStatement failed!"},
             {"R_createDropSchemaFailed", "Create/drop schema with preparedStatement failed!"},
             {"R_createDropTableFailed", "Create/drop table failed!"},
+            {"R_tableNotFound", "Table {0} not found in database."},
             {"R_createDropAlterTableFailed", "Create/drop/alter table with preparedStatement failed!"},
             {"R_grantFailed", "grant table with preparedStatement failed!"},
             {"R_connectionIsClosed", "The connection is closed."},

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -24,8 +24,6 @@ import java.util.Calendar;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
-import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.sqlType.SqlBigInt;
 import com.microsoft.sqlserver.testframework.sqlType.SqlBinary;
 import com.microsoft.sqlserver.testframework.sqlType.SqlBit;
@@ -279,36 +277,74 @@ public class TestUtils {
     }
 
     /**
-     * mimic "DROP TABLE IF EXISTS ..." for older versions of SQL Server
+     * mimic "DROP TABLE ..."
      */
     public static void dropTableIfExists(String tableName, java.sql.Statement stmt) throws SQLException {
-        dropObjectIfExists(tableName, "IsTable", stmt);
+        dropObjectIfExists(tableName, "U", stmt);
     }
 
     /**
-     * mimic "DROP PROCEDURE IF EXISTS ..." for older versions of SQL Server
+     * mimic "DROP PROCEDURE ..."
      */
     public static void dropProcedureIfExists(String procName, java.sql.Statement stmt) throws SQLException {
-        dropObjectIfExists(procName, "IsProcedure", stmt);
+        dropObjectIfExists(procName, "P", stmt);
     }
 
+    /**
+     * mimic "DROP FUNCTION ..."
+     */
+    public static void dropFunctionIfExists(String functionName, java.sql.Statement stmt) throws SQLException {
+        dropObjectIfExists(functionName, "FN", stmt);
+    }
+
+    /**
+     * mimic "DROP TRIGGER ..."
+     */
+    public static void dropTriggerIfExists(String triggerName, java.sql.Statement stmt) throws SQLException {
+        dropObjectIfExists(triggerName, "TR", stmt);
+    }
+
+    /**
+     * mimic "CREATE TYPE ..."
+     */
+    public static void dropTypeIfExists(String typeName, java.sql.Statement stmt) throws SQLException {
+        dropObjectIfExists(typeName, "TT", stmt);
+    }
+
+    /**
+     * mimic "DROP DATABASE ..."
+     */
     public static void dropDatabaseIfExists(String databaseName, java.sql.Statement stmt) throws SQLException {
         stmt.executeUpdate("USE MASTER; IF EXISTS(SELECT * from sys.databases WHERE name='"
                 + escapeSingleQuotes(databaseName) + "') DROP DATABASE [" + databaseName + "]");
     }
 
-    public static void dropTriggerIfExists(String triggerName, java.sql.Statement stmt) throws SQLException {
-        stmt.execute("IF EXISTS (\r\n" + "    SELECT *\r\n" + "    FROM sys.objects\r\n"
-                + "    WHERE [type] = 'TR' AND [name] = '" + TestUtils.escapeSingleQuotes(triggerName) + "'\r\n"
-                + "    )\r\n" + "    DROP TRIGGER " + AbstractSQLGenerator.escapeIdentifier(triggerName)
-                + Constants.SEMI_COLON);
-    }
-
     /**
-     * actually perform the "DROP TABLE / PROCEDURE"
+     * Can drop objects for below types: TT - TYPE_TABLE TR - TRIGGER FN - SQL_SCALAR_FUNCTION P - SQL_STORED_PROCEDURE
+     * TF - SQL_TABLE_VALUED_FUNCTION V - VIEW F - FOREIGN_KEY_CONSTRAINT U - USER_TABLE
      */
-    private static void dropObjectIfExists(String objectName, String objectProperty,
+    private static void dropObjectIfExists(String objectName, String objectType,
             java.sql.Statement stmt) throws SQLException {
+        String typeName = "";
+
+        switch (objectType) {
+            case "TT":
+                typeName = "TYPE";
+                break;
+            case "TR":
+                typeName = "TRIGGER";
+                break;
+            case "FN":
+                typeName = "FUNCTION";
+                break;
+            case "P":
+                typeName = "PROCEDURE";
+                break;
+            case "U":
+                typeName = "TABLE";
+            default:
+                break;
+        }
         StringBuilder sb = new StringBuilder();
         if (!objectName.startsWith("[")) {
             sb.append("[");
@@ -318,10 +354,9 @@ public class TestUtils {
             sb.append("]");
         }
         String bracketedObjectName = sb.toString();
-        String sql = String.format("IF EXISTS " + "( " + "SELECT * from sys.objects "
-                + "WHERE object_id = OBJECT_ID(N'%s') AND OBJECTPROPERTY(object_id, N'%s') = 1 " + ") " + "DROP %s %s ",
-                escapeSingleQuotes(bracketedObjectName), objectProperty,
-                "IsProcedure".equals(objectProperty) ? "PROCEDURE" : "TABLE", bracketedObjectName);
+        String sql = "IF EXISTS ( SELECT * from sys.objects WHERE object_id = OBJECT_ID(N'"
+                + escapeSingleQuotes(bracketedObjectName) + "') AND type='" + objectType + "') DROP " + typeName + " "
+                + bracketedObjectName;
         try {
             stmt.executeUpdate(sql);
         } catch (SQLException e) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -74,7 +74,8 @@ public class CallableMixedTest extends AbstractTest {
             }
         } finally {
             try (Statement stmt = connection.createStatement()) {
-                TestUtils.dropTableIfExists(escapedTableName, stmt);
+                TestUtils.dropTableIfExists(tableName, stmt);
+                TestUtils.dropProcedureIfExists(procName, stmt);
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
@@ -135,13 +135,9 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
                         holdability2, sendTimeAsDatetime2, statementPoolingCacheSize2, disableStatementPooling2,
                         serverPreparedStatementDiscardThreshold2, enablePrepareOnFirstPreparedStatementCall2, sCatalog2,
                         useBulkCopyForBatchInsert2);
-                // drop the database
-                con.setCatalog("master");
             }
         } finally {
-            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
-                TestUtils.dropDatabaseIfExists(sCatalog2, stmt);
-            }
+            TestUtils.dropDatabaseIfExists(sCatalog2, connectionString);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -484,36 +484,35 @@ public class DatabaseMetaDataTest extends AbstractTest {
         try (Connection conn = getConnection()) {
 
             DatabaseMetaData databaseMetaData = conn.getMetaData();
+            boolean functionFound = false;
 
             try (ResultSet rsFunctions = databaseMetaData.getFunctions(null, null, "%")) {
                 if (rsFunctions.next()) {
-                    boolean tableFound = false;
                     do {
                         if (rsFunctions.getString("FUNCTION_NAME").equalsIgnoreCase(functionName)) {
-                            tableFound = true;
+                            functionFound = true;
                         }
-                    } while (!tableFound && rsFunctions.next());
-                } else {
-                    MessageFormat form1 = new MessageFormat(TestResource.getResource("R_atLeastOneFound"));
-                    Object[] msgArgs1 = {"table"};
-                    fail(form1.format(msgArgs1));
+                    } while (rsFunctions.next() && !functionFound);
                 }
-                try (ResultSet rs = databaseMetaData.getFunctionColumns(null, null,
-                        AbstractSQLGenerator.escapeIdentifier(functionName), "%")) {
 
-                    MessageFormat form2 = new MessageFormat(TestResource.getResource("R_nameNull"));
-                    Object[][] msgArgs2 = {{"FUNCTION_CAT"}, {"FUNCTION_SCHEM"}, {"FUNCTION_NAME"}, {"COLUMN_NAME"},
-                            {"COLUMN_TYPE"}, {"DATA_TYPE"}, {"TYPE_NAME"}, {"NULLABLE"}, {"IS_NULLABLE"}};
-                    while (rs.next()) {
-                        assertTrue(!StringUtils.isEmpty(rs.getString("FUNCTION_CAT")), form2.format(msgArgs2[0]));
-                        assertTrue(!StringUtils.isEmpty(rs.getString("FUNCTION_SCHEM")), form2.format(msgArgs2[1]));
-                        assertTrue(!StringUtils.isEmpty(rs.getString("FUNCTION_NAME")), form2.format(msgArgs2[2]));
-                        assertTrue(!StringUtils.isEmpty(rs.getString("COLUMN_NAME")), form2.format(msgArgs2[3]));
-                        assertTrue(!StringUtils.isEmpty(rs.getString("COLUMN_TYPE")), form2.format(msgArgs2[4]));
-                        assertTrue(!StringUtils.isEmpty(rs.getString("DATA_TYPE")), form2.format(msgArgs2[5]));
-                        assertTrue(!StringUtils.isEmpty(rs.getString("TYPE_NAME")), form2.format(msgArgs2[6]));
-                        assertTrue(!StringUtils.isEmpty(rs.getString("NULLABLE")), form2.format(msgArgs2[7])); // 12
-                        assertTrue(!StringUtils.isEmpty(rs.getString("IS_NULLABLE")), form2.format(msgArgs2[8])); // 19
+                if (!functionFound) {
+                    try (ResultSet rs = databaseMetaData.getFunctionColumns(null, null,
+                            AbstractSQLGenerator.escapeIdentifier(functionName), "%")) {
+
+                        MessageFormat form2 = new MessageFormat(TestResource.getResource("R_nameNull"));
+                        Object[][] msgArgs2 = {{"FUNCTION_CAT"}, {"FUNCTION_SCHEM"}, {"FUNCTION_NAME"}, {"COLUMN_NAME"},
+                                {"COLUMN_TYPE"}, {"DATA_TYPE"}, {"TYPE_NAME"}, {"NULLABLE"}, {"IS_NULLABLE"}};
+                        while (rs.next()) {
+                            assertTrue(!StringUtils.isEmpty(rs.getString("FUNCTION_CAT")), form2.format(msgArgs2[0]));
+                            assertTrue(!StringUtils.isEmpty(rs.getString("FUNCTION_SCHEM")), form2.format(msgArgs2[1]));
+                            assertTrue(!StringUtils.isEmpty(rs.getString("FUNCTION_NAME")), form2.format(msgArgs2[2]));
+                            assertTrue(!StringUtils.isEmpty(rs.getString("COLUMN_NAME")), form2.format(msgArgs2[3]));
+                            assertTrue(!StringUtils.isEmpty(rs.getString("COLUMN_TYPE")), form2.format(msgArgs2[4]));
+                            assertTrue(!StringUtils.isEmpty(rs.getString("DATA_TYPE")), form2.format(msgArgs2[5]));
+                            assertTrue(!StringUtils.isEmpty(rs.getString("TYPE_NAME")), form2.format(msgArgs2[6]));
+                            assertTrue(!StringUtils.isEmpty(rs.getString("NULLABLE")), form2.format(msgArgs2[7])); // 12
+                            assertTrue(!StringUtils.isEmpty(rs.getString("IS_NULLABLE")), form2.format(msgArgs2[8])); // 19
+                        }
                     }
                 }
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -345,10 +345,6 @@ public class DatabaseMetaDataTest extends AbstractTest {
                             tableFound = true;
                         }
                     } while (rs.next() && !tableFound);
-                } else {
-                    MessageFormat form1 = new MessageFormat(TestResource.getResource("R_atLeastOneFound"));
-                    Object[] msgArgs1 = {"table"};
-                    fail(form1.format(msgArgs1));
                 }
 
                 if (!tableFound) {
@@ -398,34 +394,38 @@ public class DatabaseMetaDataTest extends AbstractTest {
         try (Connection conn = getConnection()) {
             DatabaseMetaData databaseMetaData = conn.getMetaData();
             String[] types = {"TABLE"};
+            boolean tableFound = false;
+
             try (ResultSet rs = databaseMetaData.getTables(null, null, "%", types)) {
                 if (rs.next()) {
-                    boolean tableFound = false;
                     do {
                         if (rs.getString("TABLE_NAME").equalsIgnoreCase(tableName)) {
                             tableFound = true;
                         }
-                    } while (!tableFound && rs.next());
-                } else {
-                    MessageFormat form1 = new MessageFormat(TestResource.getResource("R_atLeastOneFound"));
-                    Object[] msgArgs1 = {"table"};
-                    fail(form1.format(msgArgs1));
+                    } while (rs.next() && !tableFound);
                 }
-                try (ResultSet rs1 = databaseMetaData.getColumnPrivileges(null, null,
-                        AbstractSQLGenerator.escapeIdentifier(tableName), "%")) {
 
-                    MessageFormat form2 = new MessageFormat(TestResource.getResource("R_nameEmpty"));
-                    Object[][] msgArgs2 = {{"Category"}, {"SCHEMA"}, {"Table"}, {"COLUMN"}, {"GRANTOR"}, {"GRANTEE"},
-                            {"PRIVILEGE"}, {"IS_GRANTABLE"}};
-                    while (rs1.next()) {
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_CAT")), form2.format(msgArgs2[0]));
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_SCHEM")), form2.format(msgArgs2[1]));
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_NAME")), form2.format(msgArgs2[2]));
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("COLUMN_NAME")), form2.format(msgArgs2[3]));
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("GRANTOR")), form2.format(msgArgs2[4]));
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("GRANTEE")), form2.format(msgArgs2[5]));
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("PRIVILEGE")), form2.format(msgArgs2[6]));
-                        assertTrue(!StringUtils.isEmpty(rs1.getString("IS_GRANTABLE")), form2.format(msgArgs2[7]));
+                if (!tableFound) {
+                    MessageFormat form1 = new MessageFormat(TestResource.getResource("R_tableNotFound"));
+                    Object[] msgArgs1 = {tableName};
+                    fail(form1.format(msgArgs1));
+                } else {
+                    try (ResultSet rs1 = databaseMetaData.getColumnPrivileges(null, null,
+                            AbstractSQLGenerator.escapeIdentifier(tableName), "%")) {
+
+                        MessageFormat form2 = new MessageFormat(TestResource.getResource("R_nameEmpty"));
+                        Object[][] msgArgs2 = {{"Category"}, {"SCHEMA"}, {"Table"}, {"COLUMN"}, {"GRANTOR"},
+                                {"GRANTEE"}, {"PRIVILEGE"}, {"IS_GRANTABLE"}};
+                        while (rs1.next()) {
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_CAT")), form2.format(msgArgs2[0]));
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_SCHEM")), form2.format(msgArgs2[1]));
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_NAME")), form2.format(msgArgs2[2]));
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("COLUMN_NAME")), form2.format(msgArgs2[3]));
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("GRANTOR")), form2.format(msgArgs2[4]));
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("GRANTEE")), form2.format(msgArgs2[5]));
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("PRIVILEGE")), form2.format(msgArgs2[6]));
+                            assertTrue(!StringUtils.isEmpty(rs1.getString("IS_GRANTABLE")), form2.format(msgArgs2[7]));
+                        }
                     }
                 }
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPAllTypesTest.java
@@ -195,8 +195,8 @@ public class TVPAllTypesTest extends AbstractTest {
         tvpName = RandomUtil.getIdentifier("TVP");
         procedureName = RandomUtil.getIdentifier("TVP");
 
-        TestUtils.dropProcedureIfExists(AbstractSQLGenerator.escapeIdentifier(procedureName), stmt);
-        TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tvpName), stmt);
+        TestUtils.dropProcedureIfExists(procedureName, stmt);
+        TestUtils.dropTypeIfExists(tvpName, stmt);
 
         try (DBConnection dbConnection = new DBConnection(connectionString);
                 DBStatement dbStmt = dbConnection.createStatement()) {
@@ -217,9 +217,11 @@ public class TVPAllTypesTest extends AbstractTest {
     private void terminateVariation() throws SQLException {
         try (Statement stmt = connection.createStatement()) {
             TestUtils.dropProcedureIfExists(AbstractSQLGenerator.escapeIdentifier(procedureName), stmt);
-            TestUtils.dropTableIfExists(tableSrc.getEscapedTableName(), stmt);
-            TestUtils.dropTableIfExists(tableDest.getEscapedTableName(), stmt);
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tvpName), stmt);
+            if (null != tableSrc)
+                TestUtils.dropTableIfExists(tableSrc.getTableName(), stmt);
+            if (null != tableDest)
+                TestUtils.dropTableIfExists(tableDest.getTableName(), stmt);
+            TestUtils.dropTypeIfExists(tvpName, stmt);
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPIssuesTest.java
@@ -135,8 +135,6 @@ public class TVPIssuesTest extends AbstractTest {
     public static void beforeAll() throws SQLException {
         try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
 
-            dropObjects(stmt);
-
             String sql = "create table " + AbstractSQLGenerator.escapeIdentifier(srcTable_varcharMax)
                     + " (c1 varchar(max) null);";
             stmt.execute(sql);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPIssuesTest.java
@@ -37,12 +37,12 @@ import com.microsoft.sqlserver.testframework.Constants;
 @Tag(Constants.xAzureSQLDW)
 public class TVPIssuesTest extends AbstractTest {
 
-    private static String tvp_varcharMax = RandomUtil.getIdentifier("TVPIssuesTest_varcharMax_TVP");
+    private static String tvp_varcharMax = RandomUtil.getIdentifier("TVP");
     private static String spName_varcharMax = RandomUtil.getIdentifier("TVPIssuesTest_varcharMax_SP");
     private static String srcTable_varcharMax = RandomUtil.getIdentifier("TVPIssuesTest_varcharMax_srcTable");
     private static String desTable_varcharMax = RandomUtil.getIdentifier("TVPIssuesTest_varcharMax_destTable");
 
-    private static String tvp_time_6 = RandomUtil.getIdentifier("TVPIssuesTest_time_6_TVP");
+    private static String tvp_time_6 = RandomUtil.getIdentifier("TVP");
     private static String srcTable_time_6 = RandomUtil.getIdentifier("TVPIssuesTest_time_6_srcTable");
     private static String desTable_time_6 = RandomUtil.getIdentifier("TVPIssuesTest_time_6_destTable");
 
@@ -75,7 +75,7 @@ public class TVPIssuesTest extends AbstractTest {
         try (Statement stmt = connection.createStatement(); ResultSet rs = stmt
                 .executeQuery("select * from " + AbstractSQLGenerator.escapeIdentifier(srcTable_varcharMax))) {
 
-            dropProcedure(stmt);
+            TestUtils.dropProcedureIfExists(spName_varcharMax, stmt);
             String sql = "{call " + AbstractSQLGenerator.escapeIdentifier(spName_varcharMax) + "(?)}";
 
             try (SQLServerCallableStatement Cstmt = (SQLServerCallableStatement) connection.prepareCall(sql)) {
@@ -135,19 +135,7 @@ public class TVPIssuesTest extends AbstractTest {
     public static void beforeAll() throws SQLException {
         try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
 
-            dropProcedure(stmt);
-
-            stmt.executeUpdate("IF EXISTS (SELECT * FROM sys.types WHERE is_table_type = 1 AND name = '"
-                    + TestUtils.escapeSingleQuotes(tvp_varcharMax) + "') " + " drop type "
-                    + AbstractSQLGenerator.escapeIdentifier(tvp_varcharMax));
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(srcTable_varcharMax), stmt);
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(desTable_varcharMax), stmt);
-
-            stmt.executeUpdate("IF EXISTS (SELECT * FROM sys.types WHERE is_table_type = 1 AND name = '"
-                    + TestUtils.escapeSingleQuotes(tvp_time_6) + "') " + " drop type "
-                    + AbstractSQLGenerator.escapeIdentifier(tvp_time_6));
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(srcTable_time_6), stmt);
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(desTable_time_6), stmt);
+            dropObjects(stmt);
 
             String sql = "create table " + AbstractSQLGenerator.escapeIdentifier(srcTable_varcharMax)
                     + " (c1 varchar(max) null);";
@@ -197,10 +185,6 @@ public class TVPIssuesTest extends AbstractTest {
         stmt.execute(sql);
     }
 
-    private static void dropProcedure(Statement stmt) throws SQLException {
-        TestUtils.dropProcedureIfExists(AbstractSQLGenerator.escapeIdentifier(spName_varcharMax), stmt);
-    }
-
     private static void createProcedure(Statement stmt) throws SQLException {
         String sql = "CREATE PROCEDURE " + AbstractSQLGenerator.escapeIdentifier(spName_varcharMax) + " @InputData "
                 + AbstractSQLGenerator.escapeIdentifier(tvp_varcharMax) + " READONLY " + " AS " + " BEGIN "
@@ -213,18 +197,19 @@ public class TVPIssuesTest extends AbstractTest {
     @AfterAll
     public static void terminateVariation() throws SQLException {
         try (Statement stmt = connection.createStatement()) {
-            dropProcedure(stmt);
-            stmt.executeUpdate("IF EXISTS (SELECT * FROM sys.types WHERE is_table_type = 1 AND name = '"
-                    + TestUtils.escapeSingleQuotes(tvp_varcharMax) + "') " + " drop type "
-                    + AbstractSQLGenerator.escapeIdentifier(tvp_varcharMax));
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(srcTable_varcharMax), stmt);
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(desTable_varcharMax), stmt);
-
-            stmt.executeUpdate("IF EXISTS (SELECT * FROM sys.types WHERE is_table_type = 1 AND name = '"
-                    + TestUtils.escapeSingleQuotes(tvp_time_6) + "') " + " drop type "
-                    + AbstractSQLGenerator.escapeIdentifier(tvp_time_6));
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(srcTable_time_6), stmt);
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(desTable_time_6), stmt);
+            dropObjects(stmt);
         }
+    }
+
+    private static void dropObjects(Statement stmt) throws SQLException {
+        TestUtils.dropProcedureIfExists(spName_varcharMax, stmt);
+
+        TestUtils.dropTypeIfExists(tvp_varcharMax, stmt);
+        TestUtils.dropTableIfExists(srcTable_varcharMax, stmt);
+        TestUtils.dropTableIfExists(desTable_varcharMax, stmt);
+
+        TestUtils.dropTypeIfExists(tvp_time_6, stmt);
+        TestUtils.dropTableIfExists(srcTable_time_6, stmt);
+        TestUtils.dropTableIfExists(desTable_time_6, stmt);
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPNumericTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPNumericTest.java
@@ -4,13 +4,12 @@
  */
 package com.microsoft.sqlserver.jdbc.tvp;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
 import java.sql.Statement;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -33,6 +32,7 @@ public class TVPNumericTest extends AbstractTest {
     static String expectecValue1 = "hello";
     static String expectecValue2 = "world";
     static String expectecValue3 = "again";
+
     private static String tvpName;
     private static String charTable;
     private static String procedureName;
@@ -54,79 +54,58 @@ public class TVPNumericTest extends AbstractTest {
         try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement(
                 "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(charTable) + " select * from ? ;")) {
             pstmt.setStructured(1, tvpName, tvp);
-
             pstmt.execute();
         }
     }
 
-    @BeforeEach
-    public void testSetup() throws SQLException {
+    @BeforeAll
+    public static void testSetup() throws SQLException {
         tvpName = RandomUtil.getIdentifier("numericTVP");
         procedureName = RandomUtil.getIdentifier("procedureThatCallsTVP");
         charTable = RandomUtil.getIdentifier("tvpNumericTable");
 
-        dropProcedure();
-        dropTables();
-        dropTVPS();
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropProcedureIfExists(procedureName, stmt);
+            TestUtils.dropTableIfExists(charTable, stmt);
+            TestUtils.dropTypeIfExists(tvpName, stmt);
+        }
 
         createTVPS();
         createTables();
-        createPreocedure();
+        createProcedure();
     }
 
-    private void dropProcedure() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            String sql = " IF EXISTS (select * from sysobjects where id = object_id(N'"
-                    + TestUtils.escapeSingleQuotes(procedureName) + "') and OBJECTPROPERTY(id, N'IsProcedure') = 1)"
-                    + " DROP PROCEDURE " + AbstractSQLGenerator.escapeIdentifier(procedureName);
-            stmt.execute(sql);
-        }
-    }
-
-    private static void dropTables() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("if object_id('" + TestUtils.escapeSingleQuotes(charTable) + "','U') is not null"
-                    + " drop table " + AbstractSQLGenerator.escapeIdentifier(charTable));
-        }
-    }
-
-    private static void dropTVPS() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("IF EXISTS (SELECT * FROM sys.types WHERE is_table_type = 1 AND name = '"
-                    + TestUtils.escapeSingleQuotes(tvpName) + "') " + " drop type "
-                    + AbstractSQLGenerator.escapeIdentifier(tvpName));
-        }
-    }
-
-    private static void createPreocedure() throws SQLException {
+    private static void createProcedure() throws SQLException {
         String sql = "CREATE PROCEDURE " + AbstractSQLGenerator.escapeIdentifier(procedureName) + " @InputData "
                 + AbstractSQLGenerator.escapeIdentifier(tvpName) + " READONLY " + " AS " + " BEGIN " + " INSERT INTO "
                 + AbstractSQLGenerator.escapeIdentifier(charTable) + " SELECT * FROM @InputData" + " END";
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             stmt.execute(sql);
         }
     }
 
-    private void createTables() throws SQLException {
+    private static void createTables() throws SQLException {
         String sql = "create table " + AbstractSQLGenerator.escapeIdentifier(charTable) + " (c1 numeric(6,3) null);";
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             stmt.execute(sql);
         }
     }
 
-    private void createTVPS() throws SQLException {
+    private static void createTVPS() throws SQLException {
         String TVPCreateCmd = "CREATE TYPE " + AbstractSQLGenerator.escapeIdentifier(tvpName)
                 + " as table (c1 numeric(6,3) null)";
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             stmt.executeUpdate(TVPCreateCmd);
         }
     }
 
-    @AfterEach
-    public void terminateVariation() throws SQLException {
-        dropProcedure();
-        dropTables();
-        dropTVPS();
+    @AfterAll
+    public static void terminateVariation() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropProcedureIfExists(procedureName, stmt);
+            TestUtils.dropTableIfExists(charTable, stmt);
+            TestUtils.dropTypeIfExists(tvpName, stmt);
+        }
 
         if (null != tvp) {
             tvp.clear();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPNumericTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPNumericTest.java
@@ -64,12 +64,6 @@ public class TVPNumericTest extends AbstractTest {
         procedureName = RandomUtil.getIdentifier("procedureThatCallsTVP");
         charTable = RandomUtil.getIdentifier("tvpNumericTable");
 
-        try (Statement stmt = connection.createStatement()) {
-            TestUtils.dropProcedureIfExists(procedureName, stmt);
-            TestUtils.dropTableIfExists(charTable, stmt);
-            TestUtils.dropTypeIfExists(tvpName, stmt);
-        }
-
         createTVPS();
         createTables();
         createProcedure();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPResultSetCursorTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPResultSetCursorTest.java
@@ -384,7 +384,7 @@ public class TVPResultSetCursorTest extends AbstractTest {
 
     private static void dropProcedure() throws SQLException {
         try (Statement stmt = connection.createStatement()) {
-            TestUtils.dropProcedureIfExists(AbstractSQLGenerator.escapeIdentifier(procedureName), stmt);
+            TestUtils.dropProcedureIfExists(procedureName, stmt);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPSchemaTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPSchemaTest.java
@@ -159,10 +159,10 @@ public class TVPSchemaTest extends AbstractTest {
 
     private void dropObjects() throws SQLException {
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-        dropProcedure(stmt);
-        dropTables(stmt);
-        dropTVPS(stmt);
-        dropSchema(stmt);
+            dropProcedure(stmt);
+            dropTables(stmt);
+            dropTVPS(stmt);
+            dropSchema(stmt);
         }
     }
 
@@ -183,7 +183,7 @@ public class TVPSchemaTest extends AbstractTest {
                 + TestUtils.escapeSingleQuotes(procedureName) + "') and OBJECTPROPERTY(id, N'IsProcedure') = 1)"
                 + " DROP PROCEDURE " + procedureName;
 
-            stmt.execute(sql);
+        stmt.execute(sql);
     }
 
     private static void dropTables(Statement stmt2) throws SQLException {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPSchemaTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPSchemaTest.java
@@ -39,7 +39,7 @@ public class TVPSchemaTest extends AbstractTest {
     static String expectecValue2 = "world";
     static String expectecValue3 = "again";
     private static String schemaName;
-    private static String tvpNameWithouSchema;
+    private static String tvpNameWithoutSchema;
     private static String tvpNameWithSchema;
     private static String charTable;
     private static String procedureName;
@@ -132,21 +132,17 @@ public class TVPSchemaTest extends AbstractTest {
     @BeforeEach
     public void testSetup() throws SQLException {
         schemaName = RandomUtil.getIdentifier("anotherSchema");
-        tvpNameWithouSchema = RandomUtil.getIdentifier("charTVP");
+        tvpNameWithoutSchema = RandomUtil.getIdentifier("charTVP");
         tvpNameWithSchema = AbstractSQLGenerator.escapeIdentifier(schemaName) + "."
-                + AbstractSQLGenerator.escapeIdentifier(tvpNameWithouSchema);
-
+                + AbstractSQLGenerator.escapeIdentifier(tvpNameWithoutSchema);
         charTable = AbstractSQLGenerator.escapeIdentifier(schemaName) + "."
                 + AbstractSQLGenerator.escapeIdentifier("tvpCharTable");
         procedureName = AbstractSQLGenerator.escapeIdentifier(schemaName) + "."
                 + AbstractSQLGenerator.escapeIdentifier("procedureThatCallsTVP");
 
-        dropProcedure();
-        dropTables();
-        dropTVPS();
+        dropObjects();
 
-        dropAndCreateSchema();
-
+        createSchema();
         createTVPS();
         createTables();
         createPreocedure();
@@ -161,6 +157,13 @@ public class TVPSchemaTest extends AbstractTest {
         tvp.addRow(expectecValue1, expectecValue2, expectecValue3);
         tvp.addRow(expectecValue1, expectecValue2, expectecValue3);
         tvp.addRow(expectecValue1, expectecValue2, expectecValue3);
+    }
+
+    private void dropObjects() throws SQLException {
+        dropProcedure();
+        dropTables();
+        dropTVPS();
+        dropSchema();
     }
 
     private void verify(ResultSet rs) throws SQLException {
@@ -186,24 +189,20 @@ public class TVPSchemaTest extends AbstractTest {
     }
 
     private static void dropTables() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("if object_id('" + TestUtils.escapeSingleQuotes(charTable) + "','U') is not null"
-                    + " drop table " + charTable);
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(charTable, stmt);
         }
     }
 
     private static void dropTVPS() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             stmt.executeUpdate("IF EXISTS (SELECT * FROM sys.types WHERE is_table_type = 1 AND name = '"
-                    + TestUtils.escapeSingleQuotes(tvpNameWithouSchema) + "') " + " drop type " + tvpNameWithSchema);
+                    + TestUtils.escapeSingleQuotes(tvpNameWithoutSchema) + "') " + " drop type " + tvpNameWithSchema);
         }
     }
 
-    private static void dropAndCreateSchema() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.execute(
-                    "if EXISTS (SELECT * FROM sys.schemas where name = '" + TestUtils.escapeSingleQuotes(schemaName)
-                            + "') drop schema " + AbstractSQLGenerator.escapeIdentifier(schemaName));
+    private static void createSchema() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
             stmt.execute("CREATE SCHEMA " + AbstractSQLGenerator.escapeIdentifier(schemaName));
         }
     }
@@ -211,8 +210,7 @@ public class TVPSchemaTest extends AbstractTest {
     private static void createPreocedure() throws SQLException {
         String sql = "CREATE PROCEDURE " + procedureName + " @InputData " + tvpNameWithSchema + " READONLY " + " AS "
                 + " BEGIN " + " INSERT INTO " + charTable + " SELECT * FROM @InputData" + " END";
-
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             stmt.execute(sql);
         }
     }
@@ -220,7 +218,7 @@ public class TVPSchemaTest extends AbstractTest {
     private void createTables() throws SQLException {
         String sql = "create table " + charTable + " (" + "PlainChar char(50) null," + "PlainVarchar varchar(50) null,"
                 + "PlainVarcharMax varchar(max) null," + ");";
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             stmt.execute(sql);
         }
     }
@@ -228,19 +226,25 @@ public class TVPSchemaTest extends AbstractTest {
     private void createTVPS() throws SQLException {
         String TVPCreateCmd = "CREATE TYPE " + tvpNameWithSchema + " as table ( " + "PlainChar char(50) null,"
                 + "PlainVarchar varchar(50) null," + "PlainVarcharMax varchar(max) null" + ")";
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             stmt.executeUpdate(TVPCreateCmd);
         }
     }
 
     @AfterEach
     public void terminateVariation() throws SQLException {
-        dropProcedure();
-        dropTables();
-        dropTVPS();
+        dropObjects();
 
         if (null != tvp) {
             tvp.clear();
+        }
+    }
+
+    private void dropSchema() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                    "if EXISTS (SELECT * FROM sys.schemas where name = '" + TestUtils.escapeSingleQuotes(schemaName)
+                            + "') drop schema " + AbstractSQLGenerator.escapeIdentifier(schemaName));
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypesTest.java
@@ -506,48 +506,36 @@ public class TVPTypesTest extends AbstractTest {
         tableName = RandomUtil.getIdentifier("TVPTable");
         procedureName = RandomUtil.getIdentifier("procedureThatCallsTVP");
 
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            dropProcedure();
-            dropTables();
-            dropTVPS();
+        try (Statement stmt = connection.createStatement()) {
+            dropProcedure(stmt);
+            dropTables(stmt);
+            dropTVPS(stmt);
         }
     }
 
     @AfterAll
     public static void terminate() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            dropProcedure();
-            dropTables();
-            dropTVPS();
+        try (Statement stmt = connection.createStatement()) {
+            dropProcedure(stmt);
+            dropTables(stmt);
+            dropTVPS(stmt);
         }
     }
 
-    private static void dropProcedure() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            String sql = " IF EXISTS (select * from sysobjects where id = object_id(N'"
-                    + TestUtils.escapeSingleQuotes(procedureName) + "') and OBJECTPROPERTY(id, N'IsProcedure') = 1)"
-                    + " DROP PROCEDURE " + AbstractSQLGenerator.escapeIdentifier(procedureName);
-            stmt.execute(sql);
-        }
+    private static void dropProcedure(Statement stmt) throws SQLException {
+        TestUtils.dropProcedureIfExists(procedureName, stmt);
     }
 
-    private static void dropTables() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("if object_id('" + TestUtils.escapeSingleQuotes(tableName) + "','U') is not null"
-                    + " drop table " + AbstractSQLGenerator.escapeIdentifier(tableName));
-        }
+    private static void dropTables(Statement stmt) throws SQLException {
+        TestUtils.dropTableIfExists(tableName, stmt);
     }
 
-    private static void dropTVPS() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("IF EXISTS (SELECT * FROM sys.types WHERE is_table_type = 1 AND name = '"
-                    + TestUtils.escapeSingleQuotes(tvpName) + "') " + " drop type "
-                    + AbstractSQLGenerator.escapeIdentifier(tvpName));
-        }
+    private static void dropTVPS(Statement stmt) throws SQLException {
+        TestUtils.dropTypeIfExists(tvpName, stmt);
     }
 
     private static void createPreocedure() throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             String sql = "CREATE PROCEDURE " + AbstractSQLGenerator.escapeIdentifier(procedureName) + " @InputData "
                     + AbstractSQLGenerator.escapeIdentifier(tvpName) + " READONLY " + " AS " + " BEGIN "
                     + " INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(tableName) + " SELECT * FROM @InputData"
@@ -557,7 +545,7 @@ public class TVPTypesTest extends AbstractTest {
     }
 
     private void createTables(String colType) throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             String sql = "create table " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (c1 " + colType
                     + " null);";
             stmt.execute(sql);
@@ -565,7 +553,7 @@ public class TVPTypesTest extends AbstractTest {
     }
 
     private void createTVPS(String colType) throws SQLException {
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        try (Statement stmt = connection.createStatement()) {
             String TVPCreateCmd = "CREATE TYPE " + AbstractSQLGenerator.escapeIdentifier(tvpName) + " as table (c1 "
                     + colType + " null)";
             stmt.executeUpdate(TVPCreateCmd);
@@ -583,9 +571,11 @@ public class TVPTypesTest extends AbstractTest {
 
     @AfterEach
     public void terminateVariation() throws SQLException {
-        dropProcedure();
-        dropTables();
-        dropTVPS();
+        try (Statement stmt = connection.createStatement()) {
+            dropProcedure(stmt);
+            dropTables(stmt);
+            dropTVPS(stmt);
+        }
 
         if (null != tvp) {
             tvp.clear();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypesTest.java
@@ -505,12 +505,6 @@ public class TVPTypesTest extends AbstractTest {
         tvpName = RandomUtil.getIdentifier("TVP");
         tableName = RandomUtil.getIdentifier("TVPTable");
         procedureName = RandomUtil.getIdentifier("procedureThatCallsTVP");
-
-        try (Statement stmt = connection.createStatement()) {
-            dropProcedure(stmt);
-            dropTables(stmt);
-            dropTVPS(stmt);
-        }
     }
 
     @AfterAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/UTF8SupportTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/UTF8SupportTest.java
@@ -115,9 +115,8 @@ public class UTF8SupportTest extends AbstractTest {
 
     @AfterAll
     public static void cleanUp() throws SQLException {
-        try (Statement stmt = connection.createStatement()) {
-            TestUtils.dropDatabaseIfExists(databaseName, stmt);
-        }
+        connection.close();
+        TestUtils.dropDatabaseIfExists(databaseName, connectionString);
     }
 
     private static void createDatabaseWithUTF8Collation() throws SQLException {


### PR DESCRIPTION
The PR:
- Fixes Database Metadata tests that expect existing table in target database.
- Fixes Maven build warnings with JavaDocs
- Cleans all remaining database objects in Junit Tests (User Defined Table Types (TVP), Stored Procedures, Scalar Functions)