### PR TITLE
Fix | SQLServerBulkCSVFileRecord dropping empty trailing columns when escapeDelimiters = true

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -196,7 +196,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
             if (null != currentLine) {
                 columnNames = (escapeDelimiters && currentLine.contains("\""))
                                                                                ? escapeQuotesRFC4180(currentLine.split(
-                                                                                       delimiter + escapeSplitPattern))
+                                                                                       delimiter + escapeSplitPattern, -1))
                                                                                : currentLine.split(delimiter, -1);
             }
         }
@@ -243,7 +243,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
              */
             String[] data = (escapeDelimiters && currentLine.contains("\""))
                                                                              ? escapeQuotesRFC4180(currentLine.split(
-                                                                                     delimiter + escapeSplitPattern))
+                                                                                     delimiter + escapeSplitPattern, -1))
                                                                              : currentLine.split(delimiter, -1);
 
             // Cannot go directly from String[] to Object[] and expect it to act as an array.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -194,10 +194,8 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
         if (firstLineIsColumnNames) {
             currentLine = fileReader.readLine();
             if (null != currentLine) {
-                columnNames = (escapeDelimiters && currentLine.contains("\""))
-                                                                               ? escapeQuotesRFC4180(currentLine.split(
-                                                                                       delimiter + escapeSplitPattern, -1))
-                                                                               : currentLine.split(delimiter, -1);
+                columnNames = (escapeDelimiters && currentLine.contains("\"")) ? escapeQuotesRFC4180(
+                        currentLine.split(delimiter + escapeSplitPattern, -1)) : currentLine.split(delimiter, -1);
             }
         }
     }
@@ -241,10 +239,8 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
              * Binary data may be corrupted The limit in split() function should be a negative value, otherwise trailing
              * empty strings are discarded. Empty string is returned if there is no value.
              */
-            String[] data = (escapeDelimiters && currentLine.contains("\""))
-                                                                             ? escapeQuotesRFC4180(currentLine.split(
-                                                                                     delimiter + escapeSplitPattern, -1))
-                                                                             : currentLine.split(delimiter, -1);
+            String[] data = (escapeDelimiters && currentLine.contains("\"")) ? escapeQuotesRFC4180(
+                    currentLine.split(delimiter + escapeSplitPattern, -1)) : currentLine.split(delimiter, -1);
 
             // Cannot go directly from String[] to Object[] and expect it to act as an array.
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -149,21 +149,21 @@ public class BulkCopyCSVTest extends AbstractTest {
         String tableName = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("BulkEscape"));
         String fileName = filePath + inputFileDelimiterEscape;
         /*
-         * The list below is the copy of inputFileDelimiterEscape with quotes removed.
+         * The list below is the copy of inputFileDelimiterEsc ape with quotes removed.
          */
         String[][] expectedEscaped = new String[11][4];
-        expectedEscaped[0] = new String[] {"test", " test\"", "no@split", " testNoQuote"};
-        expectedEscaped[1] = new String[] {null, null, null, null};
-        expectedEscaped[2] = new String[] {"\"", "test\"test", "test@\"  test", null};
+        expectedEscaped[0] = new String[] {"test", " test\"", "no@split", " testNoQuote", ""};
+        expectedEscaped[1] = new String[] {null, null, null, null, ""};
+        expectedEscaped[2] = new String[] {"\"", "test\"test", "test@\"  test", null, ""};
         expectedEscaped[3] = new String[] {"testNoQuote  ", " testSpaceAround ", " testSpaceInside ",
-                "  testSpaceQuote\" "};
-        expectedEscaped[4] = new String[] {null, null, null, " testSpaceInside "};
-        expectedEscaped[5] = new String[] {"1997", "Ford", "E350", "E63"};
-        expectedEscaped[6] = new String[] {"1997", "Ford", "E350", "E63"};
-        expectedEscaped[7] = new String[] {"1997", "Ford", "E350", "Super@ luxurious truck"};
-        expectedEscaped[8] = new String[] {"1997", "Ford", "E350", "Super@ \"luxurious\" truck"};
-        expectedEscaped[9] = new String[] {"1997", "Ford", "E350", "E63"};
-        expectedEscaped[10] = new String[] {"1997", "Ford", "E350", " Super luxurious truck "};
+                "  testSpaceQuote\" ", ""};
+        expectedEscaped[4] = new String[] {null, null, null, " testSpaceInside ", ""};
+        expectedEscaped[5] = new String[] {"1997", "Ford", "E350", "E63", ""};
+        expectedEscaped[6] = new String[] {"1997", "Ford", "E350", "E63", ""};
+        expectedEscaped[7] = new String[] {"1997", "Ford", "E350", "Super@ luxurious truck", ""};
+        expectedEscaped[8] = new String[] {"1997", "Ford", "E350", "Super@ \"luxurious\" truck", ""};
+        expectedEscaped[9] = new String[] {"1997", "Ford", "E350", "E63", ""};
+        expectedEscaped[10] = new String[] {"1997", "Ford", "E350", " Super luxurious truck ", ""};
 
         try (Connection con = getConnection(); Statement stmt = con.createStatement();
                 SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(con);
@@ -176,8 +176,9 @@ public class BulkCopyCSVTest extends AbstractTest {
             fileRecord.addColumnMetadata(3, null, java.sql.Types.VARCHAR, 50, 0);
             fileRecord.addColumnMetadata(4, null, java.sql.Types.VARCHAR, 50, 0);
             fileRecord.addColumnMetadata(5, null, java.sql.Types.VARCHAR, 50, 0);
+            fileRecord.addColumnMetadata(6, null, java.sql.Types.VARCHAR, 50, 0);
             stmt.executeUpdate("CREATE TABLE " + tableName
-                    + " (id INT IDENTITY(1,1), c1 VARCHAR(50), c2 VARCHAR(50), c3 VARCHAR(50), c4 VARCHAR(50))");
+                    + " (id INT IDENTITY(1,1), c1 VARCHAR(50), c2 VARCHAR(50), c3 VARCHAR(50), c4 VARCHAR(50), c5 VARCHAR(50))");
             bulkCopy.writeToServer(fileRecord);
 
             int i = 0;
@@ -193,10 +194,10 @@ public class BulkCopyCSVTest extends AbstractTest {
             }
         }
     }
-    
+
     /**
-     * test simple csv file for bulkcopy, for GitHub issue 1391
-     * Tests to ensure that the set returned by getColumnOrdinals doesn't have to be ordered
+     * test simple csv file for bulkcopy, for GitHub issue 1391 Tests to ensure that the set returned by
+     * getColumnOrdinals doesn't have to be ordered
      */
     @Test
     @DisplayName("Test SQLServerBulkCSVFileRecord GitHb 1391")
@@ -212,7 +213,7 @@ public class BulkCopyCSVTest extends AbstractTest {
             fail(e.getMessage());
         }
     }
-    
+
     // Used for testing issue reported in https://github.com/microsoft/mssql-jdbc/issues/1391
     private class BulkData1391 extends SQLServerBulkCSVFileRecord {
 

--- a/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
+++ b/src/test/resources/BulkCopyCSVTestInputDelimiterEscape.csv
@@ -1,11 +1,11 @@
-1@"test"@ " test"""@ "no@split" @ testNoQuote
-2@""@  ""@ ""@ ""
-3@""""@ "test""test"@ "test@""  test"@ ""
-4@testNoQuote  @ testSpaceAround @ " testSpaceInside "@  "  testSpaceQuote"" "
-5@""@  ""@ ""@ " testSpaceInside "
-6@1997@Ford@E350@E63
-7@"1997"@"Ford"@"E350"@"E63"
-8@1997@Ford@E350@"Super@ luxurious truck"
-9@1997@Ford@E350@"Super@ ""luxurious"" truck"
-10@1997@ "Ford" @E350@  "E63"
-11@1997@Ford@E350@" Super luxurious truck "
+1@"test"@ " test"""@ "no@split" @ testNoQuote@ 
+2@""@  ""@ ""@ ""@ 
+3@""""@ "test""test"@ "test@""  test"@ ""@ 
+4@testNoQuote  @ testSpaceAround @ " testSpaceInside "@  "  testSpaceQuote"" "@ 
+5@""@  ""@ ""@ " testSpaceInside "@ 
+6@1997@Ford@E350@E63@ 
+7@"1997"@"Ford"@"E350"@"E63"@ 
+8@1997@Ford@E350@"Super@ luxurious truck"@ 
+9@1997@Ford@E350@"Super@ ""luxurious"" truck"@ 
+10@1997@ "Ford" @E350@  "E63"@ 
+11@1997@Ford@E350@" Super luxurious truck "@ 


### PR DESCRIPTION
Fixes #1426 as suggested by @rripley.