### PR TITLE
Added support for create databases on the fly

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
@@ -1066,4 +1066,19 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
      *        String value for 'maxResultBuffer'
      */
     void setMaxResultBuffer(String maxResultBuffer);
+
+    /**
+     * Returns value of 'createDatabaseIfNotExists' from Connection String.
+     *
+     * @return 'createDatabaseIfNotExists' property.
+     */
+    boolean getCreateDatabaseIfNotExist();
+
+    /**
+     * Specifies value for 'createDatabaseIfNotExist' property
+     *
+     * @param createDatabaseIfNotExist
+     *        Boolean value for 'createDatabaseIfNotExist' property
+     */
+    void setCreateDatabaseIfNotExist(boolean createDatabaseIfNotExist);
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -1067,6 +1067,17 @@ public class SQLServerDataSource
         setStringProperty(connectionProps, SQLServerDriverStringProperty.MAX_RESULT_BUFFER.toString(), maxResultBuffer);
     }
 
+    @Override
+    public boolean getCreateDatabaseIfNotExist() {
+        return getBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.CREATE_DATABASE_IF_NOT_EXISTS.toString(),
+                SQLServerDriverBooleanProperty.CREATE_DATABASE_IF_NOT_EXISTS.getDefaultValue());
+    }
+
+    @Override
+    public void setCreateDatabaseIfNotExist(boolean createDatabaseIfNotExist) {
+        setBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.CREATE_DATABASE_IF_NOT_EXISTS.toString(), createDatabaseIfNotExist);
+    }
+
     /**
      * Sets a property string value.
      * 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -460,7 +460,8 @@ enum SQLServerDriverBooleanProperty {
     USE_BULK_COPY_FOR_BATCH_INSERT("useBulkCopyForBatchInsert", false),
     USE_FMT_ONLY("useFmtOnly", false),
     SEND_TEMPORAL_DATATYPES_AS_STRING_FOR_BULK_COPY("sendTemporalDataTypesAsStringForBulkCopy", true),
-    DELAY_LOADING_LOBS("delayLoadingLobs", true);
+    DELAY_LOADING_LOBS("delayLoadingLobs", true),
+    CREATE_DATABASE_IF_NOT_EXISTS("createDatabaseIfNotExist", false);
 
     private final String name;
     private final boolean defaultValue;
@@ -658,6 +659,9 @@ public final class SQLServerDriver implements java.sql.Driver {
                     SQLServerDriverStringProperty.CLIENT_KEY_PASSWORD.getDefaultValue(), false, null),
             new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.DELAY_LOADING_LOBS.toString(),
                     Boolean.toString(SQLServerDriverBooleanProperty.DELAY_LOADING_LOBS.getDefaultValue()), false,
+                    TRUE_FALSE),
+            new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.CREATE_DATABASE_IF_NOT_EXISTS.toString(),
+                    Boolean.toString(SQLServerDriverBooleanProperty.CREATE_DATABASE_IF_NOT_EXISTS.getDefaultValue()), false,
                     TRUE_FALSE),
             new SQLServerDriverPropertyInfo(
                     SQLServerDriverBooleanProperty.SEND_TEMPORAL_DATATYPES_AS_STRING_FOR_BULK_COPY.toString(),


### PR DESCRIPTION
I have been developing the logic of what I comment in the Issue #1548 that I opened a while ago. I have tried to keep it as clean as possible and am currently using such a solution in my lab tests.

I remain open to any questions or constructive criticism about the Pull Request