### PR TITLE
Fix | Remove clientKeyPassword from memory

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2708,6 +2708,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             tdsChannel.enableSSL(serverInfo.getServerName(), serverInfo.getPortNumber(), clientCertificate, clientKey,
                     clientKeyPassword);
         }
+        
+        activeConnectionProperties.remove(SQLServerDriverStringProperty.CLIENT_KEY_PASSWORD.toString());
 
         // We have successfully connected, now do the login. logon takes seconds timeout
         executeCommand(new LogonCommand());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2707,6 +2707,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (TDS.ENCRYPT_NOT_SUP != negotiatedEncryptionLevel) {
             tdsChannel.enableSSL(serverInfo.getServerName(), serverInfo.getPortNumber(), clientCertificate, clientKey,
                     clientKeyPassword);
+            clientKeyPassword = "";
         }
         
         activeConnectionProperties.remove(SQLServerDriverStringProperty.CLIENT_KEY_PASSWORD.toString());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAConnection.java
@@ -68,6 +68,20 @@ public final class SQLServerXAConnection extends SQLServerPooledConnection imple
                     trustStorePassword);
         }
 
+        // Add clientKeyPassword password property for creating the control connection. This will be removed again
+        // first check if clientCertificate is there to see if the clientKeyPassword was possibly provided
+        String clientCertificate = ds.getClientCertificate();
+        if (null != clientCertificate && clientCertificate.length() > 0) {
+            Properties urlProps = Util.parseUrl(ds.getURL(), xaLogger);
+            String clientKeyPassword = urlProps
+                    .getProperty(SQLServerDriverStringProperty.CLIENT_KEY_PASSWORD.toString());
+
+            if (null != clientKeyPassword) {
+                controlConnectionProperties.setProperty(SQLServerDriverStringProperty.CLIENT_KEY_PASSWORD.toString(),
+                        clientKeyPassword);
+            }
+        }
+
         if (xaLogger.isLoggable(Level.FINER))
             xaLogger.finer("Creating an internal control connection for" + toString());
         physicalControlConnection = null;


### PR DESCRIPTION
From PenTest results.

As with other passwords that have been removed from memory, I temporarily add it back for XA connections because XA connections create two connections (one for control connection, one for actual connections), but the outcome is the same in that this password will not remain in memory after the connection has been established.