### PR TITLE
Send the driver version to the database during prelogin

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3046,9 +3046,15 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         // PL_OPTION_DATA
         byte[] preloginOptionData = {
-                // - Server version -
-                // (out param, filled in by the server in the prelogin response).
-                0, 0, 0, 0, 0, 0,
+                // Driver major and minor version, 1 byte each
+                (byte) SQLJdbcVersion.major,
+                (byte) SQLJdbcVersion.minor,
+                // Revision (Big Endian), 2 bytes
+                (byte) ((SQLJdbcVersion.patch & 0xff00) >> 8),
+                (byte) (SQLJdbcVersion.patch & 0xff),
+                // Build (Little Endian), 2 bytes
+                (byte) (SQLJdbcVersion.build & 0xff),
+                (byte) ((SQLJdbcVersion.build & 0xff00) >> 8),
 
                 // - Encryption -
                 (null == clientCertificate) ? requestedEncryptionLevel


### PR DESCRIPTION
Previously it was hard coded to 0.0.0.0.

## Wireshark captures

### Original code
![image](https://user-images.githubusercontent.com/26262303/118877309-23848700-b8a3-11eb-9c06-b73679506035.png)

### New code with with version set to 9.3.1
![image](https://user-images.githubusercontent.com/26262303/118877096-df918200-b8a2-11eb-9f52-da1c630a75f0.png)

### New code with with version set to 9.3.11234.23455 (to test larger, 2 byte build/patch values)
![image](https://user-images.githubusercontent.com/26262303/118877444-4fa00800-b8a3-11eb-8bda-6c5342759805.png)

