### PR TITLE
Send client process ID to server on Java 9+

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ClientProcessIdTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ClientProcessIdTest.java
@@ -1,0 +1,55 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+
+/*
+ * This test is for validating that client process ID gets registered with the server when available to the driver.
+ */
+@RunWith(JUnitPlatform.class)
+public class ClientProcessIdTest extends AbstractTest {
+
+    private static int pid = 0;
+
+    static {
+        long pidLong = 0;
+        try {
+            pidLong = ProcessHandle.current().pid();
+        } catch (NoClassDefFoundError e) { // ProcessHandle is Java 9+
+        }
+        pid = (pidLong > Integer.MAX_VALUE) ? 0 : (int)pidLong;
+    }
+
+    @Test
+    public void testClientProcessId() throws SQLException {
+        SQLServerDataSource ds = new SQLServerDataSource();
+        ds.setURL(connectionString);
+        String sqlSelect = "select host_process_id from sys.dm_exec_sessions where session_id = @@SPID";
+
+        try (Connection con = ds.getConnection(); Statement stmt = con.createStatement()) {
+            try (ResultSet rs = stmt.executeQuery(sqlSelect)) {
+                if (rs.next()) {
+                    assertEquals(rs.getInt(1), pid);
+                } else {
+                    assertTrue(false, "Expected row of data was not found.");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since we can easily do it in Java 9 and up, we should. If catching NoClassDefFoundError is objectionable, I'm open to other suggestions.

You can validate the behavior by querying `sys.dm_exec_sessions` when a connection is active:
`select * from sys.dm_exec_sessions`