### PR TITLE
Fix conversion of LocalDateTime and LocalTime to String in Bulk Copy

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2292,22 +2292,25 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                         if (null == colValue) {
                             writeNullToTdsWriter(tdsWriter, bulkJdbcType, isStreaming);
                         } else {
-                            String colValueStr = colValue.toString();
 
+                            String colValueStr;
                             if (colValue instanceof LocalDateTime) {
                                 colValueStr = ((LocalDateTime)colValue).format(DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS"));
                             }
                             else if (colValue instanceof LocalTime) {
                                 colValueStr = ((LocalTime)colValue).format(DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS"));
                             }
+                            else {
+                                colValueStr = colValue.toString();
+                            }
 
                             if (unicodeConversionRequired(bulkJdbcType, destSSType)) {
-                                int stringLength = colValue.toString().length();
+                                int stringLength = colValueStr.length();
                                 byte[] typevarlen = new byte[2];
                                 typevarlen[0] = (byte) (2 * stringLength & 0xFF);
                                 typevarlen[1] = (byte) ((2 * stringLength >> 8) & 0xFF);
                                 tdsWriter.writeBytes(typevarlen);
-                                tdsWriter.writeString(colValue.toString());
+                                tdsWriter.writeString(colValueStr);
                             } else {
                                 if ((SSType.BINARY == destSSType) || (SSType.VARBINARY == destSSType)) {
                                     byte[] bytes = null;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2296,11 +2296,9 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                             String colValueStr;
                             if (colValue instanceof LocalDateTime) {
                                 colValueStr = ((LocalDateTime)colValue).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-                            }
-                            else if (colValue instanceof LocalTime) {
+                            } else if (colValue instanceof LocalTime) {
                                 colValueStr = ((LocalTime)colValue).format(DateTimeFormatter.ISO_LOCAL_TIME);
-                            }
-                            else {
+                            } else {
                                 colValueStr = colValue.toString();
                             }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2294,10 +2294,11 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                         } else {
                             String colValueStr = colValue.toString();
 
-                            // Remove extra trailing zeros added from toString
-                            if (colValue instanceof LocalDateTime || colValue instanceof LocalTime) {
-                                colValueStr = colValueStr.contains(".") ? colValueStr.replaceAll("0*$", "")
-                                                                        : colValueStr;
+                            if (colValue instanceof LocalDateTime) {
+                                colValueStr = ((LocalDateTime)colValue).format(DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS"));
+                            }
+                            else if (colValue instanceof LocalTime) {
+                                colValueStr = ((LocalTime)colValue).format(DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS"));
                             }
 
                             if (unicodeConversionRequired(bulkJdbcType, destSSType)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2295,10 +2295,10 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
 
                             String colValueStr;
                             if (colValue instanceof LocalDateTime) {
-                                colValueStr = ((LocalDateTime)colValue).format(DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS"));
+                                colValueStr = ((LocalDateTime)colValue).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                             }
                             else if (colValue instanceof LocalTime) {
-                                colValueStr = ((LocalTime)colValue).format(DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS"));
+                                colValueStr = ((LocalTime)colValue).format(DateTimeFormatter.ISO_LOCAL_TIME);
                             }
                             else {
                                 colValueStr = colValue.toString();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
@@ -14,10 +14,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
-import java.time.format.DateTimeFormatter;
+import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -238,17 +237,9 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
         BulkData bData = new BulkData(variation);
         query = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(destTable) + " (col1 datetime2(7))";
         int counter = 0;
-        String[] result = {
-                "2021-01-01 00:00:00.0000000",
-                "2021-01-01 12:00:00.0000000",
-                "2021-01-01 12:30:00.0000000",
-                "2021-01-01 12:30:44.0000000",
-                "2021-01-01 12:30:44.0000000",
-                "2021-01-01 12:30:44.0030000",
-                "2021-01-01 12:30:44.1000000",
-                "2021-01-01 12:30:44.1230000",
-                "2021-01-01 12:30:44.9990000"
-        };
+        String[] result = {"2021-01-01 00:00:00.0000000", "2021-01-01 12:00:00.0000000", "2021-01-01 12:30:00.0000000",
+                "2021-01-01 12:30:44.0000000", "2021-01-01 12:30:44.0000000", "2021-01-01 12:30:44.0030000",
+                "2021-01-01 12:30:44.1000000", "2021-01-01 12:30:44.1230000", "2021-01-01 12:30:44.9990000"};
         try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
             stmt.executeUpdate(query);
 
@@ -280,19 +271,10 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
         BulkData bData = new BulkData(variation);
         query = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(destTable) + " (col1 datetime2(7))";
         int counter = 0;
-        String[] result = {
-                "2021-01-01 00:00:00.0000000",
-                "2021-01-01 12:00:00.0000000",
-                "2021-01-01 12:30:00.0000000",
-                "2021-01-01 12:30:44.0000000",
-                "2021-01-01 12:30:44.0000000",
-                "2021-01-01 12:30:44.0000007",
-                "2021-01-01 12:30:44.0030000",
-                "2021-01-01 12:30:44.1000000",
-                "2021-01-01 12:30:44.1230000",
-                "2021-01-01 12:30:44.1234567",
-                "2021-01-01 12:30:44.9999999"
-        };
+        String[] result = {"2021-01-01 00:00:00.0000000", "2021-01-01 12:00:00.0000000", "2021-01-01 12:30:00.0000000",
+                "2021-01-01 12:30:44.0000000", "2021-01-01 12:30:44.0000000", "2021-01-01 12:30:44.0000007",
+                "2021-01-01 12:30:44.0030000", "2021-01-01 12:30:44.1000000", "2021-01-01 12:30:44.1230000",
+                "2021-01-01 12:30:44.1234567", "2021-01-01 12:30:44.9999999"};
         try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
             stmt.executeUpdate(query);
 
@@ -324,18 +306,10 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
         BulkData bData = new BulkData(variation);
         query = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(destTable) + " (col1 datetime2(7))";
         int counter = 0;
-        String[] result = {
-                "1900-01-01 00:00:00.0000000",
-                "1900-01-01 12:00:00.0000000",
-                "1900-01-01 12:30:00.0000000",
-                "1900-01-01 12:30:44.0000000",
-                "1900-01-01 12:30:44.0000007",
-                "1900-01-01 12:30:44.0030000",
-                "1900-01-01 12:30:44.1000000",
-                "1900-01-01 12:30:44.1230000",
-                "1900-01-01 12:30:44.1234567",
-                "1900-01-01 12:30:44.9999999"
-        };
+        String[] result = {"1900-01-01 00:00:00.0000000", "1900-01-01 12:00:00.0000000", "1900-01-01 12:30:00.0000000",
+                "1900-01-01 12:30:44.0000000", "1900-01-01 12:30:44.0000007", "1900-01-01 12:30:44.0030000",
+                "1900-01-01 12:30:44.1000000", "1900-01-01 12:30:44.1230000", "1900-01-01 12:30:44.1234567",
+                "1900-01-01 12:30:44.9999999"};
         try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
             stmt.executeUpdate(query);
 
@@ -442,7 +416,6 @@ class BulkData implements ISQLServerBulkData {
             dateData = new ArrayList<>();
             dateData.add(Timestamp.valueOf("1954-05-22 02:43:37.1234"));
             rowCount = dateData.size();
-
         } else if (variation.equalsIgnoreCase("testBinaryColumnAsByte")) {
             isStringData = false;
             columnMetadata = new HashMap<>();
@@ -452,7 +425,6 @@ class BulkData implements ISQLServerBulkData {
             byteData = new ArrayList<>();
             byteData.add("helloo".getBytes());
             rowCount = byteData.size();
-
         } else if (variation.equalsIgnoreCase("testBinaryColumnAsString")) {
             isStringData = true;
             columnMetadata = new HashMap<>();
@@ -462,7 +434,6 @@ class BulkData implements ISQLServerBulkData {
             stringData = new ArrayList<>();
             stringData.add("616368697412");
             rowCount = stringData.size();
-
         } else if (variation.equalsIgnoreCase("testSendValidValueforBinaryColumnAsString")) {
             isStringData = true;
             columnMetadata = new HashMap<>();
@@ -472,7 +443,6 @@ class BulkData implements ISQLServerBulkData {
             stringData = new ArrayList<>();
             stringData.add("010101");
             rowCount = stringData.size();
-
         } else if (variation.equalsIgnoreCase("testSendValidValueforDatetime3ColumnAsLocalDateTime")) {
             isStringData = false;
             columnMetadata = new HashMap<>();
@@ -490,7 +460,6 @@ class BulkData implements ISQLServerBulkData {
             datetime3Data.add(LocalDateTime.of(2021, 1, 1, 12, 30, 44, 123000000));
             datetime3Data.add(LocalDateTime.of(2021, 1, 1, 12, 30, 44, 999000000));
             rowCount = datetime3Data.size();
-
         } else if (variation.equalsIgnoreCase("testSendValidValueforDatetime7ColumnAsLocalDateTime")) {
             isStringData = false;
             columnMetadata = new HashMap<>();
@@ -510,7 +479,6 @@ class BulkData implements ISQLServerBulkData {
             datetime7Data.add(LocalDateTime.of(2021, 1, 1, 12, 30, 44, 123456700));
             datetime7Data.add(LocalDateTime.of(2021, 1, 1, 12, 30, 44, 999999900));
             rowCount = datetime7Data.size();
-
         } else if (variation.equalsIgnoreCase("testSendValidValueforDatetime2ColumnAsLocalTime")) {
             isStringData = false;
             columnMetadata = new HashMap<>();
@@ -529,11 +497,9 @@ class BulkData implements ISQLServerBulkData {
             timeData.add(LocalTime.of(12, 30, 44, 123456700));
             timeData.add(LocalTime.of(12, 30, 44, 999999900));
             rowCount = timeData.size();
-
         }
 
         counter = 0;
-
     }
 
     @Override

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
@@ -14,6 +14,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -225,6 +228,92 @@ public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
     }
 
     /**
+     * Testing that sending valid values of LocalDateTime for datetime2 column are successful
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendValidValueforDatetime2ColumnAsLocalDateTime() throws Exception {
+        variation = "testSendValidValueforDatetime2ColumnAsLocalDateTime";
+        BulkData bData = new BulkData(variation);
+        query = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(destTable) + " (col1 datetime2(7))";
+        int counter = 0;
+        String[] result = {
+                "2021-01-01 00:00:00.0000000",
+                "2021-01-01 12:00:00.0000000",
+                "2021-01-01 12:30:00.0000000",
+                "2021-01-01 12:30:44.0000000",
+                "2021-01-01 12:30:44.0000007",
+                "2021-01-01 12:30:44.0030000",
+                "2021-01-01 12:30:44.1000000",
+                "2021-01-01 12:30:44.1230000",
+                "2021-01-01 12:30:44.1234567",
+                "2021-01-01 12:30:44.9999999"
+        };
+        try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+            stmt.executeUpdate(query);
+
+            try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
+                bcOperation.setDestinationTableName(AbstractSQLGenerator.escapeIdentifier(destTable));
+                bcOperation.writeToServer(bData);
+
+                try (ResultSet rs = stmt
+                        .executeQuery("select * from " + AbstractSQLGenerator.escapeIdentifier(destTable))) {
+                    while (rs.next()) {
+                        assertEquals(rs.getString(1), result[counter]);
+                        counter++;
+                    }
+                }
+            } catch (Exception e) {
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Testing that sending valid values of LocalTime for datetime2 column are successful
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSendValidValueforDatetime2ColumnAsLocalTime() throws Exception {
+        variation = "testSendValidValueforDatetime2ColumnAsLocalTime";
+        BulkData bData = new BulkData(variation);
+        query = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(destTable) + " (col1 datetime2(7))";
+        int counter = 0;
+        String[] result = {
+                "1900-01-01 00:00:00.0000000",
+                "1900-01-01 12:00:00.0000000",
+                "1900-01-01 12:30:00.0000000",
+                "1900-01-01 12:30:44.0000000",
+                "1900-01-01 12:30:44.0000007",
+                "1900-01-01 12:30:44.0030000",
+                "1900-01-01 12:30:44.1000000",
+                "1900-01-01 12:30:44.1230000",
+                "1900-01-01 12:30:44.1234567",
+                "1900-01-01 12:30:44.9999999"
+        };
+        try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+            stmt.executeUpdate(query);
+
+            try (SQLServerBulkCopy bcOperation = new SQLServerBulkCopy(connectionString)) {
+                bcOperation.setDestinationTableName(AbstractSQLGenerator.escapeIdentifier(destTable));
+                bcOperation.writeToServer(bData);
+
+                try (ResultSet rs = stmt
+                        .executeQuery("select * from " + AbstractSQLGenerator.escapeIdentifier(destTable))) {
+                    while (rs.next()) {
+                        assertEquals(rs.getString(1), result[counter]);
+                        counter++;
+                    }
+                }
+            } catch (Exception e) {
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    /**
      * Prepare test
      * 
      * @throws SQLException
@@ -272,7 +361,9 @@ class BulkData implements ISQLServerBulkData {
     }
 
     Map<Integer, ColumnMetadata> columnMetadata;
+    ArrayList<LocalDateTime> datetimeData;
     ArrayList<Timestamp> dateData;
+    ArrayList<LocalTime> timeData;
     ArrayList<String> stringData;
     ArrayList<byte[]> byteData;
 
@@ -328,9 +419,7 @@ class BulkData implements ISQLServerBulkData {
             stringData.add("616368697412");
             rowCount = stringData.size();
 
-        }
-
-        else if (variation.equalsIgnoreCase("testSendValidValueforBinaryColumnAsString")) {
+        } else if (variation.equalsIgnoreCase("testSendValidValueforBinaryColumnAsString")) {
             isStringData = true;
             columnMetadata = new HashMap<>();
 
@@ -340,7 +429,46 @@ class BulkData implements ISQLServerBulkData {
             stringData.add("010101");
             rowCount = stringData.size();
 
+        } else if (variation.equalsIgnoreCase("testSendValidValueforDatetime2ColumnAsLocalDateTime")) {
+            isStringData = false;
+            columnMetadata = new HashMap<>();
+
+            columnMetadata.put(1, new ColumnMetadata("datetime2(7)", java.sql.Types.VARCHAR, 0, 0));
+
+            datetimeData = new ArrayList<>();
+            datetimeData.add(LocalDateTime.parse("2021-01-01T00:00:00.0000000", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:00:00.0000000", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:00.0000000", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:44.0000000", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:44.0000007", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:44.0030000", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:44.1000000", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:44.1230000", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:44.1234567", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            datetimeData.add(LocalDateTime.parse("2021-01-01T12:30:44.9999999", DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSS")));
+            rowCount = datetimeData.size();
+
+        } else if (variation.equalsIgnoreCase("testSendValidValueforDatetime2ColumnAsLocalTime")) {
+            isStringData = false;
+            columnMetadata = new HashMap<>();
+
+            columnMetadata.put(1, new ColumnMetadata("datetime2(7)", java.sql.Types.TIME, 0, 0));
+
+            timeData = new ArrayList<>();
+            timeData.add(LocalTime.parse("00:00:00.0000000", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:00:00.0000000", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:00.0000000", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:44.0000000", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:44.0000007", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:44.0030000", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:44.1000000", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:44.1230000", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:44.1234567", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            timeData.add(LocalTime.parse("12:30:44.9999999", DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSS")));
+            rowCount = timeData.size();
+
         }
+
         counter = 0;
 
     }
@@ -378,6 +506,10 @@ class BulkData implements ISQLServerBulkData {
         else {
             if (null != dateData)
                 dataRow[0] = dateData.get(counter);
+            else if (null != datetimeData)
+                dataRow[0] = datetimeData.get(counter);
+            else if (null != timeData)
+                dataRow[0] = timeData.get(counter);
             else if (null != byteData)
                 dataRow[0] = byteData.get(counter);
         }


### PR DESCRIPTION
When writing a LocalDateTime with bulk copy, the driver may return an error when second-of-minute and nano-of-second is 0:

```
com.microsoft.sqlserver.jdbc.SQLServerException: Conversion failed when converting date and/or time from character string. Msg 241, Level 16, State 1, Conversion failed when converting date and/or time from character string.
```

When time units to the right of the minute are all 0's, the LocalDateTime.toString() will simplify the string format to **uuuu-MM-dd'T'HH:mm**, which SQL Server is not able to process due to the missing seconds. This PR changes the string conversion to use the DateTimeFormatter and ensures that it includes the necessary padding.

For example:
```
LocalDateTime                  = 2021-08-13 00:00:00

Current - toString()           = 2021-08-13T00:00              // Returns error
New     - DateTimeFormatter    = 2021-08-13T00:00:00           // It works!
```

Note that this is very similar to PR #1485.