### PR TITLE
MSI expiry date format fix for Azure Functions

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
@@ -309,7 +309,7 @@ class SQLServerSecurityUtility {
                 try (InputStream stream = connection.getInputStream()) {
 
                     BufferedReader reader = new BufferedReader(new InputStreamReader(stream, UTF_8), 100);
-                    String result = reader.readLine();
+                    StringBuilder result = new StringBuilder(reader.readLine());
 
                     int startIndex_AT = result.indexOf(ActiveDirectoryAuthentication.ACCESS_TOKEN_IDENTIFIER)
                             + ActiveDirectoryAuthentication.ACCESS_TOKEN_IDENTIFIER.length();


### PR DESCRIPTION
Fixes issue #1135.

The format in which the expires_on property is sent to the driver from Azure server used to be in the form of a string, but starting from the latest API version (2019-08-01), this value is now an integer value, which is consistent across all regions and operating systems (Windows/Linux).

Note that this fix only applies to retrieving access tokens for MSI authentication from Azure Functions (and Azure Web Apps), and it doesn't affect the usual Azure IMDS routine for MSI authentication.