### PR TITLE
Optimize the retrieval of Java8 dates/times

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -1243,7 +1243,11 @@ final class DDC {
                     subSecondNanos = 0;
                 } else {
                     long nanoOfDay = ticksSinceMidnight * Nanos.PER_MILLISECOND;
-                    ldt = LocalDateTime.of(ld, LocalTime.ofNanoOfDay(nanoOfDay));
+                    if (nanoOfDay > LocalTime.MAX.toNanoOfDay()) {
+                        ldt = LocalDateTime.of(ld, LocalTime.MIN).plusNanos(nanoOfDay);
+                    } else {
+                        ldt = LocalDateTime.of(ld, LocalTime.ofNanoOfDay(nanoOfDay));
+                    }
                     subSecondNanos = (int) (nanoOfDay % Nanos.PER_SECOND);
                 }
                 break;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -38,6 +38,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.sql.Timestamp;
 import java.text.MessageFormat;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.ArrayList;
@@ -452,6 +453,9 @@ final class TDS {
     final static int BASE_YEAR_1900 = 1900;
     final static int BASE_YEAR_1970 = 1970;
     final static String BASE_DATE_1970 = "1970-01-01";
+
+    final static LocalDate BASE_LOCAL_DATE = LocalDate.of(1, 1, 1);
+    final static LocalDate BASE_LOCAL_DATE_1900 = LocalDate.of(1900, 1, 1);
 
     static int timeValueLength(int scale) {
         return nanosSinceMidnightLength(scale);


### PR DESCRIPTION
Retrieval of Java8 dates/times with calls such as `rs.getObject(columnIndex, LocalDate.class)` can be made much faster, mostly because many unnecessary allocations are done.

For instance, when a datetime column is read, the convertTemporalToObject function:
1. Creates a new LocalDateTime, which internally creates a new LocalDate and a new LocalTime
2. Adds days, which creates a new LocalDate, wrapped in a new LDT
3. Adds nanos, which after complex computations (mostly useless because it's intraday nanos) creates a new LocalTime, wrapped in a new LDT

That's 7 allocations, when only 3 (or 2 for dates) are really useful.

I've also extended the test to ignore the time component, because I see many cases in the open world were timeless dates are stored in needlessly large types such as datetime.

I've only tested it on the table I was working on, but it should be fairly straightforward, and reduced CPU usage by a factor of ~3 when reading a date column.