### PR TITLE
Fix spatial datatypes cast error when AE is enabled

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -885,6 +885,10 @@ final class Util {
                     return ((null == scale) ? TDS.MAX_FRACTIONAL_SECONDS_SCALE : scale);
                 } else if (JDBCType.BINARY == jdbcType || JDBCType.VARBINARY == jdbcType) {
                     return ((null == value) ? 0 : (ParameterUtils.HexToBin((String) value).length));
+                } else if (JDBCType.GEOMETRY == jdbcType) {
+                    return ((null == value) ? 0 : ((Geometry) value).serialize().length);
+                } else if (JDBCType.GEOGRAPHY == jdbcType) {
+                    return ((null == value) ? 0 : ((Geography) value).serialize().length);
                 } else {
                     return ((null == value) ? 0 : ((String) value).length());
                 }


### PR DESCRIPTION
Just needed the same treatment as in dtv.java:

https://github.com/microsoft/mssql-jdbc/blob/dbb3547960e5f624665bd9b1c4a8a86df653dee0/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java#L1609

In the case where the javaType is String but the JDBCType is Geometry or Geography, we need to handle the data a bit differently. Tests with AE enabled passed, and Maven test passed as well.