### PR TITLE
Ignore exceptions in exception-handling code

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -659,10 +659,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                 if (null != pstmt) {
                     try {
                         pstmt.close();
-                    } catch (SQLServerException ignore) {
+                    } catch (Throwable ignore) {
                         if (loggerExternal.isLoggable(Level.FINER)) {
-                            loggerExternal.finer(
-                                    "getColumns() threw an exception when attempting to close PreparedStatement");
+                            loggerExternal.log(Level.FINER,
+                                    "getColumns() threw an exception when attempting to close PreparedStatement",
+                                    ignore);
                         }
                     }
                 }
@@ -763,10 +764,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                     if (null != resultPstmt) {
                         try {
                             resultPstmt.close();
-                        } catch (SQLServerException ignore) {
+                        } catch (Throwable ignore) {
                             if (loggerExternal.isLoggable(Level.FINER)) {
-                                loggerExternal.finer(
-                                        "getColumns() threw an exception when attempting to close PreparedStatement");
+                                loggerExternal.log(Level.FINER,
+                                        "getColumns() threw an exception when attempting to close PreparedStatement",
+                                        ignore);
                             }
                         }
                     }
@@ -1100,10 +1102,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                 if (null != pstmt) {
                     try {
                         pstmt.close();
-                    } catch (SQLServerException ignore) {
+                    } catch (Throwable ignore) {
                         if (loggerExternal.isLoggable(Level.FINER)) {
-                            loggerExternal.finer(
-                                    "executeSPFkeys() threw an exception when attempting to close PreparedStatement");
+                            loggerExternal.log(Level.FINER,
+                                    "executeSPFkeys() threw an exception when attempting to close PreparedStatement",
+                                    ignore);
                         }
                     }
                 }


### PR DESCRIPTION
But write exceptions to log

When using an older version of sql-server (14.0.2027) with jdbc-driver 7.4.1 or newer, a call to SQLServerDatabaseMetaData.getColumns results in a NullPointerException:
```
    at com.microsoft.sqlserver.jdbc.TDSParser.parse(tdsparser.java:61)
    at com.microsoft.sqlserver.jdbc.TDSParser.parse(tdsparser.java:37)
    at com.microsoft.sqlserver.jdbc.TDSParser.parse(tdsparser.java:26)
    at com.microsoft.sqlserver.jdbc.SQLServerStatement.processExecuteResults(SQLServerStatement.java:1279)
    at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement$PrepStmtExecCmd.processResponse(SQLServerPreparedStatement.java:530)
    at com.microsoft.sqlserver.jdbc.TDSCommand.close(IOBuffer.java:7264)
    at com.microsoft.sqlserver.jdbc.SQLServerStatement.discardLastExecutionResults(SQLServerStatement.java:143)
    at com.microsoft.sqlserver.jdbc.SQLServerStatement.closeInternal(SQLServerStatement.java:654)
    at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.closeInternal(SQLServerPreparedStatement.java:328)
    at com.microsoft.sqlserver.jdbc.SQLServerStatement.close(SQLServerStatement.java:669)
    at com.microsoft.sqlserver.jdbc.SQLServerDatabaseMetaData.getColumns(SQLServerDatabaseMetaData.java:656)
```

This is probably fine, due to using an old sql-server-version. But it should report the correct error and not a NullPointerException from the error handling code.