### PR TITLE
Fix: Initialization vector cannot be reused

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
@@ -130,9 +130,7 @@ final class SecureStringUtil {
             return null;
 
         byte[] iv = new byte[IV_LENGTH];
-        byte[] encryptedBytes = new byte[bytes.length - IV_LENGTH];
         System.arraycopy(bytes, 0, iv, 0, IV_LENGTH);
-        System.arraycopy(bytes, IV_LENGTH, encryptedBytes, 0, bytes.length - IV_LENGTH);
 
         GCMParameterSpec ivParamSpec = new GCMParameterSpec(TAG_LENGTH * 8, iv);
 
@@ -140,7 +138,7 @@ final class SecureStringUtil {
         try {
             decryptCipher.init(Cipher.DECRYPT_MODE, secretKey, ivParamSpec);
 
-            plainText = decryptCipher.doFinal(encryptedBytes);
+            plainText = decryptCipher.doFinal(bytes, IV_LENGTH, bytes.length - IV_LENGTH);
             return Util.bytesToChars(plainText);
         } catch (Exception e) {
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_DecryptionFailed"));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -66,6 +66,8 @@ public class UtilTest {
     }
 
     private static String testString = "A ß € 嗨 𝄞 🙂ăѣ𝔠ծềſģȟᎥ𝒋ǩľḿꞑȯ𝘱𝑞𝗋𝘴ȶ𝞄𝜈ψ𝒙𝘆𝚣1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢ȚЦ𝒱Ѡ𝓧ƳȤѧᖯć𝗱ễ𝑓𝙜Ⴙ𝞲𝑗𝒌ļṃŉо𝞎𝒒ᵲꜱ𝙩ừ𝗏ŵ𝒙𝒚ź1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~АḂⲤ𝗗𝖤𝗙ꞠꓧȊ𝐉𝜥ꓡ𝑀𝑵Ǭ𝙿𝑄Ŗ𝑆𝒯𝖴𝘝𝘞ꓫŸ𝜡ả𝘢ƀ𝖼ḋếᵮℊ𝙝Ꭵ𝕛кιṃդⱺ𝓅𝘲𝕣𝖘ŧ𝑢ṽẉ𝘅ყž1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~Ѧ𝙱ƇᗞΣℱԍҤ١𝔍К𝓛𝓜ƝȎ𝚸𝑄Ṛ𝓢ṮṺƲᏔꓫ𝚈𝚭𝜶Ꮟçძ𝑒𝖿𝗀ḧ𝗂𝐣ҝɭḿ𝕟𝐨𝝔𝕢ṛ𝓼тú𝔳ẃ⤬𝝲𝗓1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝖠Β𝒞𝘋𝙴𝓕ĢȞỈ𝕵ꓗʟ𝙼ℕ০𝚸𝗤ՀꓢṰǓⅤ𝔚Ⲭ𝑌𝙕𝘢𝕤";
+    private static String testString2 = "ssdfsdflkjh9u0345)*&)(*&%$";
+    private static String testString3 = "ss345(*&^%oujdf.';lk2345(*&()*$#~!`1\\]wer><.,/?dfsdflkjh9u0345)*&)(*&%$";
 
     @Test
     public void testArrayConversions() {
@@ -79,9 +81,17 @@ public class UtilTest {
 
     @Test
     public void testSecureStringUtil() throws SQLException {
+        // Encrypt/decrypt multiple values in overlapping orders
         byte[] bytes = SecureStringUtil.getInstance().getEncryptedBytes(testString.toCharArray());
+        byte[] bytes2 = SecureStringUtil.getInstance().getEncryptedBytes(testString2.toCharArray());
         String end = String.valueOf(SecureStringUtil.getInstance().getDecryptedChars(bytes));
+        byte[] bytes3 = SecureStringUtil.getInstance().getEncryptedBytes(testString3.toCharArray());
+        String end3 = String.valueOf(SecureStringUtil.getInstance().getDecryptedChars(bytes3));
+        String end2 = String.valueOf(SecureStringUtil.getInstance().getDecryptedChars(bytes2));
+
         assertEquals(testString, end);
+        assertEquals(testString2, end2);
+        assertEquals(testString3, end3);
     }
 
     private void writeAndReadLong(long valueToTest) {


### PR DESCRIPTION
Prepend iv onto the encrypted bytes so that each iv is unique and preserved with its encrypted bytes for later decryption.