### PR TITLE
Fix SQLServerDatabaseMetada.getColumns not escaping wildcard

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -677,11 +677,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
              */
             try (PreparedStatement storedProcPstmt = this.connection
                     .prepareStatement("EXEC sp_columns_100 ?,?,?,?,?,?;")) {
-                storedProcPstmt.setString(1, (null != table && !table.isEmpty()) ? table : "%");
-                storedProcPstmt.setString(2, (null != schema && !schema.isEmpty()) ? schema : "%");
+                storedProcPstmt.setString(1, (null != table && !table.isEmpty()) ? EscapeIDName(table) : "%");
+                storedProcPstmt.setString(2, (null != schema && !schema.isEmpty()) ? EscapeIDName(schema) : "%");
                 storedProcPstmt.setString(3,
                         (null != catalog && !catalog.isEmpty()) ? catalog : this.connection.getCatalog());
-                storedProcPstmt.setString(4, (null != col && !col.isEmpty()) ? col : "%");
+                storedProcPstmt.setString(4, (null != col && !col.isEmpty()) ? EscapeIDName(col) : "%");
                 storedProcPstmt.setInt(5, 2);// show sparse columns
                 storedProcPstmt.setInt(6, 3);// odbc version
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -638,10 +638,10 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             PreparedStatement pstmt = (SQLServerPreparedStatement) this.connection.prepareStatement(spColumnsSql);
             pstmt.closeOnCompletion();
             try {
-                pstmt.setString(1, (null != table && !table.isEmpty()) ? table : "%");
-                pstmt.setString(2, (null != schema && !schema.isEmpty()) ? schema : "%");
+                pstmt.setString(1, (null != table && !table.isEmpty()) ? EscapeIDName(table) : "%");
+                pstmt.setString(2, (null != schema && !schema.isEmpty()) ? EscapeIDName(schema) : "%");
                 pstmt.setString(3, (null != catalog && !catalog.isEmpty()) ? catalog : this.connection.getCatalog());
-                pstmt.setString(4, (null != col && !col.isEmpty()) ? col : "%");
+                pstmt.setString(4, (null != col && !col.isEmpty()) ? EscapeIDName(col) : "%");
                 pstmt.setInt(5, 2);// show sparse columns
                 pstmt.setInt(6, 3);// odbc version
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -179,5 +179,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_incorrectSyntaxTableDW", "Incorrect syntax near 'table'."},
             {"R_ConnectionStringNull", "Connection String should not be null"},
             {"R_OperandTypeClash", "Operand type clash"},
-            {"R_NoPrivilege", "The EXECUTE permission was denied on the object {0}"}};
+            {"R_NoPrivilege", "The EXECUTE permission was denied on the object {0}"},
+            {"R_resultSetEmpty", "Result set is empty."}};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -359,6 +359,14 @@ public class DatabaseMetaDataTest extends AbstractTest {
                     try (ResultSet rs1 = databaseMetaData.getColumns(null, null, tableName, "col\\_1")) {
                         testGetDBColumnInternal(rs1, databaseMetaData);
                     }
+                    
+                    try (ResultSet rs1 = databaseMetaData.getColumns(null, null, tableName, "col\\%2")) {
+                        testGetDBColumnInternal(rs1, databaseMetaData);
+                    }
+                    
+                    try (ResultSet rs1 = databaseMetaData.getColumns(null, null, tableName, "col\\[3")) {
+                        testGetDBColumnInternal(rs1, databaseMetaData);
+                    }
                 }
             }
         } catch (Exception e) {
@@ -604,7 +612,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
     public static void setupTable() throws SQLException {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute("CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableName)
-                    + " (col_1 int NOT NULL, col_2 varchar(200), col_3 decimal(15,2))");
+                    + " ([col_1] int NOT NULL, [col%2] varchar(200), [col[3] decimal(15,2))");
             stmt.execute("CREATE FUNCTION " + AbstractSQLGenerator.escapeIdentifier(functionName)
                     + " (@p1 INT, @p2 INT) RETURNS INT AS BEGIN DECLARE @result INT; SET @result = @p1 + @p2; RETURN @result; END");
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -353,27 +353,39 @@ public class DatabaseMetaDataTest extends AbstractTest {
                     fail(form1.format(msgArgs1));
                 } else {
                     try (ResultSet rs1 = databaseMetaData.getColumns(null, null, tableName, "%")) {
-                        MessageFormat form2 = new MessageFormat(TestResource.getResource("R_nameEmpty"));
-                        Object[][] msgArgs2 = {{"Category"}, {"SCHEMA"}, {"Table"}, {"COLUMN"}, {"Data Type"}, {"Type"},
-                                {"Column Size"}, {"Nullable value"}, {"IS_NULLABLE"}, {"IS_AUTOINCREMENT"}};
-                        while (rs1.next()) {
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_CAT")), form2.format(msgArgs2[0]));
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_SCHEM")), form2.format(msgArgs2[1]));
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_NAME")), form2.format(msgArgs2[2]));
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("COLUMN_NAME")), form2.format(msgArgs2[3]));
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("DATA_TYPE")), form2.format(msgArgs2[4]));
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("TYPE_NAME")), form2.format(msgArgs2[5]));
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("COLUMN_SIZE")), form2.format(msgArgs2[6]));
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("NULLABLE")), form2.format(msgArgs2[7])); // 11
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("IS_NULLABLE")), form2.format(msgArgs2[8])); // 18
-                            assertTrue(!StringUtils.isEmpty(rs1.getString("IS_AUTOINCREMENT")),
-                                    form2.format(msgArgs2[9])); // 22
-                        }
+                        testGetDBColumnInternal(rs1, databaseMetaData);
+                    }
+                    
+                    try (ResultSet rs1 = databaseMetaData.getColumns(null, null, tableName, "col\\_1")) {
+                        testGetDBColumnInternal(rs1, databaseMetaData);
                     }
                 }
             }
         } catch (Exception e) {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.getMessage());
+        }
+    }
+
+    private void testGetDBColumnInternal(ResultSet rs1, DatabaseMetaData databaseMetaData) throws SQLException {
+        MessageFormat form2 = new MessageFormat(TestResource.getResource("R_nameEmpty"));
+        Object[][] msgArgs2 = {{"Category"}, {"SCHEMA"}, {"Table"}, {"COLUMN"}, {"Data Type"}, {"Type"},
+                {"Column Size"}, {"Nullable value"}, {"IS_NULLABLE"}, {"IS_AUTOINCREMENT"}};
+        if (!rs1.next()) {
+            fail(TestResource.getResource("R_resultSetEmpty"));
+        } else {
+            do {
+                assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_CAT")), form2.format(msgArgs2[0]));
+                assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_SCHEM")), form2.format(msgArgs2[1]));
+                assertTrue(!StringUtils.isEmpty(rs1.getString("TABLE_NAME")), form2.format(msgArgs2[2]));
+                assertTrue(!StringUtils.isEmpty(rs1.getString("COLUMN_NAME")), form2.format(msgArgs2[3]));
+                assertTrue(!StringUtils.isEmpty(rs1.getString("DATA_TYPE")), form2.format(msgArgs2[4]));
+                assertTrue(!StringUtils.isEmpty(rs1.getString("TYPE_NAME")), form2.format(msgArgs2[5]));
+                assertTrue(!StringUtils.isEmpty(rs1.getString("COLUMN_SIZE")), form2.format(msgArgs2[6]));
+                assertTrue(!StringUtils.isEmpty(rs1.getString("NULLABLE")), form2.format(msgArgs2[7])); // 11
+                assertTrue(!StringUtils.isEmpty(rs1.getString("IS_NULLABLE")), form2.format(msgArgs2[8])); // 18
+                assertTrue(!StringUtils.isEmpty(rs1.getString("IS_AUTOINCREMENT")),
+                        form2.format(msgArgs2[9])); // 22
+            } while (rs1.next());
         }
     }
 
@@ -592,7 +604,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
     public static void setupTable() throws SQLException {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute("CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableName)
-                    + " (col1 int NOT NULL, col2 varchar(200), col3 decimal(15,2))");
+                    + " (col_1 int NOT NULL, col_2 varchar(200), col_3 decimal(15,2))");
             stmt.execute("CREATE FUNCTION " + AbstractSQLGenerator.escapeIdentifier(functionName)
                     + " (@p1 INT, @p2 INT) RETURNS INT AS BEGIN DECLARE @result INT; SET @result = @p1 + @p2; RETURN @result; END");
         }


### PR DESCRIPTION
Fixes issue #1136. Added extra test that tests this case as well. 