### PR TITLE
Fix #1325, return correct sql state when connection is closed

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -155,7 +155,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     SharedTimer getSharedTimer() throws SQLServerException {
         if (state == State.Closed) {
             SQLServerException.makeFromDriverError(null, null, SQLServerException.getErrString("R_connectionIsClosed"),
-                    null, false);
+                    SQLServerException.EXCEPTION_XOPEN_CONNECTION_FAILURE, false);
         }
         if (null == sharedTimer) {
             this.sharedTimer = SharedTimer.getTimer();
@@ -1167,7 +1167,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     void checkClosed() throws SQLServerException {
         if (isSessionUnAvailable()) {
             SQLServerException.makeFromDriverError(null, null, SQLServerException.getErrString("R_connectionIsClosed"),
-                    null, false);
+                    SQLServerException.EXCEPTION_XOPEN_CONNECTION_FAILURE, false);
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
@@ -72,7 +72,7 @@ class SQLServerConnectionPoolProxy implements ISQLServerConnection, java.io.Seri
     void checkClosed() throws SQLServerException {
         if (!bIsOpen) {
             SQLServerException.makeFromDriverError(null, null, SQLServerException.getErrString("R_connectionIsClosed"),
-                    null, false);
+                    SQLServerException.EXCEPTION_XOPEN_CONNECTION_FAILURE, false);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -425,6 +425,7 @@ public class SQLServerConnectionTest extends AbstractTest {
         } catch (SQLServerException e) {
             assertEquals(e.getMessage(), TestResource.getResource("R_connectionIsClosed"),
                     TestResource.getResource("R_wrongExceptionMessage"));
+            assertEquals("08S01", e.getSQLState(), TestResource.getResource("R_wrongSqlState"));
         }
         try (Connection conn = getConnection()) {
             conn.close();
@@ -433,6 +434,7 @@ public class SQLServerConnectionTest extends AbstractTest {
         } catch (SQLServerException e) {
             assertEquals(e.getMessage(), TestResource.getResource("R_connectionIsClosed"),
                     TestResource.getResource("R_wrongExceptionMessage"));
+          assertEquals("08S01", e.getSQLState(), TestResource.getResource("R_wrongSqlState"));
         }
     }
 
@@ -567,6 +569,7 @@ public class SQLServerConnectionTest extends AbstractTest {
             } catch (SQLException e) {
                 assertEquals(e.getMessage(), TestResource.getResource("R_connectionIsClosed"),
                         TestResource.getResource("R_wrongExceptionMessage"));
+              assertEquals("08S01", e.getSQLState(), TestResource.getResource("R_wrongSqlState"));
             }
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -61,6 +61,7 @@ public final class TestResource extends ListResourceBundle {
             {"R_connectionReset", "Connection reset"}, {"R_unknownException", "Unknown exception"},
             {"R_deadConnection", "Dead connection should be invalid"},
             {"R_wrongExceptionMessage", "Wrong exception message"},
+            {"R_wrongSqlState", "Wrong sql state"},
             {"R_parameterNotDefined", "Parameter {0} was not defined"},
             {"R_unexpectedExceptionContent", "Unexpected content in exception message"},
             {"R_connectionClosed", "The connection has been closed"},


### PR DESCRIPTION
When driver detects the connection close, it is not returning the correct sql/xopen compliant state. This is causing the connection pool managers like `hikari` to detect a connection closed state correctly. This fixes issue #1325 