### PR TITLE
Added Azure Active Directory tests for Azure Data Explorer using user/password/applicationName AND removed deprecated tags to fix build warnings

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -172,11 +172,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     private String clientKeyPassword = "";
 
     /** AAD principal id */
-    @Deprecated
     private String aadPrincipalID = "";
 
     /** AAD principal secret */
-    @Deprecated
     private String aadPrincipalSecret = "";
 
     /** sendTemporalDataTypesAsStringForBulkCopy flag */

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -376,9 +376,7 @@ enum SQLServerDriverStringProperty {
     CLIENT_CERTIFICATE("clientCertificate", ""),
     CLIENT_KEY("clientKey", ""),
     CLIENT_KEY_PASSWORD("clientKeyPassword", ""),
-    @Deprecated
     AAD_SECURE_PRINCIPAL_ID("AADSecurePrincipalId", ""),
-    @Deprecated
     AAD_SECURE_PRINCIPAL_SECRET("AADSecurePrincipalSecret", ""),
     MAX_RESULT_BUFFER("maxResultBuffer", "-1");
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthCommon.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthCommon.java
@@ -47,6 +47,9 @@ public class FedauthCommon extends AbstractTest {
 
     static boolean enableADIntegrated = false;
 
+    static String hostNameInCertificate = null;
+    static String applicationName = null;
+    static String kustoServer = null;
     static String spn = null;
     static String stsurl = null;
     static String fedauthClientId = null;
@@ -140,6 +143,9 @@ public class FedauthCommon extends AbstractTest {
         fedauthJksPaths = getConfiguredProperty("fedauthJksPaths", "").split(Constants.SEMI_COLON);
         fedauthJavaKeyAliases = getConfiguredProperty("fedauthJavaKeyAliases", "").split(Constants.SEMI_COLON);
 
+        hostNameInCertificate = getConfiguredProperty("hostNameInCertificate");
+        applicationName = getConfiguredProperty("applicationName");
+        kustoServer = getConfiguredProperty("kustoServer");
         spn = getConfiguredProperty("spn");
         stsurl = getConfiguredProperty("stsurl");
         fedauthClientId = getConfiguredProperty("fedauthClientId");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -247,6 +247,32 @@ public class FedauthTest extends FedauthCommon {
     }
 
     /**
+     * Test AAD Password Authentication using username/password in connection string, data source and SSL
+     * encryption, in addition to application name in order to use different authorities.
+     *
+     * @throws Exception
+     *          if an exception occurs
+     */
+    @Test
+    public void testAADPasswordApplicationName() throws Exception {
+        String url = "jdbc:sqlserver://" + kustoServer
+                + ";database=" + azureDatabase
+                + ";user=" + azureUserName
+                + ";password=" + azurePassword
+                + ";Authentication=" + SqlAuthentication.ActiveDirectoryPassword.toString()
+                + ";hostNameInCertificate=" + hostNameInCertificate
+                + ";applicationName=" + applicationName
+                + ";encrypt=true;trustServerCertificate=true;";
+        SQLServerDataSource ds = new SQLServerDataSource();
+        ds.setURL(url);
+
+        try (Connection con = ds.getConnection()) {
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
      * Test AAD Service Principal Authentication using AADSecurePrincipalId/AADSecurePrincipalSecret in connection
      * string, data source and SSL encryption.
      * 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -255,13 +255,10 @@ public class FedauthTest extends FedauthCommon {
      */
     @Test
     public void testAADPasswordApplicationName() throws Exception {
-        String url = "jdbc:sqlserver://" + kustoServer
-                + ";database=" + azureDatabase
-                + ";user=" + azureUserName
-                + ";password=" + azurePassword
-                + ";Authentication=" + SqlAuthentication.ActiveDirectoryPassword.toString()
-                + ";hostNameInCertificate=" + hostNameInCertificate
-                + ";applicationName=" + applicationName
+        String url = "jdbc:sqlserver://" + kustoServer + ";database=" + azureDatabase + ";user=" + azureUserName
+                + ";password=" + azurePassword + ";Authentication="
+                + SqlAuthentication.ActiveDirectoryPassword.toString() + ";hostNameInCertificate="
+                + hostNameInCertificate + ";applicationName=" + applicationName
                 + ";encrypt=true;trustServerCertificate=true;";
         SQLServerDataSource ds = new SQLServerDataSource();
         ds.setURL(url);


### PR DESCRIPTION
After migration from ADAL to MSAL4J, clients were unable to connect to certain endpoints (e.g. Azure Data Explorer). This issue was resolved by the Azure Data Explorer / Kusto team, by allowing another property to be passed into the connection string, changing the authority used when connecting with MSAL4J, and resolving the error.

An Azure Active Directory test was implemented to confirm the workaround does work for JDBC driver, and for authentication using Azure Active Directory username and password. 

Original issue and fix: https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/382

--------------------------------------------------------------------------------------------------------------------------------------------

On build, warnings were given regarding deprecated properties. There wasn't a need for these properties to be marked as deprecated, and as such, the tags have been removed, removing the warnings.