### PR TITLE
Change supportsLikeEscapeClause to check for AzureDW

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1986,7 +1986,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     @Override
     public boolean supportsLikeEscapeClause() throws SQLServerException {
         checkClosed();
-        return true;
+        return !connection.isAzureDW();
     }
 
     @Override


### PR DESCRIPTION
Change `supportsLikeEscapeClause() to return false if server is Azure DW, as ESCAPE clause is not supported there (https://learn.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql?view=sql-server-ver16).