### PR TITLE
Socket Factory Test Fix

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/socketfactory/CustomSocketFactoryTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/socketfactory/CustomSocketFactoryTest.java
@@ -91,7 +91,6 @@ public class CustomSocketFactoryTest extends AbstractTest {
         try (Connection con = PrepUtil.getConnection(url)) {
             Assert.assertTrue(con != null);
         }
-        Assert.assertEquals("The custom socket factory should have been used once", 1, dummyLog.size());
     }
 
     /**
@@ -105,7 +104,6 @@ public class CustomSocketFactoryTest extends AbstractTest {
         try (Connection con = PrepUtil.getConnection(url)) {
             Assert.assertTrue(con != null);
         }
-        Assert.assertEquals("The custom socket factory should have been used once", 1, dummyLog.size());
         Assert.assertEquals("The custom arg should be been assigned", constructorArg, dummyLog.get(0));
     }
 


### PR DESCRIPTION
Connection attempt can be made multiple times depending on the environment (such as URL redirection is involved in the case of the client being inside Azure network), so remove this part of the test.