### PR TITLE
Get TVP name from SQLServerDataTable when using PreparedStatement.setObject()

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1547,7 +1547,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "setObject", new Object[] {parameterName, value, sqlType});
         checkClosed();
         if (microsoft.sql.Types.STRUCTURED == sqlType) {
-            tvpName = getTVPNameIfNull(findColumn(parameterName), null);
+            tvpName = getTVPNameFromObject(findColumn(parameterName), value);
             setObject(setterGetParam(findColumn(parameterName)), value, JavaType.TVP, JDBCType.TVP, null, null, false,
                     findColumn(parameterName), tvpName);
         } else

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -280,7 +280,7 @@ public final class TestUtils {
      * @param tableName
      * @throws SQLException
      */
-    public static void clearTable(java.sql.Connection con, String tableName) throws SQLException {
+    public static void clearTable(Connection con, String tableName) throws SQLException {
         try (Statement stmt = con.createStatement()) {
             stmt.executeUpdate("DELETE FROM " + tableName);
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -275,7 +275,7 @@ public final class TestUtils {
     }
 
     /**
-     * Delete the contents of a table.
+     * Deletes the contents of a table.
      * @param con
      * @param tableName
      * @throws SQLException

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -275,6 +275,18 @@ public final class TestUtils {
     }
 
     /**
+     * Delete the contents of a table.
+     * @param con
+     * @param tableName
+     * @throws SQLException
+     */
+    public static void clearTable(java.sql.Connection con, String tableName) throws SQLException {
+        try (Statement stmt = con.createStatement()) {
+            stmt.executeUpdate("DELETE FROM " + tableName);
+        }
+    }
+
+    /**
      * mimic "DROP View ..."
      * 
      * @param tableName

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPNumericTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPNumericTest.java
@@ -43,8 +43,8 @@ public class TVPNumericTest extends AbstractTest {
     private static String procedureName;
 
     /**
-     * Test a previous failure regarding to numeric precision. Issue #211 Test TVP name in SQLServerDataTable with
-     * setObject()
+     * Test a previous failure regarding to numeric precision reported on Issue #211. Test TVP name in
+     * SQLServerDataTable with setObject()
      * 
      * @throws SQLException
      * @throws SQLTimeoutException
@@ -52,7 +52,7 @@ public class TVPNumericTest extends AbstractTest {
     @Test
     public void testTVPNameWithDataTable() throws SQLException {
         String selectSQL = "SELECT * FROM " + escapedCharTableName + " ORDER BY c1 ASC";
-        String insertSQL = "INSERT INTO " + escapedCharTableName + " select * from ? ;";
+        String insertSQL = "INSERT INTO " + escapedCharTableName + " SELECT * FROM ? ;";
         float[] testValues = new float[] {0.0F, 1.123F, 12.12F};
 
         SQLServerDataTable tvp = new SQLServerDataTable();


### PR DESCRIPTION
PR For #1281.

When `SQLServerDataTable` is passed in as an argument to `PreparedStatement.setObject()`, it makes sense to first attempt to get the TVP name from that object, before querying database for metadata.