### PR TITLE
Escape schemaPattern for getSchemas

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1518,7 +1518,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         if (loggerExternal.isLoggable(Level.FINER) && Util.isActivityTraceOn()) {
             loggerExternal.finer(toString() + ACTIVITY_ID + ActivityCorrelator.getCurrent().toString());
         }
-        return getSchemasInternal(catalog, schemaPattern);
+        return getSchemasInternal(catalog, escapeIDName(schemaPattern));
     }
 
     @Override

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -252,6 +252,8 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @Tag(Constants.xAzureSQLDW)
+    @Tag(Constants.xAzureSQLDB)
     public void testDBSchemasForDashedCatalogName() throws SQLException {
         UUID id = UUID.randomUUID();
         String testCatalog = "dash-catalog" + id;
@@ -303,6 +305,8 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @Tag(Constants.xAzureSQLDW)
+    @Tag(Constants.xAzureSQLDB)
     public void testDBSchemasForDashedCatalogNameWithPattern() throws SQLException {
         UUID id = UUID.randomUUID();
         String testCatalog = "dash-catalog" + id;
@@ -348,6 +352,8 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @Tag(Constants.xAzureSQLDW)
+    @Tag(Constants.xAzureSQLDB)
     public void testDBSchemasForSchemaPatternWithWildcards() throws SQLException {
         UUID id = UUID.randomUUID();
         String testCatalog = "catalog" + id;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -346,6 +346,57 @@ public class DatabaseMetaDataTest extends AbstractTest {
     }
 
     /**
+     * Tests that the schemaPattern parameter containing _ and % are escaped by
+     * {@link SQLServerDatabaseMetaData#getSchemas(String catalog, String schemaPattern)}.
+     *
+     * @throws SQLException
+     */
+    @Test
+    @Tag(Constants.xAzureSQLDW)
+    @Tag(Constants.xAzureSQLDB)
+    public void testDBSchemasForSchemaPatternWithWildcards() throws SQLException {
+        UUID id = UUID.randomUUID();
+        String testCatalog = "catalog" + id;
+        String[] schemas = {"some_schema", "some%schema", "some[schema"};
+        String[] schemaPatterns = {"some\\_schema", "some\\%schema", "some\\[schema"};
+
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropDatabaseIfExists(testCatalog, connectionString);
+            stmt.execute(String.format("CREATE DATABASE [%s]", testCatalog));
+            stmt.execute(String.format("USE [%s]", testCatalog));
+
+            for (int i = 0; i < schemas.length; ++i) {
+                stmt.execute(String.format("CREATE SCHEMA [%s]", schemas[i]));
+
+                try (ResultSet rs = conn.getMetaData().getSchemas(testCatalog, schemaPatterns[i])) {
+
+                    MessageFormat schemaEmptyFormat = new MessageFormat(TestResource.getResource("R_nameEmpty"));
+                    Object[] schemaMsgArgs = {schemas[i]};
+                    Object[] catalogMsgArgs = {testCatalog};
+
+                    boolean hasResults = false;
+                    while (rs.next()) {
+                        hasResults = true;
+                        String schemaName = rs.getString(1);
+                        String catalogName = rs.getString(2);
+                        assertTrue(!StringUtils.isEmpty(schemaName), schemaEmptyFormat.format(schemaMsgArgs));
+                        assertTrue(!StringUtils.isEmpty(catalogName), schemaEmptyFormat.format(catalogMsgArgs));
+                        assertEquals(schemaName, schemaMsgArgs[0]);
+                        assertEquals(catalogName, catalogMsgArgs[0]);
+                    }
+
+                    MessageFormat atLeastOneFoundFormat = new MessageFormat(TestResource.getResource("R_atLeastOneFound"));
+                    assertTrue(hasResults, atLeastOneFoundFormat.format(schemaMsgArgs));
+                }
+            }
+        } catch (Exception e) {
+            fail(TestResource.getResource("R_unexpectedErrorMessage") + e.getMessage());
+        } finally {
+            TestUtils.dropDatabaseIfExists(testCatalog, connectionString);
+        }
+    }
+
+    /**
      * Get All Tables.
      * 
      * @throws SQLException

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -356,34 +356,38 @@ public class DatabaseMetaDataTest extends AbstractTest {
     @Tag(Constants.xAzureSQLDB)
     public void testDBSchemasForSchemaPatternWithWildcards() throws SQLException {
         UUID id = UUID.randomUUID();
-        String testCatalog = "dash-catalog" + id;
-        String testSchema = "some_schema" + id;
+        String testCatalog = "catalog" + id;
+        String[] schemas = {"some_schema", "some%schema", "some[schema"};
+        String[] schemaPatterns = {"some\\_schema", "some\\%schema", "some\\[schema"};
 
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
             TestUtils.dropDatabaseIfExists(testCatalog, connectionString);
             stmt.execute(String.format("CREATE DATABASE [%s]", testCatalog));
             stmt.execute(String.format("USE [%s]", testCatalog));
-            stmt.execute(String.format("CREATE SCHEMA [%s]", testSchema));
 
-            try (ResultSet rs = conn.getMetaData().getSchemas(testCatalog, "some\\_%")) {
+            for (int i = 0; i < schemas.length; ++i) {
+                stmt.execute(String.format("CREATE SCHEMA [%s]", schemas[i]));
 
-                MessageFormat schemaEmptyFormat = new MessageFormat(TestResource.getResource("R_nameEmpty"));
-                Object[] schemaMsgArgs = {testSchema};
-                Object[] catalogMsgArgs = {testCatalog};
+                try (ResultSet rs = conn.getMetaData().getSchemas(testCatalog, schemaPatterns[i])) {
 
-                boolean hasResults = false;
-                while (rs.next()) {
-                    hasResults = true;
-                    String schemaName = rs.getString(1);
-                    String catalogName = rs.getString(2);
-                    assertTrue(!StringUtils.isEmpty(schemaName), schemaEmptyFormat.format(schemaMsgArgs));
-                    assertTrue(!StringUtils.isEmpty(catalogName), schemaEmptyFormat.format(catalogMsgArgs));
-                    assertEquals(schemaName, schemaMsgArgs[0]);
-                    assertEquals(catalogName, catalogMsgArgs[0]);
+                    MessageFormat schemaEmptyFormat = new MessageFormat(TestResource.getResource("R_nameEmpty"));
+                    Object[] schemaMsgArgs = {schemas[i]};
+                    Object[] catalogMsgArgs = {testCatalog};
+
+                    boolean hasResults = false;
+                    while (rs.next()) {
+                        hasResults = true;
+                        String schemaName = rs.getString(1);
+                        String catalogName = rs.getString(2);
+                        assertTrue(!StringUtils.isEmpty(schemaName), schemaEmptyFormat.format(schemaMsgArgs));
+                        assertTrue(!StringUtils.isEmpty(catalogName), schemaEmptyFormat.format(catalogMsgArgs));
+                        assertEquals(schemaName, schemaMsgArgs[0]);
+                        assertEquals(catalogName, catalogMsgArgs[0]);
+                    }
+
+                    MessageFormat atLeastOneFoundFormat = new MessageFormat(TestResource.getResource("R_atLeastOneFound"));
+                    assertTrue(hasResults, atLeastOneFoundFormat.format(schemaMsgArgs));
                 }
-
-                MessageFormat atLeastOneFoundFormat = new MessageFormat(TestResource.getResource("R_atLeastOneFound"));
-                assertTrue(hasResults, atLeastOneFoundFormat.format(schemaMsgArgs));
             }
         } catch (Exception e) {
             fail(TestResource.getResource("R_unexpectedErrorMessage") + e.getMessage());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -252,8 +252,6 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
-    @Tag(Constants.xAzureSQLDW)
-    @Tag(Constants.xAzureSQLDB)
     public void testDBSchemasForDashedCatalogName() throws SQLException {
         UUID id = UUID.randomUUID();
         String testCatalog = "dash-catalog" + id;
@@ -305,8 +303,6 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
-    @Tag(Constants.xAzureSQLDW)
-    @Tag(Constants.xAzureSQLDB)
     public void testDBSchemasForDashedCatalogNameWithPattern() throws SQLException {
         UUID id = UUID.randomUUID();
         String testCatalog = "dash-catalog" + id;
@@ -352,8 +348,6 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
-    @Tag(Constants.xAzureSQLDW)
-    @Tag(Constants.xAzureSQLDB)
     public void testDBSchemasForSchemaPatternWithWildcards() throws SQLException {
         UUID id = UUID.randomUUID();
         String testCatalog = "catalog" + id;


### PR DESCRIPTION
`schemaPattern` was the only pattern in `SQLServerDatabaseMetadata` that was not being escaped, it should be.