### PR TITLE
Added automatic spacing between parameter names for prepared statements

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -7431,12 +7431,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     static int makeParamName(int nParam, char[] name, int offset, boolean isPreparedSQL) {
         buildParamInitial(name, offset, isPreparedSQL);
         if (nParam < 10) {
-            return buildParamPrimaryCase(nParam, name, offset, isPreparedSQL);
+            return buildParamLt10(nParam, name, offset, isPreparedSQL);
         } else {
             if (nParam < 100) {
-                return buildParamSecondaryCase(nParam, name, offset, isPreparedSQL);
+                return buildParamLt100(nParam, name, offset, isPreparedSQL);
             } else {
-                return buildParamTertiaryCase(nParam, name, offset, isPreparedSQL);
+                return buildParamMt100(nParam, name, offset, isPreparedSQL);
             }
         }
     }
@@ -7451,7 +7451,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         name[offset + preparedSQLOffset + 1] = 'P';
     }
 
-    private static int buildParamPrimaryCase(int nParam, char[] name, int offset, boolean isPreparedSQL) {
+    private static int buildParamLt10(int nParam, char[] name, int offset, boolean isPreparedSQL) {
         int preparedSQLOffset = 0;
 
         if (isPreparedSQL) {
@@ -7468,7 +7468,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return 3;
     }
 
-    private static int buildParamSecondaryCase(int nParam, char[] name, int offset, boolean isPreparedSQL) {
+    private static int buildParamLt100(int nParam, char[] name, int offset, boolean isPreparedSQL) {
         int nBase = 2;
         int preparedSQLOffset = 0;
 
@@ -7492,7 +7492,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         }
     }
 
-    private static int buildParamTertiaryCase(int nParam, char[] name, int offset, boolean isPreparedSQL) {
+    private static int buildParamMt100(int nParam, char[] name, int offset, boolean isPreparedSQL) {
         int preparedSQLOffset = 0;
         String sParam = Integer.toString(nParam);
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -461,7 +461,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             if (i > 0)
                 sb.append(',');
 
-            int l = SQLServerConnection.makeParamName(i, cParamName, 0);
+            int l = SQLServerConnection.makeParamName(i, cParamName, 0, false);
             String parameterName = String.valueOf(cParamName, 0, l);
             sb.append(parameterName);
             sb.append(' ');
@@ -750,7 +750,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         for (int index = 0; index < params.length; index++) {
             if (JDBCType.TVP == params[index].getJdbcType()) {
                 cParamName = new char[10];
-                int paramNameLen = SQLServerConnection.makeParamName(index, cParamName, 0);
+                int paramNameLen = SQLServerConnection.makeParamName(index, cParamName, 0, false);
                 tdsWriter.writeByte((byte) paramNameLen);
                 tdsWriter.writeString(new String(cParamName, 0, paramNameLen));
             }


### PR DESCRIPTION
Parameter names eg. P1, P2, ... PN will have spaces applied automatically between them.

When the driver parses `select * from table where a=?and b=?` it will become `select * from table where a= ? and b= ? `.