### PR TITLE
Added SQLState 22005 to driver conversion exceptions

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
@@ -1115,7 +1115,7 @@ final class DataTypes {
     static final void throwConversionError(String fromType, String toType) throws SQLServerException {
         MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_unsupportedConversionFromTo"));
         Object[] msgArgs = {fromType, toType};
-        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), SQLState.ERROR_IN_ASSIGNMENT.getSQLStateCode(), true);
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -17,7 +17,8 @@ enum SQLState {
     DATA_EXCEPTION_DATETIME_FIELD_OVERFLOW("22008"),
     NUMERIC_DATA_OUT_OF_RANGE("22003"),
     DATA_EXCEPTION_LENGTH_MISMATCH("22026"),
-    COL_NOT_FOUND("42S22");
+    COL_NOT_FOUND("42S22"),
+    ERROR_IN_ASSIGNMENT("22005");
 
     private final String sqlStateCode;
 
@@ -59,6 +60,7 @@ public final class SQLServerException extends java.sql.SQLException {
     static final String EXCEPTION_XOPEN_CONNECTION_CANT_ESTABLISH = "08001";
     static final String EXCEPTION_XOPEN_CONNECTION_DOES_NOT_EXIST = "08003";
     static final String EXCEPTION_XOPEN_CONNECTION_FAILURE = "08006"; // After connection was connected OK
+    static final String EXCEPTION_XOPEN_ERROR_IN_ASSIGNMENT = "22005"; // Error code is the same in both SQL-99 and X/Open
 
     static final String LOG_CLIENT_CONNECTION_ID_PREFIX = " ClientConnectionId:";
 
@@ -302,6 +304,8 @@ public final class SQLServerException extends java.sql.SQLException {
                     return "08S01";
                 case SQLServerException.EXCEPTION_XOPEN_CONNECTION_FAILURE:
                     return "08S01";
+                case SQLServerException.EXCEPTION_XOPEN_ERROR_IN_ASSIGNMENT:
+                    return "22005";
                 default:
                     return "";
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -1624,6 +1624,20 @@ public class DataTypesTest extends AbstractTest {
                         fail(TestResource.getResource("R_expectedExceptionNotThrown"));
                     }
 
+                    // Verify SQLState 22005 is in exception for conversion errors
+                    try {
+                        Timestamp timestamp = Timestamp.valueOf("9999-12-31 23:59:59.998");
+                        rs.updateTimestamp(1, timestamp);
+                        rs.updateRow();
+                        rs.getLong(1);
+                    } catch (SQLServerException e) {
+                        assertEquals("22005", e.getSQLState());
+                    }
+
+                    if (!exceptionThrown) {
+                        fail(TestResource.getResource("R_expectedExceptionNotThrown"));
+                    }
+
                     // Update time(5) from Timestamp with nanos more precise than 100ns
                     Timestamp ts = Timestamp.valueOf("2010-01-12 11:05:23");
                     ts.setNanos(987659999);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -1624,12 +1624,15 @@ public class DataTypesTest extends AbstractTest {
                         fail(TestResource.getResource("R_expectedExceptionNotThrown"));
                     }
 
+
+                    exceptionThrown = true;
                     // Verify SQLState 22005 is in exception for conversion errors
                     try {
                         Timestamp timestamp = Timestamp.valueOf("9999-12-31 23:59:59.998");
                         rs.updateTimestamp(1, timestamp);
                         rs.updateRow();
                         rs.getLong(1);
+                        exceptionThrown = false;
                     } catch (SQLServerException e) {
                         assertEquals("22005", e.getSQLState());
                     }


### PR DESCRIPTION
Fix for https://github.com/microsoft/mssql-jdbc/issues/2167.

Driver by default returns SQL-99 state codes. If `xopenStates` is set to true, driver will return X\Open state codes. SQLState code 22005 is the same in both value and meaning for SQL-99 and X\Open standards.

SQL-99 source: https://github.com/crate/sql-99/blob/main/docs/chapters/47.rst

X\Open source: [xopen_sql_states.pdf](https://github.com/microsoft/mssql-jdbc/files/12264968/xopen_sql_states.pdf)
