### PR TITLE
Simplify traceID creation in DataSource and PooledConnection.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -76,11 +76,8 @@ public class SQLServerDataSource
      */
     public SQLServerDataSource() {
         connectionProps = new Properties();
-        int dataSourceID = nextDataSourceID();
-        String nameL = getClass().getName();
-        traceID = nameL.substring(1 + nameL.lastIndexOf('.')) + ":" + dataSourceID;
-        loggingClassName = "com.microsoft.sqlserver.jdbc." + nameL.substring(1 + nameL.lastIndexOf('.')) + ":"
-                + dataSourceID;
+        traceID = getClass().getSimpleName() + ':' + nextDataSourceID();
+        loggingClassName = "com.microsoft.sqlserver.jdbc." + traceID;
     }
 
     String getClassNameLogging() {
@@ -176,7 +173,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the the database to connect to.
-     * 
+     *
      * @param databaseName
      *        if not set, returns the default value of null.
      */
@@ -192,7 +189,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the the SQL Server instance name to connect to.
-     * 
+     *
      * @param instanceName
      *        if not set, returns the default value of null.
      */
@@ -390,7 +387,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the lock timeout value.
-     * 
+     *
      * @param lockTimeout
      *        the number of milliseconds to wait before the database reports a lock timeout. The default value of -1
      *        means wait forever. If specified, this value will be the default for all statements on the connection.
@@ -409,7 +406,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the password that will be used when connecting to SQL Server.
-     * 
+     *
      * @param password
      *        Note getPassword is deliberately declared non-public for security reasons. If the password is not set,
      *        getPassword returns the default value of null.
@@ -425,7 +422,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the TCP-IP port number used when opening a socket connection to SQL Server.
-     * 
+     *
      * @param portNumber
      *        if not set, getPortNumber returns the default of 1433. Note as mentioned above, setPortNumber does not do
      *        any range checking on the port value passed in,\ invalid port numbers like 99999 can be passed in without
@@ -444,7 +441,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the default cursor type used for the result set.
-     * 
+     *
      * @param selectMethod
      *        This(non-Javadoc) @see com.microsoft.sqlserver.jdbc.ISQLServerDataSource#setSelectMethod(java.lang.String)
      *        property is useful when you are dealing with large result sets and do not want to store the whole result
@@ -534,7 +531,7 @@ public class SQLServerDataSource
 
     /**
      * Sets whether string parameters are sent to the server in UNICODE format.
-     * 
+     *
      * @param sendStringParametersAsUnicode
      *        if true (default), string parameters are sent to the server in UNICODE format. if false, string parameters
      *        are sent to the server in the native TDS collation format of the database, not in UNICODE. if set, returns
@@ -567,7 +564,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the host name of the target SQL Server.
-     * 
+     *
      * @param serverName
      *        if not set, returns the default value of null is returned.
      */
@@ -583,7 +580,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the realm for Kerberos authentication.
-     * 
+     *
      * @param realm
      *        realm
      */
@@ -600,7 +597,7 @@ public class SQLServerDataSource
     /**
      * Sets the Service Principal Name (SPN) of the target SQL Server.
      * https://msdn.microsoft.com/en-us/library/cc280459.aspx
-     * 
+     *
      * @param serverSpn
      *        service principal name
      */
@@ -616,7 +613,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the fail over partner of the target SQL Server.
-     * 
+     *
      * @param serverName
      *        if not set, returns the default value of null.
      */
@@ -644,7 +641,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the user name that will be used when connecting to SQL Server.
-     * 
+     *
      * @param user
      *        if not set, returns the default value of null.
      */
@@ -660,7 +657,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the name of the client machine (or client workstation).
-     * 
+     *
      * @param workstationID
      *        host name of the client. if not set, the default value is constructed by calling
      *        InetAddress.getLocalHost().getHostName() or if getHostName() returns blank then
@@ -687,7 +684,7 @@ public class SQLServerDataSource
 
     /**
      * Sets whether the driver will convert SQL states to XOPEN compliant states.
-     * 
+     *
      * @param xopenStates
      *        if true, the driver will convert SQL states to XOPEN compliant states. The default is false which causes
      *        the driver to generate SQL 99 state codes. If not set, getXopenStates returns the default value of false.
@@ -775,7 +772,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the datasource URL.
-     * 
+     *
      * @param url
      *        The URL property is exposed for backwards compatibility reasons. Also, several Java Application servers
      *        expect a setURL function on the DataSource and set it by default (JBoss and WebLogic) Note for security
@@ -828,7 +825,7 @@ public class SQLServerDataSource
 
     /**
      * Sets the packet size.
-     * 
+     *
      * @param packetSize
      *        the size (in bytes) to use for the TCP/IP send and receive buffer. It is also the value used for the TDS
      *        packet size (SQL Server Network Packet Size). Validity of the value is checked at connect time. If no
@@ -1130,7 +1127,7 @@ public class SQLServerDataSource
 
     /**
      * Sets a property string value.
-     * 
+     *
      * @param props
      * @param propKey
      * @param propValue
@@ -1150,7 +1147,7 @@ public class SQLServerDataSource
 
     /**
      * Returns a property value in String format.
-     * 
+     *
      * @param props
      * @param propKey
      * @param defaultValue
@@ -1171,7 +1168,7 @@ public class SQLServerDataSource
 
     /**
      * Sets an integer property value.
-     * 
+     *
      * @param props
      * @param propKey
      * @param propValue
@@ -1371,7 +1368,7 @@ public class SQLServerDataSource
 
     /**
      * Initializes the datasource from properties found inside the reference
-     * 
+     *
      * @param ref
      *        Called by SQLServerDataSourceObjectFactory to initialize new DataSource instance.
      */
@@ -1429,7 +1426,7 @@ public class SQLServerDataSource
 
     /**
      * writeReplace
-     * 
+     *
      * @return serialization proxy
      * @throws java.io.ObjectStreamException
      *         if error
@@ -1441,7 +1438,7 @@ public class SQLServerDataSource
     /**
      * For added security/robustness, the only way to rehydrate a serialized SQLServerDataSource is to use a
      * SerializationProxy. Direct use of readObject() is not supported.
-     * 
+     *
      * @param stream
      *        input stream object
      * @throws java.io.InvalidObjectException

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPooledConnection.java
@@ -55,6 +55,7 @@ public class SQLServerPooledConnection implements PooledConnection, Serializable
 
     SQLServerPooledConnection(SQLServerDataSource ds, String user, String password) throws SQLException {
         listeners = new Vector<>();
+        traceID = getClass().getSimpleName() + ':' + nextPooledConnectionID();
         // Piggyback SQLServerDataSource logger for now.
         pcLogger = SQLServerDataSource.dsLogger;
 
@@ -67,8 +68,6 @@ public class SQLServerPooledConnection implements PooledConnection, Serializable
             pcLogger.finer(toString() + " Start create new connection for pool.");
 
         physicalConnection = createNewConnection();
-        String nameL = getClass().getName();
-        traceID = nameL.substring(1 + nameL.lastIndexOf('.')) + ":" + nextPooledConnectionID();
         if (pcLogger.isLoggable(Level.FINE))
             pcLogger.fine(toString() + " created by (" + ds.toString() + ")" + " Physical connection " + safeCID()
                     + ", End create new connection for pool");
@@ -76,7 +75,7 @@ public class SQLServerPooledConnection implements PooledConnection, Serializable
 
     /**
      * Provides a helper function to provide an ID string suitable for tracing.
-     * 
+     *
      * @return traceID String
      */
     @Override
@@ -86,7 +85,7 @@ public class SQLServerPooledConnection implements PooledConnection, Serializable
 
     /**
      * Helper function to create a new connection for the pool.
-     * 
+     *
      * @return SQLServerConnection instance
      * @throws SQLException
      */
@@ -96,7 +95,7 @@ public class SQLServerPooledConnection implements PooledConnection, Serializable
 
     /**
      * Returns an object handle for the physical connection that this PooledConnection object represents.
-     * 
+     *
      * @throws SQLException
      *         when an error occurs
      * @return a Connection object that is a handle to this PooledConnection object


### PR DESCRIPTION
This will also make sure the traceID is set before used in toString().

The loggername handling seems to be a bit divergent- in some cases a literal package is used in others not. I am not sure if this is intentional, so I left it alone.

Sorry for the removal of trailing whitespaces, but I figured it it generally helpful. If you want me to isolate the changes, please let me know.

Signed-off-by: Bernd Eckenfels <ecki@apache.org>