### PR TITLE
Fix issue with cast exception from sql_variant

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -73,10 +73,12 @@ final class DDC {
             case BINARY:
                 return convertIntToBytes(intValue, valueLength);
             case SQL_VARIANT:
-                // specifically return short if the underlying datatype of sql_variant is tinyint or smallint
+                // return short or bit if the underlying datatype of sql_variant is tinyint, smallint or bit
                 // otherwise, return integer
                 // Longer datatypes such as double and float are handled by convertLongToObject instead.
-                if (valueLength == 3 || valueLength == 4) {
+                if (valueLength == 1) {
+                    return 0 != intValue;
+                } else if (valueLength == 3 || valueLength == 4) {
                     return (short) intValue;
                 } else {
                     return intValue;
@@ -353,6 +355,7 @@ final class DDC {
             case NUMERIC:
             case MONEY:
             case SMALLMONEY:
+            case SQL_VARIANT:
                 return bigDecimalVal;
             case FLOAT:
             case DOUBLE:

--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -72,6 +72,15 @@ final class DDC {
                 return (float) intValue;
             case BINARY:
                 return convertIntToBytes(intValue, valueLength);
+            case SQL_VARIANT:
+                // specifically return short if the underlying datatype of sql_variant is tinyint or smallint
+                // otherwise, return integer
+                // Longer datatypes such as double and float are handled by convertLongToObject instead.
+                if (valueLength == 3 || valueLength == 4) {
+                    return (short) intValue;
+                } else {
+                    return intValue;
+                }
             default:
                 return Integer.toString(intValue);
         }
@@ -93,6 +102,7 @@ final class DDC {
     static final Object convertLongToObject(long longVal, JDBCType jdbcType, SSType baseSSType, StreamType streamType) {
         switch (jdbcType) {
             case BIGINT:
+            case SQL_VARIANT:
                 return longVal;
             case INTEGER:
                 return (int) longVal;
@@ -209,6 +219,7 @@ final class DDC {
     static final Object convertFloatToObject(float floatVal, JDBCType jdbcType, StreamType streamType) {
         switch (jdbcType) {
             case REAL:
+            case SQL_VARIANT:
                 return floatVal;
             case INTEGER:
                 return (int) floatVal;
@@ -266,6 +277,7 @@ final class DDC {
         switch (jdbcType) {
             case FLOAT:
             case DOUBLE:
+            case SQL_VARIANT:
                 return doubleVal;
             case REAL:
                 return (Double.valueOf(doubleVal)).floatValue();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3922,41 +3922,32 @@ final class ServerDTVImpl extends DTVImpl {
         TDSType baseType = TDSType.valueOf(intbaseType);
         switch (baseType) {
             case INT8:
-                jdbcType = JDBCType.BIGINT;
                 convertedValue = DDC.convertLongToObject(tdsReader.readLong(), jdbcType, baseSSType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT4:
-                jdbcType = JDBCType.INTEGER;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readInt(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT2:
-                jdbcType = JDBCType.SMALLINT;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readShort(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT1:
-                jdbcType = JDBCType.TINYINT;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readUnsignedByte(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case DECIMALN:
             case NUMERICN:
-                if (TDSType.DECIMALN == baseType)
-                    jdbcType = JDBCType.DECIMAL;
-                else if (TDSType.NUMERICN == baseType)
-                    jdbcType = JDBCType.NUMERIC;
                 if (cbPropsActual != sqlVariantProbBytes.DECIMALN.getIntValue()) { // Numeric and decimal have the same
                                                                                    // probbytes value
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                jdbcType = JDBCType.DECIMAL;
                 precision = tdsReader.readUnsignedByte();
                 scale = tdsReader.readUnsignedByte();
                 typeInfo.setScale(scale); // typeInfo needs to be updated. typeInfo is usually set when reading
@@ -3969,17 +3960,14 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case FLOAT4:
-                jdbcType = JDBCType.REAL;
                 convertedValue = tdsReader.readReal(expectedValueLength, jdbcType, streamGetterArgs.streamType);
                 break;
 
             case FLOAT8:
-                jdbcType = JDBCType.FLOAT;
                 convertedValue = tdsReader.readFloat(expectedValueLength, jdbcType, streamGetterArgs.streamType);
                 break;
 
             case MONEY4:
-                jdbcType = JDBCType.SMALLMONEY;
                 precision = Long.toString(Long.MAX_VALUE).length();
                 typeInfo.setPrecision(precision);
                 scale = 4;
@@ -3991,7 +3979,6 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case MONEY8:
-                jdbcType = JDBCType.MONEY;
                 precision = Long.toString(Long.MAX_VALUE).length();
                 scale = 4;
                 typeInfo.setPrecision(precision);
@@ -4004,7 +3991,6 @@ final class ServerDTVImpl extends DTVImpl {
 
             case BIT1:
             case BITN:
-                jdbcType = JDBCType.BIT;
                 switch (expectedValueLength) {
                     case 8:
                         convertedValue = DDC.convertLongToObject(tdsReader.readLong(), jdbcType, baseSSType,
@@ -4038,10 +4024,6 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                if (TDSType.BIGVARCHAR == baseType)
-                    jdbcType = JDBCType.VARCHAR;
-                else if (TDSType.BIGCHAR == baseType)
-                    jdbcType = JDBCType.CHAR;
                 collation = tdsReader.readCollation();
                 typeInfo.setSQLCollation(collation);
                 maxLength = tdsReader.readUnsignedShort();
@@ -4063,10 +4045,6 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                if (TDSType.NCHAR == baseType)
-                    jdbcType = JDBCType.NCHAR;
-                else if (TDSType.NVARCHAR == baseType)
-                    jdbcType = JDBCType.NVARCHAR;
                 collation = tdsReader.readCollation();
                 typeInfo.setSQLCollation(collation);
                 maxLength = tdsReader.readUnsignedShort();
@@ -4083,19 +4061,16 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case DATETIME8:
-                jdbcType = JDBCType.DATETIME;
                 convertedValue = tdsReader.readDateTime(expectedValueLength, cal, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case DATETIME4:
-                jdbcType = JDBCType.SMALLDATETIME;
                 convertedValue = tdsReader.readDateTime(expectedValueLength, cal, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case DATEN:
-                jdbcType = JDBCType.DATE;
                 convertedValue = tdsReader.readDate(expectedValueLength, cal, jdbcType);
                 break;
 
@@ -4103,9 +4078,6 @@ final class ServerDTVImpl extends DTVImpl {
                 if (cbPropsActual != sqlVariantProbBytes.TIMEN.getIntValue()) {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
-                }
-                if (internalVariant.isBaseTypeTimeValue()) {
-                    jdbcType = JDBCType.TIMESTAMP;
                 }
                 scale = tdsReader.readUnsignedByte();
                 typeInfo.setScale(scale);
@@ -4118,7 +4090,6 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                jdbcType = JDBCType.TIMESTAMP;
                 scale = tdsReader.readUnsignedByte();
                 typeInfo.setScale(scale);
                 internalVariant.setScale(scale);
@@ -4131,10 +4102,6 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                if (TDSType.BIGBINARY == baseType)
-                    jdbcType = JDBCType.BINARY;// LONGVARCHAR;
-                else if (TDSType.BIGVARBINARY == baseType)
-                    jdbcType = JDBCType.VARBINARY;
                 maxLength = tdsReader.readUnsignedShort();
                 internalVariant.setMaxLength(maxLength);
                 if (maxLength > DataTypes.SHORT_VARTYPE_MAX_BYTES)
@@ -4147,7 +4114,6 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case GUID:
-                jdbcType = JDBCType.GUID;
                 internalVariant.setBaseType(intbaseType);
                 internalVariant.setBaseJDBCType(jdbcType);
                 typeInfo.setDisplaySize("NNNNNNNN-NNNN-NNNN-NNNN-NNNNNNNNNNNN".length());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3922,32 +3922,41 @@ final class ServerDTVImpl extends DTVImpl {
         TDSType baseType = TDSType.valueOf(intbaseType);
         switch (baseType) {
             case INT8:
+                jdbcType = JDBCType.BIGINT;
                 convertedValue = DDC.convertLongToObject(tdsReader.readLong(), jdbcType, baseSSType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT4:
+                jdbcType = JDBCType.INTEGER;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readInt(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT2:
+                jdbcType = JDBCType.SMALLINT;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readShort(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT1:
+                jdbcType = JDBCType.TINYINT;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readUnsignedByte(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case DECIMALN:
             case NUMERICN:
+                if (TDSType.DECIMALN == baseType)
+                    jdbcType = JDBCType.DECIMAL;
+                else if (TDSType.NUMERICN == baseType)
+                    jdbcType = JDBCType.NUMERIC;
                 if (cbPropsActual != sqlVariantProbBytes.DECIMALN.getIntValue()) { // Numeric and decimal have the same
                                                                                    // probbytes value
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
+                jdbcType = JDBCType.DECIMAL;
                 precision = tdsReader.readUnsignedByte();
                 scale = tdsReader.readUnsignedByte();
                 typeInfo.setScale(scale); // typeInfo needs to be updated. typeInfo is usually set when reading
@@ -3960,14 +3969,17 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case FLOAT4:
+                jdbcType = JDBCType.REAL;
                 convertedValue = tdsReader.readReal(expectedValueLength, jdbcType, streamGetterArgs.streamType);
                 break;
 
             case FLOAT8:
+                jdbcType = JDBCType.FLOAT;
                 convertedValue = tdsReader.readFloat(expectedValueLength, jdbcType, streamGetterArgs.streamType);
                 break;
 
             case MONEY4:
+                jdbcType = JDBCType.SMALLMONEY;
                 precision = Long.toString(Long.MAX_VALUE).length();
                 typeInfo.setPrecision(precision);
                 scale = 4;
@@ -3979,6 +3991,7 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case MONEY8:
+                jdbcType = JDBCType.MONEY;
                 precision = Long.toString(Long.MAX_VALUE).length();
                 scale = 4;
                 typeInfo.setPrecision(precision);
@@ -3991,6 +4004,7 @@ final class ServerDTVImpl extends DTVImpl {
 
             case BIT1:
             case BITN:
+                jdbcType = JDBCType.BIT;
                 switch (expectedValueLength) {
                     case 8:
                         convertedValue = DDC.convertLongToObject(tdsReader.readLong(), jdbcType, baseSSType,
@@ -4024,6 +4038,10 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
+                if (TDSType.BIGVARCHAR == baseType)
+                    jdbcType = JDBCType.VARCHAR;
+                else if (TDSType.BIGCHAR == baseType)
+                    jdbcType = JDBCType.CHAR;
                 collation = tdsReader.readCollation();
                 typeInfo.setSQLCollation(collation);
                 maxLength = tdsReader.readUnsignedShort();
@@ -4045,6 +4063,10 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
+                if (TDSType.NCHAR == baseType)
+                    jdbcType = JDBCType.NCHAR;
+                else if (TDSType.NVARCHAR == baseType)
+                    jdbcType = JDBCType.NVARCHAR;
                 collation = tdsReader.readCollation();
                 typeInfo.setSQLCollation(collation);
                 maxLength = tdsReader.readUnsignedShort();
@@ -4061,16 +4083,19 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case DATETIME8:
+                jdbcType = JDBCType.DATETIME;
                 convertedValue = tdsReader.readDateTime(expectedValueLength, cal, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case DATETIME4:
+                jdbcType = JDBCType.SMALLDATETIME;
                 convertedValue = tdsReader.readDateTime(expectedValueLength, cal, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case DATEN:
+                jdbcType = JDBCType.DATE;
                 convertedValue = tdsReader.readDate(expectedValueLength, cal, jdbcType);
                 break;
 
@@ -4078,6 +4103,9 @@ final class ServerDTVImpl extends DTVImpl {
                 if (cbPropsActual != sqlVariantProbBytes.TIMEN.getIntValue()) {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
+                }
+                if (internalVariant.isBaseTypeTimeValue()) {
+                    jdbcType = JDBCType.TIMESTAMP;
                 }
                 scale = tdsReader.readUnsignedByte();
                 typeInfo.setScale(scale);
@@ -4090,6 +4118,7 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
+                jdbcType = JDBCType.TIMESTAMP;
                 scale = tdsReader.readUnsignedByte();
                 typeInfo.setScale(scale);
                 internalVariant.setScale(scale);
@@ -4102,6 +4131,10 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
+                if (TDSType.BIGBINARY == baseType)
+                    jdbcType = JDBCType.BINARY;// LONGVARCHAR;
+                else if (TDSType.BIGVARBINARY == baseType)
+                    jdbcType = JDBCType.VARBINARY;
                 maxLength = tdsReader.readUnsignedShort();
                 internalVariant.setMaxLength(maxLength);
                 if (maxLength > DataTypes.SHORT_VARTYPE_MAX_BYTES)
@@ -4114,6 +4147,7 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case GUID:
+                jdbcType = JDBCType.GUID;
                 internalVariant.setBaseType(intbaseType);
                 internalVariant.setBaseJDBCType(jdbcType);
                 typeInfo.setDisplaySize("NNNNNNNN-NNNN-NNNN-NNNN-NNNNNNNNNNNN".length());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3922,41 +3922,32 @@ final class ServerDTVImpl extends DTVImpl {
         TDSType baseType = TDSType.valueOf(intbaseType);
         switch (baseType) {
             case INT8:
-                jdbcType = JDBCType.BIGINT;
                 convertedValue = DDC.convertLongToObject(tdsReader.readLong(), jdbcType, baseSSType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT4:
-                jdbcType = JDBCType.INTEGER;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readInt(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT2:
-                jdbcType = JDBCType.SMALLINT;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readShort(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case INT1:
-                jdbcType = JDBCType.TINYINT;
                 convertedValue = DDC.convertIntegerToObject(tdsReader.readUnsignedByte(), valueLength, jdbcType,
                         streamGetterArgs.streamType);
                 break;
 
             case DECIMALN:
             case NUMERICN:
-                if (TDSType.DECIMALN == baseType)
-                    jdbcType = JDBCType.DECIMAL;
-                else if (TDSType.NUMERICN == baseType)
-                    jdbcType = JDBCType.NUMERIC;
                 if (cbPropsActual != sqlVariantProbBytes.DECIMALN.getIntValue()) { // Numeric and decimal have the same
                                                                                    // probbytes value
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                jdbcType = JDBCType.DECIMAL;
                 precision = tdsReader.readUnsignedByte();
                 scale = tdsReader.readUnsignedByte();
                 typeInfo.setScale(scale); // typeInfo needs to be updated. typeInfo is usually set when reading
@@ -3969,12 +3960,10 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case FLOAT4:
-                jdbcType = JDBCType.REAL;
                 convertedValue = tdsReader.readReal(expectedValueLength, jdbcType, streamGetterArgs.streamType);
                 break;
 
             case FLOAT8:
-                jdbcType = JDBCType.FLOAT;
                 convertedValue = tdsReader.readFloat(expectedValueLength, jdbcType, streamGetterArgs.streamType);
                 break;
 
@@ -4038,10 +4027,6 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                if (TDSType.BIGVARCHAR == baseType)
-                    jdbcType = JDBCType.VARCHAR;
-                else if (TDSType.BIGCHAR == baseType)
-                    jdbcType = JDBCType.CHAR;
                 collation = tdsReader.readCollation();
                 typeInfo.setSQLCollation(collation);
                 maxLength = tdsReader.readUnsignedShort();
@@ -4063,10 +4048,6 @@ final class ServerDTVImpl extends DTVImpl {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidProbbytes"));
                     throw new SQLServerException(form.format(new Object[] {baseType}), null, 0, null);
                 }
-                if (TDSType.NCHAR == baseType)
-                    jdbcType = JDBCType.NCHAR;
-                else if (TDSType.NVARCHAR == baseType)
-                    jdbcType = JDBCType.NVARCHAR;
                 collation = tdsReader.readCollation();
                 typeInfo.setSQLCollation(collation);
                 maxLength = tdsReader.readUnsignedShort();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3991,31 +3991,8 @@ final class ServerDTVImpl extends DTVImpl {
 
             case BIT1:
             case BITN:
-                switch (expectedValueLength) {
-                    case 8:
-                        convertedValue = DDC.convertLongToObject(tdsReader.readLong(), jdbcType, baseSSType,
-                                streamGetterArgs.streamType);
-                        break;
-
-                    case 4:
-                        convertedValue = DDC.convertIntegerToObject(tdsReader.readInt(), expectedValueLength, jdbcType,
-                                streamGetterArgs.streamType);
-                        break;
-
-                    case 2:
-                        convertedValue = DDC.convertIntegerToObject(tdsReader.readShort(), expectedValueLength,
-                                jdbcType, streamGetterArgs.streamType);
-                        break;
-
-                    case 1:
-                        convertedValue = DDC.convertIntegerToObject(tdsReader.readUnsignedByte(), expectedValueLength,
-                                jdbcType, streamGetterArgs.streamType);
-                        break;
-
-                    default:
-                        assert false : "Unexpected valueLength" + expectedValueLength;
-                        break;
-                }
+                    convertedValue = DDC.convertIntegerToObject(tdsReader.readUnsignedByte(), expectedValueLength,
+                            jdbcType, streamGetterArgs.streamType);
                 break;
 
             case BIGVARCHAR:

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3968,7 +3968,6 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case MONEY4:
-                jdbcType = JDBCType.SMALLMONEY;
                 precision = Long.toString(Long.MAX_VALUE).length();
                 typeInfo.setPrecision(precision);
                 scale = 4;
@@ -3980,7 +3979,6 @@ final class ServerDTVImpl extends DTVImpl {
                 break;
 
             case MONEY8:
-                jdbcType = JDBCType.MONEY;
                 precision = Long.toString(Long.MAX_VALUE).length();
                 scale = 4;
                 typeInfo.setPrecision(precision);
@@ -3993,7 +3991,6 @@ final class ServerDTVImpl extends DTVImpl {
 
             case BIT1:
             case BITN:
-                jdbcType = JDBCType.BIT;
                 switch (expectedValueLength) {
                     case 8:
                         convertedValue = DDC.convertLongToObject(tdsReader.readLong(), jdbcType, baseSSType,

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
@@ -83,7 +83,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getBigDecimal(1), new BigDecimal("123.1200"));
+                assertEquals(rs.getObject(1), new BigDecimal("123.1200"));
             }
         }
     }
@@ -102,7 +102,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getBigDecimal(1), new BigDecimal("123.1200"));
+                assertEquals(rs.getObject(1), new BigDecimal("123.1200"));
             }
         }
     }
@@ -238,7 +238,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getFloat(1), value);
+                assertEquals(rs.getObject(1), Double.valueOf("5.0"));
             }
         }
     }
@@ -257,7 +257,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getLong(1), value);
+                assertEquals(rs.getObject(1), value);
             }
         }
     }
@@ -276,7 +276,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getShort(1), value);
+                assertEquals(rs.getObject(1), value);
             }
         }
     }
@@ -295,7 +295,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getShort(1), value);
+                assertEquals(rs.getObject(1), value);
             }
         }
     }
@@ -314,7 +314,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getBoolean(1), true);
+                assertEquals(rs.getObject(1), true);
             }
         }
     }
@@ -333,7 +333,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getFloat(1), value);
+                assertEquals(rs.getObject(1), Float.valueOf("5.0"));
             }
         }
     }
@@ -736,7 +736,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getInt(1), 2);
+                assertEquals(rs.getObject(1), 2);
             }
         }
     }
@@ -900,7 +900,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
                 cs.registerOutParameter(1, microsoft.sql.Types.SQL_VARIANT);
                 cs.setObject(2, col2Value, microsoft.sql.Types.SQL_VARIANT);
                 cs.execute();
-                assertEquals(cs.getInt(1), col1Value);
+                assertEquals(cs.getObject(1), col1Value);
             }
         }
     }
@@ -999,8 +999,8 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getShort(1), value1);
-                assertEquals(rs.getInt(2), value2);
+                assertEquals(rs.getObject(1), value1);
+                assertEquals(rs.getObject(2), value2);
                 assertEquals(rs.getObject(3), value3);
             }
         }
@@ -1018,10 +1018,9 @@ public class SQLVariantResultSetTest extends AbstractTest {
             int index = 0;
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT cast('abc' as sql_variant) UNION ALL SELECT cast(42 as sql_variant)")) {
-                rs.next();    
-                assertEquals(rs.getObject(1), expected[index++]);
-                rs.next();
-                assertEquals(rs.getInt(1), expected[index++]);
+                while (rs.next()) {
+                    assertEquals(rs.getObject(1), expected[index++]);
+                }
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
@@ -1061,6 +1061,16 @@ public class SQLVariantResultSetTest extends AbstractTest {
             assertEquals(object.getClass(), java.sql.Time.class);;
         }
     }
+    
+    @Test
+    public void testCastThenGetNumeric() throws SQLException {
+        try (Connection con = getConnection(); Statement stmt = con.createStatement();) {
+            SQLServerResultSet rs = (SQLServerResultSet) stmt.executeQuery("select cast(123 as sql_variant) as c1");
+            rs.next();
+            long longValue = rs.getLong("c1");
+            assertEquals(longValue, 123L);
+        }
+    }
 
     private boolean parseByte(byte[] expectedData, byte[] retrieved) {
         assertTrue(Arrays.equals(expectedData, Arrays.copyOf(retrieved, expectedData.length)),

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
@@ -1064,11 +1064,18 @@ public class SQLVariantResultSetTest extends AbstractTest {
     
     @Test
     public void testCastThenGetNumeric() throws SQLException {
-        try (Connection con = getConnection(); Statement stmt = con.createStatement();) {
-            SQLServerResultSet rs = (SQLServerResultSet) stmt.executeQuery("select cast(123 as sql_variant) as c1");
+        try (Connection con = getConnection(); Statement stmt = con.createStatement();
+                SQLServerResultSet rs = (SQLServerResultSet) stmt
+                        .executeQuery("select cast(123 as sql_variant) as c1");) {
+
             rs.next();
-            long longValue = rs.getLong("c1");
-            assertEquals(longValue, 123L);
+            assertEquals(true, rs.getBoolean("c1")); // select int as boolean inside sql_variant
+            assertEquals(123, rs.getShort("c1")); // select int as short inside sql_variant
+            assertEquals(123L, rs.getInt("c1")); // select int as int inside sql_variant
+            assertEquals(123f, rs.getFloat("c1")); // select int as float inside sql_variant
+            assertEquals(123L, rs.getLong("c1")); // select int as long inside sql_variant
+            assertEquals(123d, rs.getDouble("c1")); // select int as double inside sql_variant
+            assertEquals(new BigDecimal(123), rs.getBigDecimal("c1")); // select int as bigdecimal (money) inside sql_variant
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLVariantResultSetTest.java
@@ -83,7 +83,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), new BigDecimal("123.1200"));
+                assertEquals(rs.getBigDecimal(1), new BigDecimal("123.1200"));
             }
         }
     }
@@ -102,7 +102,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), new BigDecimal("123.1200"));
+                assertEquals(rs.getBigDecimal(1), new BigDecimal("123.1200"));
             }
         }
     }
@@ -238,7 +238,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), Double.valueOf("5.0"));
+                assertEquals(rs.getFloat(1), value);
             }
         }
     }
@@ -257,7 +257,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), value);
+                assertEquals(rs.getLong(1), value);
             }
         }
     }
@@ -276,7 +276,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), value);
+                assertEquals(rs.getShort(1), value);
             }
         }
     }
@@ -295,7 +295,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), value);
+                assertEquals(rs.getShort(1), value);
             }
         }
     }
@@ -314,7 +314,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), true);
+                assertEquals(rs.getBoolean(1), true);
             }
         }
     }
@@ -333,7 +333,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), Float.valueOf("5.0"));
+                assertEquals(rs.getFloat(1), value);
             }
         }
     }
@@ -736,7 +736,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), 2);
+                assertEquals(rs.getInt(1), 2);
             }
         }
     }
@@ -900,7 +900,7 @@ public class SQLVariantResultSetTest extends AbstractTest {
                 cs.registerOutParameter(1, microsoft.sql.Types.SQL_VARIANT);
                 cs.setObject(2, col2Value, microsoft.sql.Types.SQL_VARIANT);
                 cs.execute();
-                assertEquals(cs.getObject(1), col1Value);
+                assertEquals(cs.getInt(1), col1Value);
             }
         }
     }
@@ -999,8 +999,8 @@ public class SQLVariantResultSetTest extends AbstractTest {
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT * FROM " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
                 rs.next();
-                assertEquals(rs.getObject(1), value1);
-                assertEquals(rs.getObject(2), value2);
+                assertEquals(rs.getShort(1), value1);
+                assertEquals(rs.getInt(2), value2);
                 assertEquals(rs.getObject(3), value3);
             }
         }
@@ -1018,9 +1018,10 @@ public class SQLVariantResultSetTest extends AbstractTest {
             int index = 0;
             try (SQLServerResultSet rs = (SQLServerResultSet) stmt
                     .executeQuery("SELECT cast('abc' as sql_variant) UNION ALL SELECT cast(42 as sql_variant)")) {
-                while (rs.next()) {
-                    assertEquals(rs.getObject(1), expected[index++]);
-                }
+                rs.next();    
+                assertEquals(rs.getObject(1), expected[index++]);
+                rs.next();
+                assertEquals(rs.getInt(1), expected[index++]);
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/TVPWithSqlVariantTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/TVPWithSqlVariantTest.java
@@ -72,7 +72,7 @@ public class TVPWithSqlVariantTest extends AbstractTest {
             while (rs.next()) {
                 assertEquals(rs.getInt(1), 12);
                 assertEquals(rs.getString(1), "" + 12);
-                assertEquals(rs.getObject(1), 12);
+                assertEquals(rs.getInt(1), 12);
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/TVPWithSqlVariantTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/TVPWithSqlVariantTest.java
@@ -72,7 +72,7 @@ public class TVPWithSqlVariantTest extends AbstractTest {
             while (rs.next()) {
                 assertEquals(rs.getInt(1), 12);
                 assertEquals(rs.getString(1), "" + 12);
-                assertEquals(rs.getInt(1), 12);
+                assertEquals(rs.getObject(1), 12);
             }
         }
     }


### PR DESCRIPTION
Fixes issue #1302.

Even though the code has remained this way for a long time, I think the current behavior of sql_variant is incorrect. The `jdbcType` variable in dtv.java is the JDBC type that the user specifies when they try to retrieve the data. This variable is telling the driver what the user wants to retrieve the data as, but this variable was getting modified to become the base type of the server's column type when retrieving sql_variant data, causing this issue (this effectively ignores the data type that the user was asking to retrieve sql_variant as). Leaving `jdbcType` as it is (which we should, since that's what the user wants) solves the issue.

However, when the driver performs bulk copy on a sql_variant column, the driver does need to designate `jdbcType` as the underlying data type to perform datatype-specific conversions. This made it difficult for applying my changes to all datatypes (for the scope of this PR), and for now only the datatypes that do not require any specific conversions from going from one another (for example, numeric values and String values) have the fixes applied.