### PR TITLE
Fix | Fix bulkcopy failing when inserting non-unicode multibyte String

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2289,15 +2289,16 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                                     tdsWriter.writeShort((short) bytes.length);
                                     tdsWriter.writeBytes(bytes);
                                 } else {
-                                    tdsWriter.writeShort((short) (colValueStr.length()));
                                     // converting string into destination collation using Charset
-
                                     SQLCollation destCollation = destColumnMetadata.get(destColOrdinal).collation;
-                                    if (null != destCollation) {
-                                        tdsWriter.writeBytes(colValueStr.getBytes(
-                                                destColumnMetadata.get(destColOrdinal).collation.getCharset()));
 
+                                    if (null != destCollation) {
+                                        byte[] value = colValueStr.getBytes(
+                                                destColumnMetadata.get(destColOrdinal).collation.getCharset());
+                                        tdsWriter.writeShort((short) value.length);
+                                        tdsWriter.writeBytes(value);
                                     } else {
+                                        tdsWriter.writeShort((short) (colValueStr.length()));
                                         tdsWriter.writeBytes(colValueStr.getBytes());
                                     }
                                 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
@@ -36,6 +36,8 @@ public class BulkCopyRowSetTest extends AbstractTest {
 
     private static String tableName = AbstractSQLGenerator
             .escapeIdentifier(RandomUtil.getIdentifier("BulkCopyFloatTest"));
+    private static String tableName2 = AbstractSQLGenerator
+            .escapeIdentifier(RandomUtil.getIdentifier("BulkCopyFloatTest2"));
 
     @Test
     public void testBulkCopyFloatRowSet() throws SQLException {
@@ -71,11 +73,36 @@ public class BulkCopyRowSetTest extends AbstractTest {
         }
     }
 
+    @Test
+    public void testBulkCopyJapaneseCollation() throws SQLException {
+        try (Connection con = getConnection(); Statement stmt = connection.createStatement();
+                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);) {
+            RowSetFactory rsf = RowSetProvider.newFactory();
+            CachedRowSet crs = rsf.createCachedRowSet();
+            RowSetMetaData rsmd = new RowSetMetaDataImpl();
+            rsmd.setColumnCount(1);
+            rsmd.setColumnName(1, "c1");
+            rsmd.setColumnType(1, java.sql.Types.VARCHAR);
+            rsmd.setTableName(1, tableName2);
+
+            crs.setMetaData(rsmd);
+            crs.moveToInsertRow();
+            crs.updateString("c1", "ああ");
+            crs.insertRow();
+            crs.moveToCurrentRow();
+
+            bulkCopy.setDestinationTableName(tableName2);
+            bulkCopy.writeToServer(crs);
+        }
+    }
+
     @BeforeAll
     public static void testSetup() throws TestAbortedException, Exception {
         try (Statement stmt = connection.createStatement()) {
             String sql1 = "create table " + tableName + " (c1 float, c2 real)";
             stmt.execute(sql1);
+            String sql2 = "create table " + tableName2 + " (c1 varchar(10) COLLATE Japanese_CS_AS_KS_WS NOT NULL)";
+            stmt.execute(sql2);
         }
     }
 
@@ -83,6 +110,7 @@ public class BulkCopyRowSetTest extends AbstractTest {
     public static void terminateVariation() throws SQLException {
         try (Statement stmt = connection.createStatement()) {
             TestUtils.dropTableIfExists(tableName, stmt);
+            TestUtils.dropTableIfExists(tableName2, stmt);
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
@@ -31,7 +31,6 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 
 @RunWith(JUnitPlatform.class)
-@Tag(Constants.xAzureSQLDW)
 public class BulkCopyRowSetTest extends AbstractTest {
 
     private static String tableName = AbstractSQLGenerator
@@ -40,6 +39,7 @@ public class BulkCopyRowSetTest extends AbstractTest {
             .escapeIdentifier(RandomUtil.getIdentifier("BulkCopyFloatTest2"));
 
     @Test
+    @Tag(Constants.xAzureSQLDW)
     public void testBulkCopyFloatRowSet() throws SQLException {
         try (Connection con = getConnection(); Statement stmt = connection.createStatement()) {
             RowSetFactory rsf = RowSetProvider.newFactory();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
@@ -80,6 +80,7 @@ public class BulkCopyRowSetTest extends AbstractTest {
             RowSetFactory rsf = RowSetProvider.newFactory();
             CachedRowSet crs = rsf.createCachedRowSet();
             RowSetMetaData rsmd = new RowSetMetaDataImpl();
+            String unicodeData =  "ああ";
             rsmd.setColumnCount(1);
             rsmd.setColumnName(1, "c1");
             rsmd.setColumnType(1, java.sql.Types.VARCHAR);
@@ -87,12 +88,17 @@ public class BulkCopyRowSetTest extends AbstractTest {
 
             crs.setMetaData(rsmd);
             crs.moveToInsertRow();
-            crs.updateString("c1", "ああ");
+            crs.updateString("c1", unicodeData);
             crs.insertRow();
             crs.moveToCurrentRow();
 
             bulkCopy.setDestinationTableName(tableName2);
             bulkCopy.writeToServer(crs);
+            
+            try (ResultSet rs = stmt.executeQuery("select * from " + tableName2)) {
+                rs.next();
+                assertEquals(unicodeData, (String) rs.getString(1));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes issue #1414.

We cannot assume that length = number of bytes when destination collation is not equal to null.