### PR TITLE
Fix | Misleading error message in CallableStatement

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -26,7 +26,10 @@ import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -66,6 +69,9 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     String getClassNameInternal() {
         return "SQLServerCallableStatement";
     }
+
+    Map<String,Integer> map = new ConcurrentHashMap<>();
+    AtomicInteger ai = new AtomicInteger(0);
 
     /**
      * Create a new callable statement.
@@ -1294,10 +1300,13 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         }
 
         int l = 0;
-        if (parameterNames != null)
+        if (parameterNames != null) {
             l = parameterNames.size();
-        if (l == 0)// Server didn't return anything, user might not have access
-            return 1;// attempting to look up the first column will return no access exception
+        }
+        if (l == 0) { // Server didn't return anything, user might not have access
+            map.putIfAbsent(columnName,ai.incrementAndGet());
+            return map.get(columnName);// attempting to look up the first column will return no access exception
+        }
 
         // handle `@name` as well as `name`, since `@name` is what's returned
         // by DatabaseMetaData#getProcedureColumns

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1300,7 +1300,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         }
 
         int l = 0;
-        if (parameterNames != null) {
+        if (null != parameterNames) {
             l = parameterNames.size();
         }
         if (l == 0) { // Server didn't return anything, user might not have access

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -70,7 +70,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         return "SQLServerCallableStatement";
     }
 
-    Map<String,Integer> map = new ConcurrentHashMap<>();
+    Map<String, Integer> map = new ConcurrentHashMap<>();
     AtomicInteger ai = new AtomicInteger(0);
 
     /**
@@ -1304,7 +1304,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             l = parameterNames.size();
         }
         if (l == 0) { // Server didn't return anything, user might not have access
-            map.putIfAbsent(columnName,ai.incrementAndGet());
+            map.putIfAbsent(columnName, ai.incrementAndGet());
             return map.get(columnName);// attempting to look up the first column will return no access exception
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -18,6 +18,10 @@ public final class TestResource extends ListResourceBundle {
     public static String getResource(String key) {
         return TestResource.getBundle(Constants.MSSQL_JDBC_PACKAGE + ".TestResource").getString(key);
     }
+    
+    public static String formatErrorMsg(String resource) {
+        return (".*\\Q" + getResource(resource) + "\\E").replaceAll("\\{+[0-9]+\\}", "\\\\E.*\\\\Q");
+    }
 
     protected Object[][] getContents() {
         return contents;
@@ -173,5 +177,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_incorrectSyntaxTable", "Incorrect syntax near the keyword 'table'."},
             {"R_incorrectSyntaxTableDW", "Incorrect syntax near 'table'."},
             {"R_ConnectionStringNull", "Connection String should not be null"},
-            {"R_OperandTypeClash", "Operand type clash"}};
+            {"R_OperandTypeClash", "Operand type clash"},
+            {"R_NoPrivilege", "The EXECUTE permission was denied on the object {0}"}};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -90,13 +89,11 @@ public class CallableMixedTest extends AbstractTest {
     @Tag("xAzureSQLDW")
     @Tag("xAzureSQLMI")
     public void noPrivilegeTest() throws SQLException {
-        try (Connection c = getConnection();
-                Statement stmt = c.createStatement()) {
+        try (Connection c = getConnection(); Statement stmt = c.createStatement()) {
             String tableName = RandomUtil.getIdentifier("jdbc_priv");
             String procName = RandomUtil.getIdentifier("priv_proc");
             String user = "priv_user" + UUID.randomUUID();
             String pass = "priv_pass" + UUID.randomUUID();
-
 
             stmt.execute(
                     "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (id int, name varchar(50))");
@@ -113,11 +110,9 @@ public class CallableMixedTest extends AbstractTest {
             } catch (SQLException e) {
                 assertTrue(e.getMessage().matches(TestResource.formatErrorMsg("R_NoPrivilege")));
             } finally {
-                TestUtils.dropProcedureIfExists(procName, stmt);
-                TestUtils.dropTableIfExists(tableName, stmt);
-                stmt.close();
-                c.close();
                 try (Connection c2 = getConnection(); Statement stmt2 = c2.createStatement()) {
+                    TestUtils.dropProcedureIfExists(procName, stmt2);
+                    TestUtils.dropTableIfExists(tableName, stmt2);
                     stmt2.execute("DROP USER " + AbstractSQLGenerator.escapeIdentifier(user));
                     stmt2.execute("DROP LOGIN " + AbstractSQLGenerator.escapeIdentifier(user));
                 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -89,11 +89,13 @@ public class CallableMixedTest extends AbstractTest {
     @Tag("xAzureSQLDW")
     @Tag("xAzureSQLMI")
     public void noPrivilegeTest() throws SQLException {
-        try (Connection c = getConnection(); Statement stmt = c.createStatement()) {
+        try (Connection c = getConnection();
+                Statement stmt = c.createStatement()) {
             String tableName = RandomUtil.getIdentifier("jdbc_priv");
             String procName = RandomUtil.getIdentifier("priv_proc");
             String user = "priv_user" + UUID.randomUUID();
             String pass = "priv_pass" + UUID.randomUUID();
+
 
             stmt.execute(
                     "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (id int, name varchar(50))");
@@ -110,9 +112,11 @@ public class CallableMixedTest extends AbstractTest {
             } catch (SQLException e) {
                 assertTrue(e.getMessage().matches(TestResource.formatErrorMsg("R_NoPrivilege")));
             } finally {
+                TestUtils.dropProcedureIfExists(procName, stmt);
+                TestUtils.dropTableIfExists(tableName, stmt);
+                stmt.close();
+                c.close();
                 try (Connection c2 = getConnection(); Statement stmt2 = c2.createStatement()) {
-                    TestUtils.dropProcedureIfExists(procName, stmt2);
-                    TestUtils.dropTableIfExists(tableName, stmt2);
                     stmt2.execute("DROP USER " + AbstractSQLGenerator.escapeIdentifier(user));
                     stmt2.execute("DROP LOGIN " + AbstractSQLGenerator.escapeIdentifier(user));
                 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -114,6 +114,11 @@ public class CallableMixedTest extends AbstractTest {
                 fail();
             } catch (SQLException e) {
                 assertTrue(e.getMessage().matches(TestResource.formatErrorMsg("R_NoPrivilege")));
+            } finally {
+                TestUtils.dropProcedureIfExists(procName, stmt);
+                TestUtils.dropTableIfExists(tableName, stmt);
+                stmt.execute("DROP USER " + user);
+                stmt.execute("DROP LOGIN " + user);
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -89,13 +89,11 @@ public class CallableMixedTest extends AbstractTest {
     @Tag("xAzureSQLDW")
     @Tag("xAzureSQLMI")
     public void noPrivilegeTest() throws SQLException {
-        try (Connection c = getConnection();
-                Statement stmt = c.createStatement()) {
+        try (Connection c = getConnection(); Statement stmt = c.createStatement()) {
             String tableName = RandomUtil.getIdentifier("jdbc_priv");
             String procName = RandomUtil.getIdentifier("priv_proc");
             String user = "priv_user" + UUID.randomUUID();
             String pass = "priv_pass" + UUID.randomUUID();
-
 
             stmt.execute(
                     "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (id int, name varchar(50))");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -115,8 +115,12 @@ public class CallableMixedTest extends AbstractTest {
             } finally {
                 TestUtils.dropProcedureIfExists(procName, stmt);
                 TestUtils.dropTableIfExists(tableName, stmt);
-                stmt.execute("DROP USER " + user);
-                stmt.execute("DROP LOGIN " + user);
+                stmt.close();
+                c.close();
+                try (Connection c2 = getConnection(); Statement stmt2 = c2.createStatement()) {
+                    stmt2.execute("DROP USER " + AbstractSQLGenerator.escapeIdentifier(user));
+                    stmt2.execute("DROP LOGIN " + AbstractSQLGenerator.escapeIdentifier(user));
+                }
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -89,7 +89,7 @@ public class CallableMixedTest extends AbstractTest {
     @Tag("xAzureSQLDB")
     @Tag("xAzureSQLDW")
     @Tag("xAzureSQLMI")
-    public void noPrivilege() throws SQLException {
+    public void noPrivilegeTest() throws SQLException {
         try (Connection c = getConnection();
                 Statement stmt = c.createStatement()) {
             String tableName = RandomUtil.getIdentifier("jdbc_priv");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableMixedTest.java
@@ -109,7 +109,7 @@ public class CallableMixedTest extends AbstractTest {
             try {
                 stmt.execute("EXECUTE AS USER='" + user + "';EXECUTE " + AbstractSQLGenerator.escapeIdentifier(procName)
                         + " 1,'hi';");
-                fail(TestResource.getResource("R_shouldThrowException");
+                fail(TestResource.getResource("R_shouldThrowException"));
             } catch (SQLException e) {
                 assertTrue(e.getMessage().matches(TestResource.formatErrorMsg("R_NoPrivilege")));
             } finally {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -56,7 +56,7 @@ public class CallableStatementTest extends AbstractTest {
 
             createGUIDTable(stmt);
             createGUIDStoredProcedure(stmt);
-            createSetNullPreocedure(stmt);
+            createSetNullProcedure(stmt);
             createInputParamsProcedure(stmt);
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -195,7 +195,7 @@ public class CallableStatementTest extends AbstractTest {
         stmt.execute(sql);
     }
 
-    private static void createSetNullPreocedure(Statement stmt) throws SQLException {
+    private static void createSetNullProcedure(Statement stmt) throws SQLException {
         stmt.execute("create procedure " + AbstractSQLGenerator.escapeIdentifier(setNullProcedureName)
                 + " (@p1 nvarchar(255), @p2 nvarchar(255) output) as select @p2=@p1 return 0");
     }


### PR DESCRIPTION
Fixed an issue where CallableStatement was not setting parameter indexes properly when columns aren't found via column name lookup. This results in the driver returning a misleading error message early instead of executing the statement and receiving the proper message from server. Addresses issue #1059.