### PR TITLE
Fix | Sort column ordinal mapping during bulk copy

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -32,6 +32,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1839,7 +1840,9 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                 // if no mapping is provided for csv file and metadata is missing for some columns throw error
                 if (null != serverBulkData) {
                     Set<Integer> columnOrdinals = serverBulkData.getColumnOrdinals();
-                    Iterator<Integer> columnsIterator = columnOrdinals.iterator();
+                    List<Integer> sortedList = new ArrayList<>(columnOrdinals);
+                    Collections.sort(sortedList);
+                    Iterator<Integer> columnsIterator = sortedList.iterator();
                     int j = 1;
                     while (columnsIterator.hasNext()) {
                         int currentOrdinal = columnsIterator.next();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -9,9 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -188,6 +186,25 @@ public class BulkCopyCSVTest extends AbstractTest {
                     i++;
                 }
             }
+        }
+    }
+    
+    /**
+     * test simple csv file for bulkcopy, for GitHub issue 1391
+     * Tests to ensure that the set returned by getColumnOrdinals doesn't have to be ordered
+     */
+    @Test
+    @DisplayName("Test SQLServerBulkCSVFileRecord GitHb 1391")
+    public void testCSV1391() {
+        String fileName = filePath + inputFile;
+        try (SQLServerBulkCSVFileRecord f1 = new BulkData1391(fileName, encoding, delimiter, true);
+                SQLServerBulkCSVFileRecord f2 = new BulkData1391(fileName, encoding, delimiter, true);) {
+            testBulkCopyCSV(f1, true);
+
+            f2.setEscapeColumnDelimitersCSV(true);
+            testBulkCopyCSV(f2, true);
+        } catch (SQLException e) {
+            fail(e.getMessage());
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -18,7 +18,11 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,6 +36,7 @@ import com.microsoft.sqlserver.jdbc.ComparisonUtil;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCSVFileRecord;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
@@ -205,6 +210,24 @@ public class BulkCopyCSVTest extends AbstractTest {
             testBulkCopyCSV(f2, true);
         } catch (SQLException e) {
             fail(e.getMessage());
+        }
+    }
+    
+    // Used for testing issue reported in https://github.com/microsoft/mssql-jdbc/issues/1391
+    private class BulkData1391 extends SQLServerBulkCSVFileRecord {
+
+        public BulkData1391(String fileToParse, String encoding, String delimiter,
+                boolean firstLineIsColumnNames) throws SQLServerException {
+            super(fileToParse, encoding, delimiter, firstLineIsColumnNames);
+        }
+
+        @Override
+        public Set<Integer> getColumnOrdinals() {
+            List<Integer> list = new ArrayList<>(columnMetadata.keySet());
+            Integer temp = list.get(0);
+            list.set(0, list.get(1));
+            list.set(1, temp);
+            return new LinkedHashSet<>(list);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
@@ -17,8 +17,6 @@ import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,7 +29,6 @@ import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.ISQLServerBulkData;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
-import com.microsoft.sqlserver.jdbc.SQLServerBulkCSVFileRecord;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.TestResource;
@@ -255,26 +252,6 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
         }
     }
 }
-
-
-// Used for testing issue reported in https://github.com/microsoft/mssql-jdbc/issues/1391
-class BulkData1391 extends SQLServerBulkCSVFileRecord {
-
-    public BulkData1391(String fileToParse, String encoding, String delimiter,
-            boolean firstLineIsColumnNames) throws SQLServerException {
-        super(fileToParse, encoding, delimiter, firstLineIsColumnNames);
-    }
-
-    @Override
-    public Set<Integer> getColumnOrdinals() {
-        List<Integer> list = new ArrayList<>(columnMetadata.keySet());
-        Integer temp = list.get(0);
-        list.set(0, list.get(1));
-        list.set(1, temp);
-        return new LinkedHashSet<>(list);
-    }
-}
-
 
 class BulkData implements ISQLServerBulkData {
     private static final long serialVersionUID = 1L;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
@@ -17,6 +17,8 @@ import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.ISQLServerBulkData;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
+import com.microsoft.sqlserver.jdbc.SQLServerBulkCSVFileRecord;
 import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.TestResource;
@@ -252,6 +255,26 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
         }
     }
 }
+
+
+// Used for testing issue reported in https://github.com/microsoft/mssql-jdbc/issues/1391
+class BulkData1391 extends SQLServerBulkCSVFileRecord {
+
+    public BulkData1391(String fileToParse, String encoding, String delimiter,
+            boolean firstLineIsColumnNames) throws SQLServerException {
+        super(fileToParse, encoding, delimiter, firstLineIsColumnNames);
+    }
+
+    @Override
+    public Set<Integer> getColumnOrdinals() {
+        List<Integer> list = new ArrayList<>(columnMetadata.keySet());
+        Integer temp = list.get(0);
+        list.set(0, list.get(1));
+        list.set(1, temp);
+        return new LinkedHashSet<>(list);
+    }
+}
+
 
 class BulkData implements ISQLServerBulkData {
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Fixes issue #1391.

Straightforward fix, sorts the 'columnOrdinals' object if the returned set happens to be unordered.