### PR TITLE
Reverted the IBM check to vendor check AND added an additional vm name check to remove false positives

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -48,13 +48,8 @@ final class Util {
     private static final Lock LOCK = new ReentrantLock();
 
     static boolean isIBM() {
-        Class<?> clazz = null;
-        try {
-            clazz = Class.forName("com.ibm.lang.management.MemoryUsage");
-        } catch (ClassNotFoundException e) {
-            //We're using the try-catch to test for IBM jdk, no need to handle exception.
-        }
-        return null != clazz;
+        String vmName = System.getProperty("java.vm.name");
+        return SYSTEM_JRE.startsWith("IBM") && vmName.startsWith("IBM");
     }
 
     static String getJVMArchOnWindows() {


### PR DESCRIPTION
The current `isIBM` check causes issues with OSGi environments. Instead, we're reverting to the previous check with `vendor` name, and adding an additional check with `vm` name to remove false positives, e.g. Semaru builds.

original issue #2139 