### PR TITLE
Fix for setting KeepAlive extended options (backport of 1953 to 10.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [10.2.2] HotFix & Stable Release
+### Fixed issues
+- Clear prepared statement cache on idle connection resiliency reconnections [1982](https://github.com/microsoft/mssql-jdbc/pull/1982)
+
+to be back ported:
+- Fixed double connection issue when enabling TDS 8.0 and SSL by reusing original socket connection [1817](https://github.com/microsoft/mssql-jdbc/pull/1817)
+- Added check for DONE_ERROR status token which may occur from a killed session on the server [1857](https://github.com/microsoft/mssql-jdbc/pull/1857)
+- Fixed issue where the driver may assert when canceling a statement [1872](https://github.com/microsoft/mssql-jdbc/pull/1872)
+- Fixed query cancellation bug [1897](https://github.com/microsoft/mssql-jdbc/pull/1897)
+- Fixed callable statement index out of bounds error [1898](https://github.com/microsoft/mssql-jdbc/pull/1898)
+- Fixed check for DONE token when fetching result sets [1943](https://github.com/microsoft/mssql-jdbc/pull/1943)
+
 ## [10.2.1] HotFix & Stable Release
 ### Fixed issues
 - Refactored Idle Connection Resiliency timeout to use existing SharedTimer [1794](https://github.com/microsoft/mssql-jdbc/pull/1794)

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -23,7 +23,6 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
-import java.net.SocketOption;
 import java.net.SocketTimeoutException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -75,79 +74,6 @@ import javax.net.ssl.X509TrustManager;
 
 import com.microsoft.sqlserver.jdbc.SQLServerConnection.FedAuthTokenCommand;
 import com.microsoft.sqlserver.jdbc.dataclassification.SensitivityClassification;
-
-
-/**
- * ExtendedSocketOptions provides methods to keep track of keep alive and socket information.
- *
- */
-final class ExtendedSocketOptions {
-    private static class ExtSocketOption<T> implements SocketOption<T> {
-        private final String name;
-        private final Class<T> type;
-
-        ExtSocketOption(String name, Class<T> type) {
-            this.name = name;
-            this.type = type;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public Class<T> type() {
-            return type;
-        }
-
-        @Override
-        public String toString() {
-            return name;
-        }
-    }
-
-    private ExtendedSocketOptions() {}
-
-    /**
-     * Keep-Alive idle time.
-     *
-     * <p>
-     * The value of this socket option is an {@code Integer} that is the number of seconds of idle time before
-     * keep-alive initiates a probe. The socket option is specific to stream-oriented sockets using the TCP/IP protocol.
-     * The exact semantics of this socket option are system dependent.
-     *
-     * <p>
-     * When the {@link java.net.StandardSocketOptions#SO_KEEPALIVE SO_KEEPALIVE} option is enabled, TCP probes a
-     * connection that has been idle for some amount of time. The default value for this idle period is system
-     * dependent, but is typically 2 hours. The {@code TCP_KEEPIDLE} option can be used to affect this value for a given
-     * socket.
-     *
-     * @since 11
-     */
-    public static final SocketOption<Integer> TCP_KEEPIDLE = new ExtSocketOption<Integer>("TCP_KEEPIDLE",
-            Integer.class);
-
-    /**
-     * Keep-Alive retransmission interval time.
-     *
-     * <p>
-     * The value of this socket option is an {@code Integer} that is the number of seconds to wait before retransmitting
-     * a keep-alive probe. The socket option is specific to stream-oriented sockets using the TCP/IP protocol. The exact
-     * semantics of this socket option are system dependent.
-     *
-     * <p>
-     * When the {@link java.net.StandardSocketOptions#SO_KEEPALIVE SO_KEEPALIVE} option is enabled, TCP probes a
-     * connection that has been idle for some amount of time. If the remote system does not respond to a keep-alive
-     * probe, TCP retransmits the probe after some amount of time. The default value for this retransmission interval is
-     * system dependent, but is typically 75 seconds. The {@code TCP_KEEPINTERVAL} option can be used to affect this
-     * value for a given socket.
-     *
-     * @since 11
-     */
-    public static final SocketOption<Integer> TCP_KEEPINTERVAL = new ExtSocketOption<Integer>("TCP_KEEPINTERVAL",
-            Integer.class);
-}
 
 
 final class TDS {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc43.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerJdbc43.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jdk.net.ExtendedSocketOptions;
 
 /**
  * Shims for JDBC 4.3 JAR.


### PR DESCRIPTION
backport of #1953 