### PR TITLE
Remove Commands from TimeoutPoller when they have Completed

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/TimeoutPoller.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/TimeoutPoller.java
@@ -61,7 +61,12 @@ final class TimeoutPoller implements Runnable {
                     while (timeoutCommandIterator.hasNext()) {
                         TimeoutCommand<TDSCommand> timeoutCommand = timeoutCommandIterator.next();
                         try {
-                            if (timeoutCommand.canTimeout()) {
+                            // Remove complete command from the poller
+                            if (timeoutCommand.getCommand().getRequestComplete()) {
+                                timeoutCommandIterator.remove();
+                            }
+                            // If not complete, then check for timeout
+                            else if (timeoutCommand.canTimeout()) {
                                 try {
                                     timeoutCommand.interrupt();
                                 } finally {


### PR DESCRIPTION
The TimeoutPoller previously did not release completed commands, and retained the instance in the command array until the entire timeout period has elapsed. Then it would unnecessarily call interrupt() on the command, before removing it from the TimeoutPoller.

This had the side effect that object being added to the TimeoutPoller would not be Garbage Collected until after the entire timeout period. If the query timeout was sufficiently long, it could potentially result in out-of-memory exceptions when the frequency of queries is high. Managing this by reducing the query timeout becomes an unnecessary "tuning" problem, where you choose between memory usage and the possibility of cancelling fully working but long lasting queries.

This commit fixes this issue by removing completed commands from the TimeoutPoller regardless of being timed out or not. This insures the command instances can be garbage collected. The issue has been reported here:

https://github.com/microsoft/mssql-jdbc/issues/1781