### PR TITLE
Fix to ignore computed columns during BulkCopy

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1710,6 +1710,24 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
     }
 
     /**
+     * True if computed cols are supported by database server
+     *
+     * @return true if computed cols are supported
+     */
+    private boolean isComputedColsSupported() {
+        if (connection.sqlServerVersion != null) {
+            try {
+                int majorVersion = Integer.parseInt(connection.sqlServerVersion.split("\\.")[0]);
+                if (majorVersion >= 13) { // SQL Server 2016
+                    return true;
+                }
+            } catch (NumberFormatException e) {
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns the column metadata for the destination table (and saves it for later)
      */
     private void getDestinationMetadata() throws SQLServerException {
@@ -1729,40 +1747,36 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                 if (null != destinationTableMetadata) {
                     rs = (SQLServerResultSet) destinationTableMetadata;
                 } else {
-                    stmt = (SQLServerStatement) connection.createStatement(ResultSet.TYPE_FORWARD_ONLY,
-                            ResultSet.CONCUR_READ_ONLY, connection.getHoldability(), stmtColumnEncriptionSetting);
+                    stmt = (SQLServerStatement) connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY, connection.getHoldability(), stmtColumnEncriptionSetting);
 
                     // Get destination metadata
-                    rs = stmt.executeQueryInternal(
-                            "sp_executesql N'SET FMTONLY ON SELECT * FROM " + escapedDestinationTableName + " '");
+                    rs = stmt.executeQueryInternal("sp_executesql N'SET FMTONLY ON SELECT * FROM " + escapedDestinationTableName + " '");
                 }
 
-                destColumnCount = rs.getMetaData().getColumnCount();
+                int destColumnMetadataCount = rs.getMetaData().getColumnCount();
                 destColumnMetadata = new HashMap<>();
                 destCekTable = rs.getCekTable();
 
-                if (!connection.getServerSupportsColumnEncryption()) {
-                    metaDataQuery = "select collation_name from sys.columns where " + "object_id=OBJECT_ID('"
-                            + escapedDestinationTableName + "') " + "order by column_id ASC";
-                } else {
-                    metaDataQuery = "select collation_name, encryption_type from sys.columns where "
-                            + "object_id=OBJECT_ID('" + escapedDestinationTableName + "') " + "order by column_id ASC";
-                }
+                metaDataQuery = "select * from sys.columns where " + "object_id=OBJECT_ID('" + escapedDestinationTableName + "') " + "order by column_id ASC";
 
                 try (SQLServerStatement statementMoreMetadata = (SQLServerStatement) connection.createStatement();
-                     SQLServerResultSet rsMoreMetaData = statementMoreMetadata.executeQueryInternal(metaDataQuery)) {
-                    for (int i = 1; i <= destColumnCount; ++i) {
+                        SQLServerResultSet rsMoreMetaData = statementMoreMetadata.executeQueryInternal(metaDataQuery)) {
+                    for (int i = 1; i <= destColumnMetadataCount; ++i) {
                         if (rsMoreMetaData.next()) {
                             String bulkCopyEncryptionType = null;
                             if (connection.getServerSupportsColumnEncryption()) {
                                 bulkCopyEncryptionType = rsMoreMetaData.getString("encryption_type");
                             }
-                            destColumnMetadata.put(i, new BulkColumnMetaData(rs.getColumn(i),
-                                    rsMoreMetaData.getString("collation_name"), bulkCopyEncryptionType));
+                            // Skip computed columns
+                            if (Boolean.FALSE.equals(rsMoreMetaData.getBoolean("is_computed"))) {
+                                destColumnMetadata.put(i, new BulkColumnMetaData(rs.getColumn(i), rsMoreMetaData.getString("collation_name"),
+                                        bulkCopyEncryptionType));
+                            }
                         } else {
                             destColumnMetadata.put(i, new BulkColumnMetaData(rs.getColumn(i)));
                         }
                     }
+                    destColumnCount = destColumnMetadata.size();
                 }
             } catch (SQLException e) {
                 // Unable to retrieve metadata for destination

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1710,24 +1710,6 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
     }
 
     /**
-     * True if computed cols are supported by database server
-     *
-     * @return true if computed cols are supported
-     */
-    private boolean isComputedColsSupported() {
-        if (connection.sqlServerVersion != null) {
-            try {
-                int majorVersion = Integer.parseInt(connection.sqlServerVersion.split("\\.")[0]);
-                if (majorVersion >= 13) { // SQL Server 2016
-                    return true;
-                }
-            } catch (NumberFormatException e) {
-            }
-        }
-        return false;
-    }
-
-    /**
      * Returns the column metadata for the destination table (and saves it for later)
      */
     private void getDestinationMetadata() throws SQLServerException {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1750,7 +1750,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                                 bulkCopyEncryptionType = rsMoreMetaData.getString("encryption_type");
                             }
                             // Skip computed columns
-                            if (Boolean.FALSE.equals(rsMoreMetaData.getBoolean("is_computed"))) {
+                            if (!rsMoreMetaData.getBoolean("is_computed")) {
                                 destColumnMetadata.put(i, new BulkColumnMetaData(rs.getColumn(i), rsMoreMetaData.getString("collation_name"),
                                         bulkCopyEncryptionType));
                             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2142,6 +2142,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                             CryptoMetadata cryptoMetadata = c.getCryptoMetadata();
                             int jdbctype;
                             TypeInfo ti = c.getTypeInfo();
+                            if (ti.getUpdatability() == 0) { // Skip read only columns
+                                continue;
+                            }
                             checkValidColumns(ti);
                             if (null != cryptoMetadata) {
                                 jdbctype = cryptoMetadata.getBaseTypeInfo().getSSType().getJDBCType().getIntValue();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -59,6 +59,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
     static String squareBracketTableName = RandomUtil.getIdentifier("BulkCopy]]]]test'");
     static String doubleQuoteTableName = RandomUtil.getIdentifier("\"BulkCopy\"\"\"\"test\"");
     static String schemaTableName = "\"dbo\"         . /*some comment */     " + squareBracketTableName;
+    static String tableNameBulkComputedCols = RandomUtil.getIdentifier("BulkCopyComputedCols");
 
     private Object[] generateExpectedValues() {
         float randomFloat = RandomData.generateReal(false);
@@ -756,6 +757,45 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
                 for (int i = 0; i < expected.length; i++) {
                     assertEquals(expected[i], rs.getObject(i + 1));
                 }
+            }
+        }
+    }
+
+    @Test
+    @Tag(Constants.xAzureSQLDW)
+    @Tag(Constants.xSQLv12)
+    public void testComputedCols() throws Exception {
+        String valid = "insert into " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkComputedCols) + " (id, json)"
+                + " values (?, ?)";
+
+        try (Connection connection = PrepUtil.getConnection(connectionString + ";useBulkCopyForBatchInsert=true;");
+             SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement(valid);
+             Statement stmt = (SQLServerStatement) connection.createStatement();) {
+            Field f1 = SQLServerConnection.class.getDeclaredField("isAzureDW");
+            f1.setAccessible(true);
+            f1.set(connection, true);
+
+            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableNameBulkComputedCols), stmt);
+            String createTable = "create table " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkComputedCols)
+                    + " (id nvarchar(100) not null, json nvarchar(max) not null,"
+                    + " vcol1 as json_value([json], '$.vcol1'), vcol2 as json_value([json], '$.vcol2'))";
+            stmt.execute(createTable);
+
+            String jsonValue =
+                    "{\"vcol1\":\"" + UUID.randomUUID().toString() + "\",\"vcol2\":\"" + UUID.randomUUID().toString()
+                            + "\" }";
+            String idValue = UUID.randomUUID().toString();
+            pstmt.setString(1, idValue);
+            pstmt.setString(2, jsonValue);
+            pstmt.addBatch();
+            pstmt.executeBatch();
+
+            try (ResultSet rs = stmt.executeQuery(
+                    "select * from " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkComputedCols))) {
+                rs.next();
+
+                assertEquals(idValue, rs.getObject(1));
+                assertEquals(jsonValue, rs.getObject(2));
             }
         }
     }


### PR DESCRIPTION
Hello,

I'm facing a problem with the bulk API for batch insert with computed columns.
I'm using an SQL table with computed columns like
```
create table myTable (
  id nvarchar(100) not null, 
  json nvarchar(max) not null,
  vcol1 as json_value([json], '$.vcol1')
)
```
My insert query uses for bulk:
`insert into myTable (id, json) values (?, ?)`
The current behavior of the driver is to reject the query with:
`java.sql.BatchUpdateException: The column "vcol1" cannot be modified because it is either a computed column or is the result of a UNION operator.`

After investigating and testing this fix on my project, **there is no specific reason to reject the batch insert**. The current Bulk code simply reads and compares all the columns found in the table.
I updated the current code to ignore irrelevant computed columns when inserting in bulk and it works like a charm.

Currently, the relevant documentation does not mention any limitation on the computed columns (so the documentation is still true):
https://docs.microsoft.com/en-us/sql/connect/jdbc/use-bulk-copy-api-batch-insert-operation?view=sql-server-ver15

I also added a new unit test to verify and demonstrate this use case: `BatchExecutionWithBulkCopyTest#testComputedCols`

_EDIT: Code updated to be compatible with versions prior than SQL Server 2016_

Sincerely