### PR TITLE
Fix | Unexpected Token 0x0 fix + additional check for columnName 

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataColumn.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataColumn.java
@@ -67,8 +67,8 @@ public final class SQLServerDataColumn {
             SQLServerDataColumn aSQLServerDataColumn = (SQLServerDataColumn) object;
             if (hashCode() == aSQLServerDataColumn.hashCode()) {
                 // Compare objects to avoid collision
-                return ((null == columnName && null == aSQLServerDataColumn.columnName
-                        || columnName.equals(aSQLServerDataColumn.columnName))
+                return (((null == columnName && null == aSQLServerDataColumn.columnName)
+                        || (null != columnName && columnName.equals(aSQLServerDataColumn.columnName)))
                         && javaSqlType == aSQLServerDataColumn.javaSqlType
                         && numberOfDigitsIntegerPart == aSQLServerDataColumn.numberOfDigitsIntegerPart
                         && precision == aSQLServerDataColumn.precision && scale == aSQLServerDataColumn.scale);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/tdsparser.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/tdsparser.java
@@ -124,6 +124,10 @@ final class TDSParser {
                 case TDS.TDS_FEDAUTHINFO:
                     parsing = tdsTokenHandler.onFedAuthInfo(tdsReader);
                     break;
+                case 0:
+                    if (logger.isLoggable(Level.FINEST)) {
+                        logger.log(Level.FINEST, "Encountered token 0x0 which will be treated as EOF.");
+                    }
                 case -1:
                     tdsReader.getCommand().onTokenEOF();
                     tdsTokenHandler.onEOF(tdsReader);


### PR DESCRIPTION
* Unexpected Token 0x0
An unexpected token 0x0 is received intermittently from SQL Server which causes intermittent exceptions. There is no documentation for when/why this token is sent/thrown by SQL Server in TDS documentation. The only possible workaround looks like we should stop streaming when this token is received, similar to `-1` token.

Putting up the PR for further extensive testing, triggering discussions for any known issues with this approach. If not, we should look forward to fix the behavior to avoid intermittent driver exceptions.

* Additional check for ColumnName
Change for Static Code Analysis complains, tests already cover this scenario.