### PR TITLE
Changed serverName sent in LOGIN packet to include instanceName

### DIFF
--- a/mssql-jdbc.properties
+++ b/mssql-jdbc.properties
@@ -1,0 +1,3 @@
+#
+#Mon Jun 05 08:57:20 PDT 2023
+AKVTrustedEndpoints=;vault.azure.net

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6331,7 +6331,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         } else {
             serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString());
             if (null != activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString())) {
-                serverName += "\\" + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
+                serverName += "\\" +
+                        activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
             }
         }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6331,8 +6331,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         } else {
             serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString());
             if (null != activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString())) {
-                serverName += "\\"
-                        + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
+                serverName += "\\" + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
             }
         }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6331,7 +6331,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         } else {
             serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString());
             if (null != activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString())) {
-                serverName += "\\" + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
+                serverName += "\\"
+                        + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
             }
         }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6324,10 +6324,26 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         String interfaceLibName = "Microsoft JDBC Driver " + SQLJdbcVersion.MAJOR + "." + SQLJdbcVersion.MINOR;
         String databaseName = activeConnectionProperties
                 .getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
-        String serverName = (null != currentConnectPlaceHolder)
-                ? (currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName())
-                : (activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
-                + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString()));
+        // TESTING TO SEE IF THE ISSUE IS THAT IM SENDING IN INSTANCE NAME WITHOUT CHECKING IF ITS BEEN SET FIRST
+        String serverName = "";
+        if (null != currentConnectPlaceHolder) {
+            if (null != currentConnectPlaceHolder.getInstanceName()) {
+                serverName = currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName();
+            } else {
+                serverName = currentConnectPlaceHolder.getServerName();
+            }
+        } else {
+            if (null != activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString())) {
+                serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
+                        + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
+            } else {
+                serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString());
+            }
+        }
+//        String serverName = (null != currentConnectPlaceHolder)
+//                ? (currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName())
+//                : (activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
+//                + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString()));
 
         if (null != serverName && serverName.length() > 128) {
             serverName = serverName.substring(0, 128);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6325,9 +6325,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         String databaseName = activeConnectionProperties
                 .getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
         String serverName = (null != currentConnectPlaceHolder)
-                ? currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName()
-                : activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
-                + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
+                ? (currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName())
+                : (activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
+                + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString()));
 
         if (null != serverName && serverName.length() > 128) {
             serverName = serverName.substring(0, 128);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6324,26 +6324,16 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         String interfaceLibName = "Microsoft JDBC Driver " + SQLJdbcVersion.MAJOR + "." + SQLJdbcVersion.MINOR;
         String databaseName = activeConnectionProperties
                 .getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
-        // TESTING TO SEE IF THE ISSUE IS THAT IM SENDING IN INSTANCE NAME WITHOUT CHECKING IF ITS BEEN SET FIRST
-        String serverName = "";
+
+        String serverName;
         if (null != currentConnectPlaceHolder) {
-            if (null != currentConnectPlaceHolder.getInstanceName()) {
-                serverName = currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName();
-            } else {
-                serverName = currentConnectPlaceHolder.getServerName();
-            }
+            serverName = currentConnectPlaceHolder.getFullServerName();
         } else {
+            serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString());
             if (null != activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString())) {
-                serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
-                        + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
-            } else {
-                serverName = activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString());
+                serverName += "\\" + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
             }
         }
-//        String serverName = (null != currentConnectPlaceHolder)
-//                ? (currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName())
-//                : (activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
-//                + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString()));
 
         if (null != serverName && serverName.length() > 128) {
             serverName = serverName.substring(0, 128);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6324,10 +6324,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         String interfaceLibName = "Microsoft JDBC Driver " + SQLJdbcVersion.MAJOR + "." + SQLJdbcVersion.MINOR;
         String databaseName = activeConnectionProperties
                 .getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
-        String serverName = (null != currentConnectPlaceHolder) ? currentConnectPlaceHolder.getServerName()
-                                                                : activeConnectionProperties.getProperty(
-                                                                        SQLServerDriverStringProperty.SERVER_NAME
-                                                                                .toString());
+        String serverName = (null != currentConnectPlaceHolder)
+                ? currentConnectPlaceHolder.getServerName() + "\\" + currentConnectPlaceHolder.getInstanceName()
+                : activeConnectionProperties.getProperty(SQLServerDriverStringProperty.SERVER_NAME.toString()) + "\\"
+                + activeConnectionProperties.getProperty(SQLServerDriverStringProperty.INSTANCE_NAME.toString());
+
         if (null != serverName && serverName.length() > 128) {
             serverName = serverName.substring(0, 128);
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ServerPortPlaceHolder.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ServerPortPlaceHolder.java
@@ -18,9 +18,9 @@ final class ServerPortPlaceHolder implements Serializable {
      * Always update serialVersionUID when prompted.
      */
     private static final long serialVersionUID = 7393779415545731523L;
-
     private final String serverName;
     private final String parsedServerName;
+    private final String fullServerName;
     private final int port;
     private final String instanceName;
     private final boolean checkLink;
@@ -32,6 +32,9 @@ final class ServerPortPlaceHolder implements Serializable {
         // serverName without named instance
         int px = serverName.indexOf('\\');
         parsedServerName = (px >= 0) ? serverName.substring(0, px) : serverName;
+
+        // serverName with named instance
+        fullServerName = (null != instance) ? (serverName + "\\" + instance) : serverName;
 
         port = conPort;
         instanceName = instance;
@@ -55,6 +58,10 @@ final class ServerPortPlaceHolder implements Serializable {
 
     String getParsedServerName() {
         return parsedServerName;
+    }
+
+    String getFullServerName() {
+        return fullServerName;
     }
 
     void doSecurityCheck() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ServerPortPlaceHolder.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ServerPortPlaceHolder.java
@@ -18,6 +18,7 @@ final class ServerPortPlaceHolder implements Serializable {
      * Always update serialVersionUID when prompted.
      */
     private static final long serialVersionUID = 7393779415545731523L;
+
     private final String serverName;
     private final String parsedServerName;
     private final String fullServerName;


### PR DESCRIPTION
To match behavior of other drivers, serverName has been modified in LOGIN packet to include instanceName.