### PR TITLE
Improvements | String Literals on the left on comparisons (SonarQube)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
@@ -272,9 +272,9 @@ public class SQLServerBulkBatchInsertRecord extends SQLServerBulkCommon {
                 /*
                  * if the user has provided a wildcard for this column, fetch the set value from the batchParam.
                  */
-                if (valueData.equalsIgnoreCase("?")) {
+                if ("?".equalsIgnoreCase(valueData)) {
                     rowData = batchParam.get(batchParamIndex)[valueIndex++].getSetterValue();
-                } else if (valueData.equalsIgnoreCase("null")) {
+                } else if ("null".equalsIgnoreCase(valueData)) {
                     rowData = null;
                 }
                 /*
@@ -297,9 +297,9 @@ public class SQLServerBulkBatchInsertRecord extends SQLServerBulkCommon {
                 if (columnList.size() > columnListIndex
                         && columnList.get(columnListIndex).equalsIgnoreCase(columnMetadata.get(index + 1).columnName)) {
                     valueData = valueList.get(columnListIndex);
-                    if (valueData.equalsIgnoreCase("?")) {
+                    if ("?".equalsIgnoreCase(valueData)) {
                         rowData = batchParam.get(batchParamIndex)[valueIndex++].getSetterValue();
-                    } else if (valueData.equalsIgnoreCase("null")) {
+                    } else if ("null".equalsIgnoreCase(valueData)) {
                         rowData = null;
                     } else {
                         rowData = removeSingleQuote(valueData);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -175,9 +175,9 @@ public final class SQLServerDataTable {
                     } else {
                         String valString = val.toString();
 
-                        if (valString.equals("0") || valString.equalsIgnoreCase(Boolean.FALSE.toString())) {
+                        if ("0".equals(valString) || valString.equalsIgnoreCase(Boolean.FALSE.toString())) {
                             rowValues.set(key, Boolean.FALSE);
-                        } else if (valString.equals("1") || valString.equalsIgnoreCase(Boolean.TRUE.toString())) {
+                        } else if ("1".equals(valString) || valString.equalsIgnoreCase(Boolean.TRUE.toString())) {
                             rowValues.set(key, Boolean.TRUE);
                         } else {
                             MessageFormat form = new MessageFormat(

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -645,7 +645,7 @@ public final class SQLServerDriver implements java.sql.Driver {
                 if (null != val) {
                     // replace with the driver approved name
                     fixedup.setProperty(newname, val);
-                } else if (newname.equalsIgnoreCase("gsscredential") && (props.get(name) instanceof GSSCredential)) {
+                } else if ("gsscredential".equalsIgnoreCase(newname) && (props.get(name) instanceof GSSCredential)) {
                     fixedup.put(newname, props.get(name));
                 } else {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidpropertyValue"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerFMTQuery.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerFMTQuery.java
@@ -59,10 +59,10 @@ class SQLServerFMTQuery {
      */
     String constructColumnTargets() {
         if (userColumns.contains("?")) {
-            return userColumns.stream().filter(s -> !s.equals("?")).map(s -> s.equals("") ? "NULL" : s)
+            return userColumns.stream().filter(s -> !"?".equals(s)).map(s -> "".equals(s) ? "NULL" : s)
                     .collect(Collectors.joining(","));
         } else {
-            return userColumns.isEmpty() ? "*" : userColumns.stream().map(s -> s.equals("") ? "NULL" : s)
+            return userColumns.isEmpty() ? "*" : userColumns.stream().map(s -> "".equals(s) ? "NULL" : s)
                     .collect(Collectors.joining(","));
         }
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -112,10 +112,10 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                         if (matcher.matches()) {
                             // the datatype has some precision/scale defined explicitly.
                             ssType = SSType.of(matcher.group(1));
-                            if (typename.equalsIgnoreCase("varchar(max)")
-                                    || typename.equalsIgnoreCase("varbinary(max)")) {
+                            if ("varchar(max)".equalsIgnoreCase(typename)
+                                    || "varbinary(max)".equalsIgnoreCase(typename)) {
                                 qm.precision = SQLServerDatabaseMetaData.MAXLOBSIZE;
-                            } else if (typename.equalsIgnoreCase("nvarchar(max)")) {
+                            } else if ("nvarchar(max)".equalsIgnoreCase(typename)) {
                                 qm.precision = SQLServerDatabaseMetaData.MAXLOBSIZE / 2;
                             } else if (SSType.Category.CHARACTER == ssType.category
                                     || SSType.Category.BINARY == ssType.category
@@ -196,9 +196,9 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                  * values bracket. The '*' will retrieve all values from the table and we'll use the '?'s to match their
                  * position here
                  */
-                if (columns.get(i).equals("*")) {
+                if ("*".equals(columns.get(i))) {
                     for (int j = 0; j < params.get(valueListOffset).size(); j++) {
-                        if (params.get(valueListOffset).get(j).equals("?")) {
+                        if ("?".equals(params.get(valueListOffset).get(j))) {
                             if (!md.isAutoIncrement(mdIndex + j)) {
                                 QueryMeta qm = getQueryMetaFromResultSetMetaData(md, mdIndex + j);
                                 queryMetaMap.put(mapIndex++, qm);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParser.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParser.java
@@ -90,7 +90,7 @@ final class SQLServerParser {
                                     query.getColumns().add("*");
                                 }
                                 for (int i = 0; i < ls.size(); i++) {
-                                    if (ls.get(i).equalsIgnoreCase("?")) {
+                                    if ("?".equalsIgnoreCase(ls.get(i))) {
                                         if (0 == tableValues.size()) {
                                             query.getColumns().add("?");
                                         } else {
@@ -202,7 +202,7 @@ final class SQLServerParser {
         iter.previous();
         String value = findColumnBeforeParameter(iter);
         resetIteratorIndex(iter, index);
-        if (value.equalsIgnoreCase("")) {
+        if ("".equalsIgnoreCase(value)) {
             value = findColumnAfterParameter(iter);
             resetIteratorIndex(iter, index);
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2284,7 +2284,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             case java.sql.Types.VARBINARY:
                 // Spatial datatypes fall under Varbinary, check if the UDT is geometry/geography.
                 typeName = ti.getSSTypeName();
-                if (typeName.equalsIgnoreCase("geometry") || typeName.equalsIgnoreCase("geography")) {
+                if ("geometry".equalsIgnoreCase(typeName) || "geography".equalsIgnoreCase(typeName)) {
                     form = new MessageFormat(SQLServerException.getErrString("R_BulkTypeNotSupported"));
                     throw new IllegalArgumentException(form.format(new Object[] {typeName}));
                 }
@@ -2327,7 +2327,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         // This if statement is needed to handle the case where the user has something like:
         // [dbo] . /* random comment */ [tableName]
         if (hasTableBeenFound && !isExpectingTableName) {
-            if (checkSQLLength(1) && localUserSQL.substring(0, 1).equalsIgnoreCase(".")) {
+            if (checkSQLLength(1) && ".".equalsIgnoreCase(localUserSQL.substring(0, 1))) {
                 sb.append(".");
                 localUserSQL = localUserSQL.substring(1);
                 return sb.toString() + parseUserSQLForTableNameDW(true, true, true, true);
@@ -2336,12 +2336,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             }
         }
 
-        if (!hasInsertBeenFound && checkSQLLength(6) && localUserSQL.substring(0, 6).equalsIgnoreCase("insert")) {
+        if (!hasInsertBeenFound && checkSQLLength(6) && "insert".equalsIgnoreCase(localUserSQL.substring(0, 6))) {
             localUserSQL = localUserSQL.substring(6);
             return parseUserSQLForTableNameDW(true, hasIntoBeenFound, hasTableBeenFound, isExpectingTableName);
         }
 
-        if (!hasIntoBeenFound && checkSQLLength(6) && localUserSQL.substring(0, 4).equalsIgnoreCase("into")) {
+        if (!hasIntoBeenFound && checkSQLLength(6) && "into".equalsIgnoreCase(localUserSQL.substring(0, 4))) {
             // is it really "into"?
             // if the "into" is followed by a blank space or /*, then yes.
             if (Character.isWhitespace(localUserSQL.charAt(4))
@@ -2360,7 +2360,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         // It could be encapsulated in [], "", or have a database name preceding the table name.
         // If it's encapsulated in [] or "", we need be more careful with parsing as anything could go into []/"".
         // For ] or ", they can be escaped by ]] or "", watch out for this too.
-        if (checkSQLLength(1) && localUserSQL.substring(0, 1).equalsIgnoreCase("[")) {
+        if (checkSQLLength(1) && "[".equalsIgnoreCase(localUserSQL.substring(0, 1))) {
             int tempint = localUserSQL.indexOf("]", 1);
 
             // ] has not been found, this is wrong.
@@ -2381,7 +2381,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         }
 
         // do the same for ""
-        if (checkSQLLength(1) && localUserSQL.substring(0, 1).equalsIgnoreCase("\"")) {
+        if (checkSQLLength(1) && "\"".equalsIgnoreCase(localUserSQL.substring(0, 1))) {
             int tempint = localUserSQL.indexOf("\"", 1);
 
             // \" has not been found, this is wrong.
@@ -2426,7 +2426,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
         // check if optional column list was provided
         // Columns can have the form of c1, [c1] or "c1". It can escape ] or " by ]] or "".
-        if (checkSQLLength(1) && localUserSQL.substring(0, 1).equalsIgnoreCase("(")) {
+        if (checkSQLLength(1) && "(".equalsIgnoreCase(localUserSQL.substring(0, 1))) {
             localUserSQL = localUserSQL.substring(1);
             return parseUserSQLForColumnListDWHelper(new ArrayList<String>());
         }
@@ -2531,13 +2531,13 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
         if (!hasValuesBeenFound) {
             // look for keyword "VALUES"
-            if (checkSQLLength(6) && localUserSQL.substring(0, 6).equalsIgnoreCase("VALUES")) {
+            if (checkSQLLength(6) && "VALUES".equalsIgnoreCase(localUserSQL.substring(0, 6))) {
                 localUserSQL = localUserSQL.substring(6);
 
                 // ignore all comments
                 while (checkAndRemoveCommentsAndSpace(false)) {}
 
-                if (checkSQLLength(1) && localUserSQL.substring(0, 1).equalsIgnoreCase("(")) {
+                if (checkSQLLength(1) && "(".equalsIgnoreCase(localUserSQL.substring(0, 1))) {
                     localUserSQL = localUserSQL.substring(1);
                     return parseUserSQLForValueListDWHelper(new ArrayList<String>());
                 }
@@ -2546,7 +2546,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             // ignore all comments
             while (checkAndRemoveCommentsAndSpace(false)) {}
 
-            if (checkSQLLength(1) && localUserSQL.substring(0, 1).equalsIgnoreCase("(")) {
+            if (checkSQLLength(1) && "(".equalsIgnoreCase(localUserSQL.substring(0, 1))) {
                 localUserSQL = localUserSQL.substring(1);
                 return parseUserSQLForValueListDWHelper(new ArrayList<String>());
             }
@@ -2569,7 +2569,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             if (localUserSQL.charAt(0) == ',' || localUserSQL.charAt(0) == ')') {
                 if (localUserSQL.charAt(0) == ',') {
                     localUserSQL = localUserSQL.substring(1);
-                    if (!sb.toString().equals("?")) {
+                    if (!"?".equals(sb.toString())) {
                         // throw IllegalArgumentException and fallback to original logic for batch insert
                         throw new IllegalArgumentException(
                                 "Only fully parameterized queries are allowed for using Bulk Copy API for batch insert at the moment.");
@@ -2627,7 +2627,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             return false;
         }
 
-        if (localUserSQL.substring(0, 2).equalsIgnoreCase("/*")) {
+        if ("/*".equalsIgnoreCase(localUserSQL.substring(0, 2))) {
             int temp = localUserSQL.indexOf("*/") + 2;
             if (temp <= 0) {
                 localUserSQL = "";
@@ -2637,7 +2637,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             return true;
         }
 
-        if (localUserSQL.substring(0, 2).equalsIgnoreCase("--")) {
+        if ("--".equalsIgnoreCase(localUserSQL.substring(0, 2))) {
             int temp = localUserSQL.indexOf("\n") + 1;
             if (temp <= 0) {
                 localUserSQL = "";

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSpatialDatatype.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSpatialDatatype.java
@@ -333,13 +333,13 @@ abstract class SQLServerSpatialDatatype {
             }
             byte fa = 0;
 
-            if (version == 1 && (nextToken.equals("CIRCULARSTRING") || nextToken.equals("COMPOUNDCURVE")
-                    || nextToken.equals("CURVEPOLYGON"))) {
+            if (version == 1 && ("CIRCULARSTRING".equals(nextToken) || "COMPOUNDCURVE".equals(nextToken)
+                    || "CURVEPOLYGON".equals(nextToken))) {
                 version = 2;
             }
 
             // check for FULLGLOBE before reading the first open bracket, since FULLGLOBE doesn't have one.
-            if (nextToken.equals("FULLGLOBE")) {
+            if ("FULLGLOBE".equals(nextToken)) {
                 if (sd instanceof Geometry) {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_illegalTypeForGeometry"));
                     throw new SQLServerException(form.format(new Object[] {"Fullglobe"}), null, 0, null);
@@ -364,7 +364,7 @@ abstract class SQLServerSpatialDatatype {
 
             switch (nextToken) {
                 case "POINT":
-                    if (startPos == 0 && nextToken.toUpperCase().equals("POINT")) {
+                    if (startPos == 0 && "POINT".equals(nextToken.toUpperCase())) {
                         isSinglePoint = true;
                         internalType = InternalSpatialDatatype.POINT;
                     }
@@ -385,7 +385,7 @@ abstract class SQLServerSpatialDatatype {
 
                     readLineWkt();
 
-                    if (startPos == 0 && nextToken.toUpperCase().equals("LINESTRING") && pointList.size() == 2) {
+                    if (startPos == 0 && "LINESTRING".equals(nextToken.toUpperCase()) && pointList.size() == 2) {
                         isSingleLineSegment = true;
                     }
                     break;
@@ -881,7 +881,7 @@ abstract class SQLServerSpatialDatatype {
                 // handle NULL case
                 // the first check ensures that there is enough space for the wkt to have NULL
                 if (wkt.length() > currentWktPos + 3
-                        && wkt.substring(currentWktPos, currentWktPos + 4).equalsIgnoreCase("null")) {
+                        && "null".equalsIgnoreCase(wkt.substring(currentWktPos, currentWktPos + 4))) {
                     coords[numOfCoordinates] = Double.NaN;
                     currentWktPos = currentWktPos + 4;
                 } else {
@@ -945,29 +945,29 @@ abstract class SQLServerSpatialDatatype {
 
             // if next keyword is empty, continue the loop.
             // Do not check this for polygon.
-            if (!nextToken.equals("POLYGON")
+            if (!"POLYGON".equals(nextToken)
                     && checkEmptyKeyword(parentShapeIndex, InternalSpatialDatatype.valueOf(nextToken), true)) {
                 continue;
             }
 
-            if (nextToken.equals("MULTIPOINT")) {
+            if ("MULTIPOINT".equals(nextToken)) {
                 shapeList.add(
                         new Shape(parentShapeIndex, figureList.size(), InternalSpatialDatatype.POINT.getTypeCode()));
-            } else if (nextToken.equals("MULTILINESTRING")) {
+            } else if ("MULTILINESTRING".equals(nextToken)) {
                 shapeList.add(new Shape(parentShapeIndex, figureList.size(),
                         InternalSpatialDatatype.LINESTRING.getTypeCode()));
             }
 
             if (version == 1) {
-                if (nextToken.equals("MULTIPOINT")) {
+                if ("MULTIPOINT".equals(nextToken)) {
                     fa = FA_STROKE;
-                } else if (nextToken.equals("MULTILINESTRING") || nextToken.equals("POLYGON")) {
+                } else if ("MULTILINESTRING".equals(nextToken) || "POLYGON".equals(nextToken)) {
                     fa = FA_EXTERIOR_RING;
                 }
                 version_one_shape_indexes.add(figureList.size());
             } else if (version == 2) {
-                if (nextToken.equals("MULTIPOINT") || nextToken.equals("MULTILINESTRING") || nextToken.equals("POLYGON")
-                        || nextToken.equals("MULTIPOLYGON")) {
+                if ("MULTIPOINT".equals(nextToken) || "MULTILINESTRING".equals(nextToken) || "POLYGON".equals(nextToken)
+                        || "MULTIPOLYGON".equals(nextToken)) {
                     fa = FA_LINE;
                 }
             }
@@ -998,12 +998,12 @@ abstract class SQLServerSpatialDatatype {
     protected void readCurvePolygon() throws SQLServerException {
         while (currentWktPos < wkt.length() && wkt.charAt(currentWktPos) != ')') {
             String nextPotentialToken = getNextStringToken().toUpperCase(Locale.US);
-            if (nextPotentialToken.equals("CIRCULARSTRING")) {
+            if ("CIRCULARSTRING".equals(nextPotentialToken)) {
                 figureList.add(new Figure(FA_ARC, pointList.size()));
                 readOpenBracket();
                 readLineWkt();
                 readCloseBracket();
-            } else if (nextPotentialToken.equals("COMPOUNDCURVE")) {
+            } else if ("COMPOUNDCURVE".equals(nextPotentialToken)) {
                 figureList.add(new Figure(FA_COMPOSITE_CURVE, pointList.size()));
                 readOpenBracket();
                 readCompoundCurveWkt(true);
@@ -1109,7 +1109,7 @@ abstract class SQLServerSpatialDatatype {
     protected void readCompoundCurveWkt(boolean isFirstIteration) throws SQLServerException {
         while (currentWktPos < wkt.length() && wkt.charAt(currentWktPos) != ')') {
             String nextPotentialToken = getNextStringToken().toUpperCase(Locale.US);
-            if (nextPotentialToken.equals("CIRCULARSTRING")) {
+            if ("CIRCULARSTRING".equals(nextPotentialToken)) {
                 readOpenBracket();
                 readSegmentWkt(SEGMENT_FIRST_ARC, isFirstIteration);
                 readCloseBracket();
@@ -1429,7 +1429,7 @@ abstract class SQLServerSpatialDatatype {
     protected boolean checkEmptyKeyword(int parentShapeIndex, InternalSpatialDatatype isd,
             boolean isInsideAnotherShape) throws SQLServerException {
         String potentialEmptyKeyword = getNextStringToken().toUpperCase(Locale.US);
-        if (potentialEmptyKeyword.equals("EMPTY")) {
+        if ("EMPTY".equals(potentialEmptyKeyword)) {
 
             byte typeCode = 0;
 
@@ -1460,7 +1460,7 @@ abstract class SQLServerSpatialDatatype {
             return true;
         }
 
-        if (!potentialEmptyKeyword.equals("")) {
+        if (!"".equals(potentialEmptyKeyword)) {
             throwIllegalWKTPosition();
         }
         return false;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -559,7 +559,7 @@ public class SQLServerStatement implements ISQLServerStatement {
                 // TYPE_SS_SERVER_CURSOR_FORWARD_ONLY accordingly.
                 String selectMethod = con.getSelectMethod();
                 resultSetType = (null == selectMethod
-                        || !selectMethod.equals("cursor")) ? SQLServerResultSet.TYPE_SS_DIRECT_FORWARD_ONLY : // Default
+                        || !"cursor".equals(selectMethod)) ? SQLServerResultSet.TYPE_SS_DIRECT_FORWARD_ONLY : // Default
                                                                                                               // forward-only,
                                                                                                               // read-only
                                                                                                               // cursor
@@ -972,7 +972,7 @@ public class SQLServerStatement implements ISQLServerStatement {
         if (null == sql || sql.length() < 6) {
             return false;
         }
-        return temp.substring(0, 6).equalsIgnoreCase("select");
+        return "select".equalsIgnoreCase(temp.substring(0, 6));
     }
 
     /**
@@ -990,11 +990,11 @@ public class SQLServerStatement implements ISQLServerStatement {
         if (null == sql || sql.length() < 6) {
             return false;
         }
-        if (temp.substring(0, 2).equalsIgnoreCase("/*")) {
+        if ("/*".equalsIgnoreCase(temp.substring(0, 2))) {
             int index = temp.indexOf("*/") + 2;
             return isInsert(temp.substring(index));
         }
-        return temp.substring(0, 6).equalsIgnoreCase("insert");
+        return "insert".equalsIgnoreCase(temp.substring(0, 6));
     }
 
     /**
@@ -1032,7 +1032,7 @@ public class SQLServerStatement implements ISQLServerStatement {
             final StringBuilder retSql = new StringBuilder();
             while (st.hasMoreTokens()) {
                 String str = st.nextToken();
-                if (str.equals("'")) {
+                if ("'".equals(str)) {
                     retSql.append("'");
                     beforeColon = !beforeColon;
                     continue;


### PR DESCRIPTION
Transforming from `someString.equals("string")`  to `"string".equals(someString)`. This avoids checking for `null` and also prevents `NullPointerException` being thrown.

These fixes multiple SonarQube violations of the rule: [Strings literals should be placed on the left side when checking for equality](https://rules.sonarsource.com/java/RSPEC-1132)