### PR TITLE
Revert MSAL version back to 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<org.osgi.core.version>6.0.0</org.osgi.core.version>
 		<azure-security-keyvault-keys.version>4.4.4</azure-security-keyvault-keys.version>
 		<azure-identity.version>1.5.3</azure-identity.version>
-		<msal.version>1.13.2</msal.version>
+		<msal.version>1.13.0</msal.version>
 		<org.osgi.compendium.version>5.0.0</org.osgi.compendium.version>
 		<antlr-runtime.version>4.9.3</antlr-runtime.version>
 		<com.google.code.gson.version>2.9.0</com.google.code.gson.version>
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>msal4j</artifactId>
-			<version>1.13.2</version>
+			<version>1.13.0</version>
 			<optional>true</optional>
 		</dependency>
 


### PR DESCRIPTION
Latest 1.13.2 contains a bug which breaks federated authentication (see AzureAD/microsoft-authentication-library-for-java#560)