### PR TITLE
Add check for MSAL library when attempting ActiveDirectoryServicePrincipal authentication

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5328,6 +5328,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 break;
             } else if (authenticationString
                     .equalsIgnoreCase(SqlAuthentication.ActiveDirectoryServicePrincipal.toString())) {
+                if (!msalContextExists()) {
+                    MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_MSALMissing"));
+                    throw new SQLServerException(form.format(new Object[] {authenticationString}), null, 0, null);
+                }
 
                 // aadPrincipalID and aadPrincipalSecret is deprecated replaced by username and password
                 if (aadPrincipalID != null && !aadPrincipalID.isEmpty() && aadPrincipalSecret != null


### PR DESCRIPTION
Minor change. This check exists for other AD auth cases, but will just throw java.lang.ClassNotFoundException if ActiveDirectoryServicePrincipal is used and MSAL libraries are not in the classpath. In another project, I had spent some time trying to determine the issue, only to notice this missing check would have been helpful.

This just adds the check used in other AD auth cases to the ActiveDirectoryServicePrincipal case.

> Caused by: java.lang.NoClassDefFoundError: com/microsoft/aad/msal4j/IClientCredential
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.getFedAuthToken(SQLServerConnection.java:5341)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.onFedAuthInfo(SQLServerConnection.java:5293)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.processFedAuthInfo(SQLServerConnection.java:5180)
        at com.microsoft.sqlserver.jdbc.TDSTokenHandler.onFedAuthInfo(tdsparser.java:305)
        at com.microsoft.sqlserver.jdbc.TDSParser.parse(tdsparser.java:128)

now returns:

> Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: Failed to load MSAL4J Java library for performing ActiveDirectoryServicePrincipal authentication.
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.getFedAuthToken(SQLServerConnection.java:5333)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.onFedAuthInfo(SQLServerConnection.java:5290)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.processFedAuthInfo(SQLServerConnection.java:5177)
        at com.microsoft.sqlserver.jdbc.TDSTokenHandler.onFedAuthInfo(tdsparser.java:305)
        at com.microsoft.sqlserver.jdbc.TDSParser.parse(tdsparser.java:128)

Thanks