### PR TITLE
Fix ActiveDirectoryInteractive not using cache

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -190,7 +190,7 @@ class SQLServerMSAL4JUtils {
     private static IAccount getAccountByUsername(Set<IAccount> accounts, String username) {
         if (!accounts.isEmpty()) {
             for (IAccount account : accounts) {
-                if (account.username().equals(username)) {
+                if (account.username().contentEquals(username)) {
                     return account;
                 }
             }


### PR DESCRIPTION
After authenticating, current implementation does not use cache because it uses a wrong comparison of strings and since the TokenCache is serialized and deserialized, the comparison is false