### PR TITLE
Fix a warning when retrieving architecture from Microsoft SQL Azure server

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
@@ -479,7 +479,7 @@ public final class SQLServerXAResource implements javax.transaction.xa.XAResourc
                              */
                             String buildInfo = rs.getString(4);
                             // SQL Server Linux is x64-compatible only.
-                            if (null != buildInfo && buildInfo.contains("Linux")) {
+                            if (null != buildInfo && (buildInfo.contains("Linux") || buildInfo.contains("Microsoft SQL Azure"))) {
                                 architectureOS = 64;
                             } else if (null != buildInfo) {
                                 architectureOS = Integer.parseInt(buildInfo.substring(buildInfo.lastIndexOf('<') + 2,


### PR DESCRIPTION
While using JDBC on Azure SQL Managed Instance it displays a warning while trying to figure out OS architecture.

The warning is:
_Feb 05, 2021 1:19:02 PM com.microsoft.sqlserver.jdbc.SQLServerXAResource DTC_XA_Interface
WARNING:  XAResourceID:1 Cannot retrieve server information: :begin 1, end -1, length 106_

This is a [similar problem](https://github.com/microsoft/mssql-jdbc/issues/1278) resolved earlier for SQL Server in Docker. This PR adds one more check for SQL Azure servers.