### PR TITLE
avoid ClassCastException for floats

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2167,8 +2167,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                         if (bulkNullable) {
                             tdsWriter.writeByte((byte) 0x08);
                         }
-                        float floatValue = ((Number)colValue).floatValue();
-                        tdsWriter.writeDouble(floatValue);
+                        tdsWriter.writeDouble(((Number) colValue).floatValue());
                     }
                     break;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2167,7 +2167,8 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                         if (bulkNullable) {
                             tdsWriter.writeByte((byte) 0x08);
                         }
-                        tdsWriter.writeDouble((float) colValue);
+                        float floatValue = ((Number)colValue).floatValue();
+                        tdsWriter.writeDouble(floatValue);
                     }
                     break;
 


### PR DESCRIPTION
prior to this change, a ClassCastException occured if foreign (third-party) JDBC drivers return a Java Double and not a Float for JDBC FLOAT columns

actually, one could argue to even pass ((Number)colValue).doubleValue() to tdsWriter.writeDouble (for max  precision)