### PR TITLE
Exclude Idle Connection Resiliency tests on Azure DW

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -30,6 +30,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 
 @Tag(Constants.xSQLv11)
+@Tag(Constants.xAzureSQLDW)
 public class BasicConnectionTest extends AbstractTest {
 
     @BeforeAll
@@ -78,7 +79,6 @@ public class BasicConnectionTest extends AbstractTest {
 
     @Test
     @Tag(Constants.xAzureSQLDB) // Switching databases is not supported against Azure, skip/
-    @Tag(Constants.xAzureSQLDW)
     public void testCatalog() throws SQLException {
         String expectedDatabaseName = null;
         String actualDatabaseName = null;
@@ -106,7 +106,6 @@ public class BasicConnectionTest extends AbstractTest {
 
     @Test
     @Tag(Constants.xAzureSQLDB) // Switching databases is not supported against Azure, skip/
-    @Tag(Constants.xAzureSQLDW)
     public void testUseDb() throws SQLException {
         String expectedDatabaseName = null;
         String actualDatabaseName = null;
@@ -203,7 +202,6 @@ public class BasicConnectionTest extends AbstractTest {
 
     @Test
     @Tag(Constants.xAzureSQLDB) // Switching databases is not supported against Azure, skip/
-    @Tag(Constants.xAzureSQLDW)
     public void testPooledConnectionDB() throws SQLException {
         SQLServerConnectionPoolDataSource mds = new SQLServerConnectionPoolDataSource();
         mds.setURL(connectionString);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/PropertyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/PropertyTest.java
@@ -24,6 +24,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 
 @Tag(Constants.xSQLv11)
+@Tag(Constants.xAzureSQLDW)
 public class PropertyTest extends AbstractTest {
 
     @BeforeAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
@@ -30,6 +30,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 
 @Tag(Constants.xSQLv11)
+@Tag(Constants.xAzureSQLDW)
 public class ReflectiveTests extends AbstractTest {
 
     @BeforeAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResiliencyUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResiliencyUtils.java
@@ -29,6 +29,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 
 @Tag(Constants.xSQLv11)
+@Tag(Constants.xAzureSQLDW)
 final class ResiliencyUtils {
 
     private static final String[] ON_OFF = new String[] {"ON", "OFF"};

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
@@ -28,6 +28,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 
 @Tag(Constants.xSQLv11)
+@Tag(Constants.xAzureSQLDW)
 public class ResultSetsWithResiliencyTest extends AbstractTest {
     static String tableName = "[" + RandomUtil.getIdentifier("resTable") + "]";
     static int numberOfRows = 10;


### PR DESCRIPTION
Azure DW engine edition is 10 which is even older than SQL 2012 which is 11.  Idle Connection Resiliency seem to require 12 and above