### PR TITLE
Change | Enclave caching key

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
@@ -426,8 +426,10 @@ final class EnclaveSessionCache {
         sessionCache = new Hashtable<>(0);
     }
 
-    void addEntry(String servername, String attestationUrl, BaseAttestationRequest b, EnclaveSession e) {
-        sessionCache.put(servername + attestationUrl, new EnclaveCacheEntry(b, e));
+    void addEntry(String servername, String catalog, String attestationUrl, BaseAttestationRequest b, EnclaveSession e) {
+        StringBuilder sb = new StringBuilder(servername);
+        sb.append(catalog).append(attestationUrl);
+        sessionCache.put(sb.toString(), new EnclaveCacheEntry(b, e));
     }
 
     void removeEntry(EnclaveSession e) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
@@ -426,9 +426,9 @@ final class EnclaveSessionCache {
         sessionCache = new Hashtable<>(0);
     }
 
-    void addEntry(String servername, String catalog, String attestationUrl, BaseAttestationRequest b, EnclaveSession e) {
-        StringBuilder sb = new StringBuilder(servername);
-        sb.append(catalog).append(attestationUrl);
+    void addEntry(String servername, String catalog, String attestationUrl, BaseAttestationRequest b,
+            EnclaveSession e) {
+        StringBuilder sb = new StringBuilder(servername).append(catalog).append(attestationUrl);
         sessionCache.put(sb.toString(), new EnclaveCacheEntry(b, e));
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
@@ -46,15 +46,15 @@ public class SQLServerAASEnclaveProvider implements ISQLServerEnclaveProvider {
 
     private AASAttestationParameters aasParams = null;
     private AASAttestationResponse hgsResponse = null;
-    private String attestationURL = null;
+    private String attestationUrl = null;
     private EnclaveSession enclaveSession = null;
 
     @Override
     public void getAttestationParameters(String url) throws SQLServerException {
         if (null == aasParams) {
-            attestationURL = url;
+            attestationUrl = url;
             try {
-                aasParams = new AASAttestationParameters(attestationURL);
+                aasParams = new AASAttestationParameters(attestationUrl);
             } catch (IOException e) {
                 SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);
             }
@@ -65,21 +65,24 @@ public class SQLServerAASEnclaveProvider implements ISQLServerEnclaveProvider {
     public ArrayList<byte[]> createEnclaveSession(SQLServerConnection connection, String userSql,
             String preparedTypeDefinitions, Parameter[] params,
             ArrayList<String> parameterNames) throws SQLServerException {
+        // Check if the session exists in our cache
+        StringBuilder keyLookup = new StringBuilder(connection.getServerName()).append(connection.getCatalog())
+                .append(attestationUrl);
+        EnclaveCacheEntry entry = enclaveCache.getSession(keyLookup.toString());
+        if (null != entry) {
+            this.enclaveSession = entry.getEnclaveSession();
+            this.aasParams = (AASAttestationParameters) entry.getBaseAttestationRequest();
+        }
         ArrayList<byte[]> b = describeParameterEncryption(connection, userSql, preparedTypeDefinitions, params,
                 parameterNames);
-        if (null != hgsResponse && !connection.enclaveEstablished()) {
-            // Check if the session exists in our cache
-            EnclaveCacheEntry entry = enclaveCache.getSession(connection.getServerName() + attestationURL);
-            if (null != entry) {
-                this.enclaveSession = entry.getEnclaveSession();
-                this.aasParams = (AASAttestationParameters) entry.getBaseAttestationRequest();
-                return b;
-            }
+        if (connection.enclaveEstablished()) {
+            return b;
+        } else if (null != hgsResponse && !connection.enclaveEstablished()) {
             try {
                 enclaveSession = new EnclaveSession(hgsResponse.getSessionID(),
                         aasParams.createSessionSecret(hgsResponse.getDHpublicKey()));
-                enclaveCache.addEntry(connection.getServerName(), connection.enclaveAttestationUrl, aasParams,
-                        enclaveSession);
+                enclaveCache.addEntry(connection.getServerName(), connection.getCatalog(),
+                        connection.enclaveAttestationUrl, aasParams, enclaveSession);
             } catch (GeneralSecurityException e) {
                 SQLServerException.makeFromDriverError(connection, this, e.getLocalizedMessage(), "0", false);
             }
@@ -94,7 +97,7 @@ public class SQLServerAASEnclaveProvider implements ISQLServerEnclaveProvider {
         }
         enclaveSession = null;
         aasParams = null;
-        attestationURL = null;
+        attestationUrl = null;
     }
 
     @Override
@@ -105,7 +108,7 @@ public class SQLServerAASEnclaveProvider implements ISQLServerEnclaveProvider {
     private void validateAttestationResponse() throws SQLServerException {
         if (null != hgsResponse) {
             try {
-                hgsResponse.validateToken(attestationURL, aasParams.getNonce());
+                hgsResponse.validateToken(attestationUrl, aasParams.getNonce());
                 hgsResponse.validateDHPublicKey(aasParams.getNonce());
             } catch (GeneralSecurityException e) {
                 SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3609,10 +3609,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return sCatalog;
     }
 
-    String getSCatalog() throws SQLServerException {
-        return sCatalog;
-    }
-
     @Override
     public void setTransactionIsolation(int level) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER)) {


### PR DESCRIPTION
Added database name to caching key. The new key format is `serverName` + `databaseName` + `attestationUrl`.

Removed an unused package privatate SQLServerConnection getter `getScatalog()` which returned the same value as the public getter `getCatalog`.

Changed cache key lookup to occur before calling sp_de because doing so after would cause a new connection to call sp_de with 3 parameters which would create another enclave session.