### PR TITLE
add useDefaultGSSCredential property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 test {
     useJUnitPlatform {
-        excludeTags (hasProperty('excludedGroups') ? excludedGroups : 'xSQLv15','xGradle','reqExternalSetup','NTLM','MSI','clientCertAuth','fedAuth')
+        excludeTags (hasProperty('excludedGroups') ? excludedGroups : 'xSQLv15','xGradle','reqExternalSetup','NTLM','MSI','clientCertAuth','fedAuth','kerberos')
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 			xAzureSQLDW - - - - For tests not compatible with Azure Data Warehouse - 
 			xAzureSQLMI - - - - For tests not compatible with Azure SQL Managed Instance 
 			NTLM  - - - - - - - For tests using NTLM Authentication mode (excluded by default)
-			Kerberos -  - - - - For tests using Kerberos authentication (excluded by default)
+			kerberos -  - - - - For tests using Kerberos authentication (excluded by default)
 			reqExternalSetup - For tests requiring external setup (excluded by default)
 			clientCertAuth - - For tests requiring client certificate authentication 
 			setup (excluded by default) - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
@@ -595,8 +595,23 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
     String getServerSpn();
 
     /**
+     * Sets the Boolean  value that indicates if the useDefaultGSSCredential property is enabled.
+     *
+     * @param enable
+     *        true if useDefaultGSSCredential is enabled. Otherwise, false.
+     */
+    void setUseDefaultGSSCredential(boolean enable);
+
+    /**
+     * Returns the useDefaultGSSCredential.
+     *
+     * @return if enabled, return true. Otherwise, false.
+     */
+    boolean getUseDefaultGSSCredential();
+
+    /**
      * Sets the GSSCredential.
-     * 
+     *
      * @param userCredential
      *        the credential
      */
@@ -604,7 +619,7 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
 
     /**
      * Returns the GSSCredential.
-     * 
+     *
      * @return GSSCredential
      */
     GSSCredential getGSSCredentials();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
@@ -595,7 +595,7 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
     String getServerSpn();
 
     /**
-     * Sets the Boolean  value that indicates if the useDefaultGSSCredential property is enabled.
+     * Sets the value to indicate whether useDefaultGSSCredential is enabled.
      *
      * @param enable
      *        true if useDefaultGSSCredential is enabled. Otherwise, false.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
@@ -39,6 +39,7 @@ final class KerbAuthentication extends SSPIAuthentication {
     private LoginContext lc = null;
     private boolean isUserCreatedCredential = false;
     private GSSCredential peerCredentials = null;
+    private boolean useDefaultNativeGSSCredential = false;
     private GSSContext peerContext = null;
 
     static {
@@ -62,6 +63,10 @@ final class KerbAuthentication extends SSPIAuthentication {
             // We pass null to indicate that the system should interpret the SPN
             // as it is.
             GSSName remotePeerName = manager.createName(spn, null);
+
+            if (useDefaultNativeGSSCredential) {
+                peerCredentials = manager.createCredential(null, GSSCredential.DEFAULT_LIFETIME, kerberos, GSSCredential.INITIATE_ONLY);
+            }
 
             if (null != peerCredentials) {
                 peerContext = manager.createContext(remotePeerName, kerberos, peerCredentials,
@@ -220,10 +225,11 @@ final class KerbAuthentication extends SSPIAuthentication {
      * @param impersonatedUserCred
      */
     KerbAuthentication(SQLServerConnection con, String address, int port, GSSCredential impersonatedUserCred,
-            boolean isUserCreated) {
+            boolean isUserCreated, boolean useDefaultNativeGSSCredential) {
         this(con, address, port);
         this.peerCredentials = impersonatedUserCred;
         this.isUserCreatedCredential = isUserCreated;
+        this.useDefaultNativeGSSCredential = useDefaultNativeGSSCredential;
     }
 
     byte[] generateClientContext(byte[] pin, boolean[] done) throws SQLServerException {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
@@ -241,9 +241,9 @@ final class KerbAuthentication extends SSPIAuthentication {
 
     void releaseClientContext() {
         try {
-            if (null != peerCredentials && !isUserCreatedCredential) {
+            if (null != peerCredentials && !isUserCreatedCredential && !useDefaultNativeGSSCredential) {
                 peerCredentials.dispose();
-            } else if (null != peerCredentials && isUserCreatedCredential) {
+            } else if (null != peerCredentials && (isUserCreatedCredential || useDefaultNativeGSSCredential)) {
                 peerCredentials = null;
             }
             if (null != peerContext) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionCertificateStoreProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionCertificateStoreProvider.java
@@ -19,8 +19,6 @@ public final class SQLServerColumnEncryptionCertificateStoreProvider extends SQL
     static final private java.util.logging.Logger windowsCertificateStoreLogger = java.util.logging.Logger
             .getLogger("com.microsoft.sqlserver.jdbc.SQLServerColumnEncryptionCertificateStoreProvider");
 
-    static boolean isWindows;
-
     String name = "MSSQL_CERTIFICATE_STORE";
 
     static final String LOCAL_MACHINE_DIRECTORY = "LocalMachine";
@@ -28,14 +26,6 @@ public final class SQLServerColumnEncryptionCertificateStoreProvider extends SQL
     static final String MY_CERTIFICATE_STORE = "My";
 
     private static final Lock lock = new ReentrantLock();
-
-    static {
-        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
-            isWindows = true;
-        } else {
-            isWindows = false;
-        }
-    }
 
     /**
      * Constructs a SQLServerColumnEncryptionCertificateStoreProvider.
@@ -67,7 +57,7 @@ public final class SQLServerColumnEncryptionCertificateStoreProvider extends SQL
         windowsCertificateStoreLogger.entering(SQLServerColumnEncryptionCertificateStoreProvider.class.getName(),
                 "decryptColumnEncryptionKey", "Decrypting Column Encryption Key.");
         byte[] plainCek;
-        if (isWindows) {
+        if (SQLServerConnection.isWindows) {
             plainCek = decryptColumnEncryptionKeyWindows(masterKeyPath, encryptionAlgorithm,
                     encryptedColumnEncryptionKey);
         } else {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -89,7 +89,7 @@ import mssql.googlecode.concurrentlinkedhashmap.EvictionListener;
  * NOTE: All the public functions in this class also need to be defined in SQLServerConnectionPoolProxy Declare all new
  * custom (non-static) Public APIs in ISQLServerConnection interface such that they can also be implemented by
  * SQLServerConnectionPoolProxy
- *
+ * 
  */
 public class SQLServerConnection implements ISQLServerConnection, java.io.Serializable {
 
@@ -111,7 +111,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Thresholds related to when prepared statement handles are cleaned-up. 1 == immediately.
-     *
+     * 
      * The default for the prepared statement clean-up action threshold (i.e. when sp_unprepare is called).
      */
     static final int DEFAULT_SERVER_PREPARED_STATEMENT_DISCARD_THRESHOLD = 10; // Used to set the initial default, can
@@ -123,7 +123,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /**
      * The default for if prepared statements should execute sp_executesql before following the prepare, unprepare
      * pattern.
-     *
+     * 
      * Used to set the initial default, can be changed later. false == use sp_executesql -> sp_prepexec -> sp_execute ->
      * batched -> sp_unprepare pattern, true == skip sp_executesql part of pattern.
      */
@@ -265,7 +265,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Generate a 6 byte random array for netAddress
-     *
+     * 
      * @return byte[]
      */
     private static byte[] getRandomNetAddress() {
@@ -279,7 +279,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * Return an existing cached SharedTimer associated with this Connection or create a new one.
      *
      * The SharedTimer will be released when the Connection is closed.
-     *
+     * 
      * @throws SQLServerException
      */
     SharedTimer getSharedTimer() throws SQLServerException {
@@ -295,7 +295,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Get the server name string including redirected server if applicable
-     *
+     * 
      * @param serverName
      * @return
      */
@@ -412,7 +412,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         /**
          * Makes sure handle cannot be re-used.
-         *
+         * 
          * @return false: Handle could not be discarded, it is in use. true: Handle was successfully put on path for
          *         discarding.
          */
@@ -427,7 +427,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         /**
          * Adds a new reference to this handle, i.e. re-using it.
-         *
+         * 
          * @return false: Reference could not be added, statement has been discarded or does not have a handle
          *         associated with it. true: Reference was successfully added.
          */
@@ -523,7 +523,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Locates statement parameters.
-     *
+     * 
      * @param sql
      *        SQL text to parse for positions of parameters to initialize.
      */
@@ -756,7 +756,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the cancelTimeout in seconds.
-     *
+     * 
      * @return
      */
     final int getCancelQueryTimeoutSeconds() {
@@ -777,7 +777,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the useBulkCopyForBatchInsert value.
-     *
+     * 
      * @return flag for using Bulk Copy API for batch insert operations.
      */
     public boolean getUseBulkCopyForBatchInsert() {
@@ -786,7 +786,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Specifies the flag for using Bulk Copy API for batch insert operations.
-     *
+     * 
      * @param useBulkCopyForBatchInsert
      *        boolean value for useBulkCopyForBatchInsert.
      */
@@ -999,7 +999,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Registers key store providers in the globalCustomColumnEncryptionKeyStoreProviders.
-     *
+     * 
      * @param clientKeyStoreProviders
      *        a map containing the store providers information.
      * @throws SQLServerException
@@ -1290,7 +1290,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Sets Trusted Master Key Paths in the columnEncryptionTrustedMasterKeyPaths.
-     *
+     * 
      * @param trustedKeyPaths
      *        all master key paths that are trusted
      */
@@ -1315,7 +1315,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Updates the columnEncryptionTrustedMasterKeyPaths with the new Server and trustedKeyPaths.
-     *
+     * 
      * @param server
      *        String server name
      * @param trustedKeyPaths
@@ -1339,7 +1339,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Removes the trusted Master key Path from the columnEncryptionTrustedMasterKeyPaths.
-     *
+     * 
      * @param server
      *        String server name
      */
@@ -1701,7 +1701,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Generates the next unique connection id.
-     *
+     * 
      * @return the next conn id
      */
     private static int nextConnectionID() {
@@ -1725,7 +1725,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if the connection is closed
-     *
+     * 
      * @throws SQLServerException
      */
     void checkClosed() throws SQLServerException {
@@ -1737,7 +1737,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns if Federated Authentication is in use or is about to expire soon
-     *
+     * 
      * @return true/false
      */
     protected boolean needsReconnect() {
@@ -1746,7 +1746,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns if a string property is enabled.
-     *
+     * 
      * @param propName
      *        the string property name
      * @param propValue
@@ -1783,7 +1783,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /**
      * Validates propName against maximum allowed length MAX_SQL_LOGIN_NAME_WCHARS. Throws exception if name length
      * exceeded.
-     *
+     * 
      * @param propName
      *        the name of the property.
      * @param propValue
@@ -3478,7 +3478,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Get time remaining to timer expiry
-     *
+     * 
      * @param timerExpire
      * @return remaining time to expiry
      */
@@ -3492,7 +3492,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * This is a helper function to connect this gets the port of the server to connect and the server name to connect
      * and the timeout This function achieves one connection attempt Create a prepared statement for internal use by the
      * driver.
-     *
+     * 
      * @param serverInfo
      * @param timeOutSliceInMillis
      *        -timeout value in milli seconds for one try
@@ -4281,7 +4281,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Build the syntax to initialize the connection at the database side.
-     *
+     * 
      * @return the syntax string
      */
     private String sqlStatementToInitialize() {
@@ -4293,7 +4293,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Sets the syntax to set the database calatog to use.
-     *
+     * 
      * @param sDB
      *        the new catalog
      */
@@ -4317,7 +4317,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the syntax to set the database isolation level.
-     *
+     * 
      * @return the required syntax
      */
     String sqlStatementToSetTransactionIsolationLevel() throws SQLServerException {
@@ -4355,7 +4355,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the syntax to set the database commit mode.
-     *
+     * 
      * @return the required syntax
      */
     static String sqlStatementToSetCommit(boolean autoCommit) {
@@ -4446,7 +4446,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * Makes all changes made since the previous commit/rollback permanent and releases any database locks currently
      * held by this <code>Connection</code> object. This method should be used only when auto-commit mode has been
      * disabled.
-     *
+     * 
      * @param delayedDurability
      *        flag to indicate whether the commit will occur with delayed durability on.
      * @throws SQLServerException
@@ -6158,7 +6158,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Delist the local transaction with DTC.
-     *
+     * 
      * @throws SQLServerException
      */
     final void jtaUnenlistConnection() throws SQLServerException {
@@ -6169,7 +6169,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Enlist this connection's local transaction with MS DTC
-     *
+     * 
      * @param cookie
      *        the cookie identifying the transaction
      * @throws SQLServerException
@@ -6186,7 +6186,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Convert to a String UCS16 encoding.
-     *
+     * 
      * @param s
      *        the string
      * @return the encoded data
@@ -6208,7 +6208,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Encrypt a password for the SQL Server logon.
-     *
+     * 
      * @param pwd
      *        the password
      * @return the encrypted password
@@ -6232,7 +6232,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Send a TDS 7.x logon packet.
-     *
+     * 
      * @param logonCommand
      *        the logon command
      * @param authentication
@@ -7388,7 +7388,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Replaces JDBC syntax parameter markets '?' with SQL Server parameter markers @p1, @p2 etc...
-     *
+     * 
      * @param sql
      *        the user's SQL
      * @throws SQLServerException
@@ -7428,7 +7428,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Makes a SQL Server style parameter name.
-     *
+     * 
      * @param nParam
      *        the parameter number
      * @param name
@@ -7545,7 +7545,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Determines the listening port of a named SQL Server instance.
-     *
+     * 
      * @param server
      *        the server name
      * @param instanceName
@@ -7688,7 +7688,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * feature. The default value is 2 hours. This variable holds the value in seconds. This only applies to
      * global-level key store providers. Connection and Statement-level providers need to set their own cache TTL
      * values.
-     *
+     * 
      * @param columnEncryptionKeyCacheTTL
      *        The timeunit in seconds
      * @param unit
@@ -7723,7 +7723,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Enqueues a discarded prepared statement handle to be clean-up on the server.
-     *
+     * 
      * @param statementHandle
      *        The prepared statement handle that should be scheduled for unprepare.
      */
@@ -7828,7 +7828,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /**
      * Cleans up discarded prepared statement handles on the server using batched un-prepare actions if the batching
      * threshold has been reached.
-     *
+     * 
      * @param force
      *        When force is set to true we ignore the current threshold for if the discard actions should run and run
      *        them anyway.
@@ -8027,12 +8027,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if connection is established to SQL Azure server
-     *
+     * 
      * SERVERPROPERTY('EngineEdition') is used to determine if the db server is SQL Azure. This is more reliable
      * than @@version or serverproperty('edition').
-     *
+     * 
      * Reference: https://docs.microsoft.com/sql/t-sql/functions/serverproperty-transact-sql
-     *
+     * 
      * <pre>
      * SERVERPROPERTY('EngineEdition') means
      * Database Engine edition of the instance of SQL Server installed on the server.
@@ -8047,9 +8047,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * 11 = Azure Synapse serverless SQL pool
      * Base data type: int
      * </pre>
-     *
+     * 
      * @return if connected to SQL Azure
-     *
+     * 
      */
     boolean isAzure() {
         if (null == isAzure) {
@@ -8082,7 +8082,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if connection is established to SQL Azure DW
-     *
+     * 
      * @return if connected to SQL Azure DW
      */
     boolean isAzureDW() {
@@ -8092,7 +8092,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if connection is established to Azure Managed Instance
-     *
+     * 
      * @return if connected to SQL Azure MI
      */
     boolean isAzureMI() {
@@ -8126,7 +8126,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Adds statement to openStatements
-     *
+     * 
      * @param st
      *        Statement to add to openStatements
      */
@@ -8143,7 +8143,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Removes state from openStatements
-     *
+     * 
      * @param st
      *        Statement to remove from openStatements
      */
@@ -8227,7 +8227,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
 /**
  * Provides Helper class for security manager functions used by SQLServerConnection class.
- *
+ * 
  */
 final class SQLServerConnectionSecurityManager {
     static final String DLLNAME = SQLServerDriver.AUTH_DLL_NAME + ".dll";
@@ -8241,7 +8241,7 @@ final class SQLServerConnectionSecurityManager {
 
     /**
      * Checks if the calling thread is allowed to open a socket connection to the specified serverName and portNumber.
-     *
+     * 
      * @throws SecurityException
      *         when an error occurs
      */
@@ -8255,7 +8255,7 @@ final class SQLServerConnectionSecurityManager {
 
     /**
      * Checks if the calling thread is allowed to dynamically link the library code.
-     *
+     * 
      * @throws SecurityException
      *         when an error occurs
      */

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -982,10 +982,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /** global system ColumnEncryptionKeyStoreProviders */
     static Map<String, SQLServerColumnEncryptionKeyStoreProvider> globalSystemColumnEncryptionKeyStoreProviders = new HashMap<>();
-    static boolean isWindows;
+
+    static boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows");
 
     static {
-        isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows");
         if (isWindows) {
             SQLServerColumnEncryptionCertificateStoreProvider provider = new SQLServerColumnEncryptionCertificateStoreProvider();
             globalSystemColumnEncryptionKeyStoreProviders.put(provider.getName(), provider);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -982,9 +982,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /** global system ColumnEncryptionKeyStoreProviders */
     static Map<String, SQLServerColumnEncryptionKeyStoreProvider> globalSystemColumnEncryptionKeyStoreProviders = new HashMap<>();
+    static boolean isWindows;
 
     static {
-        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
+        isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows");
+        if (isWindows) {
             SQLServerColumnEncryptionCertificateStoreProvider provider = new SQLServerColumnEncryptionCertificateStoreProvider();
             globalSystemColumnEncryptionKeyStoreProviders.put(provider.getName(), provider);
         }
@@ -1425,6 +1427,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /** integrated authentication scheme */
     private AuthenticationScheme intAuthScheme = AuthenticationScheme.NATIVE_AUTHENTICATION;
+
+    /** use default native GSS-API Credential flag */
+    private boolean useDefaultGSSCredential = SQLServerDriverBooleanProperty.USE_DEFAULT_GSS_CREDENTIAL.getDefaultValue();
 
     /** impersonated user credential */
     private transient GSSCredential impersonatedUserCred;
@@ -2479,6 +2484,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     if (activeConnectionProperties.containsKey(sPropKey)) {
                         impersonatedUserCred = (GSSCredential) activeConnectionProperties.get(sPropKey);
                         isUserCreatedCredential = true;
+                    }
+                    sPropKey = SQLServerDriverBooleanProperty.USE_DEFAULT_GSS_CREDENTIAL.toString();
+                    sPropValue = activeConnectionProperties.getProperty(sPropKey);
+                    if(null != sPropValue && isWindows) {
+                        useDefaultGSSCredential = isBooleanPropertyOn(sPropKey, sPropValue);
                     }
                 } else if (intAuthScheme == AuthenticationScheme.NTLM) {
                     String sPropKeyDomain = SQLServerDriverStringProperty.DOMAIN.toString();
@@ -5099,7 +5109,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             } else if (AuthenticationScheme.JAVA_KERBEROS == intAuthScheme) {
                 if (null != impersonatedUserCred) {
                     authentication = new KerbAuthentication(this, currentConnectPlaceHolder.getServerName(),
-                            currentConnectPlaceHolder.getPortNumber(), impersonatedUserCred, isUserCreatedCredential);
+                            currentConnectPlaceHolder.getPortNumber(), impersonatedUserCred, isUserCreatedCredential, useDefaultGSSCredential);
                 } else {
                     authentication = new KerbAuthentication(this, currentConnectPlaceHolder.getServerName(),
                             currentConnectPlaceHolder.getPortNumber());
@@ -5800,8 +5810,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             } else if (authenticationString
                     .equalsIgnoreCase(SqlAuthentication.ACTIVE_DIRECTORY_INTEGRATED.toString())) {
                 // If operating system is windows and mssql-jdbc_auth is loaded then choose the DLL authentication.
-                if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows")
-                        && AuthenticationJNI.isDllLoaded()) {
+                if (isWindows && AuthenticationJNI.isDllLoaded()) {
                     try {
                         FedAuthDllInfo dllInfo = AuthenticationJNI.getAccessTokenForWindowsIntegrated(
                                 fedAuthInfo.stsurl, fedAuthInfo.spn, clientConnectionId.toString(),

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -89,7 +89,7 @@ import mssql.googlecode.concurrentlinkedhashmap.EvictionListener;
  * NOTE: All the public functions in this class also need to be defined in SQLServerConnectionPoolProxy Declare all new
  * custom (non-static) Public APIs in ISQLServerConnection interface such that they can also be implemented by
  * SQLServerConnectionPoolProxy
- * 
+ *
  */
 public class SQLServerConnection implements ISQLServerConnection, java.io.Serializable {
 
@@ -111,7 +111,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Thresholds related to when prepared statement handles are cleaned-up. 1 == immediately.
-     * 
+     *
      * The default for the prepared statement clean-up action threshold (i.e. when sp_unprepare is called).
      */
     static final int DEFAULT_SERVER_PREPARED_STATEMENT_DISCARD_THRESHOLD = 10; // Used to set the initial default, can
@@ -123,7 +123,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /**
      * The default for if prepared statements should execute sp_executesql before following the prepare, unprepare
      * pattern.
-     * 
+     *
      * Used to set the initial default, can be changed later. false == use sp_executesql -> sp_prepexec -> sp_execute ->
      * batched -> sp_unprepare pattern, true == skip sp_executesql part of pattern.
      */
@@ -265,7 +265,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Generate a 6 byte random array for netAddress
-     * 
+     *
      * @return byte[]
      */
     private static byte[] getRandomNetAddress() {
@@ -279,7 +279,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * Return an existing cached SharedTimer associated with this Connection or create a new one.
      *
      * The SharedTimer will be released when the Connection is closed.
-     * 
+     *
      * @throws SQLServerException
      */
     SharedTimer getSharedTimer() throws SQLServerException {
@@ -295,7 +295,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Get the server name string including redirected server if applicable
-     * 
+     *
      * @param serverName
      * @return
      */
@@ -412,7 +412,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         /**
          * Makes sure handle cannot be re-used.
-         * 
+         *
          * @return false: Handle could not be discarded, it is in use. true: Handle was successfully put on path for
          *         discarding.
          */
@@ -427,7 +427,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         /**
          * Adds a new reference to this handle, i.e. re-using it.
-         * 
+         *
          * @return false: Reference could not be added, statement has been discarded or does not have a handle
          *         associated with it. true: Reference was successfully added.
          */
@@ -523,7 +523,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Locates statement parameters.
-     * 
+     *
      * @param sql
      *        SQL text to parse for positions of parameters to initialize.
      */
@@ -756,7 +756,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the cancelTimeout in seconds.
-     * 
+     *
      * @return
      */
     final int getCancelQueryTimeoutSeconds() {
@@ -777,7 +777,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the useBulkCopyForBatchInsert value.
-     * 
+     *
      * @return flag for using Bulk Copy API for batch insert operations.
      */
     public boolean getUseBulkCopyForBatchInsert() {
@@ -786,7 +786,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Specifies the flag for using Bulk Copy API for batch insert operations.
-     * 
+     *
      * @param useBulkCopyForBatchInsert
      *        boolean value for useBulkCopyForBatchInsert.
      */
@@ -999,7 +999,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Registers key store providers in the globalCustomColumnEncryptionKeyStoreProviders.
-     * 
+     *
      * @param clientKeyStoreProviders
      *        a map containing the store providers information.
      * @throws SQLServerException
@@ -1290,7 +1290,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Sets Trusted Master Key Paths in the columnEncryptionTrustedMasterKeyPaths.
-     * 
+     *
      * @param trustedKeyPaths
      *        all master key paths that are trusted
      */
@@ -1315,7 +1315,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Updates the columnEncryptionTrustedMasterKeyPaths with the new Server and trustedKeyPaths.
-     * 
+     *
      * @param server
      *        String server name
      * @param trustedKeyPaths
@@ -1339,7 +1339,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Removes the trusted Master key Path from the columnEncryptionTrustedMasterKeyPaths.
-     * 
+     *
      * @param server
      *        String server name
      */
@@ -1701,7 +1701,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Generates the next unique connection id.
-     * 
+     *
      * @return the next conn id
      */
     private static int nextConnectionID() {
@@ -1725,7 +1725,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if the connection is closed
-     * 
+     *
      * @throws SQLServerException
      */
     void checkClosed() throws SQLServerException {
@@ -1737,7 +1737,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns if Federated Authentication is in use or is about to expire soon
-     * 
+     *
      * @return true/false
      */
     protected boolean needsReconnect() {
@@ -1746,7 +1746,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns if a string property is enabled.
-     * 
+     *
      * @param propName
      *        the string property name
      * @param propValue
@@ -1783,7 +1783,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /**
      * Validates propName against maximum allowed length MAX_SQL_LOGIN_NAME_WCHARS. Throws exception if name length
      * exceeded.
-     * 
+     *
      * @param propName
      *        the name of the property.
      * @param propValue
@@ -3478,7 +3478,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Get time remaining to timer expiry
-     * 
+     *
      * @param timerExpire
      * @return remaining time to expiry
      */
@@ -3492,7 +3492,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * This is a helper function to connect this gets the port of the server to connect and the server name to connect
      * and the timeout This function achieves one connection attempt Create a prepared statement for internal use by the
      * driver.
-     * 
+     *
      * @param serverInfo
      * @param timeOutSliceInMillis
      *        -timeout value in milli seconds for one try
@@ -4281,7 +4281,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Build the syntax to initialize the connection at the database side.
-     * 
+     *
      * @return the syntax string
      */
     private String sqlStatementToInitialize() {
@@ -4293,7 +4293,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Sets the syntax to set the database calatog to use.
-     * 
+     *
      * @param sDB
      *        the new catalog
      */
@@ -4317,7 +4317,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the syntax to set the database isolation level.
-     * 
+     *
      * @return the required syntax
      */
     String sqlStatementToSetTransactionIsolationLevel() throws SQLServerException {
@@ -4355,7 +4355,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Returns the syntax to set the database commit mode.
-     * 
+     *
      * @return the required syntax
      */
     static String sqlStatementToSetCommit(boolean autoCommit) {
@@ -4446,7 +4446,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * Makes all changes made since the previous commit/rollback permanent and releases any database locks currently
      * held by this <code>Connection</code> object. This method should be used only when auto-commit mode has been
      * disabled.
-     * 
+     *
      * @param delayedDurability
      *        flag to indicate whether the commit will occur with delayed durability on.
      * @throws SQLServerException
@@ -5107,7 +5107,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 authentication = new AuthenticationJNI(this, currentConnectPlaceHolder.getServerName(),
                         currentConnectPlaceHolder.getPortNumber());
             } else if (AuthenticationScheme.JAVA_KERBEROS == intAuthScheme) {
-                if (null != impersonatedUserCred) {
+                if (null != impersonatedUserCred || useDefaultGSSCredential) {
                     authentication = new KerbAuthentication(this, currentConnectPlaceHolder.getServerName(),
                             currentConnectPlaceHolder.getPortNumber(), impersonatedUserCred, isUserCreatedCredential, useDefaultGSSCredential);
                 } else {
@@ -6158,7 +6158,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Delist the local transaction with DTC.
-     * 
+     *
      * @throws SQLServerException
      */
     final void jtaUnenlistConnection() throws SQLServerException {
@@ -6169,7 +6169,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Enlist this connection's local transaction with MS DTC
-     * 
+     *
      * @param cookie
      *        the cookie identifying the transaction
      * @throws SQLServerException
@@ -6186,7 +6186,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Convert to a String UCS16 encoding.
-     * 
+     *
      * @param s
      *        the string
      * @return the encoded data
@@ -6208,7 +6208,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Encrypt a password for the SQL Server logon.
-     * 
+     *
      * @param pwd
      *        the password
      * @return the encrypted password
@@ -6232,7 +6232,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Send a TDS 7.x logon packet.
-     * 
+     *
      * @param logonCommand
      *        the logon command
      * @param authentication
@@ -7388,7 +7388,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Replaces JDBC syntax parameter markets '?' with SQL Server parameter markers @p1, @p2 etc...
-     * 
+     *
      * @param sql
      *        the user's SQL
      * @throws SQLServerException
@@ -7428,7 +7428,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Makes a SQL Server style parameter name.
-     * 
+     *
      * @param nParam
      *        the parameter number
      * @param name
@@ -7545,7 +7545,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Determines the listening port of a named SQL Server instance.
-     * 
+     *
      * @param server
      *        the server name
      * @param instanceName
@@ -7688,7 +7688,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * feature. The default value is 2 hours. This variable holds the value in seconds. This only applies to
      * global-level key store providers. Connection and Statement-level providers need to set their own cache TTL
      * values.
-     * 
+     *
      * @param columnEncryptionKeyCacheTTL
      *        The timeunit in seconds
      * @param unit
@@ -7723,7 +7723,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Enqueues a discarded prepared statement handle to be clean-up on the server.
-     * 
+     *
      * @param statementHandle
      *        The prepared statement handle that should be scheduled for unprepare.
      */
@@ -7828,7 +7828,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /**
      * Cleans up discarded prepared statement handles on the server using batched un-prepare actions if the batching
      * threshold has been reached.
-     * 
+     *
      * @param force
      *        When force is set to true we ignore the current threshold for if the discard actions should run and run
      *        them anyway.
@@ -8027,12 +8027,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if connection is established to SQL Azure server
-     * 
+     *
      * SERVERPROPERTY('EngineEdition') is used to determine if the db server is SQL Azure. This is more reliable
      * than @@version or serverproperty('edition').
-     * 
+     *
      * Reference: https://docs.microsoft.com/sql/t-sql/functions/serverproperty-transact-sql
-     * 
+     *
      * <pre>
      * SERVERPROPERTY('EngineEdition') means
      * Database Engine edition of the instance of SQL Server installed on the server.
@@ -8047,9 +8047,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * 11 = Azure Synapse serverless SQL pool
      * Base data type: int
      * </pre>
-     * 
+     *
      * @return if connected to SQL Azure
-     * 
+     *
      */
     boolean isAzure() {
         if (null == isAzure) {
@@ -8082,7 +8082,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if connection is established to SQL Azure DW
-     * 
+     *
      * @return if connected to SQL Azure DW
      */
     boolean isAzureDW() {
@@ -8092,7 +8092,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Checks if connection is established to Azure Managed Instance
-     * 
+     *
      * @return if connected to SQL Azure MI
      */
     boolean isAzureMI() {
@@ -8126,7 +8126,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Adds statement to openStatements
-     * 
+     *
      * @param st
      *        Statement to add to openStatements
      */
@@ -8143,7 +8143,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Removes state from openStatements
-     * 
+     *
      * @param st
      *        Statement to remove from openStatements
      */
@@ -8227,7 +8227,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
 /**
  * Provides Helper class for security manager functions used by SQLServerConnection class.
- * 
+ *
  */
 final class SQLServerConnectionSecurityManager {
     static final String DLLNAME = SQLServerDriver.AUTH_DLL_NAME + ".dll";
@@ -8241,7 +8241,7 @@ final class SQLServerConnectionSecurityManager {
 
     /**
      * Checks if the calling thread is allowed to open a socket connection to the specified serverName and portNumber.
-     * 
+     *
      * @throws SecurityException
      *         when an error occurs
      */
@@ -8255,7 +8255,7 @@ final class SQLServerConnectionSecurityManager {
 
     /**
      * Checks if the calling thread is allowed to dynamically link the library code.
-     * 
+     *
      * @throws SecurityException
      *         when an error occurs
      */

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -240,6 +240,17 @@ public class SQLServerDataSource
     }
 
     @Override
+    public void setUseDefaultGSSCredential(boolean enable) {
+        setBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.USE_DEFAULT_GSS_CREDENTIAL.toString(), enable);
+    }
+
+    @Override
+    public boolean getUseDefaultGSSCredential() {
+       return getBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.USE_DEFAULT_GSS_CREDENTIAL.toString(),
+               SQLServerDriverBooleanProperty.USE_DEFAULT_GSS_CREDENTIAL.getDefaultValue());
+    }
+
+    @Override
     public void setAccessToken(String accessToken) {
         setStringProperty(connectionProps, SQLServerDriverStringProperty.ACCESS_TOKEN.toString(), accessToken);
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -694,7 +694,8 @@ enum SQLServerDriverBooleanProperty {
     USE_FMT_ONLY("useFmtOnly", false),
     SEND_TEMPORAL_DATATYPES_AS_STRING_FOR_BULK_COPY("sendTemporalDataTypesAsStringForBulkCopy", true),
     DELAY_LOADING_LOBS("delayLoadingLobs", true),
-    USE_DEFAULT_JAAS_CONFIG("useDefaultJaasConfig", false);
+    USE_DEFAULT_JAAS_CONFIG("useDefaultJaasConfig", false),
+    USE_DEFAULT_GSS_CREDENTIAL("useDefaultGSSCredential", false);
 
     private final String name;
     private final boolean defaultValue;
@@ -748,7 +749,7 @@ public final class SQLServerDriver implements java.sql.Driver {
                     SQLServerDriverStringProperty.DATABASE_NAME.getDefaultValue(), false, null),
             new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.DISABLE_STATEMENT_POOLING.toString(),
                     Boolean.toString(SQLServerDriverBooleanProperty.DISABLE_STATEMENT_POOLING.getDefaultValue()), false,
-                    new String[] {"true", "false"}),
+                    TRUE_FALSE),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.ENCRYPT.toString(),
                     SQLServerDriverStringProperty.ENCRYPT.getDefaultValue(), false,
                     new String[] {EncryptOption.FALSE.toString(), EncryptOption.NO.toString(),
@@ -767,6 +768,9 @@ public final class SQLServerDriver implements java.sql.Driver {
                     SQLServerDriverStringProperty.INSTANCE_NAME.getDefaultValue(), false, null),
             new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.INTEGRATED_SECURITY.toString(),
                     Boolean.toString(SQLServerDriverBooleanProperty.INTEGRATED_SECURITY.getDefaultValue()), false,
+                    TRUE_FALSE),
+            new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.USE_DEFAULT_GSS_CREDENTIAL.toString(),
+                    Boolean.toString(SQLServerDriverBooleanProperty.USE_DEFAULT_GSS_CREDENTIAL.getDefaultValue()), false,
                     TRUE_FALSE),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.KEY_STORE_AUTHENTICATION.toString(),
                     SQLServerDriverStringProperty.KEY_STORE_AUTHENTICATION.getDefaultValue(), false,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -197,6 +197,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_lastUpdateCountPropertyDescription", "Ensures that only the last update count is returned from an SQL statement passed to the server."},
         {"R_disableStatementPoolingPropertyDescription", "Disables the statement pooling feature."},
         {"R_integratedSecurityPropertyDescription", "Indicates whether Windows authentication will be used to connect to SQL Server."},
+        {"R_useDefaultGSSCredentialPropertyDescription", "Indicates whether should GSSCredential should be created using native GSS-API."},
         {"R_authenticationSchemePropertyDescription", "The authentication scheme to be used for integrated authentication."},
         {"R_lockTimeoutPropertyDescription", "The number of milliseconds to wait before the database reports a lock time-out."},
         {"R_connectRetryCountPropertyDescription", "The number of reconnection attempts if there is a connection failure."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -197,7 +197,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_lastUpdateCountPropertyDescription", "Ensures that only the last update count is returned from an SQL statement passed to the server."},
         {"R_disableStatementPoolingPropertyDescription", "Disables the statement pooling feature."},
         {"R_integratedSecurityPropertyDescription", "Indicates whether Windows authentication will be used to connect to SQL Server."},
-        {"R_useDefaultGSSCredentialPropertyDescription", "Indicates whether should GSSCredential should be created using native GSS-API."},
+        {"R_useDefaultGSSCredentialPropertyDescription", "Indicates whether GSSCredential will be created using native GSS-API."},
         {"R_authenticationSchemePropertyDescription", "The authentication scheme to be used for integrated authentication."},
         {"R_lockTimeoutPropertyDescription", "The number of milliseconds to wait before the database reports a lock time-out."},
         {"R_connectRetryCountPropertyDescription", "The number of reconnection attempts if there is a connection failure."},

--- a/src/test/java/com/microsoft/sqlserver/jdbc/KerberosTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/KerberosTest.java
@@ -16,6 +16,7 @@ import java.sql.ResultSet;
 import java.util.HashMap;
 import java.util.Map;
 
+@Tag(Constants.kerberos)
 @RunWith(JUnitPlatform.class)
 public class KerberosTest extends AbstractTest {
 
@@ -27,48 +28,35 @@ public class KerberosTest extends AbstractTest {
         setConnection();
     }
 
-    @Tag(Constants.Kerberos)
     @Test
     public void testUseDefaultJaasConfigConnectionStringPropertyTrue() throws Exception {
         String connectionStringUseDefaultJaasConfig = connectionStringKerberos + ";useDefaultJaasConfig=true;";
 
         // Initial connection should succeed with default JAAS config
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionStringUseDefaultJaasConfig)) {
-            ResultSet rs = conn.createStatement().executeQuery(authSchemeQuery);
-            rs.next();
-            Assertions.assertEquals(kerberosAuth, rs.getString(1));
-        }
+        createKerberosConnection(connectionStringUseDefaultJaasConfig);
 
         // Attempt to overwrite JAAS config. Since useDefaultJaasConfig=true, this should have no effect
         // and subsequent connections should succeed.
         overwriteJaasConfig();
 
         // New connection should successfully connect and continue to use the default JAAS config.
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionStringUseDefaultJaasConfig)) {
-            ResultSet rs = conn.createStatement().executeQuery(authSchemeQuery);
-            rs.next();
-            Assertions.assertEquals(kerberosAuth, rs.getString(1));
-        }
+        createKerberosConnection(connectionStringUseDefaultJaasConfig);
     }
 
-    @Tag(Constants.Kerberos)
     @Test
     public void testUseDefaultJaasConfigConnectionStringPropertyFalse() throws Exception {
 
         // useDefaultJaasConfig=false by default
         // Initial connection should succeed with default JAAS config
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionStringKerberos)) {
-            ResultSet rs = conn.createStatement().executeQuery(authSchemeQuery);
-            rs.next();
-            Assertions.assertEquals(kerberosAuth, rs.getString(1));
-        }
+        createKerberosConnection(connectionStringKerberos);
 
         // Overwrite JAAS config. Since useDefaultJaasConfig=false, overwriting should succeed and have an effect.
         // Subsequent connections will fail.
         overwriteJaasConfig();
 
         // New connection should fail as it is attempting to connect using an overwritten JAAS config.
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionStringKerberos)) {
+        try {
+            createKerberosConnection(connectionStringKerberos);
             Assertions.fail(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (SQLServerException e) {
             Assertions.assertTrue(e.getMessage()
@@ -76,24 +64,27 @@ public class KerberosTest extends AbstractTest {
         }
     }
 
-    @Tag(Constants.Kerberos)
     @Test
     public void testUseDefaultNativeGSSCredential() throws Exception {
         // This is a negative test. This test should fail as expected as the JVM arg "-Dsun.security.jgss.native=true"
         // isn't provided.
         String connectionString = connectionStringKerberos + ";useDefaultGSSCredential=true;";
 
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString)) {
+        try {
+            createKerberosConnection(connectionString);
             Assertions.fail(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (SQLServerException e) {
             Assertions.assertEquals(e.getCause().getMessage(), TestResource.getResource("R_kerberosNativeGSSFailure"));
         }
     }
 
-    @Tag(Constants.Kerberos)
     @Test
     public void testBasicKerberosAuth() throws Exception {
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionStringKerberos)) {
+        createKerberosConnection(connectionStringKerberos);
+    }
+
+    private static void createKerberosConnection(String connectionString) throws Exception {
+        try (SQLServerConnection conn = (SQLServerConnection) DriverManager.getConnection(connectionString)) {
             ResultSet rs = conn.createStatement().executeQuery(authSchemeQuery);
             rs.next();
             Assertions.assertEquals(kerberosAuth, rs.getString(1));
@@ -109,7 +100,7 @@ public class KerberosTest extends AbstractTest {
                 AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
                 new HashMap<>());
         Map<String, AppConfigurationEntry[]> configurationEntries = new HashMap<>();
-        configurationEntries.put("KAFKA_CLIENT_CONTEXT_NAME",
+        configurationEntries.put("CLIENT_CONTEXT_NAME",
                 new AppConfigurationEntry[] { kafkaClientConfigurationEntry });
         Configuration.setConfiguration(new InternalConfiguration(configurationEntries));
     }
@@ -125,6 +116,5 @@ public class KerberosTest extends AbstractTest {
         public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
             return this.configurationEntries.get(name);
         }
-
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -202,7 +202,7 @@ public class SQLServerConnectionTest extends AbstractTest {
                 TestResource.getResource("R_valuesAreDifferent"));
 
         ds.setUseDefaultGSSCredential(booleanPropValue);
-        assertEquals(Boolean.toString(booleanPropValue), ds.getUseDefaultGSSCredential(),
+        assertEquals(booleanPropValue, ds.getUseDefaultGSSCredential(),
                 TestResource.getResource("R_valuesAreDifferent"));
 
         ds.setServerCertificate(stringPropValue);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -201,6 +201,10 @@ public class SQLServerConnectionTest extends AbstractTest {
         assertEquals(Boolean.toString(booleanPropValue), ds.getEncrypt(),
                 TestResource.getResource("R_valuesAreDifferent"));
 
+        ds.setUseDefaultGSSCredential(booleanPropValue);
+        assertEquals(Boolean.toString(booleanPropValue), ds.getUseDefaultGSSCredential(),
+                TestResource.getResource("R_valuesAreDifferent"));
+
         ds.setServerCertificate(stringPropValue);
         assertEquals(stringPropValue, ds.getServerCertificate(), TestResource.getResource("R_valuesAreDifferent"));
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -43,6 +43,7 @@ public final class TestResource extends ListResourceBundle {
             {"R_lengthTruncated", " The inserted length is truncated or not correct!"},
             {"R_timeValueTruncated", " The time value is truncated or not correct!"},
             {"R_invalidErrorMessage", "Invalid Error Message: "},
+            {"R_kerberosNativeGSSFailure", "No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)"},
             {"R_expectedFailPassed", "Expected failure did not fail"}, {"R_dataTypeNotFound", "Cannot find data type"},
             {"R_illegalCharWktPosition", "Illegal character in Well-Known text at position {0}."},
             {"R_illegalCharWkt", "Illegal Well-Known text. Please make sure Well-Known text is valid."},

--- a/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
@@ -42,7 +42,7 @@ public final class Constants {
     public static final String xAzureSQLDW = "xAzureSQLDW";
     public static final String xAzureSQLMI = "xAzureSQLMI";
     public static final String NTLM = "NTLM";
-    public static final String Kerberos = "kerberos";
+    public static final String kerberos = "kerberos";
     public static final String MSI = "MSI";
     public static final String reqExternalSetup = "reqExternalSetup";
     public static final String clientCertAuth = "clientCertAuth";


### PR DESCRIPTION
Proposal Pull Request for Issue #2172 
useDefaultGSSCredential: Boolean - by setting this property to true, mssql-jdbc will create the GSSCredential on behalf of user using Native GSS-API for kerberos authentication without attempting to perform JAAS login.

This will allow seamless integration with framework that only supports String value connection Properties such as Apache Spark

This property currently take effect only in a window. I currently don't have access to a Kerberzied Linux environment to test this. However, I supposed we could make this work on all platforms.