### PR TITLE
Resultset onDone Fix

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -381,20 +381,14 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                 // following the column metadata indicates an empty result set.
                 rowCount = 0;
 
-                int packetType = tdsReader.peekTokenType();
                 short status = tdsReader.peekStatusFlag();
-
-                if (TDS.TDS_DONE == packetType) {
-                    StreamDone doneToken = new StreamDone();
-                    doneToken.setFromTDS(tdsReader);
-                    stmt.connection.getSessionRecovery().decrementUnprocessedResponseCount();
-                }
 
                 if ((status & TDS.DONE_ERROR) != 0 || (status & TDS.DONE_SRVERROR) != 0) {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_serverError"));
                     Object[] msgArgs = {status};
                     SQLServerException.makeFromDriverError(stmt.connection, stmt, form.format(msgArgs), null, false);
                 }
+
                 return false;
             }
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -382,6 +382,7 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                 rowCount = 0;
 
                 short status = tdsReader.peekStatusFlag();
+                stmt.connection.getSessionRecovery().decrementUnprocessedResponseCount();
 
                 if ((status & TDS.DONE_ERROR) != 0 || (status & TDS.DONE_SRVERROR) != 0) {
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_serverError"));


### PR DESCRIPTION
When onDone is reached for a resultset, we need to stop parsing. Since https://github.com/microsoft/mssql-jdbc/pull/1857, we do not need to consume/process the done token because we are instead throwing an exception for a DONE_ERROR