### PR TITLE
Fix inner login loop repeating until loginTimeout is reached

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3247,6 +3247,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             } catch (SQLServerException sqlex) {
                 int errorCode = sqlex.getErrorCode();
                 int driverErrorCode = sqlex.getDriverErrorCode();
+                if (connectionlogger.isLoggable(Level.FINE)) {
+                    connectionlogger.fine("Connection state: " + state);
+                    connectionlogger.fine("Is mirroring? - " + isDBMirroring);
+                }
                 if (SQLServerException.LOGON_FAILED == errorCode // logon failed, ie bad password
                         || SQLServerException.PASSWORD_EXPIRED == errorCode // password expired
                         || SQLServerException.USER_ACCOUNT_LOCKED == errorCode // user account locked

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3247,10 +3247,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             } catch (SQLServerException sqlex) {
                 int errorCode = sqlex.getErrorCode();
                 int driverErrorCode = sqlex.getDriverErrorCode();
-                if (connectionlogger.isLoggable(Level.FINE)) {
-                    connectionlogger.fine("Connection state: " + state);
-                    connectionlogger.fine("Is mirroring? - " + isDBMirroring);
-                }
+                    System.out.println("Connection state: " + state);
+                    System.out.println("Is mirroring? - " + isDBMirroring);
                 if (SQLServerException.LOGON_FAILED == errorCode // logon failed, ie bad password
                         || SQLServerException.PASSWORD_EXPIRED == errorCode // password expired
                         || SQLServerException.USER_ACCOUNT_LOCKED == errorCode // user account locked

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3292,9 +3292,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // Whereas for dbMirroring, we sleep for every two attempts as each attempt is to a different server.
             if (!isDBMirroring || (1 == attemptNumber % 2)) {
                 if (connectionlogger.isLoggable(Level.FINE)) {
-                    connectionlogger.fine(toString() + " sleeping milisec: " + sleepInterval);
                     connectionlogger.fine(toString() + " Connection state: " + state);
-                    connectionlogger.fine(toString() + " isMirroring?: " + isDBMirroring);
                 }
                 try {
                     Thread.sleep(sleepInterval);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3262,6 +3262,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         || (state.equals(State.CONNECTED) && !isDBMirroring)
                 // for non-dbmirroring cases, do not retry after tcp socket connection succeeds
                 ) {
+                    if (connectionlogger.isLoggable(Level.FINE)) {
+                        connectionlogger.fine(toString() + " Success Connection state: " + state);
+                    }
                     // close the connection and throw the error back
                     close();
                     throw sqlex;
@@ -3292,7 +3295,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             // Whereas for dbMirroring, we sleep for every two attempts as each attempt is to a different server.
             if (!isDBMirroring || (1 == attemptNumber % 2)) {
                 if (connectionlogger.isLoggable(Level.FINE)) {
-                    connectionlogger.fine(toString() + " Connection state: " + state);
+                    connectionlogger.fine(toString() + " Failed Connection state: " + state);
                 }
                 try {
                     Thread.sleep(sleepInterval);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3247,8 +3247,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             } catch (SQLServerException sqlex) {
                 int errorCode = sqlex.getErrorCode();
                 int driverErrorCode = sqlex.getDriverErrorCode();
-                    System.out.println("Connection state: " + state);
-                    System.out.println("Is mirroring? - " + isDBMirroring);
                 if (SQLServerException.LOGON_FAILED == errorCode // logon failed, ie bad password
                         || SQLServerException.PASSWORD_EXPIRED == errorCode // password expired
                         || SQLServerException.USER_ACCOUNT_LOCKED == errorCode // user account locked
@@ -3295,6 +3293,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             if (!isDBMirroring || (1 == attemptNumber % 2)) {
                 if (connectionlogger.isLoggable(Level.FINE)) {
                     connectionlogger.fine(toString() + " sleeping milisec: " + sleepInterval);
+                    connectionlogger.fine(toString() + " Connection state: " + state);
+                    connectionlogger.fine(toString() + " isMirroring?: " + isDBMirroring);
                 }
                 try {
                     Thread.sleep(sleepInterval);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3259,6 +3259,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         || (SQLServerException.ERROR_SOCKET_TIMEOUT == driverErrorCode // socket timeout
                                 && (!isDBMirroring || attemptNumber > 0)) // If mirroring, only close after failover has been tried (attempt >= 1)
                         || timerHasExpired(timerExpire)
+                        || (state.equals(State.CONNECTED) && !isDBMirroring)
                 // for non-dbmirroring cases, do not retry after tcp socket connection succeeds
                 ) {
                     // close the connection and throw the error back

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -456,9 +456,11 @@ public class SQLServerConnectionTest extends AbstractTest {
     @Test
     public void testConnectCountInLoginAndCorrectRetryCount() {
         long timerStart = 0;
+
         int connectRetryCount = 3;
         int connectRetryInterval = 1;
         int longLoginTimeout = loginTimeOutInSeconds * 4; // 120 seconds
+
         try {
             SQLServerDataSource ds = new SQLServerDataSource();
             ds.setURL(connectionString);
@@ -467,6 +469,7 @@ public class SQLServerConnectionTest extends AbstractTest {
             ds.setConnectRetryInterval(connectRetryInterval);
             ds.setDatabaseName(RandomUtil.getIdentifier("DataBase"));
             timerStart = System.currentTimeMillis();
+
             try (Connection con = ds.getConnection()) {
                 assertTrue(con == null, TestResource.getResource("R_shouldNotConnect"));
             }
@@ -474,6 +477,7 @@ public class SQLServerConnectionTest extends AbstractTest {
             assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
             long totalTime = System.currentTimeMillis() - timerStart;
             int expectedMinimumTimeInMillis = (connectRetryCount * connectRetryInterval) * 1000; // 3 seconds
+
             // Minimum time is 0 seconds per attempt and connectRetryInterval * connectRetryCount seconds of interval.
             // Maximum is unknown, but is needs to be less than longLoginTimeout or else this is an issue.
             assertTrue(totalTime > expectedMinimumTimeInMillis, TestResource.getResource("R_executionNotLong"));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -478,10 +478,13 @@ public class SQLServerConnectionTest extends AbstractTest {
             long totalTime = System.currentTimeMillis() - timerStart;
             int expectedMinimumTimeInMillis = (connectRetryCount * connectRetryInterval) * 1000; // 3 seconds
 
+            System.out.println("TOTAL TIME: " + totalTime);
+
             // Minimum time is 0 seconds per attempt and connectRetryInterval * connectRetryCount seconds of interval.
             // Maximum is unknown, but is needs to be less than longLoginTimeout or else this is an issue.
             assertTrue(totalTime > expectedMinimumTimeInMillis, TestResource.getResource("R_executionNotLong"));
-            assertTrue(totalTime < (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+
         }
     }
 
@@ -513,8 +516,10 @@ public class SQLServerConnectionTest extends AbstractTest {
             assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
             long totalTime = System.currentTimeMillis() - timerStart;
 
+            System.out.println("TOTAL TIME: " + totalTime);
+
             // Maximum is unknown, but is needs to be less than longLoginTimeout or else this is an issue.
-            assertTrue(totalTime < (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.sql.ConnectionEvent;
@@ -461,6 +463,13 @@ public class SQLServerConnectionTest extends AbstractTest {
         int connectRetryInterval = 1;
         int longLoginTimeout = loginTimeOutInSeconds * 4; // 120 seconds
 
+        final ConsoleHandler handler = new ConsoleHandler();
+        handler.setLevel(Level.FINE);
+        Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc");
+        logger.addHandler(handler);
+        logger.setLevel(Level.FINEST);
+        logger.log(Level.FINE, "The Sql Server logger is correctly configured.");
+
         try {
             SQLServerDataSource ds = new SQLServerDataSource();
             ds.setURL(connectionString);
@@ -499,6 +508,13 @@ public class SQLServerConnectionTest extends AbstractTest {
         int connectRetryCount = 0;
         int connectRetryInterval = 60;
         int longLoginTimeout = loginTimeOutInSeconds * 3; // 90 seconds
+
+        final ConsoleHandler handler = new ConsoleHandler();
+        handler.setLevel(Level.FINE);
+        Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc");
+        logger.addHandler(handler);
+        logger.setLevel(Level.FINEST);
+        logger.log(Level.FINE, "The Sql Server logger is correctly configured.");
 
         try {
             SQLServerDataSource ds = new SQLServerDataSource();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -456,10 +456,42 @@ public class SQLServerConnectionTest extends AbstractTest {
     @Test
     public void testConnectCountInLoginAndCorrectRetryCount() {
         long timerStart = 0;
-
         int connectRetryCount = 3;
         int connectRetryInterval = 1;
-        int longLoginTimeout = 120;
+        int longLoginTimeout = loginTimeOutInSeconds * 4; // 120 seconds
+        try {
+            SQLServerDataSource ds = new SQLServerDataSource();
+            ds.setURL(connectionString);
+            ds.setLoginTimeout(longLoginTimeout);
+            ds.setConnectRetryCount(connectRetryCount);
+            ds.setConnectRetryInterval(connectRetryInterval);
+            ds.setDatabaseName(RandomUtil.getIdentifier("DataBase"));
+            timerStart = System.currentTimeMillis();
+            try (Connection con = ds.getConnection()) {
+                assertTrue(con == null, TestResource.getResource("R_shouldNotConnect"));
+            }
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
+            long totalTime = System.currentTimeMillis() - timerStart;
+            int expectedMinimumTimeInMillis = (connectRetryCount * connectRetryInterval) * 1000; // 3 seconds
+            // Minimum time is 0 seconds per attempt and connectRetryInterval * connectRetryCount seconds of interval.
+            // Maximum is unknown, but is needs to be less than longLoginTimeout or else this is an issue.
+            assertTrue(totalTime > expectedMinimumTimeInMillis, TestResource.getResource("R_executionNotLong"));
+            assertTrue(totalTime < (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+        }
+    }
+
+    /**
+     * Tests whether connectRetryCount and connectRetryInterval are properly respected in the login loop. As well, tests
+     * that connection is retried the proper number of times. This is for cases with zero retries.
+     */
+    @Test
+    public void testConnectCountInLoginAndCorrectRetryCountWithZeroRetry() {
+        long timerStart = 0;
+
+        int connectRetryCount = 0;
+        int connectRetryInterval = 60;
+        int longLoginTimeout = loginTimeOutInSeconds * 3; // 90 seconds
 
         try {
             SQLServerDataSource ds = new SQLServerDataSource();
@@ -476,47 +508,12 @@ public class SQLServerConnectionTest extends AbstractTest {
         } catch (Exception e) {
             assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
             long totalTime = System.currentTimeMillis() - timerStart;
-            int expectedMinimumTimeInMillis = (connectRetryCount * connectRetryInterval) * 1000; // 3 seconds
 
-            // Minimum time is 0 seconds per attempt and connectRetryInterval * connectRetryCount seconds of interval.
-            // Maximum is unknown, but previously runtime was within a second of loginTimeout. Check that this is fixed.
-            assertTrue(totalTime > expectedMinimumTimeInMillis, TestResource.getResource("R_executionNotLong"));
-            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
-            System.out.println(totalTime);
+            // Maximum is unknown, but is needs to be less than longLoginTimeout or else this is an issue.
+            assertTrue(totalTime < (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
         }
     }
 
-    /**
-     * Tests whether connectRetryCount and connectRetryInterval are properly respected in the login loop.
-     * This is for cases with zero retries.
-     */
-    @Test
-    public void testConnectCountInLoginAndCorrectRetryCountWithZeroRetry() {
-        long timerStart = 0;
-
-        int connectRetryCount = 0;
-        int longLoginTimeout = 90;
-
-        try {
-            SQLServerDataSource ds = new SQLServerDataSource();
-            ds.setURL(connectionString);
-            ds.setLoginTimeout(longLoginTimeout);
-            ds.setConnectRetryCount(connectRetryCount);
-            ds.setDatabaseName(RandomUtil.getIdentifier("DataBase"));
-            timerStart = System.currentTimeMillis();
-
-            try (Connection con = ds.getConnection()) {
-                assertTrue(con == null, TestResource.getResource("R_shouldNotConnect"));
-            }
-        } catch (Exception e) {
-            assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
-            long totalTime = System.currentTimeMillis() - timerStart;
-
-            // Maximum is unknown, but previously runtime was within a second of loginTimeout. Check that this is fixed.
-            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
-            System.out.println(totalTime);
-        }
-    }
 
     @Test
     @Tag(Constants.xAzureSQLDW)

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -463,13 +463,6 @@ public class SQLServerConnectionTest extends AbstractTest {
         int connectRetryInterval = 1;
         int longLoginTimeout = loginTimeOutInSeconds * 4; // 120 seconds
 
-        final ConsoleHandler handler = new ConsoleHandler();
-        handler.setLevel(Level.FINE);
-        Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc");
-        logger.addHandler(handler);
-        logger.setLevel(Level.FINEST);
-        logger.log(Level.FINE, "The Sql Server logger is correctly configured.");
-
         try {
             SQLServerDataSource ds = new SQLServerDataSource();
             ds.setURL(connectionString);
@@ -508,13 +501,6 @@ public class SQLServerConnectionTest extends AbstractTest {
         int connectRetryCount = 0;
         int connectRetryInterval = 60;
         int longLoginTimeout = loginTimeOutInSeconds * 3; // 90 seconds
-
-        final ConsoleHandler handler = new ConsoleHandler();
-        handler.setLevel(Level.FINE);
-        Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc");
-        logger.addHandler(handler);
-        logger.setLevel(Level.FINEST);
-        logger.log(Level.FINE, "The Sql Server logger is correctly configured.");
 
         try {
             SQLServerDataSource ds = new SQLServerDataSource();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -461,7 +461,7 @@ public class SQLServerConnectionTest extends AbstractTest {
 
         int connectRetryCount = 3;
         int connectRetryInterval = 1;
-        int longLoginTimeout = loginTimeOutInSeconds * 4; // 120 seconds
+        int longLoginTimeout = loginTimeOutInSeconds * 4; // 40 seconds
 
         try {
             SQLServerDataSource ds = new SQLServerDataSource();
@@ -480,12 +480,12 @@ public class SQLServerConnectionTest extends AbstractTest {
             long totalTime = System.currentTimeMillis() - timerStart;
             int expectedMinimumTimeInMillis = (connectRetryCount * connectRetryInterval) * 1000; // 3 seconds
 
-            System.out.println("TOTAL TIME: " + totalTime);
+            System.out.println("testConnectCountInLoginAndCorrectRetryCount TOTAL TIME: " + totalTime);
 
             // Minimum time is 0 seconds per attempt and connectRetryInterval * connectRetryCount seconds of interval.
             // Maximum is unknown, but is needs to be less than longLoginTimeout or else this is an issue.
             assertTrue(totalTime > expectedMinimumTimeInMillis, TestResource.getResource("R_executionNotLong"));
-            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            assertTrue(totalTime < longLoginTimeout * 1000L, TestResource.getResource("R_executionTooLong"));
 
         }
     }
@@ -500,7 +500,7 @@ public class SQLServerConnectionTest extends AbstractTest {
 
         int connectRetryCount = 0;
         int connectRetryInterval = 60;
-        int longLoginTimeout = loginTimeOutInSeconds * 3; // 90 seconds
+        int longLoginTimeout = loginTimeOutInSeconds * 3; // 30 seconds
 
         try {
             SQLServerDataSource ds = new SQLServerDataSource();
@@ -518,10 +518,10 @@ public class SQLServerConnectionTest extends AbstractTest {
             assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
             long totalTime = System.currentTimeMillis() - timerStart;
 
-            System.out.println("TOTAL TIME: " + totalTime);
+            System.out.println("testConnectCountInLoginAndCorrectRetryCountWithZeroRetry TOTAL TIME: " + totalTime);
 
             // Maximum is unknown, but is needs to be less than longLoginTimeout or else this is an issue.
-            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            assertTrue(totalTime < longLoginTimeout * 1000L, TestResource.getResource("R_executionTooLong"));
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -479,9 +479,10 @@ public class SQLServerConnectionTest extends AbstractTest {
             int expectedMinimumTimeInMillis = (connectRetryCount * connectRetryInterval) * 1000; // 3 seconds
 
             // Minimum time is 0 seconds per attempt and connectRetryInterval * connectRetryCount seconds of interval.
-            // Maximum is unknown, but will be considerably less than loginTimeout (measured here as 1/2 loginTimeout).
+            // Maximum is unknown, but previously runtime was within a second of loginTimeout. Check that this is fixed.
             assertTrue(totalTime > expectedMinimumTimeInMillis, TestResource.getResource("R_executionNotLong"));
-            assertTrue(totalTime < 0.5 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            System.out.println(totalTime);
         }
     }
 
@@ -511,8 +512,9 @@ public class SQLServerConnectionTest extends AbstractTest {
             assertTrue(e.getMessage().contains(TestResource.getResource("R_cannotOpenDatabase")), e.getMessage());
             long totalTime = System.currentTimeMillis() - timerStart;
 
-            // Maximum is unknown, but will be considerably less than loginTimeout (measured here as 1/2 loginTimeout).
-            assertTrue(totalTime < 0.5 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            // Maximum is unknown, but previously runtime was within a second of loginTimeout. Check that this is fixed.
+            assertTrue(totalTime < 0.9 * (longLoginTimeout * 1000L), TestResource.getResource("R_executionTooLong"));
+            System.out.println(totalTime);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
@@ -384,7 +384,7 @@ public class ErrorMessageTest extends FedauthCommon {
     public void testADPasswordWrongPasswordWithConnectionStringUserName() throws SQLException {
         try (Connection connection = DriverManager
                 .getConnection(connectionUrl + ";userName=" + azureUserName + ";password=WrongPassword;"
-                        + "Authentication=" + SqlAuthentication.ActiveDirectoryPassword.toString())) {
+                        + "Authentication=" + SqlAuthentication.ActiveDirectoryPassword.toString() + ";connectRetryCount=10")) {
             fail(EXPECTED_EXCEPTION_NOT_THROWN);
         } catch (Exception e) {
             if (!(e instanceof SQLServerException)) {
@@ -409,6 +409,7 @@ public class ErrorMessageTest extends FedauthCommon {
             ds.setUser(azureUserName);
             ds.setPassword("WrongPassword");
             ds.setAuthentication(SqlAuthentication.ActiveDirectoryPassword.toString());
+            ds.setConnectRetryCount(10);
 
             try (Connection connection = ds.getConnection()) {}
             fail(EXPECTED_EXCEPTION_NOT_THROWN);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -111,6 +111,7 @@ public class FedauthTest extends FedauthCommon {
         ds.setUser(azureUserName);
         ds.setPassword(azurePassword);
         ds.setAuthentication(SqlAuthentication.ActiveDirectoryPassword.toString());
+        ds.setConnectRetryCount(10);
 
         try (Connection conn = ds.getConnection()) {
             testUserName(conn, azureUserName, SqlAuthentication.ActiveDirectoryPassword);
@@ -141,7 +142,7 @@ public class FedauthTest extends FedauthCommon {
     public void testGroupAuthentication() throws SQLException {
         // connection string with userName
         String connectionUrl = TestUtils.removeProperty(TestUtils.removeProperty(adPasswordConnectionStr, "user"),
-                "password") + ";userName=" + azureGroupUserName + ";password=" + azurePassword;
+                "password") + ";userName=" + azureGroupUserName + ";password=" + azurePassword + ";connectRetryCount=10";
         try (Connection conn = DriverManager.getConnection(connectionUrl)) {
             testUserName(conn, azureGroupUserName, SqlAuthentication.ActiveDirectoryPassword);
         } catch (Exception e) {


### PR DESCRIPTION
Same as #2212, except, where that PR had to be reverted b/c of changes to retry count, retry count is not touched here. Only changes to the inner login loop are present here. This ensures compatibility with current tests.