### PR TITLE
Update mssql-jdbc_auth_LICENSE

### DIFF
--- a/mssql-jdbc_auth_LICENSE
+++ b/mssql-jdbc_auth_LICENSE
@@ -9,7 +9,7 @@ These license terms are an agreement between you and Microsoft Corporation (or o
 
 2. DISTRIBUTABLE CODE. The software may contain code you are permitted to distribute (i.e. make available for third parties) in applications you develop, as described in this Section. 
 	a) Distribution Rights. The code and test files described below are distributable if included with the software.
-		i. REDIST.TXT Files. You may copy and distribute the object code form of code listed on the REDIST list in the software, if any, or listed at REDIST;
+		i. REDIST.TXT Files. You may copy and distribute the object code form of code listed on the REDIST list in the software, if any, or listed at REDIST (https://aka.ms/jdbceularedist);
 		ii. Image Library. You may copy and distribute images, graphics, and animations in the Image Library as described in the software documentation;
 		iii. Sample Code, Templates, and Styles. You may copy, modify, and distribute the source and object code form of code marked as “sample”, “template”, “simple styles”, and “sketch styles”; and
 		iv. Third Party Distribution. You may permit distributors of your applications to copy and distribute any of this distributable code you elect to distribute with your applications.


### PR DESCRIPTION
The REDIST section was missing the latest changes.

From #1659