### PR TITLE
Fix | Revert chartAt() change

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1311,7 +1311,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         // handle `@name` as well as `name`, since `@name` is what's returned
         // by DatabaseMetaData#getProcedureColumns
         String columnNameWithoutAtSign = null;
-        if (columnName.charAt(0) == '@') {
+        if (columnName.startsWith("@")) {
             columnNameWithoutAtSign = columnName.substring(1, columnName.length());
         } else {
             columnNameWithoutAtSign = columnName;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3930,7 +3930,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 String currentHostName = activeConnectionProperties.getProperty("hostNameInCertificate");
 
                 // skip the check for hostNameInCertificate if routingServerName is null
-                if (null != currentHostName && currentHostName.charAt(0) == '*' && (null != routingServerName)
+                if (null != currentHostName && currentHostName.startsWith("*") && (null != routingServerName)
                         && routingServerName.indexOf('.') != -1) {
                     char[] currentHostNameCharArray = currentHostName.toCharArray();
                     char[] routingServerNameCharArray = routingServerName.toCharArray();


### PR DESCRIPTION
As mentioned by @dmitri-blinov on #1075, switching from `startsWith()` to  `charAt()` may lead to an exception in case of an empty string.