### PR TITLE
Jacoco related updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
 						<fileSet>
 							<directory>jacoco-execs/</directory>
 							<includes>
-								<include>*.exec</include>
+								<include>**/*.exec</include>
 							</includes>
 						</fileSet>
 					</fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -282,18 +282,6 @@
 							</archive>
 						</configuration>
 					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0-M1</version>
-						<configuration>
-							<!-- Exclude [xJDBC42] For tests not compatible with JDBC 4.2 Specifications -->
-							<excludedGroups>${excludedGroups}, xJDBC42</excludedGroups>
-							<!-- needs to be overridden as illegal-access and MaxPermSize=256m 
-								not valid in java 8 -->
-							<argLine>-Xmx1024m -Djava.library.path=${dllPath}</argLine>
-						</configuration>
-					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -289,9 +289,6 @@
 						<configuration>
 							<!-- Exclude [xJDBC42] For tests not compatible with JDBC 4.2 Specifications -->
 							<excludedGroups>${excludedGroups}, xJDBC42</excludedGroups>
-							<!-- needs to be overridden as illegal-access and MaxPermSize=256m 
-								not valid in java 8 -->
-							<argLine>-Xmx1024m -Djava.library.path=${dllPath}</argLine>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,18 @@
 							</archive>
 						</configuration>
 					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0-M1</version>
+						<configuration>
+							<!-- Exclude [xJDBC42] For tests not compatible with JDBC 4.2 Specifications -->
+							<excludedGroups>${excludedGroups}, xJDBC42</excludedGroups>
+							<!-- needs to be overridden as illegal-access and MaxPermSize=256m 
+								not valid in java 8 -->
+							<argLine>-Xmx1024m -Djava.library.path=${dllPath}</argLine>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -504,12 +504,12 @@
 						</goals>
 					</execution>
 					<execution>
-						<id>report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
+				        <id>default-report</id>
+				        <phase>prepare-package</phase>
+				        <goals>
+				            <goal>report</goal>
+				        </goals>
+				    </execution>
 				</executions>
 				<configuration>
 					<excludes>


### PR DESCRIPTION
Bringing back CodeCov with cumulative coverage.

Sample build:
https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=42396&view=results

Keeping test failures aside, codecov report is now generated:
https://codecov.io/gh/cheenamalhotra/mssql-jdbc/commit/46029f6cbae8a0cb60a00be3970a20385ded419a/build

Once this is merged, I'll trigger report for this repo.