### PR TITLE
Fix cache account name casing issue

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -168,6 +168,16 @@ class SQLServerMSAL4JUtils {
             // try to acquire token silently if user account found in cache
             try {
                 Set<IAccount> accountsInCache = pca.getAccounts().join();
+                if (logger.isLoggable(Level.FINE)) {
+                    StringBuilder acc = new StringBuilder();
+                    if (accountsInCache != null) {
+                        for (IAccount account : accountsInCache) {
+                            if (acc.length() != 0) acc.append(", ");
+                            acc.append(account.username());
+                        }
+                    }
+                    logger.fine(logger.toString() + "Accounts in cache = " + acc + ", size = " + (accountsInCache == null ? null : accountsInCache.size()) + ", user = " + user);
+                }
                 if (null != accountsInCache && !accountsInCache.isEmpty() && null != user && !user.isEmpty()) {
                     IAccount account = getAccountByUsername(accountsInCache, user);
                     if (null != account) {
@@ -182,6 +192,9 @@ class SQLServerMSAL4JUtils {
                 }
             } catch (MsalInteractionRequiredException e) {
                 // not an error, need to get token interactively
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, e, () -> logger.toString() + "Need to get token interactively");
+                }
             }
 
             if (null != future) {
@@ -221,7 +234,7 @@ class SQLServerMSAL4JUtils {
     private static IAccount getAccountByUsername(Set<IAccount> accounts, String username) {
         if (!accounts.isEmpty()) {
             for (IAccount account : accounts) {
-                if (account.username().equals(username)) {
+                if (account.username().equalsIgnoreCase(username)) {
                     return account;
                 }
             }


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/DBE-13085
The problem is that server reply is cached and user input is searched
We've been able to track the situation where user entered `JohnnyCash@folsom.org` and cache contained `johnnycash@folsom.org` -> cache miss
I've done the quickfix by using case-insensitive comparison.
I'm not aware if the logins are truly case-insensitive. Feel free to make the fix of your own :)