### PR TITLE
Added an option to escape delimiters in CSV files when using bulk copy

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -536,9 +536,9 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
     /**
      * When set to true, the following rules will be used to parse CSV files: Each field may or may not be enclosed in
      * double quotes. If fields are not enclosed with double quotes, then double quotes may not appear inside the
-     * fields. Fields containing double quotes, and delimiters. If double-quotes are used to enclose fields, then a
-     * double-quote appearing inside a field must be escaped by preceding it with another double quote. should be
-     * enclosed in double-quotes.
+     * fields. Fields containing double quotes, and delimiters should be enclosed in double quotes. If double-quotes are
+     * used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another
+     * double quote.
      *
      * @param escapeDelimiters
      *        true if the rules above to be used.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -555,11 +555,12 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
             int j = 0;
             StringBuilder sb = new StringBuilder();
             long quoteCount = tokens[i].chars().filter(ch -> ch == '"').count();
-            if (0 != quoteCount % 2) {
-                throw new SQLServerException(SQLServerException.getErrString("R_InvalidCSVOddQuotes"), null, 0, null);
-            }
             if (quoteCount > 0) {
                 tokens[i] = tokens[i].trim();
+            }
+            if (0 != quoteCount % 2 || (quoteCount > 0
+                    && ('"' != tokens[i].charAt(0) || '"' != tokens[i].charAt(tokens[i].length() - 1)))) {
+                throw new SQLServerException(SQLServerException.getErrString("R_InvalidCSVQuotes"), null, 0, null);
             }
             while (j < tokens[i].length()) {
                 if ('"' == tokens[i].charAt(j)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -524,10 +524,25 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
         return (null != currentLine);
     }
 
+    /**
+     * Returns whether the rules to escape delimiters are used.
+     *
+     * @return true if the rules are used, false otherwise.
+     */
     public boolean isEscapeColumnDelimitersCSV() {
         return escapeDelimiters;
     }
 
+    /**
+     * When set to true, the following rules will be used to parse CSV files: Each field may or may not be enclosed in
+     * double quotes. If fields are not enclosed with double quotes, then double quotes may not appear inside the
+     * fields. Fields containing double quotes, and delimiters. If double-quotes are used to enclose fields, then a
+     * double-quote appearing inside a field must be escaped by preceding it with another double quote. should be
+     * enclosed in double-quotes.
+     *
+     * @param escapeDelimiters
+     *        true if the rules above to be used.
+     */
     public void setEscapeColumnDelimitersCSV(boolean escapeDelimiters) {
         this.escapeDelimiters = escapeDelimiters;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -639,5 +639,7 @@ public final class SQLServerResource extends ListResourceBundle {
             {"R_pvkParseError", "Could not read Private Key from PVK, check the password provided."},
             {"R_pvkHeaderError", "Cannot parse the PVK, PVK file does not contain the correct header."},
             {"R_clientCertError", "Reading client certificate failed. Please verify the location of the certificate."},
-            {"R_unassignableError", "The class specified by the {0} property must be assignable to {1}."}};
+            {"R_unassignableError", "The class specified by the {0} property must be assignable to {1}."},
+            {"R_InvalidCSVOddQuotes", "Failed to parse the CSV file: Odd number of quotes."},
+            };
 };

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -640,6 +640,6 @@ public final class SQLServerResource extends ListResourceBundle {
             {"R_pvkHeaderError", "Cannot parse the PVK, PVK file does not contain the correct header."},
             {"R_clientCertError", "Reading client certificate failed. Please verify the location of the certificate."},
             {"R_unassignableError", "The class specified by the {0} property must be assignable to {1}."},
-            {"R_InvalidCSVOddQuotes", "Failed to parse the CSV file: Odd number of quotes."},
+            {"R_InvalidCSVQuotes", "Failed to parse the CSV file, verify that the fields are correctly enclosed in double quotes."},
             };
 };

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -142,12 +142,13 @@ public class BulkCopyCSVTest extends AbstractTest {
         /*
          * The list below is the copy of inputFileDelimiterEscape with quotes removed.
          */
-        String[][] expectedEscaped = new String[4][4];
+        String[][] expectedEscaped = new String[5][4];
         expectedEscaped[0] = new String[] {"test", " test\"", "no,split", " testNoQuote"};
         expectedEscaped[1] = new String[] {null, null, null, null};
         expectedEscaped[2] = new String[] {"\"", "test\"test", "test,\"  test", null};
         expectedEscaped[3] = new String[] {"testNoQuote  ", " testSpaceAround ", " testSpaceInside ",
                 "  testSpaceQuote\" "};
+        expectedEscaped[4] = new String[] {null, null, null, " testSpaceInside "};
 
         try (Connection con = getConnection(); Statement stmt = con.createStatement();
                 SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);
@@ -155,16 +156,17 @@ public class BulkCopyCSVTest extends AbstractTest {
                         false)) {
             bulkCopy.setDestinationTableName(tableName);
             fileRecord.setEscapeColumnDelimitersCSV(true);
-            fileRecord.addColumnMetadata(1, null, java.sql.Types.VARCHAR, 50, 0);
+            fileRecord.addColumnMetadata(1, null, java.sql.Types.INTEGER, 0, 0);
             fileRecord.addColumnMetadata(2, null, java.sql.Types.VARCHAR, 50, 0);
             fileRecord.addColumnMetadata(3, null, java.sql.Types.VARCHAR, 50, 0);
             fileRecord.addColumnMetadata(4, null, java.sql.Types.VARCHAR, 50, 0);
+            fileRecord.addColumnMetadata(5, null, java.sql.Types.VARCHAR, 50, 0);
             stmt.executeUpdate(
-                    "CREATE TABLE " + tableName + " (c1 varchar(50), c2 varchar(50), c3 varchar(50), c4 varchar(50))");
+                    "CREATE TABLE " + tableName + " (id INT IDENTITY(1,1), c1 VARCHAR(50), c2 VARCHAR(50), c3 VARCHAR(50), c4 VARCHAR(50))");
             bulkCopy.writeToServer(fileRecord);
 
             int i = 0;
-            try (ResultSet rs = stmt.executeQuery("SELECT * from " + tableName);
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " ORDER BY id");
                     BufferedReader br = new BufferedReader(new FileReader(fileName));) {
                 while (rs.next()) {
                     assertEquals(expectedEscaped[i][0], rs.getString("c1"));
@@ -173,7 +175,6 @@ public class BulkCopyCSVTest extends AbstractTest {
                     assertEquals(expectedEscaped[i][3], rs.getString("c4"));
                     i++;
                 }
-
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -5,9 +5,13 @@
 package com.microsoft.sqlserver.jdbc.bulkCopy;
 
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -15,6 +19,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.AfterAll;
@@ -26,9 +31,11 @@ import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.ComparisonUtil;
+import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCSVFileRecord;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
 import com.microsoft.sqlserver.jdbc.TestUtils;
+import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.DBConnection;
@@ -54,6 +61,7 @@ public class BulkCopyCSVTest extends AbstractTest {
 
     static String inputFile = "BulkCopyCSVTestInput.csv";
     static String inputFileNoColumnName = "BulkCopyCSVTestInputNoColumnName.csv";
+    static String inputFileDelimiterEscape = "BulkCopyCSVTestInputDelimiterEscape.csv";
     static String encoding = "UTF-8";
     static String delimiter = ",";
 
@@ -77,9 +85,13 @@ public class BulkCopyCSVTest extends AbstractTest {
     @Test
     @DisplayName("Test SQLServerBulkCSVFileRecord")
     public void testCSV() {
-        try (SQLServerBulkCSVFileRecord fileRecord = new SQLServerBulkCSVFileRecord(filePath + inputFile, encoding,
-                delimiter, true)) {
-            testBulkCopyCSV(fileRecord, true);
+        String fileName = filePath + inputFile;
+        try (SQLServerBulkCSVFileRecord f1 = new SQLServerBulkCSVFileRecord(fileName, encoding, delimiter, true);
+                SQLServerBulkCSVFileRecord f2 = new SQLServerBulkCSVFileRecord(fileName, encoding, delimiter, true);) {
+            testBulkCopyCSV(f1, true);
+
+            f2.setEscapeColumnDelimitersCSV(true);
+            testBulkCopyCSV(f2, true);
         } catch (SQLException e) {
             fail(e.getMessage());
         }
@@ -91,9 +103,13 @@ public class BulkCopyCSVTest extends AbstractTest {
     @Test
     @DisplayName("Test SQLServerBulkCSVFileRecord First line not being column name")
     public void testCSVFirstLineNotColumnName() {
-        try (SQLServerBulkCSVFileRecord fileRecord = new SQLServerBulkCSVFileRecord(filePath + inputFileNoColumnName,
-                encoding, delimiter, false)) {
-            testBulkCopyCSV(fileRecord, false);
+        String fileName = filePath + inputFileNoColumnName;
+        try (SQLServerBulkCSVFileRecord f1 = new SQLServerBulkCSVFileRecord(fileName, encoding, delimiter, false);
+                SQLServerBulkCSVFileRecord f2 = new SQLServerBulkCSVFileRecord(fileName, encoding, delimiter, false)) {
+            testBulkCopyCSV(f1, false);
+
+            f2.setEscapeColumnDelimitersCSV(true);
+            testBulkCopyCSV(f2, false);
         } catch (SQLException e) {
             fail(e.getMessage());
         }
@@ -115,6 +131,44 @@ public class BulkCopyCSVTest extends AbstractTest {
             testBulkCopyCSV(fileRecord, true);
         } catch (Exception e) {
             fail(e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("Test setEscapeColumnDelimitersCSV")
+    public void testEscapeColumnDelimitersCSV() throws SQLException, FileNotFoundException, IOException {
+        String tableName = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("BulkEscape"));
+        String fileName = filePath + inputFileDelimiterEscape;
+        String escapeSplitPattern = "(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)";
+        try (Connection con = getConnection(); Statement stmt = con.createStatement();
+                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);
+                SQLServerBulkCSVFileRecord fileRecord = new SQLServerBulkCSVFileRecord(fileName, encoding, delimiter,
+                        false)) {
+            bulkCopy.setDestinationTableName(tableName);
+            fileRecord.setEscapeColumnDelimitersCSV(true);
+            fileRecord.addColumnMetadata(1, null, java.sql.Types.VARCHAR, 50, 0);
+            fileRecord.addColumnMetadata(2, null, java.sql.Types.VARCHAR, 50, 0);
+            fileRecord.addColumnMetadata(3, null, java.sql.Types.VARCHAR, 50, 0);
+            fileRecord.addColumnMetadata(4, null, java.sql.Types.VARCHAR, 50, 0);
+            stmt.executeUpdate(
+                    "CREATE TABLE " + tableName + " (c1 varchar(50), c2 varchar(50), c3 varchar(50), c4 varchar(50))");
+            bulkCopy.writeToServer(fileRecord);
+
+            String line;
+            try (ResultSet rs = stmt.executeQuery("SELECT * from " + tableName);
+                    BufferedReader br = new BufferedReader(new FileReader(fileName));) {
+                while (rs.next() && (line = br.readLine()) != null) {
+                    String[] tokens = line.split(delimiter + escapeSplitPattern, -1);
+                    for (int i = 0; i < tokens.length; i++) {
+                        tokens[i] = tokens[i].replaceAll("^\"|\"$", "").replaceAll("\"\"", "\"");
+                    }
+                    assertEquals(tokens[0], rs.getString("c1"));
+                    assertEquals(tokens[1], rs.getString("c2"));
+                    assertEquals(tokens[2], rs.getString("c3"));
+                    assertEquals(tokens[3], rs.getString("c4"));
+                }
+
+            }
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -149,22 +149,22 @@ public class BulkCopyCSVTest extends AbstractTest {
          * The list below is the copy of inputFileDelimiterEscape with quotes removed.
          */
         String[][] expectedEscaped = new String[11][4];
-        expectedEscaped[0] = new String[] {"test", " test\"", "no,split", " testNoQuote"};
+        expectedEscaped[0] = new String[] {"test", " test\"", "no@split", " testNoQuote"};
         expectedEscaped[1] = new String[] {null, null, null, null};
-        expectedEscaped[2] = new String[] {"\"", "test\"test", "test,\"  test", null};
+        expectedEscaped[2] = new String[] {"\"", "test\"test", "test@\"  test", null};
         expectedEscaped[3] = new String[] {"testNoQuote  ", " testSpaceAround ", " testSpaceInside ",
                 "  testSpaceQuote\" "};
         expectedEscaped[4] = new String[] {null, null, null, " testSpaceInside "};
         expectedEscaped[5] = new String[] {"1997", "Ford", "E350", "E63"};
         expectedEscaped[6] = new String[] {"1997", "Ford", "E350", "E63"};
-        expectedEscaped[7] = new String[] {"1997", "Ford", "E350", "Super, luxurious truck"};
-        expectedEscaped[8] = new String[] {"1997", "Ford", "E350", "Super, \"luxurious\" truck"};
+        expectedEscaped[7] = new String[] {"1997", "Ford", "E350", "Super@ luxurious truck"};
+        expectedEscaped[8] = new String[] {"1997", "Ford", "E350", "Super@ \"luxurious\" truck"};
         expectedEscaped[9] = new String[] {"1997", "Ford", "E350", "E63"};
         expectedEscaped[10] = new String[] {"1997", "Ford", "E350", " Super luxurious truck "};
 
         try (Connection con = getConnection(); Statement stmt = con.createStatement();
                 SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);
-                SQLServerBulkCSVFileRecord fileRecord = new SQLServerBulkCSVFileRecord(fileName, encoding, delimiter,
+                SQLServerBulkCSVFileRecord fileRecord = new SQLServerBulkCSVFileRecord(fileName, encoding, "@",
                         false)) {
             bulkCopy.setDestinationTableName(tableName);
             fileRecord.setEscapeColumnDelimitersCSV(true);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -134,21 +134,33 @@ public class BulkCopyCSVTest extends AbstractTest {
         }
     }
 
+    /**
+     * A test to validate that the driver parses CSV file according to RFC4180 when setEscapeColumnDelimitersCSV is set
+     * to true.
+     *
+     * @throws Exception
+     */
     @Test
     @DisplayName("Test setEscapeColumnDelimitersCSV")
-    public void testEscapeColumnDelimitersCSV() throws SQLException, FileNotFoundException, IOException {
+    public void testEscapeColumnDelimitersCSV() throws Exception {
         String tableName = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("BulkEscape"));
         String fileName = filePath + inputFileDelimiterEscape;
         /*
          * The list below is the copy of inputFileDelimiterEscape with quotes removed.
          */
-        String[][] expectedEscaped = new String[5][4];
+        String[][] expectedEscaped = new String[11][4];
         expectedEscaped[0] = new String[] {"test", " test\"", "no,split", " testNoQuote"};
         expectedEscaped[1] = new String[] {null, null, null, null};
         expectedEscaped[2] = new String[] {"\"", "test\"test", "test,\"  test", null};
         expectedEscaped[3] = new String[] {"testNoQuote  ", " testSpaceAround ", " testSpaceInside ",
                 "  testSpaceQuote\" "};
         expectedEscaped[4] = new String[] {null, null, null, " testSpaceInside "};
+        expectedEscaped[5] = new String[] {"1997", "Ford", "E350", "E63"};
+        expectedEscaped[6] = new String[] {"1997", "Ford", "E350", "E63"};
+        expectedEscaped[7] = new String[] {"1997", "Ford", "E350", "Super, luxurious truck"};
+        expectedEscaped[8] = new String[] {"1997", "Ford", "E350", "Super, \"luxurious\" truck"};
+        expectedEscaped[9] = new String[] {"1997", "Ford", "E350", "E63"};
+        expectedEscaped[10] = new String[] {"1997", "Ford", "E350", " Super luxurious truck "};
 
         try (Connection con = getConnection(); Statement stmt = con.createStatement();
                 SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);
@@ -161,8 +173,8 @@ public class BulkCopyCSVTest extends AbstractTest {
             fileRecord.addColumnMetadata(3, null, java.sql.Types.VARCHAR, 50, 0);
             fileRecord.addColumnMetadata(4, null, java.sql.Types.VARCHAR, 50, 0);
             fileRecord.addColumnMetadata(5, null, java.sql.Types.VARCHAR, 50, 0);
-            stmt.executeUpdate(
-                    "CREATE TABLE " + tableName + " (id INT IDENTITY(1,1), c1 VARCHAR(50), c2 VARCHAR(50), c3 VARCHAR(50), c4 VARCHAR(50))");
+            stmt.executeUpdate("CREATE TABLE " + tableName
+                    + " (id INT IDENTITY(1,1), c1 VARCHAR(50), c2 VARCHAR(50), c3 VARCHAR(50), c4 VARCHAR(50))");
             bulkCopy.writeToServer(fileRecord);
 
             int i = 0;

--- a/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
+++ b/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
@@ -1,0 +1,4 @@
+"test", " test""", "no,split" , testNoQuote
+"",  "", "", ""
+"""", "test""test", "test,""  test", ""
+testNoQuote  , testSpaceAround , " testSpaceInside ",  "  testSpaceQuote"" "

--- a/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
+++ b/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
@@ -3,3 +3,9 @@
 3,"""", "test""test", "test,""  test", ""
 4,testNoQuote  , testSpaceAround , " testSpaceInside ",  "  testSpaceQuote"" "
 5,"",  "", "", " testSpaceInside "
+6,1997,Ford,E350,E63
+7,"1997","Ford","E350","E63"
+8,1997,Ford,E350,"Super, luxurious truck"
+9,1997,Ford,E350,"Super, ""luxurious"" truck"
+10,1997, "Ford" ,E350,  "E63"
+11,1997,Ford,E350," Super luxurious truck "

--- a/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
+++ b/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
@@ -1,11 +1,11 @@
-1,"test", " test""", "no,split" , testNoQuote
-2,"",  "", "", ""
-3,"""", "test""test", "test,""  test", ""
-4,testNoQuote  , testSpaceAround , " testSpaceInside ",  "  testSpaceQuote"" "
-5,"",  "", "", " testSpaceInside "
-6,1997,Ford,E350,E63
-7,"1997","Ford","E350","E63"
-8,1997,Ford,E350,"Super, luxurious truck"
-9,1997,Ford,E350,"Super, ""luxurious"" truck"
-10,1997, "Ford" ,E350,  "E63"
-11,1997,Ford,E350," Super luxurious truck "
+1@"test"@ " test"""@ "no@split" @ testNoQuote
+2@""@  ""@ ""@ ""
+3@""""@ "test""test"@ "test@""  test"@ ""
+4@testNoQuote  @ testSpaceAround @ " testSpaceInside "@  "  testSpaceQuote"" "
+5@""@  ""@ ""@ " testSpaceInside "
+6@1997@Ford@E350@E63
+7@"1997"@"Ford"@"E350"@"E63"
+8@1997@Ford@E350@"Super@ luxurious truck"
+9@1997@Ford@E350@"Super@ ""luxurious"" truck"
+10@1997@ "Ford" @E350@  "E63"
+11@1997@Ford@E350@" Super luxurious truck "

--- a/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
+++ b/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
@@ -1,4 +1,5 @@
-"test", " test""", "no,split" , testNoQuote
-"",  "", "", ""
-"""", "test""test", "test,""  test", ""
-testNoQuote  , testSpaceAround , " testSpaceInside ",  "  testSpaceQuote"" "
+1,"test", " test""", "no,split" , testNoQuote
+2,"",  "", "", ""
+3,"""", "test""test", "test,""  test", ""
+4,testNoQuote  , testSpaceAround , " testSpaceInside ",  "  testSpaceQuote"" "
+5,"",  "", "", " testSpaceInside "


### PR DESCRIPTION
Fix for #1173 

Adding `SQLServerBulkCSVFileRecord.setEscapeColumnDelimitersCSV`. When set to `true`, the following rules will apply.

- Each field may or may not be enclosed in double quotes.
- If fields are not enclosed with double quotes, then double quotes may not appear inside the fields.
- Fields containing double quotes, and delimiters should be enclosed in double quotes. 
- If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote.