### PR TITLE
Remove timeout commands from TimeoutPoller on command completion.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1075,7 +1075,7 @@ final class TDSChannel implements Serializable {
 
         /**
          * Poll the stream to verify connectivity.
-         * 
+         *
          * @return true if the stream is readable.
          * @throws IOException
          *         If an I/O exception occurs.
@@ -1814,7 +1814,7 @@ final class TDSChannel implements Serializable {
 
     /**
      * Enables SSL Handshake.
-     * 
+     *
      * @param host
      *        Server Host Name for SSL Handshake
      * @param port
@@ -2120,12 +2120,12 @@ final class TDSChannel implements Serializable {
 
     /**
      * Validate FIPS if fips set as true
-     * 
+     *
      * Valid FIPS settings:
      * <LI>Encrypt should be true
      * <LI>trustServerCertificate should be false
      * <LI>if certificate is not installed TrustStoreType should be present.
-     * 
+     *
      * @param trustStoreType
      * @param trustStoreFileName
      * @throws SQLServerException
@@ -2255,7 +2255,7 @@ final class TDSChannel implements Serializable {
 
     /**
      * Attempts to poll the input stream to see if the network socket is still connected.
-     * 
+     *
      * @return
      */
     final Boolean networkSocketStillConnected() {
@@ -2513,13 +2513,13 @@ final class TDSChannel implements Serializable {
 /**
  * SocketFinder is used to find a server socket to which a connection can be made. This class abstracts the logic of
  * finding a socket from TDSChannel class.
- * 
+ *
  * In the case when useParallel is set to true, this is achieved by trying to make parallel connections to multiple IP
  * addresses. This class is responsible for spawning multiple threads and keeping track of the search result and the
  * connected socket or exception to be thrown.
- * 
+ *
  * In the case where multiSubnetFailover is false, we try our old logic of trying to connect to the first ip address
- * 
+ *
  * Typical usage of this class is SocketFinder sf = new SocketFinder(traceId, conn); Socket = sf.getSocket(hostName,
  * port, timeout);
  */
@@ -2581,7 +2581,7 @@ final class SocketFinder {
 
     /**
      * Constructs a new SocketFinder object with appropriate traceId
-     * 
+     *
      * @param callerTraceID
      *        traceID of the caller
      * @param sqlServerConnection
@@ -2594,7 +2594,7 @@ final class SocketFinder {
 
     /**
      * Used to find a socket to which a connection can be made
-     * 
+     *
      * @param hostName
      * @param portNumber
      * @param timeoutInMilliSeconds
@@ -2733,7 +2733,7 @@ final class SocketFinder {
     /**
      * This function uses java NIO to connect to all the addresses in inetAddrs with in a specified timeout. If it
      * succeeds in connecting, it closes all the other open sockets and updates the result to success.
-     * 
+     *
      * @param inetAddrs
      *        the array of inetAddress to which connection should be made
      * @param portNumber
@@ -3093,7 +3093,7 @@ final class SocketFinder {
      * or exception). It updates the result, socket and exception variables of socketFinder object. This method notifies
      * the parent thread if a socket is found or if all the spawned threads have notified. It also closes a socket if it
      * is not selected for use by socketFinder.
-     * 
+     *
      * @param socket
      *        the SocketConnector's socket
      * @param exception
@@ -3197,7 +3197,7 @@ final class SocketFinder {
      * If there are multiple exceptions, that are not related to socketTimeout the first non-socketTimeout exception is
      * picked. If all exceptions are related to socketTimeout, the first exception is picked. Note: This method is not
      * thread safe. The caller should ensure thread safety.
-     * 
+     *
      * @param ex
      *        the IOException
      * @param traceId
@@ -3221,7 +3221,7 @@ final class SocketFinder {
 
     /**
      * Used fof tracing
-     * 
+     *
      * @return traceID string
      */
     public String toString() {
@@ -3303,7 +3303,7 @@ final class SocketConnector implements Runnable {
 
     /**
      * Used for tracing
-     * 
+     *
      * @return traceID string
      */
     public String toString() {
@@ -3423,7 +3423,7 @@ final class TDSWriter {
 
     /**
      * Checks If tdsMessageType is RPC or QUERY
-     * 
+     *
      * @return boolean
      */
     boolean checkIfTdsMessageTypeIsBatchOrRPC() {
@@ -3566,7 +3566,7 @@ final class TDSWriter {
 
     /**
      * writing sqlCollation information for sqlVariant type when sending character types.
-     * 
+     *
      * @param variantType
      * @throws SQLServerException
      */
@@ -3622,7 +3622,7 @@ final class TDSWriter {
 
     /**
      * Append a real value in the TDS stream.
-     * 
+     *
      * @param value
      *        the data value
      */
@@ -3632,7 +3632,7 @@ final class TDSWriter {
 
     /**
      * Append a double value in the TDS stream.
-     * 
+     *
      * @param value
      *        the data value
      */
@@ -3659,7 +3659,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal in the TDS stream.
-     * 
+     *
      * @param bigDecimalVal
      *        the big decimal data value
      * @param srcJdbcType
@@ -3700,7 +3700,7 @@ final class TDSWriter {
 
     /**
      * Append a money/smallmoney value in the TDS stream.
-     * 
+     *
      * @param moneyVal
      *        the money data value.
      * @param srcJdbcType
@@ -3722,7 +3722,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal inside sql_variant in the TDS stream.
-     * 
+     *
      * @param bigDecimalVal
      *        the big decimal data value
      * @param srcJdbcType
@@ -4595,7 +4595,7 @@ final class TDSWriter {
 
     /**
      * Write out elements common to all RPC values.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param bOut
@@ -4624,7 +4624,7 @@ final class TDSWriter {
 
     /**
      * Append a boolean value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param booleanValue
@@ -4645,7 +4645,7 @@ final class TDSWriter {
 
     /**
      * Append a short value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param byteValue
@@ -4666,7 +4666,7 @@ final class TDSWriter {
 
     /**
      * Append a short value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param shortValue
@@ -4687,7 +4687,7 @@ final class TDSWriter {
 
     /**
      * Append an int value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param intValue
@@ -4708,7 +4708,7 @@ final class TDSWriter {
 
     /**
      * Append a long value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param longValue
@@ -4729,7 +4729,7 @@ final class TDSWriter {
 
     /**
      * Append a real value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param floatValue
@@ -4763,7 +4763,7 @@ final class TDSWriter {
 
     /**
      * Append a double value in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param doubleValue
@@ -4795,7 +4795,7 @@ final class TDSWriter {
 
     /**
      * Append a big decimal in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param bdValue
@@ -4816,7 +4816,7 @@ final class TDSWriter {
 
     /**
      * Appends a standard v*max header for RPC parameter transmission.
-     * 
+     *
      * @param headerLength
      *        the total length of the PLP data block.
      * @param isNull
@@ -4858,7 +4858,7 @@ final class TDSWriter {
 
     /**
      * Writes a string value as Unicode for RPC
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param sValue
@@ -5378,7 +5378,7 @@ final class TDSWriter {
 
     /**
      * writes Header for sql_variant for TVP
-     * 
+     *
      * @param length
      * @param tdsType
      * @param probBytes
@@ -5722,7 +5722,7 @@ final class TDSWriter {
 
     /**
      * Append a timestamp in RPC transmission format as a SQL Server DATETIME data type
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param cal
@@ -6435,7 +6435,7 @@ final class TDSWriter {
 
     /**
      * Append the data in a stream in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param stream
@@ -6534,7 +6534,7 @@ final class TDSWriter {
 
     /**
      * Append the XML data in a stream in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param stream
@@ -6573,7 +6573,7 @@ final class TDSWriter {
 
     /**
      * Append the data in a character reader in RPC transmission format.
-     * 
+     *
      * @param sName
      *        the optional parameter name
      * @param re
@@ -7024,7 +7024,7 @@ final class TDSReader implements Serializable {
     }
 
     /**
-     * 
+     *
      * @return number of bytes available in the current packet
      */
     final int availableCurrentPacket() {
@@ -8024,6 +8024,12 @@ abstract class TDSCommand implements Serializable {
                 assert !attentionPending;
                 assert !processedResponse;
                 readingResponse = true;
+            }
+            // Is the command registered in the TimeoutPoller?
+            if (isRegisteredInPoller) {
+                // Yes, then remove the command from poller and clear the registration flag
+                TimeoutPoller.getTimeoutPoller().remove(this.timeoutCommand);
+                isRegisteredInPoller = false;
             }
         }
     }


### PR DESCRIPTION
This is an alternative fix to the TimeoutPoller memory leak (Issue #1781), caused by commands being retained in the poller until timeout even if the commands complete.

Link to issue:
https://github.com/microsoft/mssql-jdbc/issues/1781

The idea here is simply to remove the command from the TimeoutPoller on command completion. This is an alternative solution  to the following pull-request:
https://github.com/microsoft/mssql-jdbc/pull/1782

Note that the two requests are not in conflict with each other, and should be thread safe together. However, I think only one of them should be applied, as it will render the other redundant.
