### PR TITLE
Added a check to prevent Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1076,7 +1076,7 @@ final class TDSChannel implements Serializable {
 
         /**
          * Poll the stream to verify connectivity.
-         * 
+         *
          * @return true if the stream is readable.
          * @throws IOException
          *         If an I/O exception occurs.
@@ -1815,7 +1815,7 @@ final class TDSChannel implements Serializable {
 
     /**
      * Enables SSL Handshake.
-     * 
+     *
      * @param host
      *        Server Host Name for SSL Handshake
      * @param port
@@ -2117,12 +2117,12 @@ final class TDSChannel implements Serializable {
 
     /**
      * Validate FIPS if fips set as true
-     * 
+     *
      * Valid FIPS settings:
      * <LI>Encrypt should be true
      * <LI>trustServerCertificate should be false
      * <LI>if certificate is not installed TrustStoreType should be present.
-     * 
+     *
      * @param trustStoreType
      * @param trustStoreFileName
      * @throws SQLServerException
@@ -2252,7 +2252,7 @@ final class TDSChannel implements Serializable {
 
     /**
      * Attempts to poll the input stream to see if the network socket is still connected.
-     * 
+     *
      * @return
      */
     final Boolean networkSocketStillConnected() {
@@ -2510,13 +2510,13 @@ final class TDSChannel implements Serializable {
 /**
  * SocketFinder is used to find a server socket to which a connection can be made. This class abstracts the logic of
  * finding a socket from TDSChannel class.
- * 
+ *
  * In the case when useParallel is set to true, this is achieved by trying to make parallel connections to multiple IP
  * addresses. This class is responsible for spawning multiple threads and keeping track of the search result and the
  * connected socket or exception to be thrown.
- * 
+ *
  * In the case where multiSubnetFailover is false, we try our old logic of trying to connect to the first ip address
- * 
+ *
  * Typical usage of this class is SocketFinder sf = new SocketFinder(traceId, conn); Socket = sf.getSocket(hostName,
  * port, timeout);
  */
@@ -2578,7 +2578,7 @@ final class SocketFinder {
 
     /**
      * Constructs a new SocketFinder object with appropriate traceId
-     * 
+     *
      * @param callerTraceID
      *        traceID of the caller
      * @param sqlServerConnection
@@ -2591,7 +2591,7 @@ final class SocketFinder {
 
     /**
      * Used to find a socket to which a connection can be made
-     * 
+     *
      * @param hostName
      * @param portNumber
      * @param timeoutInMilliSeconds
@@ -2730,7 +2730,7 @@ final class SocketFinder {
     /**
      * This function uses java NIO to connect to all the addresses in inetAddrs with in a specified timeout. If it
      * succeeds in connecting, it closes all the other open sockets and updates the result to success.
-     * 
+     *
      * @param inetAddrs
      *        the array of inetAddress to which connection should be made
      * @param portNumber
@@ -3090,7 +3090,7 @@ final class SocketFinder {
      * or exception). It updates the result, socket and exception variables of socketFinder object. This method notifies
      * the parent thread if a socket is found or if all the spawned threads have notified. It also closes a socket if it
      * is not selected for use by socketFinder.
-     * 
+     *
      * @param socket
      *        the SocketConnector's socket
      * @param exception
@@ -3194,7 +3194,7 @@ final class SocketFinder {
      * If there are multiple exceptions, that are not related to socketTimeout the first non-socketTimeout exception is
      * picked. If all exceptions are related to socketTimeout, the first exception is picked. Note: This method is not
      * thread safe. The caller should ensure thread safety.
-     * 
+     *
      * @param ex
      *        the IOException
      * @param traceId
@@ -3218,7 +3218,7 @@ final class SocketFinder {
 
     /**
      * Used fof tracing
-     * 
+     *
      * @return traceID string
      */
     public String toString() {
@@ -3300,7 +3300,7 @@ final class SocketConnector implements Runnable {
 
     /**
      * Used for tracing
-     * 
+     *
      * @return traceID string
      */
     public String toString() {
@@ -3420,7 +3420,7 @@ final class TDSWriter {
 
     /**
      * Checks If tdsMessageType is RPC or QUERY
-     * 
+     *
      * @return boolean
      */
     boolean checkIfTdsMessageTypeIsBatchOrRPC() {
@@ -3563,7 +3563,7 @@ final class TDSWriter {
 
     /**
      * writing sqlCollation information for sqlVariant type when sending character types.
-     * 
+     *
      * @param variantType
      * @throws SQLServerException
      */
@@ -3619,7 +3619,7 @@ final class TDSWriter {
 
     /**
      * Append a real value in the TDS stream.
-     * 
+     *
      * @param value
      *        the data value
      */
@@ -3629,7 +3629,7 @@ final class TDSWriter {
 
     /**
      * Append a double value in the TDS stream.
-     * 
+     *
      * @param value
      *        the data value
      */
@@ -3656,7 +3656,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal in the TDS stream.
-     * 
+     *
      * @param bigDecimalVal
      *        the big decimal data value
      * @param srcJdbcType
@@ -3697,7 +3697,7 @@ final class TDSWriter {
 
     /**
      * Append a money/smallmoney value in the TDS stream.
-     * 
+     *
      * @param moneyVal
      *        the money data value.
      * @param srcJdbcType
@@ -3719,7 +3719,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal inside sql_variant in the TDS stream.
-     * 
+     *
      * @param bigDecimalVal
      *        the big decimal data value
      * @param srcJdbcType
@@ -4592,7 +4592,7 @@ final class TDSWriter {
 
     /**
      * Write out elements common to all RPC values.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param bOut
@@ -4621,7 +4621,7 @@ final class TDSWriter {
 
     /**
      * Append a boolean value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param booleanValue
@@ -4642,7 +4642,7 @@ final class TDSWriter {
 
     /**
      * Append a short value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param byteValue
@@ -4663,7 +4663,7 @@ final class TDSWriter {
 
     /**
      * Append a short value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param shortValue
@@ -4684,7 +4684,7 @@ final class TDSWriter {
 
     /**
      * Append an int value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param intValue
@@ -4705,7 +4705,7 @@ final class TDSWriter {
 
     /**
      * Append a long value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param longValue
@@ -4726,7 +4726,7 @@ final class TDSWriter {
 
     /**
      * Append a real value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param floatValue
@@ -4760,7 +4760,7 @@ final class TDSWriter {
 
     /**
      * Append a double value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param doubleValue
@@ -4792,7 +4792,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param bdValue
@@ -4813,7 +4813,7 @@ final class TDSWriter {
 
     /**
      * Appends a standard v*max header for RPC parameter transmission.
-     * 
+     *
      * @param headerLength
      *        the total length of the PLP data block.
      * @param isNull
@@ -4855,7 +4855,7 @@ final class TDSWriter {
 
     /**
      * Writes a string value as Unicode for RPC
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param sValue
@@ -5375,7 +5375,7 @@ final class TDSWriter {
 
     /**
      * writes Header for sql_variant for TVP
-     * 
+     *
      * @param length
      * @param tdsType
      * @param probBytes
@@ -5719,7 +5719,7 @@ final class TDSWriter {
 
     /**
      * Append a timestamp in RPC transmission format as a SQL Server DATETIME data type
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param cal
@@ -6432,7 +6432,7 @@ final class TDSWriter {
 
     /**
      * Append the data in a stream in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param stream
@@ -6531,7 +6531,7 @@ final class TDSWriter {
 
     /**
      * Append the XML data in a stream in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param stream
@@ -6570,7 +6570,7 @@ final class TDSWriter {
 
     /**
      * Append the data in a character reader in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param re
@@ -7021,7 +7021,7 @@ final class TDSReader implements Serializable {
     }
 
     /**
-     * 
+     *
      * @return number of bytes available in the current packet
      */
     final int availableCurrentPacket() {
@@ -7168,7 +7168,11 @@ final class TDSReader implements Serializable {
                 logger.finest(toString() + " Skipping " + bytesToSkip + " bytes from offset " + payloadOffset);
 
             bytesSkipped += bytesToSkip;
-            payloadOffset += bytesToSkip;
+            if (Util.isSafeToConvert(bytesToSkip, "int")) {
+                payloadOffset += bytesToSkip;
+            } else {
+                throw new ArithmeticException("Argument too large for 'int' conversion.");
+            }
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1076,7 +1076,7 @@ final class TDSChannel implements Serializable {
 
         /**
          * Poll the stream to verify connectivity.
-         *
+         * 
          * @return true if the stream is readable.
          * @throws IOException
          *         If an I/O exception occurs.
@@ -1815,7 +1815,7 @@ final class TDSChannel implements Serializable {
 
     /**
      * Enables SSL Handshake.
-     *
+     * 
      * @param host
      *        Server Host Name for SSL Handshake
      * @param port
@@ -2117,12 +2117,12 @@ final class TDSChannel implements Serializable {
 
     /**
      * Validate FIPS if fips set as true
-     *
+     * 
      * Valid FIPS settings:
      * <LI>Encrypt should be true
      * <LI>trustServerCertificate should be false
      * <LI>if certificate is not installed TrustStoreType should be present.
-     *
+     * 
      * @param trustStoreType
      * @param trustStoreFileName
      * @throws SQLServerException
@@ -2252,7 +2252,7 @@ final class TDSChannel implements Serializable {
 
     /**
      * Attempts to poll the input stream to see if the network socket is still connected.
-     *
+     * 
      * @return
      */
     final Boolean networkSocketStillConnected() {
@@ -2510,13 +2510,13 @@ final class TDSChannel implements Serializable {
 /**
  * SocketFinder is used to find a server socket to which a connection can be made. This class abstracts the logic of
  * finding a socket from TDSChannel class.
- *
+ * 
  * In the case when useParallel is set to true, this is achieved by trying to make parallel connections to multiple IP
  * addresses. This class is responsible for spawning multiple threads and keeping track of the search result and the
  * connected socket or exception to be thrown.
- *
+ * 
  * In the case where multiSubnetFailover is false, we try our old logic of trying to connect to the first ip address
- *
+ * 
  * Typical usage of this class is SocketFinder sf = new SocketFinder(traceId, conn); Socket = sf.getSocket(hostName,
  * port, timeout);
  */
@@ -2578,7 +2578,7 @@ final class SocketFinder {
 
     /**
      * Constructs a new SocketFinder object with appropriate traceId
-     *
+     * 
      * @param callerTraceID
      *        traceID of the caller
      * @param sqlServerConnection
@@ -2591,7 +2591,7 @@ final class SocketFinder {
 
     /**
      * Used to find a socket to which a connection can be made
-     *
+     * 
      * @param hostName
      * @param portNumber
      * @param timeoutInMilliSeconds
@@ -2730,7 +2730,7 @@ final class SocketFinder {
     /**
      * This function uses java NIO to connect to all the addresses in inetAddrs with in a specified timeout. If it
      * succeeds in connecting, it closes all the other open sockets and updates the result to success.
-     *
+     * 
      * @param inetAddrs
      *        the array of inetAddress to which connection should be made
      * @param portNumber
@@ -3090,7 +3090,7 @@ final class SocketFinder {
      * or exception). It updates the result, socket and exception variables of socketFinder object. This method notifies
      * the parent thread if a socket is found or if all the spawned threads have notified. It also closes a socket if it
      * is not selected for use by socketFinder.
-     *
+     * 
      * @param socket
      *        the SocketConnector's socket
      * @param exception
@@ -3194,7 +3194,7 @@ final class SocketFinder {
      * If there are multiple exceptions, that are not related to socketTimeout the first non-socketTimeout exception is
      * picked. If all exceptions are related to socketTimeout, the first exception is picked. Note: This method is not
      * thread safe. The caller should ensure thread safety.
-     *
+     * 
      * @param ex
      *        the IOException
      * @param traceId
@@ -3218,7 +3218,7 @@ final class SocketFinder {
 
     /**
      * Used fof tracing
-     *
+     * 
      * @return traceID string
      */
     public String toString() {
@@ -3300,7 +3300,7 @@ final class SocketConnector implements Runnable {
 
     /**
      * Used for tracing
-     *
+     * 
      * @return traceID string
      */
     public String toString() {
@@ -3420,7 +3420,7 @@ final class TDSWriter {
 
     /**
      * Checks If tdsMessageType is RPC or QUERY
-     *
+     * 
      * @return boolean
      */
     boolean checkIfTdsMessageTypeIsBatchOrRPC() {
@@ -3563,7 +3563,7 @@ final class TDSWriter {
 
     /**
      * writing sqlCollation information for sqlVariant type when sending character types.
-     *
+     * 
      * @param variantType
      * @throws SQLServerException
      */
@@ -3619,7 +3619,7 @@ final class TDSWriter {
 
     /**
      * Append a real value in the TDS stream.
-     *
+     * 
      * @param value
      *        the data value
      */
@@ -3629,7 +3629,7 @@ final class TDSWriter {
 
     /**
      * Append a double value in the TDS stream.
-     *
+     * 
      * @param value
      *        the data value
      */
@@ -3656,7 +3656,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal in the TDS stream.
-     *
+     * 
      * @param bigDecimalVal
      *        the big decimal data value
      * @param srcJdbcType
@@ -3697,7 +3697,7 @@ final class TDSWriter {
 
     /**
      * Append a money/smallmoney value in the TDS stream.
-     *
+     * 
      * @param moneyVal
      *        the money data value.
      * @param srcJdbcType
@@ -3719,7 +3719,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal inside sql_variant in the TDS stream.
-     *
+     * 
      * @param bigDecimalVal
      *        the big decimal data value
      * @param srcJdbcType
@@ -4592,7 +4592,7 @@ final class TDSWriter {
 
     /**
      * Write out elements common to all RPC values.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param bOut
@@ -4621,7 +4621,7 @@ final class TDSWriter {
 
     /**
      * Append a boolean value in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param booleanValue
@@ -4642,7 +4642,7 @@ final class TDSWriter {
 
     /**
      * Append a short value in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param byteValue
@@ -4663,7 +4663,7 @@ final class TDSWriter {
 
     /**
      * Append a short value in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param shortValue
@@ -4684,7 +4684,7 @@ final class TDSWriter {
 
     /**
      * Append an int value in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param intValue
@@ -4705,7 +4705,7 @@ final class TDSWriter {
 
     /**
      * Append a long value in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param longValue
@@ -4726,7 +4726,7 @@ final class TDSWriter {
 
     /**
      * Append a real value in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param floatValue
@@ -4760,7 +4760,7 @@ final class TDSWriter {
 
     /**
      * Append a double value in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param doubleValue
@@ -4792,7 +4792,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param bdValue
@@ -4813,7 +4813,7 @@ final class TDSWriter {
 
     /**
      * Appends a standard v*max header for RPC parameter transmission.
-     *
+     * 
      * @param headerLength
      *        the total length of the PLP data block.
      * @param isNull
@@ -4855,7 +4855,7 @@ final class TDSWriter {
 
     /**
      * Writes a string value as Unicode for RPC
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param sValue
@@ -5375,7 +5375,7 @@ final class TDSWriter {
 
     /**
      * writes Header for sql_variant for TVP
-     *
+     * 
      * @param length
      * @param tdsType
      * @param probBytes
@@ -5719,7 +5719,7 @@ final class TDSWriter {
 
     /**
      * Append a timestamp in RPC transmission format as a SQL Server DATETIME data type
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param cal
@@ -6432,7 +6432,7 @@ final class TDSWriter {
 
     /**
      * Append the data in a stream in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param stream
@@ -6531,7 +6531,7 @@ final class TDSWriter {
 
     /**
      * Append the XML data in a stream in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param stream
@@ -6570,7 +6570,7 @@ final class TDSWriter {
 
     /**
      * Append the data in a character reader in RPC transmission format.
-     *
+     * 
      * @param sName
      *        the optional parameter name
      * @param re
@@ -7021,7 +7021,7 @@ final class TDSReader implements Serializable {
     }
 
     /**
-     *
+     * 
      * @return number of bytes available in the current packet
      */
     final int availableCurrentPacket() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7154,13 +7154,13 @@ final class TDSReader implements Serializable {
      * @param valueLength
      * @throws SQLServerException
      */
-    final void readSkipBytes(long valueLength) throws SQLServerException {
-        for (long bytesSkipped = 0; bytesSkipped < valueLength;) {
+    final void readSkipBytes(int valueLength) throws SQLServerException {
+        for (int bytesSkipped = 0; bytesSkipped < valueLength;) {
             // Ensure that we have a packet to read from.
             if (!ensurePayload())
                 throwInvalidTDS();
 
-            long bytesToSkip = valueLength - bytesSkipped;
+            int bytesToSkip = valueLength - bytesSkipped;
             if (bytesToSkip > currentPacket.payloadLength - payloadOffset)
                 bytesToSkip = currentPacket.payloadLength - payloadOffset;
 
@@ -7168,11 +7168,7 @@ final class TDSReader implements Serializable {
                 logger.finest(toString() + " Skipping " + bytesToSkip + " bytes from offset " + payloadOffset);
 
             bytesSkipped += bytesToSkip;
-            if (Util.isSafeToConvert(bytesToSkip, "int")) {
-                payloadOffset += bytesToSkip;
-            } else {
-                throw new ArithmeticException("Argument too large for 'int' conversion.");
-            }
+            payloadOffset += bytesToSkip;
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -230,31 +230,6 @@ final class Util {
     }
 
     /**
-     * Checks to see if a long value can be converted to another type.
-     * 
-     * @param  valueToConvert
-     *         the value to convert
-     * @param  typeToConvertTo
-     *         the type to convert to
-     * @return true if the type can be converted safely
-     */
-    static boolean isSafeToConvert(long valueToConvert, String typeToConvertTo) {
-        boolean safeConversion = false;
-
-        switch (typeToConvertTo) {
-            // Add more cases as necessary
-            case "int":
-                if (valueToConvert <= Integer.MAX_VALUE && valueToConvert >= Integer.MIN_VALUE) {
-                    safeConversion = true;
-                }
-                break;
-            default:
-                break;
-        }
-        return safeConversion;
-    }
-
-    /**
      * Parse a JDBC URL into a set of properties.
      * 
      * @param url

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -112,7 +112,7 @@ final class Util {
 
     /**
      * Read an unsigned short int (16 bits) from a byte stream
-     *
+     * 
      * @param data
      *        the databytes
      * @param nOffset
@@ -139,7 +139,7 @@ final class Util {
 
     /**
      * Read an int from a byte stream
-     *
+     * 
      * @param data
      *        the databytes
      * @param nOffset
@@ -194,7 +194,7 @@ final class Util {
 
     /**
      * Reads a long value from byte array.
-     *
+     * 
      * @param data
      *        the byte array.
      * @param nOffset
@@ -231,7 +231,7 @@ final class Util {
 
     /**
      * Checks to see if a long value can be converted to another, smaller, type.
-     *
+     * 
      * @param  convert
      *         the short value to convert
      * @param  convertTo
@@ -256,7 +256,7 @@ final class Util {
 
     /**
      * Parse a JDBC URL into a set of properties.
-     *
+     * 
      * @param url
      *        the JDBC URL
      * @param logger
@@ -550,7 +550,7 @@ final class Util {
     /**
      * Accepts a SQL identifier (such as a column name or table name) and escapes the identifier using SQL Server
      * bracket escaping rules. Assumes that the incoming identifier is unescaped.
-     *
+     * 
      * @inID input identifier to escape.
      * @return the escaped value.
      */
@@ -581,7 +581,7 @@ final class Util {
 
     /**
      * Checks if duplicate columns exists, in O(n) time.
-     *
+     * 
      * @param columnName
      *        the name of the column
      * @throws SQLServerException
@@ -598,7 +598,7 @@ final class Util {
 
     /**
      * Reads a UNICODE string from byte buffer at offset (up to byteLength).
-     *
+     * 
      * @param b
      *        the buffer containing UNICODE bytes.
      * @param offset
@@ -627,7 +627,7 @@ final class Util {
     // NOTE: This is for display purposes ONLY. NOT TO BE USED for data conversion.
     /**
      * Converts byte array to a string representation of hex bytes for display purposes.
-     *
+     * 
      * @param b
      *        the source buffer.
      * @return "hexized" string representation of bytes.
@@ -648,7 +648,7 @@ final class Util {
 
     /**
      * Converts byte array to a string representation of hex bytes.
-     *
+     * 
      * @param b
      *        the source buffer.
      * @return "hexized" string representation of bytes.
@@ -665,7 +665,7 @@ final class Util {
 
     /**
      * Looks up local hostname of client machine.
-     *
+     * 
      * @exception UnknownHostException
      *            if local hostname is not found.
      * @return hostname string or ip of host if hostname cannot be resolved. If neither hostname or ip found returns ""
@@ -807,7 +807,7 @@ final class Util {
     /**
      * Determines if a column value should be transparently decrypted (based on SQLServerStatement and the connection
      * string settings).
-     *
+     * 
      * @return true if the value should be transparently decrypted, false otherwise.
      */
     static boolean shouldHonorAEForRead(SQLServerStatementColumnEncryptionSetting stmtColumnEncryptionSetting,
@@ -829,7 +829,7 @@ final class Util {
     /**
      * Determines if parameters should be transparently encrypted (based on SQLServerStatement and the connection string
      * settings).
-     *
+     * 
      * @return true if the value should be transparently encrypted, false otherwise.
      */
     static boolean shouldHonorAEForParameters(SQLServerStatementColumnEncryptionSetting stmtColumnEncryptionSetting,
@@ -1009,7 +1009,7 @@ final class Util {
 
     /**
      * Escapes single quotes (') in object name to convert and pass it as String safely.
-     *
+     * 
      * @param name
      *        Object name to be passed as String
      * @return Converted object name

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -112,7 +112,7 @@ final class Util {
 
     /**
      * Read an unsigned short int (16 bits) from a byte stream
-     * 
+     *
      * @param data
      *        the databytes
      * @param nOffset
@@ -139,7 +139,7 @@ final class Util {
 
     /**
      * Read an int from a byte stream
-     * 
+     *
      * @param data
      *        the databytes
      * @param nOffset
@@ -194,7 +194,7 @@ final class Util {
 
     /**
      * Reads a long value from byte array.
-     * 
+     *
      * @param data
      *        the byte array.
      * @param nOffset
@@ -230,8 +230,33 @@ final class Util {
     }
 
     /**
+     * Checks to see if a long value can be converted to another, smaller, type.
+     *
+     * @param  convert
+     *         the short value to convert
+     * @param  convertTo
+     *         the type to convert to
+     * @return true if the type can be converted
+     */
+    static boolean isSafeToConvert(long convert, String convertTo) {
+        boolean safeConversion = false;
+
+        switch (convertTo) {
+            // Add more cases as necessary
+            case "int":
+                if (convert <= Integer.MAX_VALUE && convert >= Integer.MIN_VALUE) {
+                    safeConversion = true;
+                }
+                break;
+            default:
+                break;
+        }
+        return safeConversion;
+    }
+
+    /**
      * Parse a JDBC URL into a set of properties.
-     * 
+     *
      * @param url
      *        the JDBC URL
      * @param logger
@@ -525,7 +550,7 @@ final class Util {
     /**
      * Accepts a SQL identifier (such as a column name or table name) and escapes the identifier using SQL Server
      * bracket escaping rules. Assumes that the incoming identifier is unescaped.
-     * 
+     *
      * @inID input identifier to escape.
      * @return the escaped value.
      */
@@ -556,7 +581,7 @@ final class Util {
 
     /**
      * Checks if duplicate columns exists, in O(n) time.
-     * 
+     *
      * @param columnName
      *        the name of the column
      * @throws SQLServerException
@@ -573,7 +598,7 @@ final class Util {
 
     /**
      * Reads a UNICODE string from byte buffer at offset (up to byteLength).
-     * 
+     *
      * @param b
      *        the buffer containing UNICODE bytes.
      * @param offset
@@ -602,7 +627,7 @@ final class Util {
     // NOTE: This is for display purposes ONLY. NOT TO BE USED for data conversion.
     /**
      * Converts byte array to a string representation of hex bytes for display purposes.
-     * 
+     *
      * @param b
      *        the source buffer.
      * @return "hexized" string representation of bytes.
@@ -623,7 +648,7 @@ final class Util {
 
     /**
      * Converts byte array to a string representation of hex bytes.
-     * 
+     *
      * @param b
      *        the source buffer.
      * @return "hexized" string representation of bytes.
@@ -640,7 +665,7 @@ final class Util {
 
     /**
      * Looks up local hostname of client machine.
-     * 
+     *
      * @exception UnknownHostException
      *            if local hostname is not found.
      * @return hostname string or ip of host if hostname cannot be resolved. If neither hostname or ip found returns ""
@@ -782,7 +807,7 @@ final class Util {
     /**
      * Determines if a column value should be transparently decrypted (based on SQLServerStatement and the connection
      * string settings).
-     * 
+     *
      * @return true if the value should be transparently decrypted, false otherwise.
      */
     static boolean shouldHonorAEForRead(SQLServerStatementColumnEncryptionSetting stmtColumnEncryptionSetting,
@@ -804,7 +829,7 @@ final class Util {
     /**
      * Determines if parameters should be transparently encrypted (based on SQLServerStatement and the connection string
      * settings).
-     * 
+     *
      * @return true if the value should be transparently encrypted, false otherwise.
      */
     static boolean shouldHonorAEForParameters(SQLServerStatementColumnEncryptionSetting stmtColumnEncryptionSetting,
@@ -984,7 +1009,7 @@ final class Util {
 
     /**
      * Escapes single quotes (') in object name to convert and pass it as String safely.
-     * 
+     *
      * @param name
      *        Object name to be passed as String
      * @return Converted object name

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -230,21 +230,21 @@ final class Util {
     }
 
     /**
-     * Checks to see if a long value can be converted to another, smaller, type.
+     * Checks to see if a long value can be converted to another type.
      * 
-     * @param  convert
-     *         the short value to convert
-     * @param  convertTo
+     * @param  valueToConvert
+     *         the value to convert
+     * @param  typeToConvertTo
      *         the type to convert to
-     * @return true if the type can be converted
+     * @return true if the type can be converted safely
      */
-    static boolean isSafeToConvert(long convert, String convertTo) {
+    static boolean isSafeToConvert(long valueToConvert, String typeToConvertTo) {
         boolean safeConversion = false;
 
-        switch (convertTo) {
+        switch (typeToConvertTo) {
             // Add more cases as necessary
             case "int":
-                if (convert <= Integer.MAX_VALUE && convert >= Integer.MIN_VALUE) {
+                if (valueToConvert <= Integer.MAX_VALUE && valueToConvert >= Integer.MIN_VALUE) {
                     safeConversion = true;
                 }
                 break;


### PR DESCRIPTION
(Update 3/2/2022) While the below approach works, given that the use of `readSkipBytes` has changed, its no longer necessary to pass in a `long`. Thus the changes can be reduced to ensuring all involved types are `int`, avoiding any information loss.

-----------------------------------------------------------------------------------------------------------------------------------------

As seen here: https://github.com/microsoft/mssql-jdbc/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fmain, there is an implicit cast taking place in IOBuffer.java, that may lead to a loss of information. The solution was to first check if the long value `bytesToSkip` can be converted without information loss, and only allow addition to `payloadOffset` if this is true.

The reverse, that is widening `payloadOffset` to long, to accommodate `bytesToSkip` is not possible because of the many uses `payloadOffset` has throughout the file. Lines 7043 and 7049 in `IOBuffer.java` are good examples of this. Extensive reformatting is needed to change `payloadOffset`, while `bytesToSkip` can be checked with ease.

The function used to check if `bytesToSkip` is small enough, `isSafeToConvert`, uses a switch function even though it only has one case, this is to allow future cases to be added, if needed. Additionally, other values, besides long, can be passed in to convert, provided they are cast beforehand.