### PR TITLE
Fix | Fix batch insert failing when AE is turned on

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -185,7 +185,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     private String localUserSQL;
 
-    private Vector<CryptoMetadata> cryptoMetaBatch = new Vector<>();;
+    private Vector<CryptoMetadata> cryptoMetaBatch = new Vector<>();
 
     // Internal function used in tracing
     String getClassNameInternal() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -185,6 +185,8 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     private String localUserSQL;
 
+    private Vector<CryptoMetadata> cryptoMetaBatch = new Vector<>();;
+
     // Internal function used in tracing
     String getClassNameInternal() {
         return "SQLServerPreparedStatement";
@@ -2694,7 +2696,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
         int numBatchesPrepared = 0;
         int numBatchesExecuted = 0;
-        Vector<CryptoMetadata> cryptoMetaBatch = new Vector<>();
 
         if (isSelect(userSQL)) {
             SQLServerException.makeFromDriverError(connection, this,
@@ -2720,14 +2721,14 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             boolean hasExistingTypeDefinitions = preparedTypeDefinitions != null;
             boolean hasNewTypeDefinitions = buildPreparedStrings(batchParam, false);
 
-            if ((0 == numBatchesExecuted) && !isInternalEncryptionQuery && connection.isAEv2()) {
+            if ((0 == numBatchesExecuted) && !isInternalEncryptionQuery && connection.isAEv2()
+                    && !encryptionMetadataIsRetrieved) {
                 this.enclaveCEKs = connection.initEnclaveParameters(preparedSQL, preparedTypeDefinitions, batchParam,
                         parameterNames);
                 encryptionMetadataIsRetrieved = true;
 
                 // fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is
-                // on on
-                // Connection
+                // on on Connection
                 buildPreparedStrings(batchParam, true);
 
                 // Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the
@@ -2740,11 +2741,11 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             // Get the encryption metadata for the first batch only.
             if ((0 == numBatchesExecuted) && (Util.shouldHonorAEForParameters(stmtColumnEncriptionSetting, connection))
                     && (0 < batchParam.length) && !isInternalEncryptionQuery && !encryptionMetadataIsRetrieved) {
+                encryptionMetadataIsRetrieved = true;
                 getParameterEncryptionMetadata(batchParam);
 
                 // fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is
-                // on on
-                // Connection
+                // on on Connection
                 buildPreparedStrings(batchParam, true);
 
                 // Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the
@@ -2752,10 +2753,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                 for (Parameter aBatchParam : batchParam) {
                     cryptoMetaBatch.add(aBatchParam.cryptoMeta);
                 }
-            }
-
-            // Update the crypto metadata for this batch.
-            if (0 < numBatchesExecuted) {
+            } else {
                 // cryptoMetaBatch will be empty for non-AE connections/statements.
                 for (int i = 0; i < cryptoMetaBatch.size(); i++) {
                     batchParam[i].cryptoMeta = cryptoMetaBatch.get(i);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2727,12 +2727,16 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                         parameterNames);
                 encryptionMetadataIsRetrieved = true;
 
-                // fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is
-                // on on Connection
+                /*
+                 *  fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is
+                 *  on one Connection
+                 */
                 buildPreparedStrings(batchParam, true);
 
-                // Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the
-                // batches.
+                /*
+                 *  Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the
+                 *  batches.
+                 */
                 for (Parameter aBatchParam : batchParam) {
                     cryptoMetaBatch.add(aBatchParam.cryptoMeta);
                 }
@@ -2744,12 +2748,16 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                 encryptionMetadataIsRetrieved = true;
                 getParameterEncryptionMetadata(batchParam);
 
-                // fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is
-                // on on Connection
+                /*
+                 *  fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is
+                 *  on one Connection
+                 */
                 buildPreparedStrings(batchParam, true);
 
-                // Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the
-                // batches.
+                /*
+                 *  Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the
+                 *  batches.
+                 */
                 for (Parameter aBatchParam : batchParam) {
                     cryptoMetaBatch.add(aBatchParam.cryptoMeta);
                 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -54,6 +54,10 @@ public class PrecisionScaleTest extends AESetup {
 
     static String numericPrecisionTable[][] = {{"Float", "float"}, {"Decimal", "decimal"}, {"Numeric", "numeric"}};
 
+    static final String insert_sql1 = "INSERT INTO %s VALUES(?,?,?)";
+    static final String insert_sql2 = "INSERT %s VALUES(?,?,?,?,?,?,?,?,?)";
+    static final String insert_sql3 = "INSERT into %s VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+
     static {
         TimeZone tz = TimeZone.getDefault();
         offsetFromGMT = tz.getOffset(1450812362177L);
@@ -78,15 +82,14 @@ public class PrecisionScaleTest extends AESetup {
     public void testNumericPrecision8Scale2(String serverName, String url, String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql2, NUMERIC_TABLE_AE), stmtColEncSetting)) {
             dropTables(stmt);
 
             String[] numeric = {"1.12345", "12345.12", "567.70"};
-
             createPrecisionTable(NUMERIC_TABLE_AE, numericPrecisionTable, cekJks, 30, 8, 2);
-
-            populateNumeric(numeric, 8, 2);
-
+            populateNumeric(pstmt, numeric, 8, 2);
             testNumeric(numeric);
         }
     }
@@ -96,7 +99,10 @@ public class PrecisionScaleTest extends AESetup {
     public void testDateScale2(String serverName, String url, String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql3, DATE_TABLE_AE), stmtColEncSetting)) {
+
             dropTables(stmt);
 
             String[] dateNormalCase = {GMTDate + ".18", GMTDate + ".1770000",
@@ -106,8 +112,7 @@ public class PrecisionScaleTest extends AESetup {
                     dateTimeOffsetExpectedValue + ".177 +00:01", GMTDateWithoutDate, GMTDateWithoutDate,};
 
             createScaleTable(DATE_TABLE_AE, datePrecisionTable, cekJks, 2);
-            populateDate(2);
-
+            populateDate(pstmt, 2);
             testDate(dateNormalCase, dateSetObject);
         }
     }
@@ -116,16 +121,16 @@ public class PrecisionScaleTest extends AESetup {
     @MethodSource("enclaveParams")
     public void testNumericPrecision8Scale0(String serverName, String url, String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
+
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql2, NUMERIC_TABLE_AE), stmtColEncSetting)) {
             dropTables(stmt);
 
             String[] numeric2 = {"1.12345", "12345", "567"};
-
             createPrecisionTable(NUMERIC_TABLE_AE, numericPrecisionTable, cekJks, 30, 8, 0);
-
-            populateNumeric(numeric2, 8, 0);
-
+            populateNumeric(pstmt, numeric2, 8, 0);
             testNumeric(numeric2);
         }
     }
@@ -135,7 +140,10 @@ public class PrecisionScaleTest extends AESetup {
     public void testDateScale0(String serverName, String url, String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql3, DATE_TABLE_AE), stmtColEncSetting)) {
+
             dropTables(stmt);
 
             String[] dateNormalCase2 = {GMTDate, GMTDate + ".1770000", dateTimeOffsetExpectedValue + " +00:01",
@@ -145,9 +153,7 @@ public class PrecisionScaleTest extends AESetup {
                     dateTimeOffsetExpectedValue + ".177 +00:01", GMTDateWithoutDate, GMTDateWithoutDate,};
 
             createScaleTable(DATE_TABLE_AE, datePrecisionTable, cekJks, 0);
-
-            populateDate(0);
-
+            populateDate(pstmt, 0);
             testDate(dateNormalCase2, dateSetObject2);
         }
     }
@@ -157,15 +163,14 @@ public class PrecisionScaleTest extends AESetup {
     public void testNumericPrecision8Scale2Null(String serverName, String url, String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql2, NUMERIC_TABLE_AE), stmtColEncSetting)) {
             dropTables(stmt);
 
             String[] numericNull = {"null", "null", "null"};
-
             createPrecisionTable(NUMERIC_TABLE_AE, numericPrecisionTable, cekJks, 30, 8, 2);
-
-            populateNumericSetObjectNull(8, 2);
-
+            populateNumericSetObjectNull(pstmt, 8, 2);
             testNumeric(numericNull);
         }
     }
@@ -175,15 +180,14 @@ public class PrecisionScaleTest extends AESetup {
     public void testDateScale2Null(String serverName, String url, String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql3, DATE_TABLE_AE), stmtColEncSetting)) {
             dropTables(stmt);
 
             String[] dateSetObjectNull = {"null", "null", "null", "null", "null", "null"};
-
             createScaleTable(DATE_TABLE_AE, datePrecisionTable, cekJks, 2);
-
-            populateDateSetObjectNull(2);
-
+            populateDateSetObjectNull(pstmt, 2);
             testDate(dateSetObjectNull, dateSetObjectNull);
         }
     }
@@ -193,15 +197,95 @@ public class PrecisionScaleTest extends AESetup {
     public void testDateScale5Null(String serverName, String url, String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql3, DATE_TABLE_AE), stmtColEncSetting)) {
             dropTables(stmt);
 
             String[] dateSetObjectNull = {"null", "null", "null", "null", "null", "null"};
-
             createScaleTable(DATE_TABLE_AE, datePrecisionTable, cekJks, 5);
-
-            populateDateNormalCaseNull(5);
+            populateDateNormalCaseNull(pstmt, 5);
             testDate(dateSetObjectNull, dateSetObjectNull);
+        }
+    }
+
+    /*
+     * This tests executing multiple batches with the same prepared statement (github issue 1301)
+     */
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testMultiBatchNumeric(String serverName, String url, String protocol) throws Exception {
+        setAEConnectionString(serverName, url, protocol);
+
+        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql2, NUMERIC_TABLE_AE), stmtColEncSetting)) {
+            dropTables(stmt);
+
+            String[] numeric = {"1.12345", "12345.12", "567.70"};
+            createPrecisionTable(NUMERIC_TABLE_AE, numericPrecisionTable, cekJks, 30, 8, 2);
+            populateNumeric(pstmt, numeric, 8, 2);
+            populateNumeric(pstmt, numeric, 8, 2);
+        }
+    }
+
+    /*
+     * This tests executing multiple batches with the same prepared statement (github issue 1301)
+     */
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testMultiBatchDate(String serverName, String url, String protocol) throws Exception {
+        setAEConnectionString(serverName, url, protocol);
+
+        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql3, DATE_TABLE_AE), stmtColEncSetting)) {
+            dropTables(stmt);
+
+            createScaleTable(DATE_TABLE_AE, datePrecisionTable, cekJks, 2);
+            populateDate(pstmt, 2);
+            populateDate(pstmt, 2);
+        }
+    }
+
+    /*
+     * This tests executing multiple batches with the same prepared statement (github issue 1301)
+     */
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testMultiBatch(String serverName, String url, String protocol) throws Exception {
+        setAEConnectionString(serverName, url, protocol);
+        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement();
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con,
+                        String.format(insert_sql1, NUMERIC_TABLE_AE), stmtColEncSetting)) {
+            dropTables(stmt);
+
+            createTable(NUMERIC_TABLE_AE, cekJks, numericTableSimple);
+            pstmt.setInt(1, 1);
+            pstmt.setInt(2, 2);
+            pstmt.setInt(3, 3);
+            pstmt.addBatch();
+
+            pstmt.setInt(1, 1);
+            pstmt.setInt(2, 2);
+            pstmt.setInt(3, 3);
+            pstmt.addBatch();
+            pstmt.executeBatch();
+
+            pstmt.setInt(1, 1);
+            pstmt.setInt(2, 2);
+            pstmt.setInt(3, 3);
+            pstmt.addBatch();
+
+            pstmt.setInt(1, 1);
+            pstmt.setInt(2, 2);
+            pstmt.setInt(3, 3);
+            pstmt.addBatch();
+            pstmt.executeBatch();
+
         }
     }
 
@@ -388,253 +472,218 @@ public class PrecisionScaleTest extends AESetup {
         }
     }
 
-    private void populateDate(int scale) throws SQLException {
-        String sql = "insert into " + DATE_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
-                + "?,?,?" + ")";
-
-        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
-                        stmtColEncSetting)) {
-
-            // add a normal row
-            // datetime2 scale
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setTimestamp(i, new Timestamp(date.getTime()), scale);
-            }
-
-            // datetime2 default
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setTimestamp(i, new Timestamp(date.getTime()));
-            }
-
-            // datetimeoffset scale
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1),
-                        scale);
-            }
-
-            // datetimeoffset default
-            for (int i = 10; i <= 12; i++) {
-                pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1));
-            }
-
-            // time scale
-            for (int i = 13; i <= 15; i++) {
-                pstmt.setTime(i, new Time(date.getTime()), scale);
-            }
-
-            // time default
-            for (int i = 16; i <= 18; i++) {
-                pstmt.setTime(i, new Time(date.getTime()));
-            }
-
-            pstmt.addBatch();
-
-            // add a row using setObjecdt
-            // datetime2 scale
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP, scale);
-            }
-
-            // datetime2 default
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP);
-            }
-
-            // datetimeoffset scale
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1),
-                        microsoft.sql.Types.DATETIMEOFFSET, scale);
-            }
-
-            // datetimeoffset default
-            for (int i = 10; i <= 12; i++) {
-                pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1),
-                        microsoft.sql.Types.DATETIMEOFFSET);
-            }
-
-            // time scale
-            for (int i = 13; i <= 15; i++) {
-                pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME, scale);
-            }
-
-            // time default
-            for (int i = 16; i <= 18; i++) {
-                pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME);
-            }
-
-            pstmt.addBatch();
-            pstmt.executeBatch();
+    private void populateDate(SQLServerPreparedStatement pstmt, int scale) throws SQLException {
+        // add a normal row
+        // datetime2 scale
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setTimestamp(i, new Timestamp(date.getTime()), scale);
         }
+
+        // datetime2 default
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setTimestamp(i, new Timestamp(date.getTime()));
+        }
+
+        // datetimeoffset scale
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1), scale);
+        }
+
+        // datetimeoffset default
+        for (int i = 10; i <= 12; i++) {
+            pstmt.setDateTimeOffset(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1));
+        }
+
+        // time scale
+        for (int i = 13; i <= 15; i++) {
+            pstmt.setTime(i, new Time(date.getTime()), scale);
+        }
+
+        // time default
+        for (int i = 16; i <= 18; i++) {
+            pstmt.setTime(i, new Time(date.getTime()));
+        }
+
+        pstmt.addBatch();
+
+        // add a row using setObjecdt
+        // datetime2 scale
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP, scale);
+        }
+
+        // datetime2 default
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setObject(i, new Timestamp(date.getTime()), java.sql.Types.TIMESTAMP);
+        }
+
+        // datetimeoffset scale
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1),
+                    microsoft.sql.Types.DATETIMEOFFSET, scale);
+        }
+
+        // datetimeoffset default
+        for (int i = 10; i <= 12; i++) {
+            pstmt.setObject(i, microsoft.sql.DateTimeOffset.valueOf(new Timestamp(date.getTime()), 1),
+                    microsoft.sql.Types.DATETIMEOFFSET);
+        }
+
+        // time scale
+        for (int i = 13; i <= 15; i++) {
+            pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME, scale);
+        }
+
+        // time default
+        for (int i = 16; i <= 18; i++) {
+            pstmt.setObject(i, new Time(date.getTime()), java.sql.Types.TIME);
+        }
+
+        pstmt.addBatch();
+        pstmt.executeBatch();
     }
 
-    private void populateDateNormalCaseNull(int scale) throws SQLException {
-        String sql = "insert into " + DATE_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
-                + "?,?,?" + ")";
-
-        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
-                        stmtColEncSetting)) {
-
-            // datetime2 scale
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setTimestamp(i, null, scale);
-            }
-
-            // datetime2 default
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setTimestamp(i, null);
-            }
-
-            // datetimeoffset scale
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setDateTimeOffset(i, null, scale);
-            }
-
-            // datetimeoffset default
-            for (int i = 10; i <= 12; i++) {
-                pstmt.setDateTimeOffset(i, null);
-            }
-
-            // time scale
-            for (int i = 13; i <= 15; i++) {
-                pstmt.setTime(i, null, scale);
-            }
-
-            // time default
-            for (int i = 16; i <= 18; i++) {
-                pstmt.setTime(i, null);
-            }
-
-            pstmt.addBatch();
-            pstmt.executeBatch();
+    private void populateDateNormalCaseNull(SQLServerPreparedStatement pstmt, int scale) throws SQLException {
+        // datetime2 scale
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setTimestamp(i, null, scale);
         }
+
+        // datetime2 default
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setTimestamp(i, null);
+        }
+
+        // datetimeoffset scale
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setDateTimeOffset(i, null, scale);
+        }
+
+        // datetimeoffset default
+        for (int i = 10; i <= 12; i++) {
+            pstmt.setDateTimeOffset(i, null);
+        }
+
+        // time scale
+        for (int i = 13; i <= 15; i++) {
+            pstmt.setTime(i, null, scale);
+        }
+
+        // time default
+        for (int i = 16; i <= 18; i++) {
+            pstmt.setTime(i, null);
+        }
+
+        pstmt.addBatch();
+        pstmt.executeBatch();
     }
 
-    private void populateNumeric(String[] numeric, int precision, int scale) throws SQLException {
-        String sql = "insert into " + NUMERIC_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?" + ")";
-        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
-                        stmtColEncSetting)) {
-
-            // add a normal row
-            // float(30)
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setDouble(i, Double.valueOf(numeric[0]));
-            }
-
-            // decimal(10,5)
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setBigDecimal(i, new BigDecimal(numeric[1]), precision, scale);
-            }
-
-            // numeric(8,2)
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setBigDecimal(i, new BigDecimal(numeric[2]), precision, scale);
-            }
-            pstmt.addBatch();
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setDouble(i, Double.valueOf(numeric[0]));
-            }
-
-            // decimal(10,5)
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setBigDecimal(i, new BigDecimal(numeric[1]), precision, scale);
-            }
-
-            // numeric(8,2)
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setBigDecimal(i, new BigDecimal(numeric[2]), precision, scale);
-            }
-            pstmt.addBatch();
-
-            // add row using setObject
-            // float(30)
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setObject(i, Double.valueOf(numeric[0]));
-            }
-
-            // decimal(10,5)
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setObject(i, new BigDecimal(numeric[1]), java.sql.Types.DECIMAL, precision, scale);
-            }
-
-            // numeric(8,2)
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setObject(i, new BigDecimal(numeric[2]), java.sql.Types.NUMERIC, precision, scale);
-            }
-            pstmt.addBatch();
-            pstmt.executeBatch();
+    private void populateNumeric(SQLServerPreparedStatement pstmt, String[] numeric, int precision,
+            int scale) throws SQLException {
+        // add a normal row
+        // float(30)
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setDouble(i, Double.valueOf(numeric[0]));
         }
+
+        // decimal(10,5)
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setBigDecimal(i, new BigDecimal(numeric[1]), precision, scale);
+        }
+
+        // numeric(8,2)
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setBigDecimal(i, new BigDecimal(numeric[2]), precision, scale);
+        }
+        pstmt.addBatch();
+
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setDouble(i, Double.valueOf(numeric[0]));
+        }
+
+        // decimal(10,5)
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setBigDecimal(i, new BigDecimal(numeric[1]), precision, scale);
+        }
+
+        // numeric(8,2)
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setBigDecimal(i, new BigDecimal(numeric[2]), precision, scale);
+        }
+        pstmt.addBatch();
+
+        // add row using setObject
+        // float(30)
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setObject(i, Double.valueOf(numeric[0]));
+        }
+
+        // decimal(10,5)
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setObject(i, new BigDecimal(numeric[1]), java.sql.Types.DECIMAL, precision, scale);
+        }
+
+        // numeric(8,2)
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setObject(i, new BigDecimal(numeric[2]), java.sql.Types.NUMERIC, precision, scale);
+        }
+        pstmt.addBatch();
+        pstmt.executeBatch();
     }
 
-    private void populateNumericSetObjectNull(int precision, int scale) throws SQLException {
-        String sql = "insert into " + NUMERIC_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?" + ")";
-
-        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
-                        stmtColEncSetting)) {
-
-            // float(30)
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setObject(i, null, java.sql.Types.DOUBLE);
-            }
-
-            // decimal(10,5)
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setObject(i, null, java.sql.Types.DECIMAL, precision, scale);
-            }
-
-            // numeric(8,2)
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setObject(i, null, java.sql.Types.NUMERIC, precision, scale);
-            }
-
-            pstmt.addBatch();
-            pstmt.executeBatch();
+    private void populateNumericSetObjectNull(SQLServerPreparedStatement pstmt, int precision,
+            int scale) throws SQLException {
+        // float(30)
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setObject(i, null, java.sql.Types.DOUBLE);
         }
+
+        // decimal(10,5)
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setObject(i, null, java.sql.Types.DECIMAL, precision, scale);
+        }
+
+        // numeric(8,2)
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setObject(i, null, java.sql.Types.NUMERIC, precision, scale);
+        }
+
+        pstmt.addBatch();
+        pstmt.executeBatch();
     }
 
-    private void populateDateSetObjectNull(int scale) throws SQLException {
-        String sql = "insert into " + DATE_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
-                + "?,?,?" + ")";
-
-        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
-                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
-                        stmtColEncSetting)) {
-
-            // datetime2 set
-            for (int i = 1; i <= 3; i++) {
-                pstmt.setObject(i, null, java.sql.Types.TIMESTAMP, scale);
-            }
-
-            // datetime2 default
-            for (int i = 4; i <= 6; i++) {
-                pstmt.setObject(i, null, java.sql.Types.TIMESTAMP);
-            }
-
-            // datetimeoffset scale
-            for (int i = 7; i <= 9; i++) {
-                pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET, scale);
-            }
-
-            // datetimeoffset default
-            for (int i = 10; i <= 12; i++) {
-                pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET);
-            }
-
-            // time scale
-            for (int i = 13; i <= 15; i++) {
-                pstmt.setObject(i, null, java.sql.Types.TIME, scale);
-            }
-
-            // time default
-            for (int i = 16; i <= 18; i++) {
-                pstmt.setObject(i, null, java.sql.Types.TIME);
-            }
-
-            pstmt.addBatch();
-            pstmt.executeBatch();
+    private void populateDateSetObjectNull(SQLServerPreparedStatement pstmt, int scale) throws SQLException {
+        // datetime2 set
+        for (int i = 1; i <= 3; i++) {
+            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP, scale);
         }
+
+        // datetime2 default
+        for (int i = 4; i <= 6; i++) {
+            pstmt.setObject(i, null, java.sql.Types.TIMESTAMP);
+        }
+
+        // datetimeoffset scale
+        for (int i = 7; i <= 9; i++) {
+            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET, scale);
+        }
+
+        // datetimeoffset default
+        for (int i = 10; i <= 12; i++) {
+            pstmt.setObject(i, null, microsoft.sql.Types.DATETIMEOFFSET);
+        }
+
+        // time scale
+        for (int i = 13; i <= 15; i++) {
+            pstmt.setObject(i, null, java.sql.Types.TIME, scale);
+        }
+
+        // time default
+        for (int i = 16; i <= 18; i++) {
+            pstmt.setObject(i, null, java.sql.Types.TIME);
+        }
+
+        pstmt.addBatch();
+        pstmt.executeBatch();
     }
 }


### PR DESCRIPTION
Fixes issue #1301. Testing shows it also fixes #1360, but will need to confirm from user.

Continues from PR #1334. Testing has been carried over, but the fix is different.

The problem was coming from executing `sp_describe_parameter_encryption`. This statement is executed when AE is turned on to retrieve the encryption parameter. Code was currently written in such a way that `sp_describe_paramter_encryption` was being executed twice (or multiple times) if AE was enabled, which caused the driver to think that the current request was completed, which caused the driver to error out during the actual execution of the batch statement (and a plethora of other problems). Adding logic to only run param fetch once and save the encryption metadata for the subsequent batches as well solves this problem.

Before: (PrecisionScaleTest::testMultiBatch)
![image](https://user-images.githubusercontent.com/30157681/86398528-9ae50400-bc5a-11ea-9566-b7821d7bb158.png)

After:
![image](https://user-images.githubusercontent.com/30157681/86394995-5b1b1e00-bc54-11ea-9bf6-21c73c527c0d.png)

Testing was done against with both AE and AEv2 enabled.