### PR TITLE
updated AE tests to test list of enclave servers from config.properties

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     inputs:
       mavenPomFile: 'pom.xml'
       goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre13 -DuserNTLM=$(userNTLM) -DpasswordNTLM=$(passwordNTLM) -DdomainNTLM=$(domainNTLM) -DexcludedGroups=$(Ex_Groups) -Dpkcs12_truststore_password=$(pkcs12_truststore_password) -Dpkcs12_truststore=$(pkcs12_truststore.secureFilePath) 
--DapplicationClientID=$(applicationClientID) -DapplicationKey=$(applicationKey) -DkeyID=$(keyID) -DwindowsKeyPath=$(windowsKeyPath) -DenclaveAttestationUrl=$(enclaveAttestationUrl) -DenclaveAttestationProtocol=$(enclaveAttestationProtocol)'
+-DapplicationClientID=$(applicationClientID) -DapplicationKey=$(applicationKey) -DkeyID=$(keyID) -DwindowsKeyPath=$(windowsKeyPath) -DenclaveAttestationUrl=$(enclaveAttestationUrl) -DenclaveAttestationProtocol=$(enclaveAttestationProtocol) -DenclaveServer=$(enclaveServer)'
       testResultsFiles: '**/TEST-*.xml'
       testRunTitle: 'Maven build jre13'
       javaHomeOption: Path
@@ -49,8 +49,7 @@ jobs:
     inputs:
       mavenPomFile: 'pom.xml'
       goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre11 -DuserNTLM=$(userNTLM) -DpasswordNTLM=$(passwordNTLM) -DdomainNTLM=$(domainNTLM) -DexcludedGroups=$(Ex_Groups) -Dpkcs12_truststore_password=$(pkcs12_truststore_password) -Dpkcs12_truststore=$(pkcs12_truststore.secureFilePath) 
--DapplicationClientID=$(applicationClientID) -DapplicationKey=$(applicationKey) -DkeyID=$(keyID) -DwindowsKeyPath=$(windowsKeyPath) -DenclaveAttestationUrl=$(enclaveAttestationUrl) -DenclaveAttestationProtocol=$(enclaveAttestationProtocol)
-'
+-DapplicationClientID=$(applicationClientID) -DapplicationKey=$(applicationKey) -DkeyID=$(keyID) -DwindowsKeyPath=$(windowsKeyPath) -DenclaveAttestationUrl=$(enclaveAttestationUrl) -DenclaveAttestationProtocol=$(enclaveAttestationProtocol) -DenclaveServer=4(enclaveServer)'
       testResultsFiles: '**/TEST-*.xml'
       testRunTitle: 'Maven build jre11'
       javaHomeOption: Path
@@ -60,7 +59,7 @@ jobs:
     inputs:
       mavenPomFile: 'pom.xml'
       goals: 'clean -Dmssql_jdbc_test_connection_properties=jdbc:sqlserver://$(Target_SQL)$(server_domain);$(database);$(user);$(password); install -Pjre8 -DuserNTLM=$(userNTLM) -DpasswordNTLM=$(passwordNTLM) -DdomainNTLM=$(domainNTLM) -DexcludedGroups=$(Ex_Groups) -Dpkcs12_truststore_password=$(pkcs12_truststore_password) -Dpkcs12_truststore=$(pkcs12_truststore.secureFilePath) 
--DapplicationClientID=$(applicationClientID) -DapplicationKey=$(applicationKey) -DkeyID=$(keyID) -DwindowsKeyPath=$(windowsKeyPath) -DenclaveAttestationUrl=$(enclaveAttestationUrl) -DenclaveAttestationProtocol=$(enclaveAttestationProtocol)'
+-DapplicationClientID=$(applicationClientID) -DapplicationKey=$(applicationKey) -DkeyID=$(keyID) -DwindowsKeyPath=$(windowsKeyPath) -DenclaveAttestationUrl=$(enclaveAttestationUrl) -DenclaveAttestationProtocol=$(enclaveAttestationProtocol) -DenclaveServer=$(enclaveServer)'
       testResultsFiles: '**/TEST-*.xml'
       testRunTitle: 'Maven build jre8'
       javaHomeOption: Path

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -60,9 +60,9 @@ public class AESetup extends AbstractTest {
     public static String[][] enclaveParams() throws Exception {
         setup();
 
-        String[][] param = new String[enclaveServer.length][3];
+        String[][] param = new String[AbstractTest.enclaveServer.length][3];
 
-        for (int i = 0; i < enclaveServer.length; i++) {
+        for (int i = 0; i < AbstractTest.enclaveServer.length; i++) {
             param[i][0] = AbstractTest.enclaveServer[i];
             param[i][1] = AbstractTest.enclaveAttestationUrl[i];
             param[i][2] = AbstractTest.enclaveAttestationProtocol[i];
@@ -72,11 +72,9 @@ public class AESetup extends AbstractTest {
     }
 
     public AESetup(String serverName, String url, String protocol) throws TestAbortedException, Exception {
+        enclaveServer = serverName;
         enclaveAttestationUrl = url;
         enclaveAttestationProtocol = protocol;
-        AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled"
-                + ";serverName=" + serverName + ";" + Constants.ENCLAVE_ATTESTATIONURL + "=" + url + ";"
-                + Constants.ENCLAVE_ATTESTATIONPROTOCOL + "=" + protocol;
         setupAE();
     }
 
@@ -92,6 +90,7 @@ public class AESetup extends AbstractTest {
     public static String AETestConnectionString;
     protected static String enclaveAttestationUrl = null;
     protected static String enclaveAttestationProtocol = null;
+    protected static String enclaveServer = null;
 
     static Properties AEInfo;
     static Map<String, SQLServerColumnEncryptionKeyStoreProvider> map = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
@@ -178,7 +177,9 @@ public class AESetup extends AbstractTest {
      */
     @BeforeAll
     public static void setupAE() throws TestAbortedException, Exception {
-        // AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled";
+        AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled"
+                + ";serverName=" + enclaveServer + ";" + Constants.ENCLAVE_ATTESTATIONURL + "=" + enclaveAttestationUrl
+                + ";" + Constants.ENCLAVE_ATTESTATIONPROTOCOL + "=" + enclaveAttestationProtocol;
 
         if (null == applicationClientID || null == applicationKey || null == keyIDs
                 || (isWindows && null == windowsKeyPath)) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
 import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.RandomData;
@@ -55,6 +56,29 @@ import microsoft.sql.DateTimeOffset;
  */
 @RunWith(JUnitPlatform.class)
 public class AESetup extends AbstractTest {
+    @Parameters
+    public static String[][] enclaveParams() throws Exception {
+        setup();
+
+        String[][] param = new String[enclaveServer.length][3];
+
+        for (int i = 0; i < enclaveServer.length; i++) {
+            param[i][0] = AbstractTest.enclaveServer[i];
+            param[i][1] = AbstractTest.enclaveAttestationUrl[i];
+            param[i][2] = AbstractTest.enclaveAttestationProtocol[i];
+        }
+
+        return param;
+    }
+
+    public AESetup(String serverName, String url, String protocol) throws TestAbortedException, Exception {
+        enclaveAttestationUrl = url;
+        enclaveAttestationProtocol = protocol;
+        AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled"
+                + ";serverName=" + serverName + ";" + Constants.ENCLAVE_ATTESTATIONURL + "=" + url + ";"
+                + Constants.ENCLAVE_ATTESTATIONPROTOCOL + "=" + protocol;
+        setupAE();
+    }
 
     static String cmkJks = Constants.CMK_NAME + "_JKS";
     static String cmkWin = Constants.CMK_NAME + "_WIN";
@@ -63,11 +87,12 @@ public class AESetup extends AbstractTest {
     static String cekWin = Constants.CEK_NAME + "_WIN";
     static String cekAkv = Constants.CEK_NAME + "_AKV";
 
-    // static String javaKeyAliases = null;
-    // static SQLServerColumnEncryptionKeyStoreProvider jksProvider = null;
-    // static SQLServerColumnEncryptionAzureKeyVaultProvider akvProvider = null;
     static SQLServerStatementColumnEncryptionSetting stmtColEncSetting = null;
-    static String AETestConnectionString;
+
+    public static String AETestConnectionString;
+    protected static String enclaveAttestationUrl = null;
+    protected static String enclaveAttestationProtocol = null;
+
     static Properties AEInfo;
     static Map<String, SQLServerColumnEncryptionKeyStoreProvider> map = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
 
@@ -152,8 +177,8 @@ public class AESetup extends AbstractTest {
      * @throws TestAbortedException
      */
     @BeforeAll
-    public static void setUpConnection() throws TestAbortedException, Exception {
-        AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled";
+    public static void setupAE() throws TestAbortedException, Exception {
+        // AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled";
 
         if (null == applicationClientID || null == applicationKey || null == keyIDs
                 || (isWindows && null == windowsKeyPath)) {
@@ -162,17 +187,6 @@ public class AESetup extends AbstractTest {
         }
 
         readFromFile(Constants.JAVA_KEY_STORE_FILENAME, "Alias name");
-
-        String enclaveAttestationUrl = getConfiguredProperty("enclaveAttestationUrl");
-        if (null != enclaveAttestationUrl) {
-            AETestConnectionString = TestUtils.addOrOverrideProperty(AETestConnectionString, "enclaveAttestationUrl",
-                    enclaveAttestationUrl);
-        }
-        String enclaveAttestationProtocol = getConfiguredProperty("enclaveAttestationProtocol");
-        if (null != enclaveAttestationProtocol) {
-            AETestConnectionString = TestUtils.addOrOverrideProperty(AETestConnectionString,
-                    "enclaveAttestationProtocol", enclaveAttestationProtocol);
-        }
 
         dropAll();
 
@@ -282,6 +296,7 @@ public class AESetup extends AbstractTest {
                 sql += ColumnType.RANDOMIZED.name() + table[i][0] + " " + table[i][1]
                         + String.format(encryptSql, ColumnType.RANDOMIZED.name(), cekName) + ") NULL,";
             }
+            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName), stmt);
             sql = String.format(createSql, AbstractSQLGenerator.escapeIdentifier(tableName), sql);
             stmt.execute(sql);
             stmt.execute("DBCC FREEPROCCACHE");
@@ -505,10 +520,11 @@ public class AESetup extends AbstractTest {
                 encryptedValue = Constants.CEK_ENCRYPTED_VALUE;
             }
 
-            String cekSql = "CREATE COLUMN ENCRYPTION KEY " + cekName + " WITH VALUES " + "(COLUMN_MASTER_KEY = "
+            String sql = "if not exists (SELECT name from sys.column_encryption_keys where name='" + cekName + "')"
+                    + " begin" + " CREATE COLUMN ENCRYPTION KEY " + cekName + " WITH VALUES " + "(COLUMN_MASTER_KEY = "
                     + cmkName + ", ALGORITHM = '" + Constants.CEK_ALGORITHM + "', ENCRYPTED_VALUE = " + encryptedValue
-                    + ");";
-            stmt.execute(cekSql);
+                    + ") end;";
+            stmt.execute(sql);
         }
     }
 
@@ -535,7 +551,7 @@ public class AESetup extends AbstractTest {
                 + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
 
         try (SQLServerConnection con = (SQLServerConnection) PrepUtil
-                .getConnection(connectionString + ";sendTimeAsDateTime=false", AEInfo);
+                .getConnection(AETestConnectionString + ";sendTimeAsDateTime=false", AEInfo);
                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
                         stmtColEncSetting)) {
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
-import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.RandomData;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
@@ -71,7 +70,7 @@ public class AESetup extends AbstractTest {
         return param;
     }
 
-    public AESetup(String serverName, String url, String protocol) throws TestAbortedException, Exception {
+    public AESetup(String serverName, String url, String protocol) throws Exception {
         enclaveServer = serverName;
         enclaveAttestationUrl = url;
         enclaveAttestationProtocol = protocol;
@@ -173,13 +172,20 @@ public class AESetup extends AbstractTest {
      * Create connection, statement and generate path of resource file
      * 
      * @throws Exception
-     * @throws TestAbortedException
      */
     @BeforeAll
-    public static void setupAE() throws TestAbortedException, Exception {
-        AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled"
-                + ";serverName=" + enclaveServer + ";" + Constants.ENCLAVE_ATTESTATIONURL + "=" + enclaveAttestationUrl
-                + ";" + Constants.ENCLAVE_ATTESTATIONPROTOCOL + "=" + enclaveAttestationProtocol;
+    public static void setupAE() throws Exception {
+        // skip CI unix tests with localhost servers
+        if (!connectionString.substring(Constants.JDBC_PREFIX.length()).split(Constants.SEMI_COLON)[0]
+                .contains("localhost") && null != enclaveServer) {
+            AETestConnectionString = connectionString + ";sendTimeAsDateTime=false" + ";columnEncryptionSetting=enabled"
+                    + ";serverName=" + enclaveServer + ";" + Constants.ENCLAVE_ATTESTATIONURL + "="
+                    + enclaveAttestationUrl + ";" + Constants.ENCLAVE_ATTESTATIONPROTOCOL + "="
+                    + enclaveAttestationProtocol;
+        } else {
+            AETestConnectionString = connectionString + ";sendTimeAsDateTime=false"
+                    + ";columnEncryptionSetting=enabled";
+        }
 
         if (null == applicationClientID || null == applicationKey || null == keyIDs
                 || (isWindows && null == windowsKeyPath)) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.RandomData;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
@@ -52,9 +51,8 @@ import microsoft.sql.DateTimeOffset;
 @Tag(Constants.xAzureSQLDB)
 public class CallableStatementTest extends AESetup {
 
-    public CallableStatementTest(String connectionString) throws TestAbortedException, Exception {
-        super(connectionString, connectionString, connectionString);
-        // TODO Auto-generated constructor stub
+    public CallableStatementTest(String serverName, String url, String protocol) throws Exception {
+        super(serverName, url, protocol);
     }
 
     private static String multiStatementsProcedure = RandomUtil.getIdentifier("multiStatementsProcedure");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -23,8 +23,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.RandomData;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
@@ -45,11 +46,16 @@ import microsoft.sql.DateTimeOffset;
  * Test cases related to SQLServerCallableStatement.
  *
  */
-@RunWith(JUnitPlatform.class)
+@RunWith(Parameterized.class)
 @Tag(Constants.xSQLv12)
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 public class CallableStatementTest extends AESetup {
+
+    public CallableStatementTest(String connectionString) throws TestAbortedException, Exception {
+        super(connectionString, connectionString, connectionString);
+        // TODO Auto-generated constructor stub
+    }
 
     private static String multiStatementsProcedure = RandomUtil.getIdentifier("multiStatementsProcedure");
     private static String inputProcedure = RandomUtil.getIdentifier("inputProcedure");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -19,10 +19,10 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.LinkedList;
 
+import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
@@ -14,11 +14,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.LinkedList;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.Test;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.EnclavePackageTest;
@@ -37,7 +36,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
  * Tests Enclave decryption and encryption of values
  *
  */
-@RunWith(JUnitPlatform.class)
+@RunWith(Parameterized.class)
 @Tag(Constants.xSQLv12)
 @Tag(Constants.xSQLv14)
 @Tag(Constants.xAzureSQLDW)
@@ -45,11 +44,15 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.reqExternalSetup)
 public class EnclaveTest extends JDBCEncryptionDecryptionTest {
 
+    public EnclaveTest(String serverName, String url, String protocol) throws TestAbortedException, Exception {
+        super(serverName, url, protocol);
+        setupEnclave();
+    }
+
     private boolean nullable = false;
     private static boolean isAEv2 = false;
 
-    @BeforeAll
-    public static void setupEnclave() throws TestAbortedException, Exception {
+    public void setupEnclave() throws TestAbortedException, Exception {
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo)) {
             isAEv2 = TestUtils.isAEv2(con);
         } catch (SQLException e) {
@@ -60,7 +63,7 @@ public class EnclaveTest extends JDBCEncryptionDecryptionTest {
 
         org.junit.Assume.assumeTrue(isAEv2);
 
-        EnclavePackageTest.setupEnclave();
+        EnclavePackageTest.setupEnclave(enclaveAttestationUrl, enclaveAttestationProtocol);
     }
 
     /**
@@ -176,8 +179,9 @@ public class EnclaveTest extends JDBCEncryptionDecryptionTest {
         org.junit.Assume.assumeTrue(isAEv2);
 
         // connection string w/o AEv2
-        String testConnectionString = TestUtils.removeProperty(AETestConnectionString, "enclaveAttestationUrl");
-        testConnectionString = TestUtils.removeProperty(testConnectionString, "enclaveAttestationProtocol");
+        String testConnectionString = TestUtils.removeProperty(AETestConnectionString,
+                Constants.ENCLAVE_ATTESTATIONURL);
+        testConnectionString = TestUtils.removeProperty(testConnectionString, Constants.ENCLAVE_ATTESTATIONPROTOCOL);
 
         try (SQLServerConnection con = PrepUtil.getConnection(testConnectionString);
                 SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
@@ -598,7 +602,7 @@ public class EnclaveTest extends JDBCEncryptionDecryptionTest {
 
     /**
      * Test case for numeric set object for numeric values
-     * 
+     * F
      * @throws SQLException
      */
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 import org.junit.jupiter.api.Tag;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.EnclavePackageTest;
 import com.microsoft.sqlserver.jdbc.RandomData;
@@ -44,7 +43,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.reqExternalSetup)
 public class EnclaveTest extends JDBCEncryptionDecryptionTest {
 
-    public EnclaveTest(String serverName, String url, String protocol) throws TestAbortedException, Exception {
+    public EnclaveTest(String serverName, String url, String protocol) throws Exception {
         super(serverName, url, protocol);
         setupEnclave();
     }
@@ -52,7 +51,7 @@ public class EnclaveTest extends JDBCEncryptionDecryptionTest {
     private boolean nullable = false;
     private static boolean isAEv2 = false;
 
-    public void setupEnclave() throws TestAbortedException, Exception {
+    public void setupEnclave() throws Exception {
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo)) {
             isAEv2 = TestUtils.isAEv2(con);
         } catch (SQLException e) {
@@ -567,7 +566,7 @@ public class EnclaveTest extends JDBCEncryptionDecryptionTest {
      * @throws SQLException
      */
     @Test
-    public void testNumericSpecificSetter() throws TestAbortedException, Exception {
+    public void testNumericSpecificSetter() throws Exception {
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
 
@@ -586,7 +585,7 @@ public class EnclaveTest extends JDBCEncryptionDecryptionTest {
      * @throws SQLException
      */
     @Test
-    public void testNumericSpecificSetterWindows() throws TestAbortedException, Exception {
+    public void testNumericSpecificSetterWindows() throws Exception {
         org.junit.Assume.assumeTrue(System.getProperty("os.name").startsWith("Windows"));
 
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
@@ -601,8 +600,8 @@ public class EnclaveTest extends JDBCEncryptionDecryptionTest {
     }
 
     /**
-     * Test case for numeric set object for numeric values
-     * F
+     * Test case for numeric set object for numeric values F
+     * 
      * @throws SQLException
      */
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.jupiter.api.Tag;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.opentest4j.TestAbortedException;
 
 import com.microsoft.aad.adal4j.AuthenticationContext;
 import com.microsoft.aad.adal4j.AuthenticationResult;
@@ -58,8 +57,7 @@ import microsoft.sql.DateTimeOffset;
 @Tag(Constants.xAzureSQLDB)
 public class JDBCEncryptionDecryptionTest extends AESetup {
 
-    public JDBCEncryptionDecryptionTest(String serverName, String url,
-            String protocol) throws TestAbortedException, Exception {
+    public JDBCEncryptionDecryptionTest(String serverName, String url, String protocol) throws Exception {
         super(serverName, url, protocol);
     }
 
@@ -689,7 +687,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
      * @throws SQLException
      */
     @Test
-    public void testNumericSpecificSetter() throws TestAbortedException, Exception {
+    public void testNumericSpecificSetter() throws Exception {
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
 
@@ -708,7 +706,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
      * @throws SQLException
      */
     @Test
-    public void testNumericSpecificSetterWindows() throws TestAbortedException, Exception {
+    public void testNumericSpecificSetterWindows() throws Exception {
         org.junit.Assume.assumeTrue(isWindows);
 
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
@@ -21,10 +21,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.junit.Test;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.opentest4j.TestAbortedException;
 
 import com.microsoft.aad.adal4j.AuthenticationContext;
@@ -52,11 +52,16 @@ import microsoft.sql.DateTimeOffset;
  * Tests Decryption and encryption of values
  *
  */
-@RunWith(JUnitPlatform.class)
+@RunWith(Parameterized.class)
 @Tag(Constants.xSQLv12)
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 public class JDBCEncryptionDecryptionTest extends AESetup {
+
+    public JDBCEncryptionDecryptionTest(String serverName, String url,
+            String protocol) throws TestAbortedException, Exception {
+        super(serverName, url, protocol);
+    }
 
     private boolean nullable = false;
 
@@ -1776,8 +1781,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
         testChar(null, values);
 
         if (isTestEnclave) {
-            if (null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONURL)
-                    || null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONPROTOCOL)) {
+            if (null == enclaveAttestationUrl || null == enclaveAttestationProtocol) {
                 fail(TestResource.getResource("R_reqExternalSetup"));
             }
 
@@ -1815,8 +1819,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
         testBinary(null, values);
 
         if (isTestEnclave) {
-            if (null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONURL)
-                    || null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONPROTOCOL)) {
+            if (null == enclaveAttestationUrl || null == enclaveAttestationProtocol) {
                 fail(TestResource.getResource("R_reqExternalSetup"));
             }
 
@@ -1858,8 +1861,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
         testDate(null, values);
 
         if (isTestEnclave) {
-            if (null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONURL)
-                    || null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONPROTOCOL)) {
+            if (null == enclaveAttestationUrl || null == enclaveAttestationProtocol) {
                 fail(TestResource.getResource("R_reqExternalSetup"));
             }
 
@@ -1897,8 +1899,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
         testNumeric(null, values2, isNull);
 
         if (isTestEnclave) {
-            if (null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONURL)
-                    || null == getConfiguredProperty(Constants.ENCLAVE_ATTESTATIONPROTOCOL)) {
+            if (null == enclaveAttestationUrl || null == enclaveAttestationProtocol) {
                 fail(TestResource.getResource("R_reqExternalSetup"));
             }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -19,8 +19,9 @@ import java.util.TimeZone;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
@@ -37,11 +38,15 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
  * Tests datatypes that have precision and/or scale.
  *
  */
-@RunWith(JUnitPlatform.class)
+@RunWith(Parameterized.class)
 @Tag(Constants.xSQLv12)
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 public class PrecisionScaleTest extends AESetup {
+
+    public PrecisionScaleTest(String serverName, String url, String protocol) throws TestAbortedException, Exception {
+        super(serverName, url, protocol);
+    }
 
     private static java.util.Date date = null;
     private static int offsetFromGMT = 0;
@@ -418,7 +423,7 @@ public class PrecisionScaleTest extends AESetup {
             }
 
             pstmt.addBatch();
-            
+
             // add a row using setObjecdt
             // datetime2 scale
             for (int i = 1; i <= 3; i++) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
@@ -44,7 +43,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xAzureSQLDB)
 public class PrecisionScaleTest extends AESetup {
 
-    public PrecisionScaleTest(String serverName, String url, String protocol) throws TestAbortedException, Exception {
+    public PrecisionScaleTest(String serverName, String url, String protocol) throws Exception {
         super(serverName, url, protocol);
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -17,8 +17,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.junit.Test;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -15,8 +15,9 @@ import java.sql.Statement;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
@@ -24,11 +25,16 @@ import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.PrepUtil;
 
 
-@RunWith(JUnitPlatform.class)
+@RunWith(Parameterized.class)
 @Tag(Constants.xSQLv12)
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 public class RegressionAlwaysEncryptedTest extends AESetup {
+
+    public RegressionAlwaysEncryptedTest(String serverName, String url,
+            String protocol) throws TestAbortedException, Exception {
+        super(serverName, url, protocol);
+    }
 
     static String numericTable[][] = {{"Bit", "bit"}, {"Tinyint", "tinyint"}, {"Smallint", "smallint"},};
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.opentest4j.TestAbortedException;
 
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
@@ -31,8 +30,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xAzureSQLDB)
 public class RegressionAlwaysEncryptedTest extends AESetup {
 
-    public RegressionAlwaysEncryptedTest(String serverName, String url,
-            String protocol) throws TestAbortedException, Exception {
+    public RegressionAlwaysEncryptedTest(String serverName, String url, String protocol) throws Exception {
         super(serverName, url, protocol);
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -13,8 +13,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import org.junit.Test;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -822,7 +822,8 @@ public final class TestUtils {
      */
     public static String removeProperty(String connectionString, String property) {
         int start = connectionString.indexOf(property);
-        String propertyStr = connectionString.substring(start, connectionString.indexOf(";", start) + 1);
+        int end = connectionString.indexOf(";", start);
+        String propertyStr = connectionString.substring(start, -1 != end ? end + 1 : connectionString.length());
         return connectionString.replace(propertyStr, "");
     }
 

--- a/src/test/java/com/microsoft/sqlserver/testframework/AbstractTest.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/AbstractTest.java
@@ -57,6 +57,10 @@ public abstract class AbstractTest {
     protected static String applicationKey = null;
     protected static String[] keyIDs = null;
 
+    protected static String[] enclaveServer = null;
+    protected static String[] enclaveAttestationUrl = null;
+    protected static String[] enclaveAttestationProtocol = null;
+
     protected static String javaKeyPath = null;
     protected static String javaKeyAliases = null;
     protected static SQLServerColumnEncryptionKeyStoreProvider jksProvider = null;
@@ -112,6 +116,12 @@ public abstract class AbstractTest {
         javaKeyPath = TestUtils.getCurrentClassPath() + Constants.JKS_NAME;
         keyIDs = getConfiguredProperty("keyID", "").split(Constants.SEMI_COLON);
         windowsKeyPath = getConfiguredProperty("windowsKeyPath");
+
+        String enclaveServers = getConfiguredProperty("enclaveServer", null);
+        enclaveServer = null != enclaveServers ? enclaveServers.split(Constants.SEMI_COLON) : null;
+        enclaveAttestationUrl = getConfiguredProperty("enclaveAttestationUrl", "").split(Constants.SEMI_COLON);
+        enclaveAttestationProtocol = getConfiguredProperty("enclaveAttestationProtocol", "")
+                .split(Constants.SEMI_COLON);
 
         Map<String, SQLServerColumnEncryptionKeyStoreProvider> map = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
         if (null == jksProvider) {


### PR DESCRIPTION
Added new test property "enclaveServer" to define semicolon delimited list of enclave servers to test AEv2 and updated enclaveAttestationUrl and enclaveAttestionProtocol to support semicolon delimiters as well. Enclave tests will be run against the list of servers using these properties in the same order they are defined.
eg.

enclaveServer=HGS-2K19-01.galaxy.ad;jdbc-aas-sgx.westeurope.cloudapp.azure.com

enclaveAttestationUrl=http://jdbchgsservice.galaxy.ad/Attestation;http://battlestareuwattest.us.attest.azure.net/attest/SgxEnclave?api-version=2018-09-01-preview

enclaveAttestationProtocol=HGS;AAS