### PR TITLE
Allow failover partner to be tried in case of socket timeout

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3174,7 +3174,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         || SQLServerException.DRIVER_ERROR_UNSUPPORTED_CONFIG == driverErrorCode // unsupported config
                                                                                                  // (eg Sphinx, invalid
                                                                                                  // packetsize, etc)
-                        || SQLServerException.ERROR_SOCKET_TIMEOUT == driverErrorCode // socket timeout
+                        || (SQLServerException.ERROR_SOCKET_TIMEOUT == driverErrorCode // socket timeout
+                                && (!isDBMirroring || attemptNumber > 0)) // If mirroring, only close after failover has been tried (attempt >= 1)
                         || timerHasExpired(timerExpire)
                 // for non-dbmirroring cases, do not retry after tcp socket connection succeeds
                 ) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
@@ -288,8 +288,7 @@ public class TimeoutTest extends AbstractTest {
     }
     
     /**
-     * Tests failover on socketTimeout. Because FailOverPartner is defined we expect connection to retry, fail on 
-     * partner connect, and retry again leading to 'read timed out'
+     * Tests that failover is still used with socket timeout by measuring timing during a socket timeout.
      * 
      * @throws Exception
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
@@ -458,6 +458,7 @@ public class TimeoutTest extends AbstractTest {
             if (!(e instanceof SQLException)) {
                 fail(TestResource.getResource("R_unexpectedErrorMessage") + e.getMessage());
             }
+            System.out.println(e.getMessage());
             assertTrue((e.getMessage().contains(TestResource.getResource("R_readTimedOut"))));
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
@@ -442,6 +442,25 @@ public class TimeoutTest extends AbstractTest {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.getMessage());
         }
     }
+    
+    /**
+     * Tests failover on socketTimeout. Because FailOverPartner is defined we expect connection to retry, fail on 
+     * partner connect, and retry again leading to 'read timed out'
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSocketTimeoutWithFailover() throws Exception {
+        try (Connection conn = PrepUtil.getConnection(
+                connectionString + ";failoverPartner=" + RandomUtil.getIdentifier("FailoverPartner") 
+                    + ";socketTimeout=" + waitForDelaySeconds + Constants.SEMI_COLON)) {
+         } catch (Exception e) {
+            if (!(e instanceof SQLException)) {
+                fail(TestResource.getResource("R_unexpectedErrorMessage") + e.getMessage());
+            }
+            assertTrue((e.getMessage().contains(TestResource.getResource("R_readTimedOut"))));
+        }
+    }
 
     private static void dropWaitForDelayProcedure(Connection conn) throws SQLException {
         try (Statement stmt = conn.createStatement()) {


### PR DESCRIPTION
A socket timeout exception when starting connection led to connection close before failover was being attempted. This allows the failover to be tried once, with the timeout exception being returned if failover can't be connected to.