### PR TITLE
Change | Updated ISQLServerBulkData APIs to throw SQLException

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerBulkData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerBulkData.java
@@ -6,6 +6,7 @@
 package com.microsoft.sqlserver.jdbc;
 
 import java.io.Serializable;
+import java.sql.SQLException;
 
 /**
  * Provides an interface used to create classes that read in data from any source (such as a file) and allows a
@@ -66,7 +67,7 @@ public interface ISQLServerBulkData extends Serializable {
      * @throws SQLServerException
      *         If there are any errors in obtaining the data.
      */
-    Object[] getRowData() throws SQLServerException;
+    Object[] getRowData() throws SQLException;
 
     /**
      * Advances to the next data row.
@@ -75,5 +76,5 @@ public interface ISQLServerBulkData extends Serializable {
      * @throws SQLServerException
      *         If there are any errors in advancing to the next row.
      */
-    boolean next() throws SQLServerException;
+    boolean next() throws SQLException;
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerBulkRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerBulkRecord.java
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter;
  * 
  * This interface is implemented by {@link SQLServerBulkRecord} Class
  *
- * @deprecated as of 7.5.0, because the interface contains methods which are not called as part of actual bulk copy
+ * @deprecated as of 8.1.0, because the interface contains methods which are not called as part of actual bulk copy
  *             process. Use {@link ISQLServerBulkData}} instead.
  */
 @Deprecated

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -26,7 +26,6 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.ComparisonUtil;
-import com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCSVFileRecord;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
 import com.microsoft.sqlserver.jdbc.TestUtils;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
@@ -6,7 +6,6 @@ package com.microsoft.sqlserver.jdbc.bulkCopy;
 
 import java.sql.JDBCType;
 import java.sql.SQLException;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
-import com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord;
+import com.microsoft.sqlserver.jdbc.ISQLServerBulkData;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
@@ -30,7 +29,7 @@ import com.microsoft.sqlserver.testframework.sqlType.SqlType;
 
 
 /**
- * Test bulkcopy decimal sacle and precision
+ * Test bulk copy decimal scale and precision
  */
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test ISQLServerBulkRecord")
@@ -59,7 +58,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
         }
     }
 
-    class BulkData implements ISQLServerBulkRecord {
+    class BulkData implements ISQLServerBulkData {
 
         private static final long serialVersionUID = 1L;
 
@@ -146,11 +145,6 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
         }
 
         @Override
-        public boolean isAutoIncrement(int column) {
-            return false;
-        }
-
-        @Override
         public Object[] getRowData() throws SQLServerException {
             return data.get(counter++);
         }
@@ -167,44 +161,6 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
          */
         public void reset() {
             counter = 0;
-        }
-
-        @Override
-        public void addColumnMetadata(int positionInFile, String name, int jdbcType, int precision, int scale,
-                DateTimeFormatter dateTimeFormatter) throws SQLServerException {
-            // TODO Not Implemented
-        }
-
-        @Override
-        public void addColumnMetadata(int positionInFile, String name, int jdbcType, int precision,
-                int scale) throws SQLServerException {
-            // TODO Not Implemented
-        }
-
-        @Override
-        public void setTimestampWithTimezoneFormat(String dateTimeFormat) {
-            // TODO Not Implemented
-        }
-
-        @Override
-        public void setTimestampWithTimezoneFormat(DateTimeFormatter dateTimeFormatter) {
-            // TODO Not Implemented
-        }
-
-        @Override
-        public void setTimeWithTimezoneFormat(String timeFormat) {
-            // TODO Not Implemented
-        }
-
-        @Override
-        public void setTimeWithTimezoneFormat(DateTimeFormatter dateTimeFormatter) {
-            // TODO Not Implemented
-        }
-
-        @Override
-        public DateTimeFormatter getColumnDateTimeFormatter(int column) {
-            // TODO Not Implemented
-            return null;
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
@@ -15,7 +15,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.text.MessageFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
-import com.microsoft.sqlserver.jdbc.ISQLServerBulkRecord;
+import com.microsoft.sqlserver.jdbc.ISQLServerBulkData;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
@@ -39,6 +38,7 @@ import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
+@SuppressWarnings("deprecation")
 @RunWith(JUnitPlatform.class)
 public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
 
@@ -253,8 +253,7 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     }
 }
 
-
-class BulkData implements ISQLServerBulkRecord {
+class BulkData implements ISQLServerBulkData {
     private static final long serialVersionUID = 1L;
     boolean isStringData = false;
 
@@ -372,11 +371,6 @@ class BulkData implements ISQLServerBulkRecord {
     }
 
     @Override
-    public boolean isAutoIncrement(int column) {
-        return false;
-    }
-
-    @Override
     public Object[] getRowData() throws SQLServerException {
         Object[] dataRow = new Object[columnMetadata.size()];
         if (isStringData)
@@ -398,43 +392,4 @@ class BulkData implements ISQLServerBulkRecord {
         }
         return false;
     }
-
-    @Override
-    public void addColumnMetadata(int positionInFile, String name, int jdbcType, int precision, int scale,
-            DateTimeFormatter dateTimeFormatter) throws SQLServerException {
-        // TODO Not Implemented
-    }
-
-    @Override
-    public void addColumnMetadata(int positionInFile, String name, int jdbcType, int precision,
-            int scale) throws SQLServerException {
-        // TODO Not Implemented
-    }
-
-    @Override
-    public void setTimestampWithTimezoneFormat(String dateTimeFormat) {
-        // TODO Not Implemented
-    }
-
-    @Override
-    public void setTimestampWithTimezoneFormat(DateTimeFormatter dateTimeFormatter) {
-        // TODO Not Implemented
-    }
-
-    @Override
-    public void setTimeWithTimezoneFormat(String timeFormat) {
-        // TODO Not Implemented
-    }
-
-    @Override
-    public void setTimeWithTimezoneFormat(DateTimeFormatter dateTimeFormatter) {
-        // TODO Not Implemented
-    }
-
-    @Override
-    public DateTimeFormatter getColumnDateTimeFormatter(int column) {
-        // TODO Not Implemented
-        return null;
-    }
-
 }


### PR DESCRIPTION
The PR also updates Bulk Copy tests to use ISQLServerBulkData instead of ISQLServerBulkRecord.