### PR TITLE
Add encrypt utility to obfuscate password strings

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1848,8 +1848,12 @@ final class TDSChannel implements Serializable {
 
             String trustStoreFileName = con.activeConnectionProperties
                     .getProperty(SQLServerDriverStringProperty.TRUST_STORE.toString());
-            String trustStorePassword = con.activeConnectionProperties
-                    .getProperty(SQLServerDriverStringProperty.TRUST_STORE_PASSWORD.toString());
+
+            String trustStorePassword = null;
+            if (con.encryptedTrustStorePassword != null) {
+                trustStorePassword = SecureStringUtil.getInstance().getDecryptedString(con.encryptedTrustStorePassword);
+            }
+
             String hostNameInCertificate = con.activeConnectionProperties
                     .getProperty(SQLServerDriverStringProperty.HOSTNAME_IN_CERTIFICATE.toString());
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -217,6 +217,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /** flag indicating whether prelogin TLS handshake is required */
     private boolean isTDSS = false;
 
+    String encryptedTrustStorePassword = null;
+
     /**
      * Return an existing cached SharedTimer associated with this Connection or create a new one.
      *
@@ -1818,6 +1820,13 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 activeConnectionProperties = (Properties) propsIn.clone();
 
                 pooledConnectionParent = pooledConnection;
+
+                String trustStorePassword = activeConnectionProperties
+                        .getProperty(SQLServerDriverStringProperty.TRUST_STORE_PASSWORD.toString());
+                if (trustStorePassword != null) {
+                    encryptedTrustStorePassword = SecureStringUtil.getInstance().getEncryptedString(trustStorePassword);
+                    activeConnectionProperties.remove(SQLServerDriverStringProperty.TRUST_STORE_PASSWORD.toString());
+                }
 
                 String hostNameInCertificate = activeConnectionProperties
                         .getProperty(SQLServerDriverStringProperty.HOSTNAME_IN_CERTIFICATE.toString());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -266,8 +266,8 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_InvalidCipherTextSize", "Specified ciphertext has an invalid size of {0} bytes, which is below the minimum {1} bytes required for decryption."},
         {"R_InvalidAlgorithmVersion", "The specified ciphertext''s encryption algorithm version {0} does not match the expected encryption algorithm version {1} ."},
         {"R_InvalidAuthenticationTag", "Specified ciphertext has an invalid authentication tag. "},
-        {"R_EncryptionFailed", "Internal error while encryption:  {0} "},
-        {"R_DecryptionFailed", "Internal error while decryption:  {0} "},
+        {"R_EncryptionFailed", "Internal error during encryption:  {0} "},
+        {"R_DecryptionFailed", "Internal error during decryption:  {0} "},
         {"R_InvalidKeySize", "The column encryption key has been successfully decrypted but it''s length: {0} does not match the length: {1} for algorithm \"{2}\". Verify the encrypted value of the column encryption key in the database."},
         {"R_InvalidEncryptionType", "Encryption type {0} specified for the column in the database is either invalid or corrupted. Valid encryption types for algorithm {1} are: {2}."},
         {"R_UnknownColumnEncryptionAlgorithm", "The Algorithm {0} does not exist. Algorithms registered in the factory are {1}."},
@@ -503,6 +503,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_crClientSSLStateNotRecoverable", "The server did not preserve SSL encryption during a recovery attempt, connection recovery is not possible."},
         {"R_crCommandCannotTimeOut", "Request failed to time out and SQLServerConnection does not exist"},
         {"R_UnableLoadAuthDll", "Unable to load authentication DLL {0}"},
+        {"R_SecureStringInitFailed", "Failed to initialize utitily to store secure strings"},
     };
 }
 // @formatter:on

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -503,7 +503,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_crClientSSLStateNotRecoverable", "The server did not preserve SSL encryption during a recovery attempt, connection recovery is not possible."},
         {"R_crCommandCannotTimeOut", "Request failed to time out and SQLServerConnection does not exist"},
         {"R_UnableLoadAuthDll", "Unable to load authentication DLL {0}"},
-        {"R_SecureStringInitFailed", "Failed to initialize utitily to store secure strings"},
+        {"R_SecureStringInitFailed", "Failed to initialize SecureStringUtil to store secure strings"},
     };
 }
 // @formatter:on

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
@@ -12,7 +12,8 @@ import javax.crypto.spec.IvParameterSpec;
 
 /**
  * 
- * This is an utility class to encrypt and decrypt strings so it won't be visible as plaintext
+ * This is an utility class to encrypt/decrypt strings. This is used to obfuscate passwords so they won't be visible as
+ * plaintext.
  */
 final class SecureStringUtil {
     /* cipher transformation in the form of algorithm/mode/padding */

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
@@ -1,0 +1,130 @@
+package com.microsoft.sqlserver.jdbc;
+
+import java.security.SecureRandom;
+import java.text.MessageFormat;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+
+
+/**
+ * 
+ * This is an utility class to encrypt and decrypt strings so it won't be visible as plaintext
+ */
+final class SecureStringUtil {
+    /* cipher transformation in the form of algorithm/mode/padding */
+    static final String CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
+
+    /* key generator algorithm */
+    static final String KEYGEN_ALGORITHEM = "AES";
+
+    /* length of initialization vector buffer */
+    static final int IV_LENGTH = 16;
+
+    /* key size */
+    static final int KEY_SIZE = 128;
+
+    /* initialization vector params */
+    private IvParameterSpec ivParamSpec;
+
+    /** secret key for encryption/decryption */
+    private SecretKey key;
+
+    /* cryptographic cipher for encryption */
+    private Cipher encryptCipher;
+
+    /* cryptographic cipher for decryption */
+    private Cipher decryptCipher;
+
+    /* singleton instance */
+    private static SecureStringUtil instance;
+
+    /**
+     * Get reference to SecureStringUtil instance
+     * 
+     * @return the SecureStringUtil instance
+     * 
+     * @throws SQLServerException
+     *         if error
+     */
+    static SecureStringUtil getInstance() throws SQLServerException {
+        if (instance == null) {
+            instance = new SecureStringUtil();
+        }
+        return instance;
+    }
+
+    /**
+     * Creates an instance of the SecureStringUtil object and initialize values to encrypt/decrypt strings
+     * 
+     * @throws SQLServerException
+     *         if error
+     */
+    private SecureStringUtil() throws SQLServerException {
+        byte[] iv = new byte[IV_LENGTH];
+        new SecureRandom().nextBytes(iv);
+        ivParamSpec = new IvParameterSpec(iv);
+
+        try {
+            // init key */
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(KEYGEN_ALGORITHEM);
+            keyGenerator.init(KEY_SIZE);
+            key = keyGenerator.generateKey();
+
+            encryptCipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            encryptCipher.init(Cipher.ENCRYPT_MODE, key, ivParamSpec);
+            decryptCipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            decryptCipher.init(Cipher.DECRYPT_MODE, key, ivParamSpec);
+
+        } catch (Exception e) {
+            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_SecureStringInitFailed"));
+            Object[] msgArgs = {e.getMessage()};
+            throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
+        }
+    }
+
+    /**
+     * Get encrypted value of given string
+     * 
+     * @param str
+     *        string to encrypt
+     * 
+     * @return encrypted string
+     * 
+     * @throws SQLServerException
+     *         if error
+     */
+    String getEncryptedString(String str) throws SQLServerException {
+        try {
+            byte[] cipherText = encryptCipher.doFinal(str.getBytes());
+            return Base64.getEncoder().encodeToString(cipherText);
+        } catch (Exception e) {
+            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_EncryptionFailed"));
+            Object[] msgArgs = {e.getMessage()};
+            throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
+        }
+    }
+
+    /**
+     * Get decrypted value of an encrypted string
+     * 
+     * @param str
+     * 
+     * @return decrypted string
+     * 
+     * @throws SQLServerException
+     */
+    String getDecryptedString(String str) throws SQLServerException {
+        try {
+            byte[] plainText = decryptCipher.doFinal(Base64.getDecoder().decode(str));
+            return new String(plainText);
+        } catch (Exception e) {
+            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_DecryptionFailed"));
+            Object[] msgArgs = {e.getMessage()};
+            throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
+        }
+    }
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -655,7 +655,7 @@ public class SQLServerConnectionTest extends AbstractTest {
                 assertTrue(timeDiff <= milsecs, form.format(msgArgs));
             }
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")));
+            assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
             timerEnd = System.currentTimeMillis();
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -43,7 +43,7 @@ public class BasicConnectionTest extends AbstractTest {
         basicReconnect(connectionString);
     }
 
-   // @Test
+   @Test
     public void testBasicConnectionAAD() throws SQLException {
         String azureServer = getConfiguredProperty("azureServer");
         String azureDatabase = getConfiguredProperty("azureDatabase");
@@ -60,7 +60,7 @@ public class BasicConnectionTest extends AbstractTest {
         basicReconnect(connectionString);
     }
 
-   // @Test
+    @Test
     public void testGracefulClose() throws SQLException {
         try (Connection c = ResiliencyUtils.getConnection(connectionString)) {
             try (Statement s = c.createStatement()) {
@@ -146,7 +146,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
- //   @Test
+    @Test
     public void testOpenTransaction() throws SQLException {
         String tableName = RandomUtil.getIdentifier("resTable");
         try (Connection c = ResiliencyUtils.getConnection(connectionString); Statement s = c.createStatement()) {
@@ -166,7 +166,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-  //  @Test
+    @Test
     public void testOpenResultSetShouldBeCleanedUp() throws SQLException, InterruptedException {
         try (Connection c = ResiliencyUtils.getConnection(connectionString); Statement s = c.createStatement()) {
             int sessionId = ResiliencyUtils.getSessionId(c);
@@ -180,7 +180,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-  //  @Test
+    @Test
     public void testPooledConnection() throws SQLException {
         SQLServerConnectionPoolDataSource mds = new SQLServerConnectionPoolDataSource();
         mds.setURL(connectionString);
@@ -198,7 +198,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-  //  @Test
+    @Test
     @Tag(Constants.xAzureSQLDB) // Switching databases is not supported against Azure, skip/
     public void testPooledConnectionDB() throws SQLException {
         SQLServerConnectionPoolDataSource mds = new SQLServerConnectionPoolDataSource();
@@ -236,7 +236,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
- //   @Test
+    @Test
     public void testPooledConnectionLang() throws SQLException {
         SQLServerConnectionPoolDataSource mds = new SQLServerConnectionPoolDataSource();
         mds.setURL(connectionString);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -43,7 +43,7 @@ public class BasicConnectionTest extends AbstractTest {
         basicReconnect(connectionString);
     }
 
-    @Test
+   // @Test
     public void testBasicConnectionAAD() throws SQLException {
         String azureServer = getConfiguredProperty("azureServer");
         String azureDatabase = getConfiguredProperty("azureDatabase");
@@ -60,7 +60,7 @@ public class BasicConnectionTest extends AbstractTest {
         basicReconnect(connectionString);
     }
 
-    @Test
+   // @Test
     public void testGracefulClose() throws SQLException {
         try (Connection c = ResiliencyUtils.getConnection(connectionString)) {
             try (Statement s = c.createStatement()) {
@@ -146,7 +146,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-    @Test
+ //   @Test
     public void testOpenTransaction() throws SQLException {
         String tableName = RandomUtil.getIdentifier("resTable");
         try (Connection c = ResiliencyUtils.getConnection(connectionString); Statement s = c.createStatement()) {
@@ -166,7 +166,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-    @Test
+  //  @Test
     public void testOpenResultSetShouldBeCleanedUp() throws SQLException, InterruptedException {
         try (Connection c = ResiliencyUtils.getConnection(connectionString); Statement s = c.createStatement()) {
             int sessionId = ResiliencyUtils.getSessionId(c);
@@ -180,7 +180,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-    @Test
+  //  @Test
     public void testPooledConnection() throws SQLException {
         SQLServerConnectionPoolDataSource mds = new SQLServerConnectionPoolDataSource();
         mds.setURL(connectionString);
@@ -198,7 +198,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-    @Test
+  //  @Test
     @Tag(Constants.xAzureSQLDB) // Switching databases is not supported against Azure, skip/
     public void testPooledConnectionDB() throws SQLException {
         SQLServerConnectionPoolDataSource mds = new SQLServerConnectionPoolDataSource();
@@ -236,7 +236,7 @@ public class BasicConnectionTest extends AbstractTest {
         }
     }
 
-    @Test
+ //   @Test
     public void testPooledConnectionLang() throws SQLException {
         SQLServerConnectionPoolDataSource mds = new SQLServerConnectionPoolDataSource();
         mds.setURL(connectionString);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -43,7 +43,7 @@ public class BasicConnectionTest extends AbstractTest {
         basicReconnect(connectionString);
     }
 
-   @Test
+    @Test
     public void testBasicConnectionAAD() throws SQLException {
         String azureServer = getConfiguredProperty("azureServer");
         String azureDatabase = getConfiguredProperty("azureDatabase");


### PR DESCRIPTION
This allows storing of the trustStorePassword in encrypted form since it is needed for Idle Connection Resiliency when recovering connections. 