### PR TITLE
Dataclassification sensitivity max index fix

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamColumns.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamColumns.java
@@ -32,9 +32,6 @@ final class StreamColumns extends StreamPacket {
 
     private boolean sensitivityRankSupported = false;
 
-    // SensitivityLabelIndex and InformationTypeIndex as defined in the TDS spec have a max of USHORT_MAX
-    private static final int DATACLASSIFICATION_INDEX_MAX = 65535;
-
     /* Returns the CekTable */
     CekTable getCekTable() {
         return cekTable;
@@ -290,7 +287,7 @@ final class StreamColumns extends StreamPacket {
                 Label label = null;
 
                 // If sensitivity label index is equal to USHORT_MAX eg. 65535 then there is no sensitivity label
-                if (sensitivityLabelIndex != DATACLASSIFICATION_INDEX_MAX) {
+                if (sensitivityLabelIndex != DataTypes.SQL_USHORTVARMAXLEN) {
                     if (sensitivityLabelIndex >= sensitivityLabels.size()) {
                         tdsReader.throwInvalidTDS();
                     }
@@ -301,7 +298,7 @@ final class StreamColumns extends StreamPacket {
                 InformationType informationType = null;
 
                 // If information type index is equal to USHORT_MAX eg. 65535 then there is no information type
-                if (informationTypeIndex != DATACLASSIFICATION_INDEX_MAX) {
+                if (informationTypeIndex != DataTypes.SQL_USHORTVARMAXLEN) {
                     if (informationTypeIndex >= informationTypes.size()) {}
                     informationType = informationTypes.get(informationTypeIndex);
                 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamColumns.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamColumns.java
@@ -32,6 +32,9 @@ final class StreamColumns extends StreamPacket {
 
     private boolean sensitivityRankSupported = false;
 
+    // SensitivityLabelIndex and InformationTypeIndex as defined in the TDS spec have a max of USHORT_MAX
+    private static final int DATACLASSIFICATION_INDEX_MAX = 65535;
+
     /* Returns the CekTable */
     CekTable getCekTable() {
         return cekTable;
@@ -285,7 +288,9 @@ final class StreamColumns extends StreamPacket {
                 // get the label index and then lookup label to use for source
                 int sensitivityLabelIndex = tdsReader.readUnsignedShort();
                 Label label = null;
-                if (sensitivityLabelIndex != Integer.MAX_VALUE) {
+
+                // If sensitivity label index is equal to USHORT_MAX eg. 65535 then there is no sensitivity label
+                if (sensitivityLabelIndex != DATACLASSIFICATION_INDEX_MAX) {
                     if (sensitivityLabelIndex >= sensitivityLabels.size()) {
                         tdsReader.throwInvalidTDS();
                     }
@@ -294,7 +299,9 @@ final class StreamColumns extends StreamPacket {
                 // get the information type index and then lookup information type to use for source
                 int informationTypeIndex = tdsReader.readUnsignedShort();
                 InformationType informationType = null;
-                if (informationTypeIndex != Integer.MAX_VALUE) {
+
+                // If information type index is equal to USHORT_MAX eg. 65535 then there is no information type
+                if (informationTypeIndex != DATACLASSIFICATION_INDEX_MAX) {
                     if (informationTypeIndex >= informationTypes.size()) {}
                     informationType = informationTypes.get(informationTypeIndex);
                 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/DataClassificationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/DataClassificationTest.java
@@ -44,12 +44,42 @@ public class DataClassificationTest extends AbstractTest {
             .escapeIdentifier(RandomUtil.getIdentifier("DataClassification"));
     private static final String tableName1 = AbstractSQLGenerator
             .escapeIdentifier(RandomUtil.getIdentifier("SelectMethodCursor"));
+    private static final String tableName2 = AbstractSQLGenerator
+            .escapeIdentifier(RandomUtil.getIdentifier("USHORT_MAX"));
     private static final String addSensitivitySql = "ADD SENSITIVITY CLASSIFICATION TO %s.%s WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='%s', INFORMATION_TYPE_ID='%s'%s)";
     private static final String sensitivityRankSql = ", RANK=%s";
 
     @BeforeAll
     public static void setupTests() throws Exception {
         setConnection();
+    }
+
+    @Test
+    @Tag(Constants.xAzureSQLDW)
+    @Tag(Constants.xSQLv11)
+    @Tag(Constants.xSQLv12)
+    @Tag(Constants.xSQLv14)
+    public void testInformationTypeSensitivityLabelIndexMax() throws Exception {
+        String createTable = "create table " + tableName2 + " (col1 varchar(200), col2 varchar(200), col3 varchar(200))";
+        String sensitivityClassification = "ADD SENSITIVITY CLASSIFICATION TO %s.%s WITH (LABEL='PII')";
+        String query = "select * from " + tableName2;
+
+        try (SQLServerConnection conn = PrepUtil.getConnection(connectionString)) {
+            // Create table
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(createTable);
+            }
+
+            // Add sensitivity classification
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(String.format(sensitivityClassification, tableName2, "col1"));
+            }
+
+            // Execute query
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(query);
+            }
+        }
     }
 
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/DataClassificationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/DataClassificationTest.java
@@ -70,7 +70,7 @@ public class DataClassificationTest extends AbstractTest {
                 stmt.execute(createTable);
             }
 
-            // Add sensitivity classification
+            // Add sensitivity classification without an INFORMATION_TYPE
             try (Statement stmt = conn.createStatement()) {
                 stmt.execute(String.format(sensitivityClassification, tableName2, "col1"));
             }


### PR DESCRIPTION
Both SensitivityLabelIndex and InformationTypeIndex have a max of USHORT_MAX as defined in the TDS spec, and not a max of INTEGER_MAX