### PR TITLE
Upgrade to the latest OSGi JDBC specification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<azure-security-keyvault-keys.version>4.5.3</azure-security-keyvault-keys.version>
 		<azure-identity.version>1.7.0</azure-identity.version>
 		<msal.version>1.13.3</msal.version>
-		<org.osgi.compendium.version>5.0.0</org.osgi.compendium.version>
+		<osgi.jdbc.version>1.1.0</osgi.jdbc.version>
 		<antlr-runtime.version>4.9.3</antlr-runtime.version>
 		<com.google.code.gson.version>2.9.0</com.google.code.gson.version>
 		<bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
@@ -150,8 +150,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.compendium</artifactId>
-			<version>${org.osgi.compendium.version}</version>
+			<artifactId>org.osgi.service.jdbc</artifactId>
+			<version>${osgi.jdbc.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/osgi/Activator.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/osgi/Activator.java
@@ -38,6 +38,12 @@ public class Activator implements BundleActivator {
         properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, "Microsoft JDBC Driver for SQL Server");
         properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_VERSION,
                 driver.getMajorVersion() + "." + driver.getMinorVersion());
+        properties.put(DataSourceFactory.OSGI_JDBC_CAPABILITY, new String[] {
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_DRIVER,
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_DATASOURCE,
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_CONNECTIONPOOLDATASOURCE,
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_XADATASOURCE
+        });
         service = context.registerService(DataSourceFactory.class, new SQLServerDataSourceFactory(), properties);
         SQLServerDriver.register();
     }


### PR DESCRIPTION
In the latest release of the JDBC specification there was a requirement added that datasources should promote what methods they implement. mssql-jdbc implements all methods and could therefore promote all.

This also migrates from the org.osgi.enterprise artifact to the more specific org.osgi.service.jdbc one and adds the official TCK test as part of the JUnit-Suite.

FYI @stbischof