### PR TITLE
The getters and setters for useBulkCopyForBatchInsert is not available for SQLServerConnectionPoolProxy #2245

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
@@ -497,4 +497,18 @@ public interface ISQLServerConnection extends java.sql.Connection {
      *        A boolean that indicates if the driver should calculate precision from inputted big decimal values.
      */
     void setCalcBigDecimalPrecision(boolean calcBigDecimalPrecision);
+
+     /**
+     * Specifies the flag for using Bulk Copy API for batch insert operations.
+     * 
+     * @param useBulkCopyForBatchInsert
+     *        boolean value for useBulkCopyForBatchInsert.
+     */
+    void setUseBulkCopyForBatchInsert(boolean useBulkCopyForBatchInsert) ;
+    /**
+     * Returns the useBulkCopyForBatchInsert value.
+     * 
+     * @return flag for using Bulk Copy API for batch insert operations.
+     */
+    boolean getUseBulkCopyForBatchInsert();
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java
@@ -505,6 +505,7 @@ public interface ISQLServerConnection extends java.sql.Connection {
      *        boolean value for useBulkCopyForBatchInsert.
      */
     void setUseBulkCopyForBatchInsert(boolean useBulkCopyForBatchInsert) ;
+    
     /**
      * Returns the useBulkCopyForBatchInsert value.
      * 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -788,6 +788,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * 
      * @return flag for using Bulk Copy API for batch insert operations.
      */
+    @Override
     public boolean getUseBulkCopyForBatchInsert() {
         return useBulkCopyForBatchInsert;
     }
@@ -798,6 +799,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * @param useBulkCopyForBatchInsert
      *        boolean value for useBulkCopyForBatchInsert.
      */
+    @Override
     public void setUseBulkCopyForBatchInsert(boolean useBulkCopyForBatchInsert) {
         this.useBulkCopyForBatchInsert = useBulkCopyForBatchInsert;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionPoolProxy.java
@@ -712,4 +712,24 @@ class SQLServerConnectionPoolProxy implements ISQLServerConnection, java.io.Seri
     public void setCalcBigDecimalPrecision(boolean calcBigDecimalPrecision) {
         wrappedConnection.setCalcBigDecimalPrecision(calcBigDecimalPrecision);
     }
+    /**
+     * Returns the useBulkCopyForBatchInsert value.
+     * 
+     * @return flag for using Bulk Copy API for batch insert operations.
+     */
+    @Override
+    public boolean getUseBulkCopyForBatchInsert() {
+    		return wrappedConnection.getUseBulkCopyForBatchInsert();
+    }
+
+    /**
+     * Specifies the flag for using Bulk Copy API for batch insert operations.
+     * 
+     * @param useBulkCopyForBatchInsert
+     *        boolean value for useBulkCopyForBatchInsert.
+     */
+    @Override
+    public void setUseBulkCopyForBatchInsert(boolean useBulkCopyForBatchInsert) {
+    		wrappedConnection.setUseBulkCopyForBatchInsert(useBulkCopyForBatchInsert);
+    }
 }


### PR DESCRIPTION
Please help to review this pull request for https://github.com/microsoft/mssql-jdbc/issues/2245.
CC @tkyc 
