### PR TITLE
Fix | Intermittent deadlock error by querying only the procedure created

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/DBMetadataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/DBMetadataTest.java
@@ -4,6 +4,8 @@
  */
 package com.microsoft.sqlserver.jdbc.connection;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -29,14 +31,14 @@ public class DBMetadataTest extends AbstractTest {
     @Test
     public void testDatabaseMetaData() throws SQLException {
         String functionName = RandomUtil.getIdentifier("proc");
-        functionName = DBTable.escapeIdentifier(functionName);
+        String escapedFunctionName = DBTable.escapeIdentifier(functionName);
         SQLServerDataSource ds = new SQLServerDataSource();
         ds.setURL(connectionString);
 
         String sqlDropFunction = "if exists (select * from dbo.sysobjects where id = object_id(N'[dbo]."
-                + TestUtils.escapeSingleQuotes(functionName) + "')" + "and xtype in (N'FN', N'IF', N'TF'))"
-                + "drop function " + functionName;
-        String sqlCreateFunction = "CREATE  FUNCTION " + functionName
+                + TestUtils.escapeSingleQuotes(escapedFunctionName) + "')" + "and xtype in (N'FN', N'IF', N'TF'))"
+                + "drop function " + escapedFunctionName;
+        String sqlCreateFunction = "CREATE  FUNCTION " + escapedFunctionName
                 + " (@text varchar(8000), @delimiter varchar(20) = ' ') RETURNS @Strings TABLE "
                 + "(position int IDENTITY PRIMARY KEY, value varchar(8000)) AS BEGIN INSERT INTO @Strings VALUES ('DDD') RETURN END ";
 
@@ -47,11 +49,11 @@ public class DBMetadataTest extends AbstractTest {
             stmt.execute(sqlCreateFunction);
 
             DatabaseMetaData md = con.getMetaData();
-            try (ResultSet arguments = md.getProcedureColumns(null, null, null, "@TABLE_RETURN_VALUE")) {
-
+            try (ResultSet arguments = md.getProcedureColumns(null, null, functionName, "@TABLE_RETURN_VALUE")) {
                 if (arguments.next()) {
-                    arguments.getString("COLUMN_NAME");
-                    arguments.getString("DATA_TYPE"); // call this function to make sure it does not crash
+                    assertTrue(arguments.getString("PROCEDURE_NAME").startsWith(functionName), "Expected Stored Procedure was not retrieved.");
+                } else {
+                    assertTrue(false, "Expected Stored Procedure was not found.");
                 }
                 arguments.getStatement().close();
             }


### PR DESCRIPTION
sp_sproc_columns_100 returns all stored procedures that match the criteria. There is a chance that stored procedures which match the criteria are being altered/updated during the test. If we only query for the stored procedure we created in the test by restricting the SP to use the function name, this won't happen as the SP names are unique.