### PR TITLE
Formatted the check that assigns AE version to correctly assign version to protocol

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLJdbcVersion.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLJdbcVersion.java
@@ -8,7 +8,7 @@ package com.microsoft.sqlserver.jdbc;
 final class SQLJdbcVersion {
     static final int major = 11;
     static final int minor = 1;
-    static final int patch = 0;
+    static final int patch = 1;
     static final int build = 0;
     /*
      * Used to load mssql-jdbc_auth DLL.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4561,8 +4561,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (write) {
             tdsWriter.writeByte(TDS.TDS_FEATURE_EXT_AE); // FEATUREEXT_TC
             tdsWriter.writeInt(1); // length of version
-        if (null == enclaveAttestationProtocol || ((null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
-              && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
+            
+            // For protocol = HGS,AAS, we want V2, unless URL is null or empty, in which case we want V1
+            // For protocol = NONE, we always want V2, even with a URL that is none or empty
+            // For protocol = null, we always want V1
+              if (null == enclaveAttestationProtocol || ((null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
+                  && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION1);
             } else {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION2);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4565,8 +4565,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // For protocol = HGS,AAS, we want V2, unless URL is null or empty, in which case we want V1
             // For protocol = NONE, we always want V2, even with a URL that is none or empty
             // For protocol = null, we always want V1
-              if (null == enclaveAttestationProtocol || ((null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
-                  && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
+            if (null == enclaveAttestationProtocol || ((null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
+              && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION1);
             } else {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION2);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5679,7 +5679,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 serverColumnEncryptionVersion = ColumnEncryptionVersion.AE_V1;
 
                 if (null != enclaveAttestationUrl || (enclaveAttestationProtocol != null 
-                && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
+                && enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
                     if (aeVersion < TDS.COLUMNENCRYPTION_VERSION2) {
                         throw new SQLServerException(SQLServerException.getErrString("R_enclaveNotSupported"), null);
                     } else {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4564,8 +4564,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             
             // For protocol = HGS,AAS, at this point it can only have a valid URL, therefore is V2
             // For protocol = NONE, it is V2 regardless
-            // For protocol = null or empty, we always want V1
-            if (null == enclaveAttestationProtocol || enclaveAttestationProtocol.isEmpty()) {
+            // For protocol = null, we always want V1
+            if (null == enclaveAttestationProtocol) {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION1);
             } else {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION2);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4562,11 +4562,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             tdsWriter.writeByte(TDS.TDS_FEATURE_EXT_AE); // FEATUREEXT_TC
             tdsWriter.writeInt(1); // length of version
             
-            // For protocol = HGS,AAS, we want V2, unless URL is null or empty, in which case we want V1
-            // For protocol = NONE, we always want V2, even with a URL that is none or empty
-            // For protocol = null, we always want V1
-            if (null == enclaveAttestationProtocol || ((null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
-                        && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
+            // For protocol = HGS,AAS, at this point it can only have a valid URL, therefore is V2
+            // For protocol = NONE, it is V2 regardless
+            // For protocol = null or empty, we always want V1
+            if (null == enclaveAttestationProtocol || enclaveAttestationProtocol.isEmpty()) {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION1);
             } else {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION2);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4558,8 +4558,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (write) {
             tdsWriter.writeByte(TDS.TDS_FEATURE_EXT_AE); // FEATUREEXT_TC
             tdsWriter.writeInt(1); // length of version
-            if (null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty() || (enclaveAttestationProtocol != null 
-               && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
+            if (null == enclaveAttestationProtocol || (null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
+              && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString())) {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION1);
             } else {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION2);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4558,8 +4558,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         if (write) {
             tdsWriter.writeByte(TDS.TDS_FEATURE_EXT_AE); // FEATUREEXT_TC
             tdsWriter.writeInt(1); // length of version
-            if (null == enclaveAttestationProtocol || (null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
-              && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString())) {
+            if (null == enclaveAttestationProtocol || ((null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
+              && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION1);
             } else {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION2);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4566,7 +4566,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // For protocol = NONE, we always want V2, even with a URL that is none or empty
             // For protocol = null, we always want V1
             if (null == enclaveAttestationProtocol || ((null == enclaveAttestationUrl || enclaveAttestationUrl.isEmpty()) 
-              && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
+                        && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION1);
             } else {
                 tdsWriter.writeByte(TDS.COLUMNENCRYPTION_VERSION2);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5679,7 +5679,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 serverColumnEncryptionVersion = ColumnEncryptionVersion.AE_V1;
 
                 if (null != enclaveAttestationUrl || (enclaveAttestationProtocol != null 
-                && enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
+                && !enclaveAttestationProtocol.equalsIgnoreCase(AttestationProtocol.NONE.toString()))) {
                     if (aeVersion < TDS.COLUMNENCRYPTION_VERSION2) {
                         throw new SQLServerException(SQLServerException.getErrString("R_enclaveNotSupported"), null);
                     } else {


### PR DESCRIPTION
In the previous commit for attestation protocol, the check to assign the correct AE version in SQLServerConnection, 1) mistakenly assigned V1 to all HGS,AAS protocols and 2) assigned V2 to null protocols. By reformatting, the check should now correctly assign version for all cases of attestation URL and protocol.

Also included the version change in SQLJdbcVersion as it was needed to properly test that this fix was working.