### PR TITLE
Change name of BigDecimal computation property to `calcBigDecimalPrecision`

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
@@ -483,18 +483,18 @@ public interface ISQLServerConnection extends java.sql.Connection {
     void setAccessTokenCallbackClass(String accessTokenCallbackClass);
 
     /**
-     * Returns the current flag for calcBigDecimalScale.
+     * Returns the current flag for calcBigDecimalPrecision.
      *
-     * @return calcBigDecimalScale
-     *         Whether calculating big decimal scale from input values is enabled.
+     * @return calcBigDecimalPrecision
+     *         Whether calculating big decimal precision from input values is enabled.
      */
-    boolean getCalcBigDecimalScale();
+    boolean getCalcBigDecimalPrecision();
 
     /**
-     * Specifies whether to calculate scale from inputted big decimal values.
+     * Specifies whether to calculate precision from inputted big decimal values.
      *
-     * @param calcBigDecimalScale
-     *        A boolean that indicates if the driver should calculate scale from inputted big decimal values.
+     * @param calcBigDecimalPrecision
+     *        A boolean that indicates if the driver should calculate precision from inputted big decimal values.
      */
-    void setCalcBigDecimalScale(boolean calcBigDecimalScale);
+    void setCalcBigDecimalPrecision(boolean calcBigDecimalPrecision);
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerDataSource.java
@@ -1335,17 +1335,17 @@ public interface ISQLServerDataSource extends javax.sql.CommonDataSource {
     void setAccessTokenCallbackClass(String accessTokenCallbackClass);
 
     /**
-     * Returns value of 'calcBigDecimalScale' from Connection String.
+     * Returns value of 'calcBigDecimalPrecision' from Connection String.
      *
-     * @param calcBigDecimalScale
-     *        indicates whether the driver should attempt to calculate scale from inputted big decimal values
+     * @param calcBigDecimalPrecision
+     *        indicates whether the driver should attempt to calculate precision from inputted big decimal values
      */
-    void setCalcBigDecimalScale(boolean calcBigDecimalScale);
+    void setCalcBigDecimalPrecision(boolean calcBigDecimalPrecision);
 
     /**
-     * Sets the value for 'calcBigDecimalScale' property
+     * Sets the value for 'calcBigDecimalPrecision' property
      *
-     * @return calcBigDecimalScale boolean value
+     * @return calcBigDecimalPrecision boolean value
      */
-    boolean getCalcBigDecimalScale();
+    boolean getCalcBigDecimalPrecision();
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -592,7 +592,7 @@ final class Parameter {
                             param.typeDefinition = SSType.DECIMAL.toString() + "(" + valueLength + "," + scale + ")";
                         }
                     } else {
-                        if (con.getCalcBigDecimalScale() && dtv.getJavaType() == JavaType.BIGDECIMAL
+                        if (con.getCalcBigDecimalPrecision() && dtv.getJavaType() == JavaType.BIGDECIMAL
                                 && null != dtv.getSetterValue()) {
                             String[] plainValueArray = ((BigDecimal) dtv.getSetterValue()).abs().toPlainString()
                                     .split("\\.");

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -995,16 +995,16 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         this.ignoreOffsetOnDateTimeOffsetConversion = ignoreOffsetOnDateTimeOffsetConversion;
     }
 
-    private boolean calcBigDecimalScale = SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.getDefaultValue();
+    private boolean calcBigDecimalPrecision = SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.getDefaultValue();
 
     @Override
-    public boolean getCalcBigDecimalScale() {
-        return calcBigDecimalScale;
+    public boolean getCalcBigDecimalPrecision() {
+        return calcBigDecimalPrecision;
     }
 
     @Override
-    public void setCalcBigDecimalScale(boolean calcBigDecimalScale) {
-        this.calcBigDecimalScale = calcBigDecimalScale;
+    public void setCalcBigDecimalPrecision(boolean calcBigDecimalPrecision) {
+        this.calcBigDecimalPrecision = calcBigDecimalPrecision;
     }
 
     /** Session Recovery Object */
@@ -2193,15 +2193,15 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             IPAddressPreference.valueOfString(sPropValue).toString());
                 }
 
-                sPropKey = SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.toString();
+                sPropKey = SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);
                 if (null == sPropValue) {
                     sPropValue = Boolean
-                            .toString(SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.getDefaultValue());
+                            .toString(SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.getDefaultValue());
                     activeConnectionProperties.setProperty(sPropKey, sPropValue);
                 }
 
-                calcBigDecimalScale = isBooleanPropertyOn(sPropKey, sPropValue);
+                calcBigDecimalPrecision = isBooleanPropertyOn(sPropKey, sPropValue);
 
                 sPropKey = SQLServerDriverStringProperty.APPLICATION_NAME.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
@@ -693,23 +693,23 @@ class SQLServerConnectionPoolProxy implements ISQLServerConnection, java.io.Seri
     }
 
     /**
-     * Returns the current value for 'calcBigDecimalScale'.
+     * Returns the current value for 'calcBigDecimalPrecision'.
      *
-     * @return calcBigDecimalScale
+     * @return calcBigDecimalPrecision
      *         a boolean
      */
     @Override
-    public boolean getCalcBigDecimalScale() {
-        return wrappedConnection.getCalcBigDecimalScale();
+    public boolean getCalcBigDecimalPrecision() {
+        return wrappedConnection.getCalcBigDecimalPrecision();
     }
 
     /**
-     * Sets the current value of 'calculateBigDecimalScale' for the driver.
+     * Sets the current value of 'calculateBigDecimalPrecision' for the driver.
      *
-     * @param calcBigDecimalScale
+     * @param calcBigDecimalPrecision
      */
     @Override
-    public void setCalcBigDecimalScale(boolean calcBigDecimalScale) {
-        wrappedConnection.setCalcBigDecimalScale(calcBigDecimalScale);
+    public void setCalcBigDecimalPrecision(boolean calcBigDecimalPrecision) {
+        wrappedConnection.setCalcBigDecimalPrecision(calcBigDecimalPrecision);
     }
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -1341,26 +1341,26 @@ public class SQLServerDataSource
     }
 
     /**
-     * Sets the 'calcBigDecimalScale' setting.
+     * Sets the 'calcBigDecimalPrecision' setting.
      *
-     * @param calcBigDecimalScale
-     *        boolean property to have the driver calculate a big decimal's scale from input
+     * @param calcBigDecimalPrecision
+     *        boolean property to have the driver calculate a big decimal's precision from input
      */
     @Override
-    public void setCalcBigDecimalScale(boolean calcBigDecimalScale) {
-        setBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.toString(),
-                calcBigDecimalScale);
+    public void setCalcBigDecimalPrecision(boolean calcBigDecimalPrecision) {
+        setBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.toString(),
+                calcBigDecimalPrecision);
     }
 
     /**
-     * Returns the value for 'calcBigDecimalScale'.
+     * Returns the value for 'calcBigDecimalPrecision'.
      *
      * @return computeBigDecimal boolean value
      */
     @Override
-    public boolean getCalcBigDecimalScale() {
-        return getBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.toString(),
-                SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.getDefaultValue());
+    public boolean getCalcBigDecimalPrecision() {
+        return getBooleanProperty(connectionProps, SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.toString(),
+                SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.getDefaultValue());
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -698,7 +698,7 @@ enum SQLServerDriverBooleanProperty {
     USE_DEFAULT_JAAS_CONFIG("useDefaultJaasConfig", false),
     USE_DEFAULT_GSS_CREDENTIAL("useDefaultGSSCredential", false),
     USE_FLEXIBLE_CALLABLE_STATEMENTS("useFlexibleCallableStatements", true),
-    CALC_BIG_DECIMAL_SCALE("calcBigDecimalScale", false);
+    CALC_BIG_DECIMAL_PRECISION("calcBigDecimalPrecision", false);
 
     private final String name;
     private final boolean defaultValue;
@@ -906,8 +906,8 @@ public final class SQLServerDriver implements java.sql.Driver {
             new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.USE_DEFAULT_JAAS_CONFIG.toString(),
                     Boolean.toString(SQLServerDriverBooleanProperty.USE_DEFAULT_JAAS_CONFIG.getDefaultValue()), false,
                     TRUE_FALSE),
-            new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.toString(),
-                    Boolean.toString(SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_SCALE.getDefaultValue()), false,
+            new SQLServerDriverPropertyInfo(SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.toString(),
+                    Boolean.toString(SQLServerDriverBooleanProperty.CALC_BIG_DECIMAL_PRECISION.getDefaultValue()), false,
                     TRUE_FALSE),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.SSL_PROTOCOL.toString(),
                     SQLServerDriverStringProperty.SSL_PROTOCOL.getDefaultValue(), false,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -518,7 +518,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_unassignableError", "The class specified by the {0} property must be assignable to {1}."},
         {"R_InvalidCSVQuotes", "Failed to parse the CSV file, verify that the fields are correctly enclosed in double quotes."},
         {"R_TokenRequireUrl", "Token credentials require a URL using the HTTPS protocol scheme."},
-        {"R_calcBigDecimalScalePropertyDescription", "Indicates whether the driver should calculate scale for big decimal values."},
+        {"R_calcBigDecimalPrecisionPropertyDescription", "Indicates whether the driver should calculate precision for big decimal values."},
         {"R_maxResultBufferPropertyDescription", "Determines maximum amount of bytes that can be read during retrieval of result set"},
         {"R_maxResultBufferInvalidSyntax", "Invalid syntax: {0} in maxResultBuffer parameter."},
         {"R_maxResultBufferNegativeParameterValue", "MaxResultBuffer must have positive value: {0}."},

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -208,8 +208,8 @@ public class SQLServerConnectionTest extends AbstractTest {
         ds.setUseFlexibleCallableStatements(booleanPropValue);
         assertEquals(booleanPropValue, ds.getUseFlexibleCallableStatements(),
                 TestResource.getResource("R_valuesAreDifferent"));
-        ds.setCalcBigDecimalScale(booleanPropValue);
-        assertEquals(booleanPropValue, ds.getCalcBigDecimalScale(), TestResource.getResource("R_valuesAreDifferent"));
+        ds.setCalcBigDecimalPrecision(booleanPropValue);
+        assertEquals(booleanPropValue, ds.getCalcBigDecimalPrecision(), TestResource.getResource("R_valuesAreDifferent"));
 
         ds.setServerCertificate(stringPropValue);
         assertEquals(stringPropValue, ds.getServerCertificate(), TestResource.getResource("R_valuesAreDifferent"));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
@@ -523,8 +523,8 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
         verifiedMethodNames.add("setAccessTokenCallbackClass");
         verifiedMethodNames.add("getUseFlexibleCallableStatements");
         verifiedMethodNames.add("setUseFlexibleCallableStatements");
-        verifiedMethodNames.add("getCalcBigDecimalScale");
-        verifiedMethodNames.add("setCalcBigDecimalScale");
+        verifiedMethodNames.add("getCalcBigDecimalPrecision");
+        verifiedMethodNames.add("setCalcBigDecimalPrecision");
         return verifiedMethodNames;
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -1438,7 +1438,7 @@ public class StatementTest extends AbstractTest {
         public void testSmallBigDecimalValuesForLossOfPrecision() throws SQLException {
             try (SQLServerConnection con = getConnection();
                     Statement stmt = con.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE)) {
-                con.setCalcBigDecimalScale(true);
+                con.setCalcBigDecimalPrecision(true);
                 double bigDecimalLessThanOne = 0.1235;
                 double bigDecimalGreaterThanOne = 1.1235;
                 String query = "CREATE PROCEDURE " + procName
@@ -1471,7 +1471,7 @@ public class StatementTest extends AbstractTest {
         @Test
         public void testLongBigDecimalValuesForLossOfPrecision() throws SQLException {
             try (SQLServerConnection con = getConnection(); Statement stmt = con.createStatement()) {
-                con.setCalcBigDecimalScale(true);
+                con.setCalcBigDecimalPrecision(true);
                 stmt.executeUpdate("CREATE TABLE " + tableName + " (col1 decimal(38,38), col2 decimal(38,37))");
 
                 // col1 has maximum scale (38) with a leading zero, for a precision of 38. col2 has maximum scale (37) when
@@ -1499,7 +1499,7 @@ public class StatementTest extends AbstractTest {
         @Test
         public void testMathBigDecimalSubtraction() throws SQLException {
             try (SQLServerConnection con = getConnection(); Statement stmt = con.createStatement()) {
-                con.setCalcBigDecimalScale(true);
+                con.setCalcBigDecimalPrecision(true);
                 stmt.executeUpdate("CREATE TABLE " + tableName + " (test_column decimal(10,5))");
                 stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(99999.12345)");
                 try (PreparedStatement pstmt = con.prepareStatement("SELECT (test_column - ?), "
@@ -1539,7 +1539,7 @@ public class StatementTest extends AbstractTest {
         @Test
         public void testMathBigDecimalAddition() throws SQLException {
             try (SQLServerConnection con = getConnection(); Statement stmt = con.createStatement()) {
-                con.setCalcBigDecimalScale(true);
+                con.setCalcBigDecimalPrecision(true);
                 stmt.executeUpdate("CREATE TABLE " + tableName + " (test_column decimal(10,5))");
                 stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(99999.12345)");
                 try (PreparedStatement pstmt = con.prepareStatement("SELECT (test_column + ?), "
@@ -1579,7 +1579,7 @@ public class StatementTest extends AbstractTest {
         @Test
         public void testMathBigDecimalMultiplication() throws SQLException {
             try (SQLServerConnection con = getConnection(); Statement stmt = con.createStatement()) {
-                con.setCalcBigDecimalScale(true);
+                con.setCalcBigDecimalPrecision(true);
                 stmt.executeUpdate("CREATE TABLE " + tableName + " (test_column decimal(10,5))");
                 stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(99999.12345)");
                 try (PreparedStatement pstmt = con.prepareStatement("SELECT (test_column * ?), "
@@ -1619,7 +1619,7 @@ public class StatementTest extends AbstractTest {
         @Test
         public void testMathBigDecimalDivision() throws SQLException {
             try (SQLServerConnection con = getConnection(); Statement stmt = con.createStatement()) {
-                con.setCalcBigDecimalScale(true);
+                con.setCalcBigDecimalPrecision(true);
                 stmt.executeUpdate("CREATE TABLE " + tableName + " (test_column decimal(10,5))");
                 stmt.executeUpdate("INSERT INTO " + tableName + " VALUES(99999.12345)");
                 try (PreparedStatement pstmt = con.prepareStatement("select (test_column / ?), "


### PR DESCRIPTION
The property is inappropriately named. It calculates precision, not scale. This is name change for the property.