### PR TITLE
Fix the hanging issue after running the clearBatch test

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithNullTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithNullTest.java
@@ -154,6 +154,7 @@ public class BatchExecutionWithNullTest extends AbstractTest {
                 conn.rollback();
                 throw e;
             } finally {
+                conn.setAutoCommit(true);
                 TestUtils.dropTableIfExists(batchTable, s);
             }
         }


### PR DESCRIPTION
After running the BatchExecutionWithNullTest.testClearBatch(), the following tests will encounter a hanging status. The server is locked by the test process.