### PR TITLE
Fixed query cancellation bug that intermittently occurs in batch queries

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7500,7 +7500,7 @@ abstract class TDSCommand implements Serializable {
     // Flag set to indicate that an interrupt has happened.
     private volatile boolean wasInterrupted = false;
 
-    private boolean wasInterrupted() {
+    public boolean wasInterrupted() {
         return wasInterrupted;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7500,7 +7500,7 @@ abstract class TDSCommand implements Serializable {
     // Flag set to indicate that an interrupt has happened.
     private volatile boolean wasInterrupted = false;
 
-    public boolean wasInterrupted() {
+    boolean wasInterrupted() {
         return wasInterrupted;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2873,8 +2873,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     // cancellation request and then return.
                     //
                     // Otherwise, if we do continue processing the batch query, in the case where a query requires
-                    // prepexec/sp_prepare, the request will be sent regardless of query cancellation. This will
-                    // cause a TDS token error in the post processing when we close query.
+                    // prepexec/sp_prepare, the TDS request for prepexec/sp_prepare will be sent regardless of
+                    // query cancellation. This will cause a TDS token error in the post processing when we
+                    // close the query.
                     if (batchCommand.wasInterrupted()) {
                         ensureExecuteResultsReader(batchCommand.startResponse(getIsResponseBufferingAdaptive()));
                         startResults();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -54,7 +54,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_noServerResponse", "SQL Server did not return a response. The connection has been closed."},
         {"R_truncatedServerResponse", "SQL Server returned an incomplete response. The connection has been closed."},
         {"R_queryTimedOut", "The query has timed out."},
-        {"R_queryCancelled", "The query was canceled."},
+        {"R_queryCancelled", "The query was cancelled."},
         {"R_errorReadingStream", "An error occurred while reading the value from the stream object. Error: \"{0}\""},
         {"R_streamReadReturnedInvalidValue", "The stream read operation returned an invalid value for the amount of data read."},
         {"R_mismatchedStreamLength", "The stream value is not the specified length. The specified length was {0}, the actual length is {1}."},

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -161,7 +161,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_cancellationFailed", "Cancellation failed."}, {"R_executionNotTimeout", "Execution did not timeout."},
             {"R_executionTooLong", "Execution took too long."},
             {"R_executionNotLong", "Execution did not take long enough."},
-            {"R_queryCancelled", "The query was canceled."},
             {"R_statementShouldBeClosed", "statement should be closed since resultset is closed."},
             {"R_statementShouldBeOpened", "statement should be opened since resultset is opened."},
             {"R_shouldBeWrapper", "{0} should be a wrapper for {1}."},
@@ -201,6 +200,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_objectNullOrEmpty", "The {0} is null or empty."},
             {"R_cekDecryptionFailed", "Failed to decrypt a column encryption key using key store provider: {0}."},
             {"R_connectTimedOut", "connect timed out"},
-            {"R_queryCancelled", "The query was canceled."},
+            {"R_queryCancelled", "The query was cancelled."},
             {"R_sessionKilled", "Cannot continue the execution because the session is in the kill state"}};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -201,5 +201,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_objectNullOrEmpty", "The {0} is null or empty."},
             {"R_cekDecryptionFailed", "Failed to decrypt a column encryption key using key store provider: {0}."},
             {"R_connectTimedOut", "connect timed out"},
+            {"R_queryCancelled", "The query was canceled."},
             {"R_sessionKilled", "Cannot continue the execution because the session is in the kill state"}};
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/mssql-jdbc/issues/1896

doExecutePreparedStatement() isn't affected because it doesn't execute TDS requests one after the other eg. It doesn't do batching.