### PR TITLE
Exclude Azure DW for client PID test

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ClientProcessIdTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ClientProcessIdTest.java
@@ -12,17 +12,21 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.Constants;
+
 
 /*
  * This test is for validating that client process ID gets registered with the server when available to the driver.
  */
 @RunWith(JUnitPlatform.class)
+@Tag(Constants.xAzureSQLDW)
 public class ClientProcessIdTest extends AbstractTest {
 
     private static int pid = 0;
@@ -33,7 +37,7 @@ public class ClientProcessIdTest extends AbstractTest {
             pidLong = ProcessHandle.current().pid();
         } catch (NoClassDefFoundError e) { // ProcessHandle is Java 9+
         }
-        pid = (pidLong > Integer.MAX_VALUE) ? 0 : (int)pidLong;
+        pid = (pidLong > Integer.MAX_VALUE) ? 0 : (int) pidLong;
     }
 
     @Test


### PR DESCRIPTION
exclude Azure DW as command is not supported