### PR TITLE
Deprecate and Rename Service principal connection properties

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
@@ -1053,33 +1053,42 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
 
     /**
      * Returns the value for the connection property 'AADSecurePrincipalId'.
+     * 
+     * @deprecated Use {@link ISQLServerDataSource#getUser()} instead
      *
      * @return 'AADSecurePrincipalId' property value.
      */
+    @Deprecated
     String getAADSecurePrincipalId();
 
     /**
      * Sets the 'AADSecurePrincipalId' connection property used for Active Directory Service Principal authentication.
-     *
+     * 
+     * @deprecated Use {@link ISQLServerDataSource#setUser()} instead
      * @param AADSecurePrincipalId
      *        Active Directory Service Principal Id.
      */
+    @Deprecated
     void setAADSecurePrincipalId(String AADSecurePrincipalId);
 
     /**
      * Returns the value for the connection property 'AADSecurePrincipalSecret'.
-     *
+     * 
+     * @deprecated Use {@link ISQLServerDataSource#getPassword()} instead
      * @return 'AADSecurePrincipalSecret' property value.
      */
+    @Deprecated
     String getAADSecurePrincipalSecret();
 
     /**
      * Sets the 'AADSecurePrincipalSecret' connection property used for Active Directory Service Principal
      * authentication.
-     *
+     * 
+     * @deprecated Use {@link ISQLServerDataSource#setPassword()} instead
      * @param AADSecurePrincipalSecret
      *        Active Directory Service Principal secret.
      */
+    @Deprecated
     void setAADSecurePrincipalSecret(String AADSecurePrincipalSecret);
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
@@ -1064,7 +1064,7 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
     /**
      * Sets the 'AADSecurePrincipalId' connection property used for Active Directory Service Principal authentication.
      * 
-     * @deprecated Use {@link ISQLServerDataSource#setUser()} instead
+     * @deprecated Use {@link ISQLServerDataSource#setUser(String password)} instead
      * @param AADSecurePrincipalId
      *        Active Directory Service Principal Id.
      */
@@ -1072,19 +1072,10 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
     void setAADSecurePrincipalId(String AADSecurePrincipalId);
 
     /**
-     * Returns the value for the connection property 'AADSecurePrincipalSecret'.
-     * 
-     * @deprecated Use {@link ISQLServerDataSource#getPassword()} instead
-     * @return 'AADSecurePrincipalSecret' property value.
-     */
-    @Deprecated
-    String getAADSecurePrincipalSecret();
-
-    /**
      * Sets the 'AADSecurePrincipalSecret' connection property used for Active Directory Service Principal
      * authentication.
      * 
-     * @deprecated Use {@link ISQLServerDataSource#setPassword()} instead
+     * @deprecated Use {@link ISQLServerDataSource#setPassword(String password)} instead
      * @param AADSecurePrincipalSecret
      *        Active Directory Service Principal secret.
      */

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -172,9 +172,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     private String clientKeyPassword = "";
 
     /** AAD principal id */
+    @Deprecated
     private String aadPrincipalID = "";
 
     /** AAD principal secret */
+    @Deprecated
     private String aadPrincipalSecret = "";
 
     /** sendTemporalDataTypesAsStringForBulkCopy flag */
@@ -828,7 +830,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return serverColumnEncryptionVersion;
     }
 
-    /** whether server supports data classiciation */
+    /** whether server supports data classification */
     private boolean serverSupportsDataClassification = false;
 
     /** server supported data classification version */
@@ -2202,11 +2204,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     if (activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString()).isEmpty()
                             || activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString())
                                     .isEmpty()) {
-
-                        if (connectionlogger.isLoggable(Level.SEVERE)) {
-                            connectionlogger.severe(
-                                    toString() + " " + SQLServerException.getErrString("R_NtlmNoUserPasswordDomain"));
-                        }
                         throw new SQLServerException(SQLServerException.getErrString("R_NtlmNoUserPasswordDomain"),
                                 null);
                     }
@@ -2222,10 +2219,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
                 if (integratedSecurity
                         && !authenticationString.equalsIgnoreCase(SqlAuthentication.NotSpecified.toString())) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(toString() + " "
-                                + SQLServerException.getErrString("R_SetAuthenticationWhenIntegratedSecurityTrue"));
-                    }
                     throw new SQLServerException(
                             SQLServerException.getErrString("R_SetAuthenticationWhenIntegratedSecurityTrue"), null);
                 }
@@ -2235,10 +2228,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                 .isEmpty())
                                 || (!activeConnectionProperties
                                         .getProperty(SQLServerDriverStringProperty.PASSWORD.toString()).isEmpty()))) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(toString() + " "
-                                + SQLServerException.getErrString("R_IntegratedAuthenticationWithUserPassword"));
-                    }
                     throw new SQLServerException(
                             SQLServerException.getErrString("R_IntegratedAuthenticationWithUserPassword"), null);
                 }
@@ -2248,10 +2237,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                 .isEmpty())
                                 || (activeConnectionProperties
                                         .getProperty(SQLServerDriverStringProperty.PASSWORD.toString()).isEmpty()))) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(toString() + " "
-                                + SQLServerException.getErrString("R_NoUserPasswordForActivePassword"));
-                    }
                     throw new SQLServerException(SQLServerException.getErrString("R_NoUserPasswordForActivePassword"),
                             null);
                 }
@@ -2261,15 +2246,15 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                 .isEmpty())
                                 || (!activeConnectionProperties
                                         .getProperty(SQLServerDriverStringProperty.PASSWORD.toString()).isEmpty()))) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(toString() + " "
-                                + SQLServerException.getErrString("R_MSIAuthenticationWithUserPassword"));
-                    }
                     throw new SQLServerException(SQLServerException.getErrString("R_MSIAuthenticationWithUserPassword"),
                             null);
                 }
 
                 if (authenticationString.equalsIgnoreCase(SqlAuthentication.ActiveDirectoryServicePrincipal.toString())
+                        && ((activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString())
+                                .isEmpty())
+                                || (activeConnectionProperties
+                                        .getProperty(SQLServerDriverStringProperty.PASSWORD.toString()).isEmpty()))
                         && ((activeConnectionProperties
                                 .getProperty(SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_ID.toString())
                                 .isEmpty())
@@ -2277,10 +2262,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                         .getProperty(
                                                 SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString())
                                         .isEmpty()))) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(toString() + " "
-                                + SQLServerException.getErrString("R_NoUserPasswordForActiveServicePrincipal"));
-                    }
                     throw new SQLServerException(
                             SQLServerException.getErrString("R_NoUserPasswordForActiveServicePrincipal"), null);
                 }
@@ -2290,11 +2271,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                 .isEmpty())
                                 || (activeConnectionProperties
                                         .getProperty(SQLServerDriverStringProperty.PASSWORD.toString()).isEmpty()))) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(
-                                toString() + " " + SQLServerException.getErrString("R_NoUserPasswordForSqlPassword"));
-                    }
-
                     throw new SQLServerException(SQLServerException.getErrString("R_NoUserPasswordForSqlPassword"),
                             null);
                 }
@@ -2306,28 +2282,16 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 }
 
                 if ((null != accessTokenInByte) && 0 == accessTokenInByte.length) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(
-                                toString() + " " + SQLServerException.getErrString("R_AccessTokenCannotBeEmpty"));
-                    }
                     throw new SQLServerException(SQLServerException.getErrString("R_AccessTokenCannotBeEmpty"), null);
                 }
 
                 if (integratedSecurity && (null != accessTokenInByte)) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(toString() + " "
-                                + SQLServerException.getErrString("R_SetAccesstokenWhenIntegratedSecurityTrue"));
-                    }
                     throw new SQLServerException(
                             SQLServerException.getErrString("R_SetAccesstokenWhenIntegratedSecurityTrue"), null);
                 }
 
                 if ((!authenticationString.equalsIgnoreCase(SqlAuthentication.NotSpecified.toString()))
                         && (null != accessTokenInByte)) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(toString() + " "
-                                + SQLServerException.getErrString("R_SetBothAuthenticationAndAccessToken"));
-                    }
                     throw new SQLServerException(
                             SQLServerException.getErrString("R_SetBothAuthenticationAndAccessToken"), null);
                 }
@@ -2336,10 +2300,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         .getProperty(SQLServerDriverStringProperty.USER.toString()).isEmpty())
                         || (!activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString())
                                 .isEmpty()))) {
-                    if (connectionlogger.isLoggable(Level.SEVERE)) {
-                        connectionlogger.severe(
-                                toString() + " " + SQLServerException.getErrString("R_AccessTokenWithUserPassword"));
-                    }
                     throw new SQLServerException(SQLServerException.getErrString("R_AccessTokenWithUserPassword"),
                             null);
                 }
@@ -5348,8 +5308,18 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 break;
             } else if (authenticationString
                     .equalsIgnoreCase(SqlAuthentication.ActiveDirectoryServicePrincipal.toString())) {
-                fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal(fedAuthInfo, aadPrincipalID,
-                        aadPrincipalSecret, authenticationString);
+
+                // aadPrincipalID and aadPrincipalSecret is deprecated replaced by username and password
+                if (aadPrincipalID != null && !aadPrincipalID.isEmpty() && aadPrincipalSecret != null
+                        && !aadPrincipalSecret.isEmpty()) {
+                    fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal(fedAuthInfo, aadPrincipalID,
+                            aadPrincipalSecret, authenticationString);
+                } else {
+                    fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal(fedAuthInfo,
+                            activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString()),
+                            activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString()),
+                            authenticationString);
+                }
 
                 // Break out of the retry loop in successful case.
                 break;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2250,20 +2250,34 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             null);
                 }
 
-                if (authenticationString.equalsIgnoreCase(SqlAuthentication.ActiveDirectoryServicePrincipal.toString())
-                        && ((activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString())
-                                .isEmpty())
-                                || (activeConnectionProperties
-                                        .getProperty(SQLServerDriverStringProperty.PASSWORD.toString()).isEmpty()))
-                        && ((activeConnectionProperties
-                                .getProperty(SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_ID.toString())
-                                .isEmpty())
-                                || (activeConnectionProperties
-                                        .getProperty(
-                                                SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString())
-                                        .isEmpty()))) {
-                    throw new SQLServerException(
-                            SQLServerException.getErrString("R_NoUserPasswordForActiveServicePrincipal"), null);
+                if (authenticationString
+                        .equalsIgnoreCase(SqlAuthentication.ActiveDirectoryServicePrincipal.toString())) {
+                    if ((activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString()).isEmpty()
+                            || activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString())
+                                    .isEmpty())
+                            && (activeConnectionProperties
+                                    .getProperty(SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_ID.toString())
+                                    .isEmpty()
+                                    || activeConnectionProperties.getProperty(
+                                            SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString())
+                                            .isEmpty())) {
+                        throw new SQLServerException(
+                                SQLServerException.getErrString("R_NoUserPasswordForActiveServicePrincipal"), null);
+                    }
+
+                    if ((!activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString())
+                            .isEmpty()
+                            || !activeConnectionProperties
+                                    .getProperty(SQLServerDriverStringProperty.PASSWORD.toString()).isEmpty())
+                            && (!activeConnectionProperties
+                                    .getProperty(SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_ID.toString())
+                                    .isEmpty()
+                                    || !activeConnectionProperties.getProperty(
+                                            SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString())
+                                            .isEmpty())) {
+                        throw new SQLServerException(SQLServerException.getErrString("R_BothUserPasswordandDeprecated"),
+                                null);
+                    }
                 }
 
                 if (authenticationString.equalsIgnoreCase(SqlAuthentication.SqlPassword.toString())

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -1076,13 +1076,6 @@ public class SQLServerDataSource
 
     @Override
     @Deprecated
-    public String getAADSecurePrincipalSecret() {
-        return getStringProperty(connectionProps, SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString(),
-                SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.getDefaultValue());
-    }
-
-    @Override
-    @Deprecated
     public void setAADSecurePrincipalSecret(String AADSecurePrincipalSecret) {
         setStringProperty(connectionProps, SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString(),
                 AADSecurePrincipalSecret);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -1061,24 +1061,28 @@ public class SQLServerDataSource
     }
 
     @Override
+    @Deprecated
     public String getAADSecurePrincipalId() {
         return getStringProperty(connectionProps, SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_ID.toString(),
                 SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_ID.getDefaultValue());
     }
 
     @Override
+    @Deprecated
     public void setAADSecurePrincipalId(String AADSecurePrincipalId) {
         setStringProperty(connectionProps, SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_ID.toString(),
                 AADSecurePrincipalId);
     }
 
     @Override
+    @Deprecated
     public String getAADSecurePrincipalSecret() {
         return getStringProperty(connectionProps, SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString(),
                 SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.getDefaultValue());
     }
 
     @Override
+    @Deprecated
     public void setAADSecurePrincipalSecret(String AADSecurePrincipalSecret) {
         setStringProperty(connectionProps, SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString(),
                 AADSecurePrincipalSecret);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -376,7 +376,9 @@ enum SQLServerDriverStringProperty {
     CLIENT_CERTIFICATE("clientCertificate", ""),
     CLIENT_KEY("clientKey", ""),
     CLIENT_KEY_PASSWORD("clientKeyPassword", ""),
+    @Deprecated
     AAD_SECURE_PRINCIPAL_ID("AADSecurePrincipalId", ""),
+    @Deprecated
     AAD_SECURE_PRINCIPAL_SECRET("AADSecurePrincipalSecret", ""),
     MAX_RESULT_BUFFER("maxResultBuffer", "-1");
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -334,7 +334,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_AccessTokenCannotBeEmpty", "AccesToken cannot be empty."},
         {"R_SetBothAuthenticationAndAccessToken", "Cannot set the AccessToken property if \"Authentication\" has been specified in the connection string."},
         {"R_NoUserPasswordForActivePassword", "Both \"User\" (or \"UserName\") and \"Password\" connection string keywords must be specified, if \"Authentication=ActiveDirectoryPassword\"."},
-        {"R_NoUserPasswordForActiveServicePrincipal", "Both \"AADSecurePrincipalId\" and \"AADSecurePrincipalSecret\" connection string keywords must be specified, if \"Authentication=ActiveDirectoryServicePrincipal\"."},
+        {"R_NoUserPasswordForActiveServicePrincipal", "Both \"UserName\" and \"Password\" connection string keywords must be specified, if \"Authentication=ActiveDirectoryServicePrincipal\"."},
         {"R_NoUserPasswordForSqlPassword", "Both \"User\" (or \"UserName\") and \"Password\" connection string keywords must be specified, if \"Authentication=SqlPassword\"."},
         {"R_ForceEncryptionTrue_HonorAEFalse", "Cannot set Force Encryption to true for parameter {0} because enryption is not enabled for the statement or procedure {1}."},
         {"R_ForceEncryptionTrue_HonorAETrue_UnencryptedColumn", "Cannot execute statement or procedure {0} because Force Encryption was set as true for parameter {1} and the database expects this parameter to be sent as plaintext. This may be due to a configuration error."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -336,6 +336,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_NoUserPasswordForActivePassword", "Both \"User\" (or \"UserName\") and \"Password\" connection string keywords must be specified, if \"Authentication=ActiveDirectoryPassword\"."},
         {"R_NoUserPasswordForActiveServicePrincipal", "Both \"UserName\" and \"Password\" connection string keywords must be specified, if \"Authentication=ActiveDirectoryServicePrincipal\"."},
         {"R_NoUserPasswordForSqlPassword", "Both \"User\" (or \"UserName\") and \"Password\" connection string keywords must be specified, if \"Authentication=SqlPassword\"."},
+        {"R_BothUserPasswordandDeprecated", "Both \"User\" (or \"UserName\"), \"Password\" and \"AADSecurePrincipalId\", \"AADSecurePrincipalSecret\" connection string keywords are specified, please use \"User\" (or \"UserName\"), \"Password\" only."},
         {"R_ForceEncryptionTrue_HonorAEFalse", "Cannot set Force Encryption to true for parameter {0} because enryption is not enabled for the statement or procedure {1}."},
         {"R_ForceEncryptionTrue_HonorAETrue_UnencryptedColumn", "Cannot execute statement or procedure {0} because Force Encryption was set as true for parameter {1} and the database expects this parameter to be sent as plaintext. This may be due to a configuration error."},
         {"R_ForceEncryptionTrue_HonorAEFalseRS", "Cannot set Force Encryption to true for parameter {0} because encryption is not enabled for the statement or procedure."},
@@ -408,8 +409,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_certificateStoreInvalidKeyword", "Cannot set \"keyStoreSecret\", if \"keyStoreAuthentication=CertificateStore\" has been specified in the connection string."},
         {"R_certificateStoreLocationNotSet", "\"keyStoreLocation\" must be specified, if \"keyStoreAuthentication=CertificateStore\" has been specified in the connection string."},
         {"R_certificateStorePlatformInvalid", "Cannot set \"keyStoreAuthentication=CertificateStore\" on a Windows operating system."},
-        {"R_invalidKeyStoreFile", "Cannot parse \"{0}\". Either the file format is not valid or the password is not correct."}, // for
-                                                                                                                                // JKS/PKCS
+        {"R_invalidKeyStoreFile", "Cannot parse \"{0}\". Either the file format is not valid or the password is not correct."}, // for JKS/PKCS
         {"R_invalidCEKCacheTtl", "Invalid column encryption key cache time-to-live specified. The columnEncryptionKeyCacheTtl value cannot be negative and timeUnit can only be DAYS, HOURS, MINUTES or SECONDS."},
         {"R_sendTimeAsDateTimeForAE", "Use sendTimeAsDateTime=false with Always Encrypted."},
         {"R_TVPnotWorkWithSetObjectResultSet", "setObject() with ResultSet is not supported for Table-Valued Parameter. Please use setStructured()."},

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -247,7 +247,7 @@ public class FedauthTest extends FedauthCommon {
     public void testAADServicePrincipalAuthDeprecated() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
                 + SqlAuthentication.ActiveDirectoryServicePrincipal + ";AADSecurePrincipalId=" + azureAADPrincipialId
-                + ";AADSecurePrincipalSecret =" + azureAADPrincipialSecret;
+                + ";AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
         String urlEncrypted = url + ";encrypt=true;trustServerCertificate=true;";
         SQLServerDataSource ds = new SQLServerDataSource();
         updateDataSource(url, ds);
@@ -267,8 +267,8 @@ public class FedauthTest extends FedauthCommon {
     @Test
     public void testAADServicePrincipalAuth() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
-                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";Username=" + azureAADPrincipialId
-                + ";Password =" + azureAADPrincipialSecret;
+                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";Username=" + azureAADPrincipialId + ";Password="
+                + azureAADPrincipialSecret;
         String urlEncrypted = url + ";encrypt=true;trustServerCertificate=true;";
         SQLServerDataSource ds = new SQLServerDataSource();
         updateDataSource(url, ds);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -242,11 +242,33 @@ public class FedauthTest extends FedauthCommon {
     /**
      * Test the actual AAD Service Principal Authentication using connection string, data source and SSL encryption.
      */
+    @Deprecated
+    @Test
+    public void testAADServicePrincipalAuthDeprecated() {
+        String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
+                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";AADSecurePrincipalId=" + azureAADPrincipialId
+                + ";AADSecurePrincipalSecret =" + azureAADPrincipialSecret;
+        String urlEncrypted = url + ";encrypt=true;trustServerCertificate=true;";
+        SQLServerDataSource ds = new SQLServerDataSource();
+        updateDataSource(url, ds);
+        try (Connection conn1 = DriverManager.getConnection(url); Connection conn2 = ds.getConnection();
+                Connection conn3 = DriverManager.getConnection(urlEncrypted)) {
+            assertNotNull(conn1);
+            assertNotNull(conn2);
+            assertNotNull(conn3);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Test the actual AAD Service Principal Authentication using connection string, data source and SSL encryption.
+     */
     @Test
     public void testAADServicePrincipalAuth() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
-                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";AADSecurePrincipalId=" + azureAADPrincipialId
-                + ";AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
+                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";Username=" + azureAADPrincipialId
+                + ";Password =" + azureAADPrincipialSecret;
         String urlEncrypted = url + ";encrypt=true;trustServerCertificate=true;";
         SQLServerDataSource ds = new SQLServerDataSource();
         updateDataSource(url, ds);
@@ -275,15 +297,19 @@ public class FedauthTest extends FedauthCommon {
         url = baseUrl + "AADSecurePrincipalId=wrongId;AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
         validateException(url, "R_MSALExecution");
 
-        // AADSecurePrincipalSecret not provided.
+        // AADSecurePrincipalSecret/password not provided.
         url = baseUrl + "AADSecurePrincipalId=" + azureAADPrincipialId;
         validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
-
-        // AADSecurePrincipalId not provided.
-        url = baseUrl + "AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
+        url = baseUrl + "Username=" + azureAADPrincipialId;
         validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
 
-        // Both AADSecurePrincipalId and AADSecurePrincipalSecret not provided.
+        // AADSecurePrincipalId/username not provided.
+        url = baseUrl + "AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
+        validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
+        url = baseUrl + "password=" + azureAADPrincipialSecret;
+        validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
+
+        // Both AADSecurePrincipalId/username and AADSecurePrincipalSecret/password not provided.
         validateException(baseUrl, "R_NoUserPasswordForActiveServicePrincipal");
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -240,9 +240,11 @@ public class FedauthTest extends FedauthCommon {
     }
 
     /**
-     * Test the actual AAD Service Principal Authentication using connection string, data source and SSL encryption.
+     * Test AAD Service Principal Authentication using AADSecurePrincipalId/AADSecurePrincipalSecret in connection
+     * string, data source and SSL encryption.
+     * 
+     * @deprecated
      */
-    @Deprecated
     @Test
     public void testAADServicePrincipalAuthDeprecated() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
@@ -262,7 +264,8 @@ public class FedauthTest extends FedauthCommon {
     }
 
     /**
-     * Test the actual AAD Service Principal Authentication using connection string, data source and SSL encryption.
+     * Test AAD Service Principal Authentication using username/password in connection string, data source and SSL
+     * encryption.
      */
     @Test
     public void testAADServicePrincipalAuth() {
@@ -311,6 +314,12 @@ public class FedauthTest extends FedauthCommon {
 
         // Both AADSecurePrincipalId/username and AADSecurePrincipalSecret/password not provided.
         validateException(baseUrl, "R_NoUserPasswordForActiveServicePrincipal");
+
+        // both username/password and AADSecurePrincipalId/AADSecurePrincipalSecret provided
+        url = baseUrl + "Username=" + azureAADPrincipialId + ";password=" + azureAADPrincipialSecret
+                + ";AADSecurePrincipalId=" + azureAADPrincipialId + ";AADSecurePrincipalSecret="
+                + azureAADPrincipialSecret;
+        validateException(url, "R_BothUserPasswordandDeprecated");
     }
 
     private static void validateException(String url, String resourceKey) {


### PR DESCRIPTION
- deprecate AADSecurePrincipalId/AADSecurePrincipalSecret connection properrties and replace with username/password
- remove getAADSecretPrincipalId for security reasons