### PR TITLE
Let setTransactionTimeout() return false if the timeout value being p…

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
@@ -881,7 +881,8 @@ public final class SQLServerXAResource implements javax.transaction.xa.XAResourc
 
     @Override
     public boolean setTransactionTimeout(int seconds) throws XAException {
-
+		// if the timeout value exceeds the upper bound of short int, return false
+		if(seconds > 32767) return false;
         isTransacrionTimeoutSet = 1;
         timeoutSeconds = seconds;
         if (xaLogger.isLoggable(Level.FINER))


### PR DESCRIPTION
Currently if we call setTransactionTimeout(int seconds) with the parameter larger than the short int range, the driver would crash and generate a weird error:

javax.transaction.xa.XAException: com.microsoft.sqlserver.jdbc.SQLServerException: The value is not set for the parameter number 0.

How to reproduce: run setTransactionTimeout(int seconds) with value like 86400, and start this transaction. The driver would crash.

Does the timeout be stored or processed as a short int when being passed to the .dll? I've read the code that prepares the xa_start call:
```
CS = controlConnection.prepareCall(
                        "{call master..xp_sqljdbc_xa_start(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)}");
```
```
cs.setInt(n++, timeoutSeconds); // Transaction timeout in seconds.
```
seems like it's treated as an int. Could you please take a look on it and see if similar error could be reproduced? Thanks!