### PR TITLE
Updated javadoc for SQLServerBulkCSVFileRecord

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -75,11 +75,11 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
      * Constructs a simple reader to parse data from a delimited file with the given encoding.
      * 
      * @param fileToParse
-     *        File to parse data from, please ensure special regex characters are properly escaped.
+     *        File to parse data from.
      * @param encoding
      *        Charset encoding to use for reading the file, or NULL for the default encoding.
      * @param delimiter
-     *        Delimiter to used to separate each column
+     *        Delimiter to used to separate each column. Regex characters must be escaped with double backslashes.
      * @param firstLineIsColumnNames
      *        True if the first line of the file should be parsed as column names; false otherwise
      * @throws SQLServerException
@@ -128,7 +128,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
      * @param encoding
      *        Charset encoding to use for reading the file, or NULL for the default encoding.
      * @param delimiter
-     *        Delimiter to used to separate each column
+     *        Delimiter to used to separate each column. Regex characters must be escaped with double backslashes.
      * @param firstLineIsColumnNames
      *        True if the first line of the file should be parsed as column names; false otherwise
      * @throws SQLServerException

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -75,7 +75,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
      * Constructs a simple reader to parse data from a delimited file with the given encoding.
      * 
      * @param fileToParse
-     *        File to parse data from
+     *        File to parse data from, please ensure special regex characters are properly escaped.
      * @param encoding
      *        Charset encoding to use for reading the file, or NULL for the default encoding.
      * @param delimiter


### PR DESCRIPTION
Java doc updated as per user ask. SQLServerBulkCSVFileRecord now states that regex characters should be escaped.
Fixes #1691 