### PR TITLE
Fix | Rename constants to avoid CredentialScanner false positives

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -84,7 +84,7 @@ public class AESetup extends AbstractTest {
 
         AEInfo = new Properties();
         AEInfo.setProperty("ColumnEncryptionSetting", Constants.ENABLED);
-        AEInfo.setProperty("keyStoreAuthentication", Constants.JAVA_KEY_STORE_PASSWORD);
+        AEInfo.setProperty("keyStoreAuthentication", Constants.JAVA_KEY_STORE_SECRET);
         AEInfo.setProperty("keyStoreLocation", keyPath);
         AEInfo.setProperty("keyStoreSecret", Constants.JKS_SECRET);
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -175,7 +175,7 @@ public class SQLServerDriverTest extends AbstractTest {
                 assertTrue(anInfoArray.value.equalsIgnoreCase("someStore"),
                         TestResource.getResource("R_valuesAreDifferent"));
             }
-            if (anInfoArray.name.equalsIgnoreCase(Constants.TRUST_STORE_PASSWORD)) {
+            if (anInfoArray.name.equalsIgnoreCase(Constants.TRUST_STORE_SECRET_PROPERTY)) {
                 assertTrue(anInfoArray.value.equalsIgnoreCase("somepassword"),
                         TestResource.getResource("R_valuesAreDifferent"));
             }

--- a/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
@@ -89,7 +89,7 @@ public final class Constants {
     // AE Constants
     public static final String JAVA_KEY_STORE_FILENAME = "JavaKeyStore.txt";
     public static final String JAVA_KEY_STORE_NAME = "MSSQL_JAVA_KEYSTORE";
-    public static final String JAVA_KEY_STORE_PASSWORD = "JavaKeyStorePassword";
+    public static final String JAVA_KEY_STORE_SECRET = "JavaKeyStorePassword";
     public static final String JKS = "JKS";
     public static final String JKS_NAME = "clientcert.jks";
     public static final String JKS_SECRET = "password";

--- a/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
@@ -133,7 +133,7 @@ public final class Constants {
     public static final String FIPS = "FIPS";
     public static final String TRUST_STORE_TYPE = "TRUSTSTORETYPE";
     public static final String TRUST_SERVER_CERTIFICATE = "TRUSTSERVERCERTIFICATE";
-    public static final String TRUST_STORE_PASSWORD = "TRUSTSTOREPASSWORD";
+    public static final String TRUST_STORE_SECRET_PROPERTY = "TRUSTSTOREPASSWORD";
     public static final String TRUST_STORE = "TRUSTSTORE";
 
     public enum LOB {


### PR DESCRIPTION
`JAVA_KEY_STORE_PASSWORD` - Not an actual password, but a keyword to use [built-in JDBC keystore provider](https://docs.microsoft.com/en-us/sql/connect/jdbc/using-always-encrypted-with-the-jdbc-driver?view=sql-server-2017#using-java-key-store-provider).

`TRUST_STORE_PASSWORD` - Not an actual password, but a [connection string keyword.](https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-2017)