### PR TITLE
Backport #2150: Change how IBM JDK is determined to fix tests and future-proof

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -48,7 +48,13 @@ final class Util {
     private static final Lock LOCK = new ReentrantLock();
 
     static boolean isIBM() {
-        return SYSTEM_JRE.startsWith("IBM");
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName("com.ibm.lang.management.MemoryUsage");
+        } catch (ClassNotFoundException e) {
+            //We're using the try-catch to test for IBM jdk, no need to handle exception.
+        }
+        return null != clazz;
     }
 
     static String getJVMArchOnWindows() {


### PR DESCRIPTION
Backport https://github.com/microsoft/mssql-jdbc/pull/2150.