### PR TITLE
Updated fedauth tests to run on diff test server

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -735,7 +735,7 @@ final class TDSChannel implements Serializable {
     /**
      * Set TCP keep-alive options for idle connection resiliency
      */
-    private void setSocketOptions(Socket tcpSocket, TDSChannel channel) throws IOException {
+    private void setSocketOptions(Socket tcpSocket, TDSChannel channel) {
         try {
             if (SQLServerDriver.socketSetOptionMethod != null && SQLServerDriver.socketKeepIdleOption != null
                     && SQLServerDriver.socketKeepIntervalOption != null) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
@@ -35,7 +35,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1605,7 +1605,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return pooledConnectionParent;
     }
 
-    SQLServerConnection(String parentInfo) throws SQLServerException {
+    SQLServerConnection(String parentInfo) {
         int connectionID = nextConnectionID(); // sequential connection id
         traceID = "ConnectionID:" + connectionID;
         loggingClassName += ":" + connectionID;
@@ -6963,7 +6963,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return null;
     }
 
-    String getTrustedServerNameAE() throws SQLServerException {
+    String getTrustedServerNameAE() {
         return trustedServerNameAE.toUpperCase();
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -809,7 +809,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         return sb.toString();
     }
 
-    private String generateAzureDWEmptyRS(Map<Integer, String> columns) throws SQLException {
+    private String generateAzureDWEmptyRS(Map<Integer, String> columns) {
         StringBuilder sb = new StringBuilder("SELECT TOP 0 ");
         for (Entry<Integer, String> p : columns.entrySet()) {
             sb.append("NULL AS ").append(p.getValue()).append(",");
@@ -950,7 +950,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 
     @Override
     public java.sql.ResultSet getCrossReference(String cat1, String schem1, String tab1, String cat2, String schem2,
-            String tab2) throws SQLException, SQLTimeoutException {
+            String tab2) throws SQLException {
         if (loggerExternal.isLoggable(Level.FINER) && Util.isActivityTraceOn()) {
             loggerExternal.finer(toString() + ACTIVITY_ID + ActivityCorrelator.getNext().toString());
         }
@@ -1014,8 +1014,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     @Override
-    public java.sql.ResultSet getExportedKeys(String cat, String schema,
-            String table) throws SQLException, SQLTimeoutException {
+    public java.sql.ResultSet getExportedKeys(String cat, String schema, String table) throws SQLException {
         return getCrossReference(cat, schema, table, null, null, null);
     }
 
@@ -1032,12 +1031,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     @Override
-    public java.sql.ResultSet getImportedKeys(String cat, String schema,
-            String table) throws SQLException, SQLTimeoutException {
+    public java.sql.ResultSet getImportedKeys(String cat, String schema, String table) throws SQLException {
         return getCrossReference(null, null, null, cat, schema, table);
     }
 
-    private ResultSet executeSPFkeys(String[] procParams) throws SQLException, SQLTimeoutException {
+    private ResultSet executeSPFkeys(String[] procParams) throws SQLException {
         if (!this.connection.isAzureDW()) {
             String tempTableName = "@jdbc_temp_fkeys_result";
             String sql = "DECLARE " + tempTableName + " table (PKTABLE_QUALIFIER sysname, " + "PKTABLE_OWNER sysname, "
@@ -1219,7 +1217,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     @Override
-    public int getMaxConnections() throws SQLException, SQLTimeoutException {
+    public int getMaxConnections() throws SQLException {
         checkClosed();
         try (SQLServerResultSet rs = getResultSetFromInternalQueries(null,
                 "select maximum from sys.configurations where name = 'user connections'")) {
@@ -1439,7 +1437,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     @Override
-    public java.sql.ResultSet getSchemas() throws SQLException, SQLTimeoutException {
+    public java.sql.ResultSet getSchemas() throws SQLException {
         if (loggerExternal.isLoggable(Level.FINER) && Util.isActivityTraceOn()) {
             loggerExternal.finer(toString() + ACTIVITY_ID + ActivityCorrelator.getNext().toString());
         }
@@ -1448,8 +1446,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 
     }
 
-    private java.sql.ResultSet getSchemasInternal(String catalog,
-            String schemaPattern) throws SQLException, SQLTimeoutException {
+    private java.sql.ResultSet getSchemasInternal(String catalog, String schemaPattern) throws SQLException {
 
         String s;
         // The schemas that return null for catalog name, these are prebuilt
@@ -1606,14 +1603,13 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     @Override
-    public java.sql.ResultSet getTableTypes() throws SQLException, SQLTimeoutException {
+    public java.sql.ResultSet getTableTypes() throws SQLException {
         if (loggerExternal.isLoggable(Level.FINER) && Util.isActivityTraceOn()) {
             loggerExternal.finer(toString() + ACTIVITY_ID + ActivityCorrelator.getNext().toString());
         }
         checkClosed();
         String s = "SELECT 'VIEW' 'TABLE_TYPE' UNION SELECT 'TABLE' UNION SELECT 'SYSTEM TABLE'";
-        SQLServerResultSet rs = getResultSetFromInternalQueries(null, s);
-        return rs;
+        return getResultSetFromInternalQueries(null, s);
     }
 
     @Override

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -28,6 +28,7 @@ import com.microsoft.aad.msal4j.IClientCredential;
 import com.microsoft.aad.msal4j.IntegratedWindowsAuthenticationParameters;
 import com.microsoft.aad.msal4j.InteractiveRequestParameters;
 import com.microsoft.aad.msal4j.MsalInteractionRequiredException;
+import com.microsoft.aad.msal4j.MsalThrottlingException;
 import com.microsoft.aad.msal4j.PublicClientApplication;
 import com.microsoft.aad.msal4j.SilentParameters;
 import com.microsoft.aad.msal4j.SystemBrowserOptions;
@@ -74,7 +75,7 @@ class SQLServerMSAL4JUtils {
             Thread.currentThread().interrupt();
 
             throw new SQLServerException(e.getMessage(), e);
-        } catch (ExecutionException e) {
+        } catch (MsalThrottlingException | ExecutionException e) {
             throw getCorrectedException(e, user, authenticationString);
         } finally {
             executorService.shutdown();
@@ -108,7 +109,7 @@ class SQLServerMSAL4JUtils {
             Thread.currentThread().interrupt();
 
             throw new SQLServerException(e.getMessage(), e);
-        } catch (ExecutionException e) {
+        } catch (MsalThrottlingException | ExecutionException e) {
             throw getCorrectedException(e, aadPrincipalID, authenticationString);
         } finally {
             executorService.shutdown();
@@ -150,7 +151,7 @@ class SQLServerMSAL4JUtils {
             Thread.currentThread().interrupt();
 
             throw new SQLServerException(e.getMessage(), e);
-        } catch (ExecutionException e) {
+        } catch (MsalThrottlingException | ExecutionException e) {
             throw getCorrectedException(e, "", authenticationString);
         } finally {
             executorService.shutdown();
@@ -177,11 +178,13 @@ class SQLServerMSAL4JUtils {
                     StringBuilder acc = new StringBuilder();
                     if (accountsInCache != null) {
                         for (IAccount account : accountsInCache) {
-                            if (acc.length() != 0) acc.append(", ");
+                            if (acc.length() != 0)
+                                acc.append(", ");
                             acc.append(account.username());
                         }
                     }
-                    logger.fine(logger.toString() + "Accounts in cache = " + acc + ", size = " + (accountsInCache == null ? null : accountsInCache.size()) + ", user = " + user);
+                    logger.fine(logger.toString() + "Accounts in cache = " + acc + ", size = "
+                            + (accountsInCache == null ? null : accountsInCache.size()) + ", user = " + user);
                 }
                 if (null != accountsInCache && !accountsInCache.isEmpty() && null != user && !user.isEmpty()) {
                     IAccount account = getAccountByUsername(accountsInCache, user);
@@ -228,7 +231,7 @@ class SQLServerMSAL4JUtils {
             Thread.currentThread().interrupt();
 
             throw new SQLServerException(e.getMessage(), e);
-        } catch (ExecutionException e) {
+        } catch (MsalThrottlingException | ExecutionException e) {
             throw getCorrectedException(e, user, authenticationString);
         } finally {
             executorService.shutdown();
@@ -247,8 +250,7 @@ class SQLServerMSAL4JUtils {
         return null;
     }
 
-    private static SQLServerException getCorrectedException(ExecutionException e, String user,
-            String authenticationString) {
+    private static SQLServerException getCorrectedException(Exception e, String user, String authenticationString) {
         Object[] msgArgs = {user, authenticationString};
 
         if (null == e.getCause() || null == e.getCause().getMessage()) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -178,8 +178,9 @@ class SQLServerMSAL4JUtils {
                     StringBuilder acc = new StringBuilder();
                     if (accountsInCache != null) {
                         for (IAccount account : accountsInCache) {
-                            if (acc.length() != 0)
+                            if (acc.length() != 0) {
                                 acc.append(", ");
+                            }
                             acc.append(account.username());
                         }
                     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -201,5 +201,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_objectNullOrEmpty", "The {0} is null or empty."},
             {"R_cekDecryptionFailed", "Failed to decrypt a column encryption key using key store provider: {0}."},
             {"R_connectTimedOut", "connect timed out"},
-            {"R_sessionKilled", "Cannot continue the execution because the session is in the kill state"}};
+            {"R_sessionKilled", "Cannot continue the execution because the session is in the kill state"},
+            {"R_failedFedauth", "Failed to acquire fedauth token: "}};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ConnectionSuspensionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ConnectionSuspensionTest.java
@@ -83,10 +83,13 @@ public class ConnectionSuspensionTest extends FedauthCommon {
                 TestUtils.dropTableIfExists(charTable, stmt);
             }
 
+            TestUtils.setAccessTokenExpiry(connection, accessToken);
+            secondsBeforeExpiration = TestUtils.TEST_TOKEN_EXPIRY_SECONDS;
             while (secondsPassed < secondsBeforeExpiration) {
-                Thread.sleep(TimeUnit.MINUTES.toMillis(5)); // Sleep for 2 minutes
+                Thread.sleep(TimeUnit.SECONDS.toMillis(90)); // Sleep for 90s
 
                 secondsPassed = (System.currentTimeMillis() - start) / 1000;
+
                 try (Statement stmt1 = connection.createStatement()) {
                     testUserName(connection, azureUserName, authentication);
 
@@ -150,10 +153,12 @@ public class ConnectionSuspensionTest extends FedauthCommon {
                     TestUtils.dropTableIfExists(charTable, stmt);
                 }
 
+                TestUtils.setAccessTokenExpiry(connection, accessToken);
+                secondsBeforeExpiration = TestUtils.TEST_TOKEN_EXPIRY_SECONDS;
                 while (secondsPassed < secondsBeforeExpiration) {
-                    Thread.sleep(TimeUnit.MINUTES.toMillis(5)); // Sleep for 5 minutes
-
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(90)); // Sleep for 90s
                     secondsPassed = (System.currentTimeMillis() - start) / 1000;
+
                     testUserName(connection, azureUserName, authentication);
                 }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
@@ -226,11 +226,8 @@ public class ErrorMessageTest extends FedauthCommon {
             fail(EXPECTED_EXCEPTION_NOT_THROWN);
         } catch (SQLServerException e) {
             assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(),
-                    (e.getMessage()
-                            .contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + badUserName
-                                    + " in Active Directory (Authentication=ActiveDirectoryPassword).")
-                            && e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_ADD))
-                            || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
+                    e.getMessage().contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + badUserName
+                            + " in Active Directory (Authentication=ActiveDirectoryPassword)."));
         }
     }
 
@@ -248,11 +245,8 @@ public class ErrorMessageTest extends FedauthCommon {
             fail(EXPECTED_EXCEPTION_NOT_THROWN);
         } catch (SQLServerException e) {
             assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(),
-                    (e.getMessage()
-                            .contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + badUserName
-                                    + " in Active Directory (Authentication=ActiveDirectoryPassword).")
-                            && e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_ADD))
-                            || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
+                    e.getMessage().contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + badUserName
+                            + " in Active Directory (Authentication=ActiveDirectoryPassword)."));
         }
     }
 
@@ -263,11 +257,8 @@ public class ErrorMessageTest extends FedauthCommon {
             fail(EXPECTED_EXCEPTION_NOT_THROWN);
         } catch (SQLServerException e) {
             assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(),
-                    (e.getMessage()
-                            .contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + badUserName
-                                    + " in Active Directory (Authentication=ActiveDirectoryPassword).")
-                            && e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_ADD))
-                            || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
+                    e.getMessage().contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + badUserName
+                            + " in Active Directory (Authentication=ActiveDirectoryPassword)."));
         }
     }
 
@@ -400,11 +391,11 @@ public class ErrorMessageTest extends FedauthCommon {
                 fail(EXPECTED_EXCEPTION_NOT_THROWN);
             }
 
-            assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(), (e.getMessage()
+            assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(), e.getMessage()
                     .contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + azureUserName
                             + " in Active Directory (Authentication=ActiveDirectoryPassword).")
                     && e.getCause().getCause().getMessage().toLowerCase().contains("invalid username or password")
-                    || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY))
+                    || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY)
                     || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
         }
     }
@@ -426,11 +417,11 @@ public class ErrorMessageTest extends FedauthCommon {
                 fail(EXPECTED_EXCEPTION_NOT_THROWN);
             }
 
-            assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(), (e.getMessage()
+            assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(), e.getMessage()
                     .contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + azureUserName
                             + " in Active Directory (Authentication=ActiveDirectoryPassword).")
                     && e.getCause().getCause().getMessage().toLowerCase().contains("invalid username or password")
-                    || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY))
+                    || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY)
                     || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
         }
     }
@@ -446,11 +437,11 @@ public class ErrorMessageTest extends FedauthCommon {
                 fail(EXPECTED_EXCEPTION_NOT_THROWN);
             }
 
-            assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(), (e.getMessage()
+            assertTrue(INVALID_EXCEPTION_MSG + ": " + e.getMessage(), e.getMessage()
                     .contains(ERR_MSG_FAILED_AUTHENTICATE + " the user " + azureUserName
                             + " in Active Directory (Authentication=ActiveDirectoryPassword).")
                     && e.getCause().getCause().getMessage().toLowerCase().contains("invalid username or password")
-                    || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY))
+                    || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY)
                     || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -278,8 +278,8 @@ public class FedauthTest extends FedauthCommon {
     @Test
     public void testAADServicePrincipalAuthDeprecated() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
-                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";AADSecurePrincipalId=" + azureAADPrincipialId
-                + ";AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
+                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";AADSecurePrincipalId=" + azureAADPrincipalId
+                + ";AADSecurePrincipalSecret=" + azureAADPrincipalSecret;
         String urlEncrypted = url + ";encrypt=true;trustServerCertificate=true;";
         SQLServerDataSource ds = new SQLServerDataSource();
         updateDataSource(url, ds);
@@ -300,8 +300,8 @@ public class FedauthTest extends FedauthCommon {
     @Test
     public void testAADServicePrincipalAuth() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
-                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";Username=" + azureAADPrincipialId + ";Password="
-                + azureAADPrincipialSecret;
+                + SqlAuthentication.ActiveDirectoryServicePrincipal + ";Username=" + azureAADPrincipalId + ";Password="
+                + azureAADPrincipalSecret;
         String urlEncrypted = url + ";encrypt=true;trustServerCertificate=true;";
         SQLServerDataSource ds = new SQLServerDataSource();
         updateDataSource(url, ds);
@@ -323,32 +323,32 @@ public class FedauthTest extends FedauthCommon {
         String baseUrl = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
                 + SqlAuthentication.ActiveDirectoryServicePrincipal + ";";
         // Wrong AADSecurePrincipalSecret provided.
-        String url = baseUrl + "AADSecurePrincipalId=" + azureAADPrincipialId + ";AADSecurePrincipalSecret=wrongSecret";
+        String url = baseUrl + "AADSecurePrincipalId=" + azureAADPrincipalId + ";AADSecurePrincipalSecret=wrongSecret";
         validateException(url, "R_MSALExecution");
 
         // Wrong AADSecurePrincipalId provided.
-        url = baseUrl + "AADSecurePrincipalId=wrongId;AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
+        url = baseUrl + "AADSecurePrincipalId=wrongId;AADSecurePrincipalSecret=" + azureAADPrincipalSecret;
         validateException(url, "R_MSALExecution");
 
         // AADSecurePrincipalSecret/password not provided.
-        url = baseUrl + "AADSecurePrincipalId=" + azureAADPrincipialId;
+        url = baseUrl + "AADSecurePrincipalId=" + azureAADPrincipalId;
         validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
-        url = baseUrl + "Username=" + azureAADPrincipialId;
+        url = baseUrl + "Username=" + azureAADPrincipalId;
         validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
 
         // AADSecurePrincipalId/username not provided.
-        url = baseUrl + "AADSecurePrincipalSecret=" + azureAADPrincipialSecret;
+        url = baseUrl + "AADSecurePrincipalSecret=" + azureAADPrincipalSecret;
         validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
-        url = baseUrl + "password=" + azureAADPrincipialSecret;
+        url = baseUrl + "password=" + azureAADPrincipalSecret;
         validateException(url, "R_NoUserPasswordForActiveServicePrincipal");
 
         // Both AADSecurePrincipalId/username and AADSecurePrincipalSecret/password not provided.
         validateException(baseUrl, "R_NoUserPasswordForActiveServicePrincipal");
 
         // both username/password and AADSecurePrincipalId/AADSecurePrincipalSecret provided
-        url = baseUrl + "Username=" + azureAADPrincipialId + ";password=" + azureAADPrincipialSecret
-                + ";AADSecurePrincipalId=" + azureAADPrincipialId + ";AADSecurePrincipalSecret="
-                + azureAADPrincipialSecret;
+        url = baseUrl + "Username=" + azureAADPrincipalId + ";password=" + azureAADPrincipalSecret
+                + ";AADSecurePrincipalId=" + azureAADPrincipalId + ";AADSecurePrincipalSecret="
+                + azureAADPrincipalSecret;
         validateException(url, "R_BothUserPasswordandDeprecated");
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
@@ -54,13 +54,13 @@ public class PooledConnectionTest extends FedauthCommon {
     @Test
     public void testPooledConnectionAccessTokenExpiredThenReconnectADPassword() throws SQLException {
         // suspend 60 secs
-        testPooledConnectionAccessTokenExpiredThenReconnect((long) 60, SqlAuthentication.ActiveDirectoryPassword);
+        testPooledConnectionAccessTokenExpiredThenReconnect(60, SqlAuthentication.ActiveDirectoryPassword);
 
         // get another token
         getFedauthInfo();
 
         // suspend until access token expires
-        testPooledConnectionAccessTokenExpiredThenReconnect((long) 60, SqlAuthentication.ActiveDirectoryPassword);
+        testPooledConnectionAccessTokenExpiredThenReconnect(60, SqlAuthentication.ActiveDirectoryPassword);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class PooledConnectionTest extends FedauthCommon {
         org.junit.Assume.assumeTrue(enableADIntegrated);
 
         // suspend 60 secs
-        testPooledConnectionAccessTokenExpiredThenReconnect((long) 60, SqlAuthentication.ActiveDirectoryIntegrated);
+        testPooledConnectionAccessTokenExpiredThenReconnect(60, SqlAuthentication.ActiveDirectoryIntegrated);
 
         // get another token
         getFedauthInfo();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -306,11 +306,11 @@ public class BasicConnectionTest extends AbstractTest {
         AbstractTest.updateDataSource(cs, ds);
         ds.setAccessTokenCallback(TestUtils.accessTokenCallback);
 
+        // change token expiry
         SQLServerPooledConnection pc = (SQLServerPooledConnection) ds.getPooledConnection();
-        SQLServerPooledConnection spc = (SQLServerPooledConnection) pc;
         Field physicalConnectionField = SQLServerPooledConnection.class.getDeclaredField("physicalConnection");
         physicalConnectionField.setAccessible(true);
-        Object c = physicalConnectionField.get(spc);
+        Object c = physicalConnectionField.get(pc);
         String accessToken = ds.getAccessToken();
         TestUtils.setAccessTokenExpiry(c, accessToken);
 

--- a/src/test/java/com/microsoft/sqlserver/testframework/AbstractTest.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/AbstractTest.java
@@ -116,6 +116,12 @@ public abstract class AbstractTest {
 
     protected static boolean isWindows = System.getProperty("os.name").startsWith("Windows");
 
+    /**
+     * Retries due to server throttling
+     */
+    protected static final int THROTTLE_RETRY_COUNT = 3; // max number of throttling retries
+    protected static final int THROTTLE_RETRY_INTERVAL = 60000; // default throttling retry interval in ms
+
     public static Properties properties = null;
 
     /**


### PR DESCRIPTION
- updated fedauth tests to get new access token once per test suite instead of every test
- added checks and retry for throttling
- shortened access token expiry for tests that tests token expiry
- some cleanup
