### PR TITLE
Retry randomUUID() to mitigate intermittent java NativeSeedGenerator failure

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3214,7 +3214,14 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         setState(State.Connected);
 
-        clientConnectionId = UUID.randomUUID();
+        try {
+            clientConnectionId = UUID.randomUUID();
+        } catch (InternalError e) {
+            // Java's NativeSeedGenerator can sometimes fail on getSeedBytes(). Exact reason is unknown but high system
+            // load seems to contribute to likelihood. Retry once to mitigate.
+            clientConnectionId = UUID.randomUUID();
+        }
+
         assert null != clientConnectionId;
 
         Prelogin(serverInfo.getServerName(), serverInfo.getPortNumber());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3219,6 +3219,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         } catch (InternalError e) {
             // Java's NativeSeedGenerator can sometimes fail on getSeedBytes(). Exact reason is unknown but high system
             // load seems to contribute to likelihood. Retry once to mitigate.
+            if (connectionlogger.isLoggable(Level.WARNING)) {
+                connectionlogger.warning(toString() + " Generating a random UUID has failed due to : " + e.getMessage() + "Retrying once.");
+            }
             clientConnectionId = UUID.randomUUID();
         }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3219,8 +3219,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         } catch (InternalError e) {
             // Java's NativeSeedGenerator can sometimes fail on getSeedBytes(). Exact reason is unknown but high system
             // load seems to contribute to likelihood. Retry once to mitigate.
-            if (connectionlogger.isLoggable(Level.WARNING)) {
-                connectionlogger.warning(toString() + " Generating a random UUID has failed due to : " + e.getMessage() + "Retrying once.");
+            if (connectionlogger.isLoggable(Level.FINER)) {
+                connectionlogger.finer(toString() + " Generating a random UUID has failed due to : " + e.getMessage() + "Retrying once.");
             }
             clientConnectionId = UUID.randomUUID();
         }


### PR DESCRIPTION
Java's NativeSeedGenerator can sometimes fail on getSeedBytes(). Exact reason is unknown but high system load seems to contribute to likelihood. Retry once to mitigate.