### PR TITLE
Added check for DONE_ERROR status token and throw appropriate exception

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -180,6 +180,14 @@ final class TDS {
     static final int TDS_SQLRESCOLSRCS = 0xa2;
     static final int TDS_SQLDATACLASSIFICATION = 0xa3;
 
+    // DONE status https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/3c06f110-98bd-4d5b-b836-b1ba66452cb7
+    static final int DONE_FINAL = 0x0000;
+    static final int DONE_MORE = 0x0001;
+    static final int DONE_COUNT = 0x0010;
+    static final int DONE_ERROR = 0x0002;
+    static final int DONE_ATTN = 0x0020;
+    static final int DONE_SRVERROR = 0x0100;
+
     // FedAuth
     static final byte TDS_FEATURE_EXT_FEDAUTH = 0x02;
     static final int TDS_FEDAUTH_LIBRARY_SECURITYTOKEN = 0x01;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -77,7 +77,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     /** map */
     Map<String, Integer> map = new ConcurrentHashMap<>();
-    
+
     /** atomic integer */
     AtomicInteger ai = new AtomicInteger(0);
 
@@ -255,10 +255,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 // Consume the done token and decide what to do with it...
                 StreamDone doneToken = new StreamDone();
                 doneToken.setFromTDS(tdsReader);
-                if (doneToken.isFinal()) {
-                    // Response is completely processed, hence decrement unprocessed response count.
-                    connection.getSessionRecovery().decrementUnprocessedResponseCount();
-                }
+                connection.getSessionRecovery().decrementUnprocessedResponseCount();
 
                 // If this is a non-final batch-terminating DONE token,
                 // then stop parsing the response now and set up for
@@ -452,8 +449,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 new InputStreamGetterArgs(streamType, getIsResponseBufferingAdaptive(),
                         getIsResponseBufferingAdaptive(), toString()),
                 null, // calendar
-                resultsReader(),
-                this);
+                resultsReader(), this);
 
         activeStream = (Closeable) value;
         return value;
@@ -464,8 +460,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 new InputStreamGetterArgs(StreamType.SQLXML, getIsResponseBufferingAdaptive(),
                         getIsResponseBufferingAdaptive(), toString()),
                 null, // calendar
-                resultsReader(),
-                this);
+                resultsReader(), this);
 
         if (null != value)
             activeStream = value.getStream();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -518,7 +518,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_serverCertError", "Error validating Server Certificate: {0}: {1}."},
         {"R_SecureStringInitFailed", "Failed to initialize SecureStringUtil to store secure strings"},
         {"R_ALPNFailed", "Failed to negotiate Application-Layer Protocol {0}. Server returned: {1}."},
-        {"R_serverError", "An error occurred in the current command (Done status {0})."},
+        {"R_serverError", "An error occurred during the current command (Done status {0})."},
     };
 }
 // @formatter:on

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -518,6 +518,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_serverCertError", "Error validating Server Certificate: {0}: {1}."},
         {"R_SecureStringInitFailed", "Failed to initialize SecureStringUtil to store secure strings"},
         {"R_ALPNFailed", "Failed to negotiate Application-Layer Protocol {0}. Server returned: {1}."},
+        {"R_serverError", "An error occurred in the current command (Done status {0})."},
     };
 }
 // @formatter:on

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -381,10 +381,14 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                 // following the column metadata indicates an empty result set.
                 rowCount = 0;
 
+                int packetType = tdsReader.peekTokenType();
                 short status = tdsReader.peekStatusFlag();
-                StreamDone doneToken = new StreamDone();
-                doneToken.setFromTDS(tdsReader);
-                stmt.connection.getSessionRecovery().decrementUnprocessedResponseCount();
+
+                if (TDS.TDS_DONE == packetType) {
+                    StreamDone doneToken = new StreamDone();
+                    doneToken.setFromTDS(tdsReader);
+                    stmt.connection.getSessionRecovery().decrementUnprocessedResponseCount();
+                }
 
                 if ((status & TDS.DONE_ERROR) != 0 || (status & TDS.DONE_SRVERROR) != 0) {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_serverError"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -381,11 +381,10 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                 // following the column metadata indicates an empty result set.
                 rowCount = 0;
 
-                // Continue to read the error message if DONE packet has error flag
                 int packetType = tdsReader.peekTokenType();
                 short status = tdsReader.peekStatusFlag();
 
-                if (TDS.TDS_DONE == packetType && ((status & TDS.DONE_ERROR) != 0)) {
+                if (TDS.TDS_DONE == packetType) {
                     StreamDone doneToken = new StreamDone();
                     doneToken.setFromTDS(tdsReader);
                     if (doneToken.isFinal()) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -1480,11 +1480,8 @@ public class SQLServerStatement implements ISQLServerStatement {
                 // Handling DONE/DONEPROC/DONEINPROC tokens is a little tricky...
                 StreamDone doneToken = new StreamDone();
                 doneToken.setFromTDS(tdsReader);
+                connection.getSessionRecovery().decrementUnprocessedResponseCount();
 
-                if (doneToken.isFinal()) {
-                    // Response is completely processed, hence decrement unprocessed response count.
-                    connection.getSessionRecovery().decrementUnprocessedResponseCount();
-                }
                 // If the done token has the attention ack bit set, then record
                 // it as the attention ack DONE token. We may or may not throw
                 // an statement canceled/timed out exception later based on

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamDone.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamDone.java
@@ -172,7 +172,7 @@ class StreamDone extends StreamPacket {
      * @return true if final
      */
     /* L0 */ final boolean isFinal() {
-        return (status & 0x0001) == 0;
+        return (status & TDS.DONE_MORE) == 0;
     }
 
     /**
@@ -181,7 +181,7 @@ class StreamDone extends StreamPacket {
      * @return true if error
      */
     /* L0 */ final boolean isError() {
-        return (status & 0x0002) != 0;
+        return (status & TDS.DONE_ERROR) != 0;
     }
 
     /**
@@ -190,7 +190,7 @@ class StreamDone extends StreamPacket {
      * @return true if the row count is present
      */
     /* L0 */ final boolean updateCountIsValid() {
-        return (status & 0x0010) != 0;
+        return (status & TDS.DONE_COUNT) != 0;
     }
 
     /**
@@ -199,7 +199,7 @@ class StreamDone extends StreamPacket {
      * @return true if cancelled
      */
     /* L0 */ final boolean isAttnAck() {
-        return (status & 0x0020) != 0;
+        return (status & TDS.DONE_ATTN) != 0;
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -200,5 +200,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_AKVProviderNull", "The Azure key store provider is null."},
             {"R_objectNullOrEmpty", "The {0} is null or empty."},
             {"R_cekDecryptionFailed", "Failed to decrypt a column encryption key using key store provider: {0}."},
-            {"R_connectTimedOut", "connect timed out"}};
+            {"R_connectTimedOut", "connect timed out"},
+            {"R_sessionKilled", "Cannot continue the execution because the session is in the kill state"}};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -64,7 +64,7 @@ public class BasicConnectionTest extends AbstractTest {
     public void testGracefulClose() throws SQLException {
         try (Connection c = ResiliencyUtils.getConnection(connectionString)) {
             try (Statement s = c.createStatement()) {
-                ResiliencyUtils.killConnection(c, connectionString);
+                ResiliencyUtils.killConnection(c, connectionString, 0);
                 c.close();
                 s.executeQuery("SELECT 1");
                 fail("Query execution did not throw an exception on a closed execution");
@@ -89,7 +89,7 @@ public class BasicConnectionTest extends AbstractTest {
             } catch (SQLException e) {
                 return;
             }
-            ResiliencyUtils.killConnection(c, connectionString);
+            ResiliencyUtils.killConnection(c, connectionString, 0);
             try (ResultSet rs = s.executeQuery("SELECT db_name();")) {
                 while (rs.next()) {
                     actualDatabaseName = rs.getString(1);
@@ -116,7 +116,7 @@ public class BasicConnectionTest extends AbstractTest {
             } catch (SQLException e) {
                 return;
             }
-            ResiliencyUtils.killConnection(c, connectionString);
+            ResiliencyUtils.killConnection(c, connectionString, 0);
             try (ResultSet rs = s.executeQuery("SELECT db_name();")) {
                 while (rs.next()) {
                     actualDatabaseName = rs.getString(1);
@@ -135,7 +135,7 @@ public class BasicConnectionTest extends AbstractTest {
         String actualLanguage = "";
         try (Connection c = ResiliencyUtils.getConnection(connectionString); Statement s = c.createStatement()) {
             s.execute("SET LANGUAGE " + expectedLanguage);
-            ResiliencyUtils.killConnection(c, connectionString);
+            ResiliencyUtils.killConnection(c, connectionString, 0);
             try (ResultSet rs = s.executeQuery("SELECT @@LANGUAGE")) {
                 while (rs.next()) {
                     actualLanguage = rs.getString(1);
@@ -154,7 +154,7 @@ public class BasicConnectionTest extends AbstractTest {
             s.execute("CREATE TABLE [" + tableName + "] (col1 varchar(1))");
             c.setAutoCommit(false);
             s.execute("INSERT INTO [" + tableName + "] values ('x')");
-            ResiliencyUtils.killConnection(c, connectionString);
+            ResiliencyUtils.killConnection(c, connectionString, 0);
             try (ResultSet rs = s.executeQuery("SELECT db_name();")) {
                 fail("Connection resiliency should not have reconnected with an open transaction!");
             } catch (SQLException ex) {
@@ -172,7 +172,7 @@ public class BasicConnectionTest extends AbstractTest {
             int sessionId = ResiliencyUtils.getSessionId(c);
             try (ResultSet rs = s.executeQuery("select 2")) {
                 rs.next();
-                ResiliencyUtils.killConnection(sessionId, connectionString, c);
+                ResiliencyUtils.killConnection(sessionId, connectionString, c, 0);
             } catch (SQLException ex) {
                 ex.printStackTrace();
                 fail("Connection failed to clean up open resultset.");
@@ -190,7 +190,7 @@ public class BasicConnectionTest extends AbstractTest {
             c.close();
             Connection c1 = pooledConnection.getConnection();
             Statement s1 = c1.createStatement();
-            ResiliencyUtils.killConnection(c1, connectionString);
+            ResiliencyUtils.killConnection(c1, connectionString, 0);
             ResiliencyUtils.minimizeIdleNetworkTracker(c1);
             s1.executeQuery("SELECT 1");
         } catch (SQLException e) {
@@ -223,7 +223,7 @@ public class BasicConnectionTest extends AbstractTest {
             c.close();
             Connection c1 = pooledConnection.getConnection();
             Statement s1 = c1.createStatement();
-            ResiliencyUtils.killConnection(c1, connectionString);
+            ResiliencyUtils.killConnection(c1, connectionString, 0);
             ResiliencyUtils.minimizeIdleNetworkTracker(c1);
             rs = s1.executeQuery("SELECT db_name();");
             while (rs.next()) {
@@ -251,7 +251,7 @@ public class BasicConnectionTest extends AbstractTest {
             s.execute("SET LANGUAGE FRENCH;");
             c.close();
             try (Connection c1 = pooledConnection.getConnection(); Statement s1 = c1.createStatement()) {
-                ResiliencyUtils.killConnection(c1, connectionString);
+                ResiliencyUtils.killConnection(c1, connectionString, 0);
                 ResiliencyUtils.minimizeIdleNetworkTracker(c1);
                 rs = s1.executeQuery("SELECT @@LANGUAGE;");
                 while (rs.next())
@@ -272,7 +272,7 @@ public class BasicConnectionTest extends AbstractTest {
             try (Connection c = ResiliencyUtils.getConnection(connectionString)) {
                 for (int i2 = 0; i2 < 3; i2++) {
                     try (Statement s = c.createStatement()) {
-                        ResiliencyUtils.killConnection(c, connectionString);
+                        ResiliencyUtils.killConnection(c, connectionString, 0);
                         s.executeQuery("SELECT 1");
                     }
                 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/PropertyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/PropertyTest.java
@@ -38,7 +38,7 @@ public class PropertyTest extends AbstractTest {
         sb.append(connectionString).append(";").append(prop).append("=").append(val).append(";");
         try (Connection c = ResiliencyUtils.getConnection(sb.toString())) {
             try (Statement s = c.createStatement()) {
-                ResiliencyUtils.killConnection(c, connectionString);
+                ResiliencyUtils.killConnection(c, connectionString, 0);
                 s.executeQuery("SELECT 1");
                 fail(TestResource.getResource("R_expectedExceptionNotThrown") + prop + "=" + val);
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
@@ -44,7 +44,7 @@ public class ReflectiveTests extends AbstractTest {
         String cs = ResiliencyUtils.setConnectionProps(connectionString.concat(";"), props);
         try (Connection c = ResiliencyUtils.getConnection(cs)) {
             try (Statement s = c.createStatement()) {
-                ResiliencyUtils.killConnection(c, connectionString);
+                ResiliencyUtils.killConnection(c, connectionString, 0);
                 ResiliencyUtils.blockConnection(c);
                 startTime = System.currentTimeMillis();
                 s.executeQuery("SELECT 1");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
@@ -6,8 +6,8 @@
 package com.microsoft.sqlserver.jdbc.resiliency;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -15,7 +15,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -101,7 +100,7 @@ public class ResultSetsWithResiliencyTest extends AbstractTest {
             if (!e.getMessage().matches(TestUtils.formatErrorMsg("R_crClientUnrecoverable"))) {
                 e.printStackTrace();
             }
-            assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_crClientUnrecoverable")));
+            assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_crClientUnrecoverable")), e.getMessage());
 
         }
     }
@@ -122,8 +121,10 @@ public class ResultSetsWithResiliencyTest extends AbstractTest {
                 fail("Driver should not have succesfully reconnected but it did.");
             }
         } catch (SQLServerException e) {
-            assertTrue("08S01" == e.getSQLState()
-                    || e.getMessage().matches(TestUtils.formatErrorMsg("R_crClientUnrecoverable")));
+            assertTrue(
+                    "08S01" == e.getSQLState()
+                            || e.getMessage().matches(TestUtils.formatErrorMsg("R_crClientUnrecoverable")),
+                    e.getMessage());
 
         }
     }
@@ -191,7 +192,7 @@ public class ResultSetsWithResiliencyTest extends AbstractTest {
 
                     fail(TestResource.getResource("R_expectedExceptionNotThrown"));
                 } catch (SQLException e) {
-                    assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_serverError")));
+                    assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_serverError")), e.getMessage());
                 }
                 t1.join();
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
@@ -192,7 +192,10 @@ public class ResultSetsWithResiliencyTest extends AbstractTest {
 
                     fail(TestResource.getResource("R_expectedExceptionNotThrown"));
                 } catch (SQLException e) {
-                    assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_serverError")), e.getMessage());
+                    assertTrue(
+                            e.getMessage().matches(TestUtils.formatErrorMsg("R_serverError"))
+                                    || e.getMessage().matches(TestUtils.formatErrorMsg("R_sessionKilled")),
+                            e.getMessage());
                 }
                 t1.join();
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
@@ -194,7 +194,7 @@ public class ResultSetsWithResiliencyTest extends AbstractTest {
                 } catch (SQLException e) {
                     assertTrue(
                             e.getMessage().matches(TestUtils.formatErrorMsg("R_serverError"))
-                                    || e.getMessage().matches(TestUtils.formatErrorMsg("R_sessionKilled")),
+                                    || e.getMessage().matches(TestResource.getResource("R_sessionKilled")),
                             e.getMessage());
                 }
                 t1.join();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
@@ -194,7 +194,7 @@ public class ResultSetsWithResiliencyTest extends AbstractTest {
                 } catch (SQLException e) {
                     assertTrue(
                             e.getMessage().matches(TestUtils.formatErrorMsg("R_serverError"))
-                                    || e.getMessage().matches(TestResource.getResource("R_sessionKilled")),
+                                    || e.getMessage().contains(TestResource.getResource("R_sessionKilled")),
                             e.getMessage());
                 }
                 t1.join();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResultSetsWithResiliencyTest.java
@@ -192,9 +192,12 @@ public class ResultSetsWithResiliencyTest extends AbstractTest {
 
                     fail(TestResource.getResource("R_expectedExceptionNotThrown"));
                 } catch (SQLException e) {
+                    // may get different error message depending on SQL servers.
+                    // Local servers will report a TDS error where as Azure servers will have a DONE error
                     assertTrue(
                             e.getMessage().matches(TestUtils.formatErrorMsg("R_serverError"))
-                                    || e.getMessage().contains(TestResource.getResource("R_sessionKilled")),
+                                    || e.getMessage().contains(TestResource.getResource("R_sessionKilled"))
+                                    || e.getMessage().contains(TestResource.getResource("R_connectionReset")),
                             e.getMessage());
                 }
                 t1.join();


### PR DESCRIPTION
This fixes #1846 and #1505 where a DONE_ERROR status from the server resulting from a killed session was ignored by the driver.