### PR TITLE
Update SQLServerStatement.java

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -1520,7 +1520,7 @@ public class SQLServerStatement implements ISQLServerStatement {
                     if (EXECUTE_BATCH != executeMethod) {
                         // Always return update counts from statements executed in stored procedure calls.
                         if (null != procedureName)
-                            return false;
+                            return true;
 
                         // Always return all update counts from statements executed through Statement.execute()
                         if (EXECUTE == executeMethod)


### PR DESCRIPTION
fixed #1899  When executing the stored procedure, force the return of true in the dodone method of the nextresult class to allow the message parsing to continue.