### PR TITLE
Execute cstmt directly - Additional testing and changes

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -2550,8 +2550,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
                     new Object[] {index, sqlType, typeName});
 
-        checkClosed();
-
         registerOutParameterByName(index, sqlType);
 
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
@@ -2569,8 +2567,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
                     new Object[] {index, sqlType, scale});
-
-        checkClosed();
 
         registerOutParameterByName(index, sqlType);
         inOutParam[index - 1].setOutScale(scale);
@@ -2591,8 +2587,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
                     new Object[] {index, sqlType, scale, precision});
-
-        checkClosed();
 
         registerOutParameterByName(index, sqlType);
         inOutParam[index - 1].setValueLength(precision);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -191,14 +191,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
     }
 
-    private void setByIndex() throws SQLServerException {
-        isSetByIndex = true;
-        if (!connection.getUseFlexibleCallableStatements() && isSetByName && isSetByIndex) {
-            SQLServerException.makeFromDriverError(connection, this,
-                    SQLServerException.getErrString("R_noNamedAndIndexedParameters"), null, false);
-        }
-    }
-
     /**
      * Locate any output parameter values returned from the procedure call
      */

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -115,6 +115,26 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public void registerOutParameter(int index, int sqlType) throws SQLServerException {
+        // Register output parameter by index
+        isSetByIndex = true;
+        if (!connection.getUseFlexibleCallableStatements() && isSetByName && isSetByIndex) {
+            SQLServerException.makeFromDriverError(connection, this,
+                    SQLServerException.getErrString("R_noNamedAndIndexedParameters"), null, false);
+        }
+        registerOutputParameter(index, sqlType);
+    }
+
+    private void registerOutParameterByName(int index, int sqlType) throws SQLServerException {
+        // Register output parameter by name -- findColumn() sets the 'setByName' flag
+        registerOutputParameter(index, sqlType);
+    }
+
+    void registerOutParameterNonPLP(int index, int sqlType) throws SQLServerException {
+        registerOutParameter(index, sqlType);
+        inOutParam[index - 1].isNonPLP = true;
+    }
+
+    private void registerOutputParameter(int index, int sqlType) throws SQLServerException {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter", new Object[] {index, sqlType});
         checkClosed();
@@ -171,9 +191,12 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
     }
 
-    void registerOutParameterNonPLP(int index, int sqlType) throws SQLServerException {
-        registerOutParameter(index, sqlType);
-        inOutParam[index - 1].isNonPLP = true;
+    private void setByIndex() throws SQLServerException {
+        isSetByIndex = true;
+        if (!connection.getUseFlexibleCallableStatements() && isSetByName && isSetByIndex) {
+            SQLServerException.makeFromDriverError(connection, this,
+                    SQLServerException.getErrString("R_noNamedAndIndexedParameters"), null, false);
+        }
     }
 
     /**
@@ -542,6 +565,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public int getInt(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getInt", index);
         checkClosed();
         Integer value = (Integer) getValue(index, JDBCType.INTEGER);
@@ -561,6 +585,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public String getString(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getString", index);
         checkClosed();
         String value = null;
@@ -588,6 +613,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public final String getNString(int parameterIndex) throws SQLException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getNString", parameterIndex);
         checkClosed();
         String value = (String) getValue(parameterIndex, JDBCType.NCHAR);
@@ -611,6 +637,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     @Deprecated(since = "6.5.4")
     @Override
     public BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getBigDecimal", new Object[] {parameterIndex, scale});
         checkClosed();
@@ -640,6 +667,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public boolean getBoolean(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getBoolean", index);
         checkClosed();
         Boolean value = (Boolean) getValue(index, JDBCType.BIT);
@@ -659,6 +687,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public byte getByte(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getByte", index);
         checkClosed();
         Short shortValue = (Short) getValue(index, JDBCType.TINYINT);
@@ -680,6 +709,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public byte[] getBytes(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getBytes", index);
         checkClosed();
         byte[] value = (byte[]) getValue(index, JDBCType.BINARY);
@@ -699,6 +729,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Date getDate(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getDate", index);
         checkClosed();
         java.sql.Date value = (java.sql.Date) getValue(index, JDBCType.DATE);
@@ -718,6 +749,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Date getDate(int index, Calendar cal) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getDate", new Object[] {index, cal});
         checkClosed();
@@ -739,6 +771,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public double getDouble(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getDouble", index);
         checkClosed();
         Double value = (Double) getValue(index, JDBCType.DOUBLE);
@@ -758,6 +791,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public float getFloat(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getFloat", index);
         checkClosed();
         Float value = (Float) getValue(index, JDBCType.REAL);
@@ -777,7 +811,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public long getLong(int index) throws SQLServerException {
-
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getLong", index);
         checkClosed();
         Long value = (Long) getValue(index, JDBCType.BIGINT);
@@ -797,7 +831,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Object getObject(int index) throws SQLServerException {
-
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getObject", index);
         checkClosed();
         Object value = getValue(index,
@@ -809,6 +843,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public <T> T getObject(int index, Class<T> type) throws SQLException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getObject", index);
         checkClosed();
         Object returnValue;
@@ -923,6 +958,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public short getShort(int index) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getShort", index);
         checkClosed();
         Short value = (Short) getValue(index, JDBCType.SMALLINT);
@@ -942,7 +978,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Time getTime(int index) throws SQLServerException {
-
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getTime", index);
         checkClosed();
         java.sql.Time value = (java.sql.Time) getValue(index, JDBCType.TIME);
@@ -962,6 +998,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Time getTime(int index, Calendar cal) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getTime", new Object[] {index, cal});
         checkClosed();
@@ -983,6 +1020,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Timestamp getTimestamp(int index) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), GET_TIMESTAMP, index);
         checkClosed();
@@ -1003,6 +1041,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Timestamp getTimestamp(int index, Calendar cal) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), GET_TIMESTAMP, new Object[] {index, cal});
         checkClosed();
@@ -1024,6 +1063,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     LocalDateTime getLocalDateTime(int columnIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getLocalDateTime", columnIndex);
         checkClosed();
         LocalDateTime value = (LocalDateTime) getValue(columnIndex, JDBCType.LOCALDATETIME);
@@ -1033,6 +1073,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Timestamp getDateTime(int index) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getDateTime", index);
         checkClosed();
@@ -1053,6 +1094,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Timestamp getDateTime(int index, Calendar cal) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getDateTime", new Object[] {index, cal});
         checkClosed();
@@ -1075,6 +1117,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Timestamp getSmallDateTime(int index) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getSmallDateTime", index);
         checkClosed();
@@ -1096,6 +1139,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Timestamp getSmallDateTime(int index, Calendar cal) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getSmallDateTime", new Object[] {index, cal});
         checkClosed();
@@ -1118,6 +1162,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public microsoft.sql.DateTimeOffset getDateTimeOffset(int index) throws SQLServerException {
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "getDateTimeOffset", index);
         checkClosed();
@@ -1163,6 +1208,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public final java.io.InputStream getAsciiStream(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getAsciiStream", parameterIndex);
         checkClosed();
         InputStream value = (InputStream) getStream(parameterIndex, StreamType.ASCII);
@@ -1182,6 +1228,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public BigDecimal getBigDecimal(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getBigDecimal", parameterIndex);
         checkClosed();
         BigDecimal value = (BigDecimal) getValue(parameterIndex, JDBCType.DECIMAL);
@@ -1201,6 +1248,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public BigDecimal getMoney(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getMoney", parameterIndex);
         checkClosed();
         BigDecimal value = (BigDecimal) getValue(parameterIndex, JDBCType.MONEY);
@@ -1220,6 +1268,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public BigDecimal getSmallMoney(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getSmallMoney", parameterIndex);
         checkClosed();
         BigDecimal value = (BigDecimal) getValue(parameterIndex, JDBCType.SMALLMONEY);
@@ -1239,6 +1288,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public final java.io.InputStream getBinaryStream(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getBinaryStream", parameterIndex);
         checkClosed();
         InputStream value = (InputStream) getStream(parameterIndex, StreamType.BINARY);
@@ -1258,6 +1308,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Blob getBlob(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getBlob", parameterIndex);
         checkClosed();
         Blob value = (Blob) getValue(parameterIndex, JDBCType.BLOB);
@@ -1277,6 +1328,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public final java.io.Reader getCharacterStream(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getCharacterStream", parameterIndex);
         checkClosed();
         Reader reader = (Reader) getStream(parameterIndex, StreamType.CHARACTER);
@@ -1296,6 +1348,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public final java.io.Reader getNCharacterStream(int parameterIndex) throws SQLException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getNCharacterStream", parameterIndex);
         checkClosed();
         Reader reader = (Reader) getStream(parameterIndex, StreamType.NCHARACTER);
@@ -1327,6 +1380,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public Clob getClob(int parameterIndex) throws SQLServerException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getClob", parameterIndex);
         checkClosed();
         Clob clob = (Clob) getValue(parameterIndex, JDBCType.CLOB);
@@ -1346,6 +1400,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public NClob getNClob(int parameterIndex) throws SQLException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getNClob", parameterIndex);
         checkClosed();
         NClob nClob = (NClob) getValue(parameterIndex, JDBCType.NCLOB);
@@ -2455,6 +2510,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
     @Override
     public final SQLXML getSQLXML(int parameterIndex) throws SQLException {
+        setByIndex();
         loggerExternal.entering(getClassNameLogging(), "getSQLXML", parameterIndex);
         checkClosed();
         SQLServerSQLXML value = (SQLServerSQLXML) getSQLXMLInternal(parameterIndex);
@@ -2495,8 +2551,17 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
                     new Object[] {parameterName, sqlType, typeName});
         checkClosed();
-        registerOutParameter(findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD), sqlType,
-                typeName);
+
+        int index = findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD);
+
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
+                    new Object[] {index, sqlType, typeName});
+
+        checkClosed();
+
+        registerOutParameterByName(index, sqlType);
+
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
     }
 
@@ -2506,8 +2571,18 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
                     new Object[] {parameterName, sqlType, scale});
         checkClosed();
-        registerOutParameter(findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD), sqlType,
-                scale);
+
+        int index = findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD);
+
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
+                    new Object[] {index, sqlType, scale});
+
+        checkClosed();
+
+        registerOutParameterByName(index, sqlType);
+        inOutParam[index - 1].setOutScale(scale);
+
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
     }
 
@@ -2518,8 +2593,19 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
                     new Object[] {parameterName, sqlType, scale});
         checkClosed();
-        registerOutParameter(findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD), sqlType,
-                precision, scale);
+
+        int index = findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD);
+
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
+                    new Object[] {index, sqlType, scale, precision});
+
+        checkClosed();
+
+        registerOutParameterByName(index, sqlType);
+        inOutParam[index - 1].setValueLength(precision);
+        inOutParam[index - 1].setOutScale(scale);
+
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
     }
 
@@ -2529,7 +2615,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
                     new Object[] {parameterName, sqlType});
         checkClosed();
-        registerOutParameter(findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD), sqlType);
+        registerOutParameterByName(findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD), sqlType);
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -2546,10 +2546,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
         int index = findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD);
 
-        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
-                    new Object[] {index, sqlType, typeName});
-
         registerOutParameterByName(index, sqlType);
 
         loggerExternal.exiting(getClassNameLogging(), "registerOutParameter");
@@ -2564,10 +2560,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
         int index = findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD);
 
-        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
-                    new Object[] {index, sqlType, scale});
-
         registerOutParameterByName(index, sqlType);
         inOutParam[index - 1].setOutScale(scale);
 
@@ -2579,14 +2571,10 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             int scale) throws SQLServerException {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
-                    new Object[] {parameterName, sqlType, scale});
+                    new Object[] {parameterName, sqlType, scale, precision});
         checkClosed();
 
         int index = findColumn(parameterName, CallableStatementGetterSetterMethod.IS_SETTER_METHOD);
-
-        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "registerOutParameter",
-                    new Object[] {index, sqlType, scale, precision});
 
         registerOutParameterByName(index, sqlType);
         inOutParam[index - 1].setValueLength(precision);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -1352,7 +1352,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setAsciiStream", new Object[] {parameterIndex, x});
         checkClosed();
@@ -1362,7 +1362,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setAsciiStream(int n, java.io.InputStream x, int length) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setAsciiStream", new Object[] {n, x, length});
         checkClosed();
@@ -1372,7 +1372,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setAsciiStream", new Object[] {parameterIndex, x, length});
         checkClosed();
@@ -1382,7 +1382,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBigDecimal", new Object[] {parameterIndex, x});
         checkClosed();
@@ -1393,7 +1393,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setBigDecimal(int parameterIndex, BigDecimal x, int precision,
             int scale) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBigDecimal",
                     new Object[] {parameterIndex, x, precision, scale});
@@ -1405,7 +1405,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setBigDecimal(int parameterIndex, BigDecimal x, int precision, int scale,
             boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBigDecimal",
                     new Object[] {parameterIndex, x, precision, scale, forceEncrypt});
@@ -1416,7 +1416,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setMoney(int n, BigDecimal x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setMoney", new Object[] {n, x});
         checkClosed();
@@ -1426,7 +1426,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setMoney(int n, BigDecimal x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setMoney", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1436,7 +1436,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setSmallMoney(int n, BigDecimal x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setSmallMoney", new Object[] {n, x});
         checkClosed();
@@ -1446,7 +1446,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setSmallMoney(int n, BigDecimal x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setSmallMoney", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1456,7 +1456,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBinaryStreaml", new Object[] {parameterIndex, x});
         checkClosed();
@@ -1466,7 +1466,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBinaryStream(int n, java.io.InputStream x, int length) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBinaryStream", new Object[] {n, x, length});
         checkClosed();
@@ -1476,7 +1476,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBinaryStream", new Object[] {parameterIndex, x, length});
         checkClosed();
@@ -1486,7 +1486,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBoolean(int n, boolean x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBoolean", new Object[] {n, x});
         checkClosed();
@@ -1496,7 +1496,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBoolean(int n, boolean x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBoolean", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1506,7 +1506,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setByte(int n, byte x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setByte", new Object[] {n, x});
         checkClosed();
@@ -1516,7 +1516,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setByte(int n, byte x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setByte", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1526,7 +1526,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBytes(int n, byte[] x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBytes", new Object[] {n, x});
         checkClosed();
@@ -1536,7 +1536,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBytes(int n, byte[] x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBytes", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1546,7 +1546,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setUniqueIdentifier(int index, String guid) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setUniqueIdentifier", new Object[] {index, guid});
         checkClosed();
@@ -1556,7 +1556,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setUniqueIdentifier(int index, String guid, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setUniqueIdentifier",
                     new Object[] {index, guid, forceEncrypt});
@@ -1567,7 +1567,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDouble(int n, double x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDouble", new Object[] {n, x});
         checkClosed();
@@ -1577,7 +1577,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDouble(int n, double x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDouble", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1587,7 +1587,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setFloat(int n, float x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setFloat", new Object[] {n, x});
         checkClosed();
@@ -1597,7 +1597,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setFloat(int n, float x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setFloat", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1607,7 +1607,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setGeometry(int n, Geometry x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setGeometry", new Object[] {n, x});
         checkClosed();
@@ -1617,7 +1617,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setGeography(int n, Geography x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setGeography", new Object[] {n, x});
         checkClosed();
@@ -1627,7 +1627,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setInt(int n, int value) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setInt", new Object[] {n, value});
         checkClosed();
@@ -1637,7 +1637,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setInt(int n, int value, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setInt", new Object[] {n, value, forceEncrypt});
         checkClosed();
@@ -1647,7 +1647,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setLong(int n, long x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setLong", new Object[] {n, x});
         checkClosed();
@@ -1657,7 +1657,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setLong(int n, long x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setLong", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -1667,7 +1667,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNull(int index, int jdbcType) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNull", new Object[] {index, jdbcType});
         checkClosed();
@@ -1713,7 +1713,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setObject(int index, Object obj) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setObject", new Object[] {index, obj});
         checkClosed();
@@ -1723,7 +1723,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setObject(int n, Object obj, int jdbcType) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         String tvpName = null;
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setObject", new Object[] {n, obj, jdbcType});
@@ -1738,7 +1738,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setObject(int parameterIndex, Object x, int targetSqlType,
             int scaleOrLength) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setObject",
                     new Object[] {parameterIndex, x, targetSqlType, scaleOrLength});
@@ -1762,7 +1762,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setObject(int parameterIndex, Object x, int targetSqlType, Integer precision,
             int scale) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setObject",
                     new Object[] {parameterIndex, x, targetSqlType, precision, scale});
@@ -1784,7 +1784,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setObject(int parameterIndex, Object x, int targetSqlType, Integer precision, int scale,
             boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setObject",
                     new Object[] {parameterIndex, x, targetSqlType, precision, scale, forceEncrypt});
@@ -1882,7 +1882,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setShort(int index, short x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setShort", new Object[] {index, x});
         checkClosed();
@@ -1892,7 +1892,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setShort(int index, short x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setShort", new Object[] {index, x, forceEncrypt});
         checkClosed();
@@ -1902,7 +1902,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setString(int index, String str) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setString", new Object[] {index, str});
         checkClosed();
@@ -1912,7 +1912,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setString(int index, String str, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setString", new Object[] {index, str, forceEncrypt});
         checkClosed();
@@ -1922,7 +1922,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNString(int parameterIndex, String value) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNString", new Object[] {parameterIndex, value});
         checkClosed();
@@ -1932,7 +1932,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNString(int parameterIndex, String value, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNString",
                     new Object[] {parameterIndex, value, forceEncrypt});
@@ -1943,7 +1943,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setTime(int n, java.sql.Time x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTime", new Object[] {n, x});
         checkClosed();
@@ -1953,7 +1953,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setTime(int n, java.sql.Time x, int scale) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTime", new Object[] {n, x, scale});
         checkClosed();
@@ -1963,7 +1963,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setTime(int n, java.sql.Time x, int scale, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTime", new Object[] {n, x, scale, forceEncrypt});
         checkClosed();
@@ -1973,7 +1973,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setTimestamp(int n, java.sql.Timestamp x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTimestamp", new Object[] {n, x});
         checkClosed();
@@ -1983,7 +1983,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setTimestamp(int n, java.sql.Timestamp x, int scale) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTimestamp", new Object[] {n, x, scale});
         checkClosed();
@@ -1994,7 +1994,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setTimestamp(int n, java.sql.Timestamp x, int scale,
             boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTimestamp", new Object[] {n, x, scale, forceEncrypt});
         checkClosed();
@@ -2004,7 +2004,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDateTimeOffset(int n, microsoft.sql.DateTimeOffset x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDateTimeOffset", new Object[] {n, x});
         checkClosed();
@@ -2014,7 +2014,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDateTimeOffset(int n, microsoft.sql.DateTimeOffset x, int scale) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDateTimeOffset", new Object[] {n, x, scale});
         checkClosed();
@@ -2025,7 +2025,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setDateTimeOffset(int n, microsoft.sql.DateTimeOffset x, int scale,
             boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDateTimeOffset",
                     new Object[] {n, x, scale, forceEncrypt});
@@ -2036,7 +2036,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDate(int n, java.sql.Date x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDate", new Object[] {n, x});
         checkClosed();
@@ -2046,7 +2046,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDateTime(int n, java.sql.Timestamp x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDateTime", new Object[] {n, x});
         checkClosed();
@@ -2056,7 +2056,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDateTime(int n, java.sql.Timestamp x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDateTime", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -2066,7 +2066,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setSmallDateTime(int n, java.sql.Timestamp x) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setSmallDateTime", new Object[] {n, x});
         checkClosed();
@@ -2076,7 +2076,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setSmallDateTime(int n, java.sql.Timestamp x, boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setSmallDateTime", new Object[] {n, x, forceEncrypt});
         checkClosed();
@@ -2086,7 +2086,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setStructured(int n, String tvpName, SQLServerDataTable tvpDataTable) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         tvpName = getTVPNameIfNull(n, tvpName);
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setStructured", new Object[] {n, tvpName, tvpDataTable});
@@ -2097,7 +2097,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setStructured(int n, String tvpName, ResultSet tvpResultSet) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         tvpName = getTVPNameIfNull(n, tvpName);
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setStructured", new Object[] {n, tvpName, tvpResultSet});
@@ -2109,7 +2109,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setStructured(int n, String tvpName,
             ISQLServerDataRecord tvpBulkRecord) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         tvpName = getTVPNameIfNull(n, tvpName);
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setStructured", new Object[] {n, tvpName, tvpBulkRecord});
@@ -2938,6 +2938,14 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         return true;
     }
 
+    private void setByIndex() throws SQLServerException {
+        isSetByIndex = true;
+        if (!connection.getUseFlexibleCallableStatements() && isSetByName && isSetByIndex) {
+            SQLServerException.makeFromDriverError(connection, this,
+                    SQLServerException.getErrString("R_noNamedAndIndexedParameters"), null, false);
+        }
+    }
+
     /**
      * Prepare statement batch execute command
      */
@@ -3216,7 +3224,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setCharacterStream", new Object[] {parameterIndex, reader});
         checkClosed();
@@ -3226,7 +3234,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setCharacterStream(int n, java.io.Reader reader, int length) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setCharacterStream", new Object[] {n, reader, length});
         checkClosed();
@@ -3236,7 +3244,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setCharacterStream",
                     new Object[] {parameterIndex, reader, length});
@@ -3247,7 +3255,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNCharacterStream", new Object[] {parameterIndex, value});
         checkClosed();
@@ -3257,7 +3265,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNCharacterStream",
                     new Object[] {parameterIndex, value, length});
@@ -3273,7 +3281,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBlob(int i, java.sql.Blob x) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob", new Object[] {i, x});
         checkClosed();
@@ -3283,7 +3291,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob", new Object[] {parameterIndex, inputStream});
         checkClosed();
@@ -3294,7 +3302,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setBlob",
                     new Object[] {parameterIndex, inputStream, length});
@@ -3305,7 +3313,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setClob(int parameterIndex, java.sql.Clob clobValue) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterIndex, clobValue});
         checkClosed();
@@ -3315,7 +3323,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setClob(int parameterIndex, Reader reader) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterIndex, reader});
         checkClosed();
@@ -3325,7 +3333,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setClob", new Object[] {parameterIndex, reader, length});
         checkClosed();
@@ -3335,7 +3343,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNClob(int parameterIndex, NClob value) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterIndex, value});
         checkClosed();
@@ -3345,7 +3353,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNClob(int parameterIndex, Reader reader) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterIndex, reader});
         checkClosed();
@@ -3355,7 +3363,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNClob", new Object[] {parameterIndex, reader, length});
         checkClosed();
@@ -3370,7 +3378,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setDate(int n, java.sql.Date x, java.util.Calendar cal) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDate", new Object[] {n, x, cal});
         checkClosed();
@@ -3381,7 +3389,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setDate(int n, java.sql.Date x, java.util.Calendar cal,
             boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDate", new Object[] {n, x, cal, forceEncrypt});
         checkClosed();
@@ -3391,7 +3399,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setTime(int n, java.sql.Time x, java.util.Calendar cal) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTime", new Object[] {n, x, cal});
         checkClosed();
@@ -3402,7 +3410,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setTime(int n, java.sql.Time x, java.util.Calendar cal,
             boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTime", new Object[] {n, x, cal, forceEncrypt});
         checkClosed();
@@ -3412,7 +3420,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setTimestamp(int n, java.sql.Timestamp x, java.util.Calendar cal) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTimestamp", new Object[] {n, x, cal});
         checkClosed();
@@ -3423,7 +3431,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     @Override
     public final void setTimestamp(int n, java.sql.Timestamp x, java.util.Calendar cal,
             boolean forceEncrypt) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setTimestamp", new Object[] {n, x, cal, forceEncrypt});
         checkClosed();
@@ -3433,7 +3441,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setNull(int paramIndex, int sqlType, String typeName) throws SQLServerException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setNull", new Object[] {paramIndex, sqlType, typeName});
         checkClosed();
@@ -3483,7 +3491,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     @Override
     public final void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
-        isSetByIndex = true;
+        setByIndex();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setSQLXML", new Object[] {parameterIndex, xmlObject});
         checkClosed();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2938,14 +2938,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         return true;
     }
 
-    private void setByIndex() throws SQLServerException {
-        isSetByIndex = true;
-        if (!connection.getUseFlexibleCallableStatements() && isSetByName && isSetByIndex) {
-            SQLServerException.makeFromDriverError(connection, this,
-                    SQLServerException.getErrString("R_noNamedAndIndexedParameters"), null, false);
-        }
-    }
-
     /**
      * Prepare statement batch execute command
      */

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -144,7 +144,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_stringNotInHex", "The string is not in a valid hex format."},
         {"R_unknownType", "The Java type {0} is not a supported type."},
         {"R_physicalConnectionIsClosed", "The physical connection is closed for this pooled connection."},
-        {"R_noNamedAndIndexedParameters", "Detected uncompliant use of both named and indexed parameters while 'useFlexibleCallableStatements=false'. It is suggested to either exclusively use named parameters or indexed parameters."},
+        {"R_noNamedAndIndexedParameters", "Cannot specify both named and indexed parameters when 'useFlexibleCallableStatements=false'"},
         {"R_unknownOutputParameter", "Cannot acquire output parameter value by name. No parameter index was associated with the output parameter name. If acquiring output parameter by name, verify that the output parameter was initially registered by name."},
         {"R_invalidDataSourceReference", "Invalid DataSource reference."},
         {"R_cantGetColumnValueFromDeletedRow", "Cannot get a value from a deleted row."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -1136,6 +1136,14 @@ public class SQLServerStatement implements ISQLServerStatement {
         }
     }
 
+    void setByIndex() throws SQLServerException {
+        isSetByIndex = true;
+        if (!connection.getUseFlexibleCallableStatements() && isSetByName && isSetByIndex) {
+            SQLServerException.makeFromDriverError(connection, this,
+                    SQLServerException.getErrString("R_noNamedAndIndexedParameters"), null, false);
+        }
+    }
+
     /* ---------------- JDBC API methods ------------------ */
 
     @Override

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -57,7 +57,7 @@ public final class TestResource extends ListResourceBundle {
             {"R_grantFailed", "grant table with preparedStatement failed!"},
             {"R_connectionIsClosed", "The connection is closed."},
             {"R_noNamedAndIndexedParameters",
-                    "Detected uncompliant use of both named and indexed parameters while 'useFlexibleCallableStatements=false'. It is suggested to either exclusively use named parameters or indexed parameters."},
+                    "Cannot specify both named and indexed parameters when 'useFlexibleCallableStatements=false'"},
             {"R_unknownOutputParameter",
                     "Cannot acquire output parameter value by name. No parameter index was associated with the output parameter name. If acquiring output parameter by name, verify that the output parameter was initially registered by name."},
             {"R_ConnectionURLNull", "The connection URL is null."},

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -399,7 +399,7 @@ public class CallableStatementTest extends AbstractTest {
     }
 
     @Test
-    public void testNonOrderedRegisteringAndSettingOfParams() throws SQLException {
+    public void testNonOrderedRegisteringAndSettingOfIndexedAndNamedParams() throws SQLException {
         String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
 
         try (CallableStatement cstmt = connection.prepareCall(call)) {
@@ -410,12 +410,14 @@ public class CallableStatementTest extends AbstractTest {
             Float obj4 = 2015.04f;
             Integer obj5 = 3;
             String obj6 = "foo";
-            String obj7 = "bar";
+            String obj7 = "b";
             Long obj8 = 2015L;
 
+            // Set & register parameters using a mix of index and named parameters in a random
+            // non-consecutive order. When useFlexibleCallableStatements=true (the default), this should pass.
             cstmt.setObject("i5", obj5, Types.CHAR);
             cstmt.setObject("i6", obj6, Types.VARCHAR);
-            cstmt.setObject("i7", obj7, Types.CHAR);
+            cstmt.setObject(7, obj7, Types.CHAR);
             cstmt.setObject("i8", obj8, Types.SMALLINT);
 
             cstmt.setObject(1, obj1, Types.NUMERIC);
@@ -423,26 +425,327 @@ public class CallableStatementTest extends AbstractTest {
             cstmt.setObject(3, obj3, Types.INTEGER);
             cstmt.setObject(4, obj4, Types.FLOAT);
 
-            cstmt.registerOutParameter(9, Types.NUMERIC);
-            cstmt.registerOutParameter("o2", Types.NUMERIC, scale);
-            cstmt.registerOutParameter("o3", Types.INTEGER);
-            cstmt.registerOutParameter("o4", Types.FLOAT);
-
             cstmt.registerOutParameter(13, Types.CHAR);
-            cstmt.registerOutParameter(14, Types.VARCHAR);
+            cstmt.registerOutParameter("o6", Types.VARCHAR);
             cstmt.registerOutParameter(15, Types.CHAR);
             cstmt.registerOutParameter(16, Types.SMALLINT);
+
+            cstmt.registerOutParameter(9, Types.NUMERIC);
+            cstmt.registerOutParameter("o2", Types.NUMERIC, scale);
+            cstmt.registerOutParameter(11, Types.INTEGER);
+            cstmt.registerOutParameter("o4", Types.FLOAT);
+
             cstmt.execute();
+
+            // When useFlexibleCallableStatements=true (the default), getting the output parameters by either
+            // index or named should succeed.
+            assertEquals(obj1, cstmt.getDouble("o1"));
+            assertEquals(obj2, cstmt.getDouble("o2"));
+            assertEquals(obj3, cstmt.getInt("o3"));
+            assertEquals(obj4, cstmt.getFloat("o4"));
+            assertEquals(obj5, cstmt.getInt("o5"));
+            assertEquals(obj6, cstmt.getString("o6"));
+            assertEquals(obj7, cstmt.getString("o7"));
+            assertEquals(obj8, cstmt.getLong("o8"));
+
+            assertEquals(obj1, cstmt.getDouble(9));
+            assertEquals(obj2, cstmt.getDouble(10));
+            assertEquals(obj3, cstmt.getInt(11));
+            assertEquals(obj4, cstmt.getFloat(12));
+            assertEquals(obj5, cstmt.getInt(13));
+            assertEquals(obj6, cstmt.getString(14));
+            assertEquals(obj7, cstmt.getString(15));
+            assertEquals(obj8, cstmt.getLong(16));
         }
     }
 
     @Test
-    public void testNamedParametersUseFlexibleCallableStatementFalse() throws SQLException {
+    public void useFlexibleCallableStatementFalseIndexedParameters() throws SQLException {
         String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
         String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
                 "useFlexibleCallableStatements", "false");
 
-        // useFlexibleCallableStatement=false and using all named parameters
+        // When useFlexibleCallableStatement=false and when using only indexed parameters, cstmt should succeed.
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            try (CallableStatement cstmt = conn.prepareCall(call)) {
+                int scale = 6;
+                double obj1 = 2015.0123;
+                double obj2 = 2015.012345;
+                int obj3 = -3;
+                float obj4 = 2015.04f;
+                int obj5 = 3;
+                String obj6 = "foo";
+                String obj7 = "b";
+                long obj8 = 2015L;
+
+                cstmt.setObject(1, obj1, Types.NUMERIC);
+                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
+                cstmt.setObject(3, obj3, Types.INTEGER);
+                cstmt.setObject(4, obj4, Types.FLOAT);
+
+                cstmt.setObject(5, obj5, Types.CHAR);
+                cstmt.setObject(6, obj6, Types.VARCHAR);
+                cstmt.setObject(7, obj7, Types.CHAR);
+                cstmt.setObject(8, obj8, Types.SMALLINT);
+
+                cstmt.registerOutParameter(9, Types.NUMERIC);
+                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
+                cstmt.registerOutParameter(11, Types.INTEGER);
+                cstmt.registerOutParameter(12, Types.FLOAT);
+
+                cstmt.registerOutParameter(13, Types.CHAR);
+                cstmt.registerOutParameter(14, Types.VARCHAR);
+                cstmt.registerOutParameter(15, Types.CHAR);
+                cstmt.registerOutParameter(16, Types.SMALLINT);
+                cstmt.execute();
+
+                assertEquals(obj1, cstmt.getDouble(9));
+                assertEquals(obj2, cstmt.getDouble(10));
+                assertEquals(obj3, cstmt.getInt(11));
+                assertEquals(obj4, cstmt.getFloat(12));
+                assertEquals(obj5, cstmt.getInt(13));
+                assertEquals(obj6, cstmt.getString(14));
+                assertEquals(obj7, cstmt.getString(15));
+                assertEquals(obj8, cstmt.getLong(16));
+            }
+        }
+    }
+
+    @Test
+    public void useFlexibleCallableStatementFalseIndexedParametersRandomOrder() throws SQLException {
+        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
+        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
+                "useFlexibleCallableStatements", "false");
+
+        // When useFlexibleCallableStatement=false and when using only indexed parameters in a random order,
+        // cstmt should succeed.
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            try (CallableStatement cstmt = conn.prepareCall(call)) {
+                int scale = 6;
+                double obj1 = 2015.0123;
+                double obj2 = 2015.012345;
+                int obj3 = -3;
+                float obj4 = 2015.04f;
+                int obj5 = 3;
+                String obj6 = "foo";
+                String obj7 = "b";
+                long obj8 = 2015L;
+
+                cstmt.setObject(5, obj5, Types.CHAR);
+                cstmt.setObject(6, obj6, Types.VARCHAR);
+                cstmt.setObject(7, obj7, Types.CHAR);
+                cstmt.setObject(8, obj8, Types.SMALLINT);
+
+                cstmt.setObject(1, obj1, Types.NUMERIC);
+                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
+                cstmt.setObject(3, obj3, Types.INTEGER);
+                cstmt.setObject(4, obj4, Types.FLOAT);
+
+                cstmt.registerOutParameter(13, Types.CHAR);
+                cstmt.registerOutParameter(14, Types.VARCHAR);
+                cstmt.registerOutParameter(15, Types.CHAR);
+                cstmt.registerOutParameter(16, Types.SMALLINT);
+
+                cstmt.registerOutParameter(9, Types.NUMERIC);
+                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
+                cstmt.registerOutParameter(11, Types.INTEGER);
+                cstmt.registerOutParameter(12, Types.FLOAT);
+
+                cstmt.execute();
+
+                assertEquals(obj1, cstmt.getDouble(9));
+                assertEquals(obj2, cstmt.getDouble(10));
+                assertEquals(obj3, cstmt.getInt(11));
+                assertEquals(obj4, cstmt.getFloat(12));
+                assertEquals(obj5, cstmt.getInt(13));
+                assertEquals(obj6, cstmt.getString(14));
+                assertEquals(obj7, cstmt.getString(15));
+                assertEquals(obj8, cstmt.getLong(16));
+            }
+        }
+    }
+
+    @Test
+    public void useFlexibleCallableStatementFalseMainlyIndexedParametersWithSettingSingleNamedParam() {
+        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
+        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
+                "useFlexibleCallableStatements", "false");
+
+        // When useFlexibleCallableStatement=false and when mainly using only indexed parameters, setting
+        // an input parameter by name will cause the cstmt to fail.
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            try (CallableStatement cstmt = conn.prepareCall(call)) {
+                int scale = 6;
+                double obj1 = 2015.0123;
+                double obj2 = 2015.012345;
+                int obj3 = -3;
+                float obj4 = 2015.04f;
+                int obj5 = 3;
+                String obj6 = "foo";
+                String obj7 = "b";
+                long obj8 = 2015L;
+
+                cstmt.setObject(1, obj1, Types.NUMERIC);
+                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
+                cstmt.setObject(3, obj3, Types.INTEGER);
+                cstmt.setObject(4, obj4, Types.FLOAT);
+
+                cstmt.setObject(5, obj5, Types.CHAR);
+                cstmt.setObject(6, obj6, Types.VARCHAR);
+                cstmt.setObject(7, obj7, Types.CHAR);
+                cstmt.setObject("i8", obj8, Types.SMALLINT);
+
+                cstmt.registerOutParameter(9, Types.NUMERIC);
+                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
+                cstmt.registerOutParameter(11, Types.INTEGER);
+                cstmt.registerOutParameter(12, Types.FLOAT);
+
+                cstmt.registerOutParameter(13, Types.CHAR);
+                cstmt.registerOutParameter(14, Types.VARCHAR);
+                cstmt.registerOutParameter(15, Types.CHAR);
+                cstmt.registerOutParameter(16, Types.SMALLINT);
+
+                cstmt.execute();
+
+                assertEquals(obj1, cstmt.getDouble(9));
+                assertEquals(obj2, cstmt.getDouble(10));
+                assertEquals(obj3, cstmt.getInt(11));
+                assertEquals(obj4, cstmt.getFloat(12));
+                assertEquals(obj5, cstmt.getInt(13));
+                assertEquals(obj6, cstmt.getString(14));
+                assertEquals(obj7, cstmt.getString(15));
+                assertEquals(obj8, cstmt.getLong(16));
+
+                fail(TestResource.getResource("R_expectedFailPassed"));
+            }
+        } catch (Exception e) {
+            assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
+        }
+    }
+
+    @Test
+    public void useFlexibleCallableStatementFalseMainlyIndexedParametersWithRegisteringSingleNamedOutputParam() {
+        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
+        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
+                "useFlexibleCallableStatements", "false");
+
+        // When useFlexibleCallableStatement=false and when mainly using only indexed parameters, registering
+        // an output parameter by name will cause the cstmt to fail.
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            try (CallableStatement cstmt = conn.prepareCall(call)) {
+                int scale = 6;
+                double obj1 = 2015.0123;
+                double obj2 = 2015.012345;
+                int obj3 = -3;
+                float obj4 = 2015.04f;
+                int obj5 = 3;
+                String obj6 = "foo";
+                String obj7 = "b";
+                long obj8 = 2015L;
+
+                cstmt.setObject(1, obj1, Types.NUMERIC);
+                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
+                cstmt.setObject(3, obj3, Types.INTEGER);
+                cstmt.setObject(4, obj4, Types.FLOAT);
+
+                cstmt.setObject(5, obj5, Types.CHAR);
+                cstmt.setObject(6, obj6, Types.VARCHAR);
+                cstmt.setObject(7, obj7, Types.CHAR);
+                cstmt.setObject(8, obj8, Types.SMALLINT);
+
+                cstmt.registerOutParameter(9, Types.NUMERIC);
+                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
+                cstmt.registerOutParameter(11, Types.INTEGER);
+                cstmt.registerOutParameter(12, Types.FLOAT);
+
+                cstmt.registerOutParameter(13, Types.CHAR);
+                cstmt.registerOutParameter(14, Types.VARCHAR);
+                cstmt.registerOutParameter(15, Types.CHAR);
+                cstmt.registerOutParameter("o8", Types.SMALLINT);
+
+                cstmt.execute();
+
+                assertEquals(obj1, cstmt.getDouble(9));
+                assertEquals(obj2, cstmt.getDouble(10));
+                assertEquals(obj3, cstmt.getInt(11));
+                assertEquals(obj4, cstmt.getFloat(12));
+                assertEquals(obj5, cstmt.getInt(13));
+                assertEquals(obj6, cstmt.getString(14));
+                assertEquals(obj7, cstmt.getString(15));
+                assertEquals(obj8, cstmt.getLong(16));
+
+                fail(TestResource.getResource("R_expectedFailPassed"));
+            }
+        } catch (Exception e) {
+            assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
+        }
+    }
+
+    @Test
+    public void useFlexibleCallableStatementFalseMainlyIndexedParametersWithGettingOutputParamByName() {
+        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
+        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
+                "useFlexibleCallableStatements", "false");
+
+        // When useFlexibleCallableStatement=false and when mainly using only indexed parameters, getting
+        // an output parameter by name will cause the cstmt to fail.
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            try (CallableStatement cstmt = conn.prepareCall(call)) {
+                int scale = 6;
+                double obj1 = 2015.0123;
+                double obj2 = 2015.012345;
+                int obj3 = -3;
+                float obj4 = 2015.04f;
+                int obj5 = 3;
+                String obj6 = "foo";
+                String obj7 = "b";
+                long obj8 = 2015L;
+
+                cstmt.setObject(1, obj1, Types.NUMERIC);
+                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
+                cstmt.setObject(3, obj3, Types.INTEGER);
+                cstmt.setObject(4, obj4, Types.FLOAT);
+
+                cstmt.setObject(5, obj5, Types.CHAR);
+                cstmt.setObject(6, obj6, Types.VARCHAR);
+                cstmt.setObject(7, obj7, Types.CHAR);
+                cstmt.setObject(8, obj8, Types.SMALLINT);
+
+                cstmt.registerOutParameter(9, Types.NUMERIC);
+                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
+                cstmt.registerOutParameter(11, Types.INTEGER);
+                cstmt.registerOutParameter(12, Types.FLOAT);
+
+                cstmt.registerOutParameter(13, Types.CHAR);
+                cstmt.registerOutParameter(14, Types.VARCHAR);
+                cstmt.registerOutParameter(15, Types.CHAR);
+                cstmt.registerOutParameter(16, Types.SMALLINT);
+
+                cstmt.execute();
+
+                assertEquals(obj1, cstmt.getDouble(9));
+                assertEquals(obj2, cstmt.getDouble(10));
+                assertEquals(obj3, cstmt.getInt(11));
+                assertEquals(obj4, cstmt.getFloat(12));
+                assertEquals(obj5, cstmt.getInt(13));
+                assertEquals(obj6, cstmt.getString(14));
+                assertEquals(obj7, cstmt.getString(15));
+                assertEquals(obj8, cstmt.getLong("o8"));
+
+                fail(TestResource.getResource("R_expectedFailPassed"));
+            }
+        } catch (Exception e) {
+            assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
+        }
+    }
+
+    @Test
+    public void useFlexibleCallableStatementFalseNamedParameters() throws SQLException {
+        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
+        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
+                "useFlexibleCallableStatements", "false");
+
+        // When useFlexibleCallableStatement=false and when using only named parameters, cstmt should succeed.
         try (Connection conn = DriverManager.getConnection(connectionString)) {
             try (CallableStatement cstmt = conn.prepareCall(call)) {
                 int scale = 6;
@@ -489,15 +792,13 @@ public class CallableStatementTest extends AbstractTest {
     }
 
     @Test
-    public void testNamedParametersAcquireOutputParamValuesByIndexUseFlexibleCallableStatementFalse() throws SQLException {
+    public void useFlexibleCallableStatementFalseNamedParametersRandomOrder() throws SQLException {
         String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
         String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
                 "useFlexibleCallableStatements", "false");
 
-        // useFlexibleCallableStatement=false
-        // Setting parameters by name
-        // Registering output parameters by name
-        // Acquiring output parameter values by index
+        // When useFlexibleCallableStatement=false and when using only named parameters in a random order,
+        // cstmt should succeed.
         try (Connection conn = DriverManager.getConnection(connectionString)) {
             try (CallableStatement cstmt = conn.prepareCall(call)) {
                 int scale = 6;
@@ -510,161 +811,48 @@ public class CallableStatementTest extends AbstractTest {
                 String obj7 = "b";
                 long obj8 = 2015L;
 
+                cstmt.setObject("i5", obj5, Types.CHAR);
+                cstmt.setObject("i6", obj6, Types.VARCHAR);
+                cstmt.setObject("i7", obj7, Types.CHAR);
+                cstmt.setObject("i8", obj8, Types.SMALLINT);
+
                 cstmt.setObject("i1", obj1, Types.NUMERIC);
                 cstmt.setObject("i2", obj2, Types.NUMERIC, scale);
                 cstmt.setObject("i3", obj3, Types.INTEGER);
                 cstmt.setObject("i4", obj4, Types.FLOAT);
 
-                cstmt.setObject("i5", obj5, Types.CHAR);
-                cstmt.setObject("i6", obj6, Types.VARCHAR);
-                cstmt.setObject("i7", obj7, Types.CHAR);
-                cstmt.setObject("i8", obj8, Types.SMALLINT);
+                cstmt.registerOutParameter("o5", Types.CHAR);
+                cstmt.registerOutParameter("o6", Types.VARCHAR);
+                cstmt.registerOutParameter("o7", Types.CHAR);
+                cstmt.registerOutParameter("o8", Types.SMALLINT);
 
                 cstmt.registerOutParameter("o1", Types.NUMERIC);
                 cstmt.registerOutParameter("o2", Types.NUMERIC, scale);
                 cstmt.registerOutParameter("o3", Types.INTEGER);
                 cstmt.registerOutParameter("o4", Types.FLOAT);
 
-                cstmt.registerOutParameter("o5", Types.CHAR);
-                cstmt.registerOutParameter("o6", Types.VARCHAR);
-                cstmt.registerOutParameter("o7", Types.CHAR);
-                cstmt.registerOutParameter("o8", Types.SMALLINT);
-                cstmt.execute();
-
-                assertEquals(obj1, cstmt.getDouble(9));
-                assertEquals(obj2, cstmt.getDouble(10));
-                assertEquals(obj3, cstmt.getInt(11));
-                assertEquals(obj4, cstmt.getFloat(12));
-                assertEquals(obj5, cstmt.getInt(13));
-                assertEquals(obj6, cstmt.getString(14));
-                assertEquals(obj7, cstmt.getString(15));
-                assertEquals(obj8, cstmt.getLong(16));
-            }
-        }
-    }
-
-    @Test
-    public void testNamedParametersAndOutParamByIndexUseFlexibleCallableStatementFalse() throws SQLException {
-        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
-        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
-                "useFlexibleCallableStatements", "false");
-
-        // useFlexibleCallableStatement=false
-        // Setting parameters by name
-        // Registering output params by index
-        // Acquiring output param values by index
-        try (Connection conn = DriverManager.getConnection(connectionString)) {
-            try (CallableStatement cstmt = conn.prepareCall(call)) {
-                int scale = 6;
-                double obj1 = 2015.0123;
-                double obj2 = 2015.012345;
-                int obj3 = -3;
-                float obj4 = 2015.04f;
-                int obj5 = 3;
-                String obj6 = "foo";
-                String obj7 = "b";
-                long obj8 = 2015L;
-
-                cstmt.setObject("i1", obj1, Types.NUMERIC);
-                cstmt.setObject("i2", obj2, Types.NUMERIC, scale);
-                cstmt.setObject("i3", obj3, Types.INTEGER);
-                cstmt.setObject("i4", obj4, Types.FLOAT);
-
-                cstmt.setObject("i5", obj5, Types.CHAR);
-                cstmt.setObject("i6", obj6, Types.VARCHAR);
-                cstmt.setObject("i7", obj7, Types.CHAR);
-                cstmt.setObject("i8", obj8, Types.SMALLINT);
-
-                cstmt.registerOutParameter(9, Types.NUMERIC);
-                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
-                cstmt.registerOutParameter(11, Types.INTEGER);
-                cstmt.registerOutParameter(12, Types.FLOAT);
-
-                cstmt.registerOutParameter(13, Types.CHAR);
-                cstmt.registerOutParameter(14, Types.VARCHAR);
-                cstmt.registerOutParameter(15, Types.CHAR);
-                cstmt.registerOutParameter(16, Types.SMALLINT);
-                cstmt.execute();
-
-                assertEquals(obj1, cstmt.getDouble(9));
-                assertEquals(obj2, cstmt.getDouble(10));
-                assertEquals(obj3, cstmt.getInt(11));
-                assertEquals(obj4, cstmt.getFloat(12));
-                assertEquals(obj5, cstmt.getInt(13));
-                assertEquals(obj6, cstmt.getString(14));
-                assertEquals(obj7, cstmt.getString(15));
-                assertEquals(obj8, cstmt.getLong(16));
-            }
-        }
-    }
-
-    @Test
-    public void testNamedParameterOutputParameterErrorFlexibleCallableStatementFalse() throws SQLException {
-        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
-        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
-                "useFlexibleCallableStatements", "false");
-
-        // useFlexibleCallableStatement=false
-        // Setting parameters by name
-        // Registering output params by index
-        // Acquiring output param value 'o1' by name
-        try (Connection conn = DriverManager.getConnection(connectionString)) {
-            try (CallableStatement cstmt = conn.prepareCall(call)) {
-                int scale = 6;
-                double obj1 = 2015.0123;
-                double obj2 = 2015.012345;
-                int obj3 = -3;
-                float obj4 = 2015.04f;
-                int obj5 = 3;
-                String obj6 = "foo";
-                String obj7 = "b";
-                long obj8 = 2015L;
-
-                cstmt.setObject("i1", obj1, Types.NUMERIC);
-                cstmt.setObject("i2", obj2, Types.NUMERIC, scale);
-                cstmt.setObject("i3", obj3, Types.INTEGER);
-                cstmt.setObject("i4", obj4, Types.FLOAT);
-
-                cstmt.setObject("i5", obj5, Types.CHAR);
-                cstmt.setObject("i6", obj6, Types.VARCHAR);
-                cstmt.setObject("i7", obj7, Types.CHAR);
-                cstmt.setObject("i8", obj8, Types.SMALLINT);
-
-                cstmt.registerOutParameter(9, Types.NUMERIC);
-                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
-                cstmt.registerOutParameter(11, Types.INTEGER);
-                cstmt.registerOutParameter(12, Types.FLOAT);
-
-                cstmt.registerOutParameter(13, Types.CHAR);
-                cstmt.registerOutParameter(14, Types.VARCHAR);
-                cstmt.registerOutParameter(15, Types.CHAR);
-                cstmt.registerOutParameter(16, Types.SMALLINT);
                 cstmt.execute();
 
                 assertEquals(obj1, cstmt.getDouble("o1"));
-                assertEquals(obj2, cstmt.getDouble(10));
-                assertEquals(obj3, cstmt.getInt(11));
-                assertEquals(obj4, cstmt.getFloat(12));
-                assertEquals(obj5, cstmt.getInt(13));
-                assertEquals(obj6, cstmt.getString(14));
-                assertEquals(obj7, cstmt.getString(15));
-                assertEquals(obj8, cstmt.getLong(16));
-
-                fail(TestResource.getResource("R_expectedFailPassed"));
-            } catch (Exception e) {
-                assertEquals(TestResource.getResource("R_unknownOutputParameter"), e.getMessage());
+                assertEquals(obj2, cstmt.getDouble("o2"));
+                assertEquals(obj3, cstmt.getInt("o3"));
+                assertEquals(obj4, cstmt.getFloat("o4"));
+                assertEquals(obj5, cstmt.getInt("o5"));
+                assertEquals(obj6, cstmt.getString("o6"));
+                assertEquals(obj7, cstmt.getString("o7"));
+                assertEquals(obj8, cstmt.getLong("o8"));
             }
         }
     }
 
     @Test
-    public void testNamedParametersAndByIndexErrorUseFlexibleCallableStatementFalse() throws SQLException {
+    public void useFlexibleCallableStatementFalseMainlyNamedParametersWithSettingSingleIndexedParam() {
         String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
         String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
                 "useFlexibleCallableStatements", "false");
 
-        // useFlexibleCallableStatement=false
-        // Using majority named parameters and setting parameter by index
+        // When useFlexibleCallableStatement=false and when mainly using only named parameters, setting
+        // an input parameter by index will cause the cstmt to fail.
         try (Connection conn = DriverManager.getConnection(connectionString)) {
             try (CallableStatement cstmt = conn.prepareCall(call)) {
                 int scale = 6;
@@ -708,19 +896,20 @@ public class CallableStatementTest extends AbstractTest {
                 assertEquals(obj8, cstmt.getLong("o8"));
 
                 fail(TestResource.getResource("R_expectedFailPassed"));
-            } catch (Exception e) {
-                assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
             }
+        } catch (Exception e) {
+            assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
         }
     }
 
     @Test
-    public void testIndexedParametersUseFlexibleCallableStatementFalse() throws SQLException {
+    public void useFlexibleCallableStatementFalseMainlyNamedParametersWithRegisteringSingleIndexedOutputParam() {
         String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
         String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
                 "useFlexibleCallableStatements", "false");
 
-        // useFlexibleCallableStatement=false and using all index parameters
+        // When useFlexibleCallableStatement=false and when mainly using only named parameters, registering
+        // an output parameter by index will cause the cstmt to fail.
         try (Connection conn = DriverManager.getConnection(connectionString)) {
             try (CallableStatement cstmt = conn.prepareCall(call)) {
                 int scale = 6;
@@ -733,145 +922,97 @@ public class CallableStatementTest extends AbstractTest {
                 String obj7 = "b";
                 long obj8 = 2015L;
 
-                cstmt.setObject(1, obj1, Types.NUMERIC);
-                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
-                cstmt.setObject(3, obj3, Types.INTEGER);
-                cstmt.setObject(4, obj4, Types.FLOAT);
+                cstmt.setObject("i1", obj1, Types.NUMERIC);
+                cstmt.setObject("i2", obj2, Types.NUMERIC, scale);
+                cstmt.setObject("i3", obj3, Types.INTEGER);
+                cstmt.setObject("i4", obj4, Types.FLOAT);
 
-                cstmt.setObject(5, obj5, Types.CHAR);
-                cstmt.setObject(6, obj6, Types.VARCHAR);
-                cstmt.setObject(7, obj7, Types.CHAR);
-                cstmt.setObject(8, obj8, Types.SMALLINT);
-
-                cstmt.registerOutParameter(9, Types.NUMERIC);
-                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
-                cstmt.registerOutParameter(11, Types.INTEGER);
-                cstmt.registerOutParameter(12, Types.FLOAT);
-
-                cstmt.registerOutParameter(13, Types.CHAR);
-                cstmt.registerOutParameter(14, Types.VARCHAR);
-                cstmt.registerOutParameter(15, Types.CHAR);
-                cstmt.registerOutParameter(16, Types.SMALLINT);
-                cstmt.execute();
-
-                assertEquals(obj1, cstmt.getDouble(9));
-                assertEquals(obj2, cstmt.getDouble(10));
-                assertEquals(obj3, cstmt.getInt(11));
-                assertEquals(obj4, cstmt.getFloat(12));
-                assertEquals(obj5, cstmt.getInt(13));
-                assertEquals(obj6, cstmt.getString(14));
-                assertEquals(obj7, cstmt.getString(15));
-                assertEquals(obj8, cstmt.getLong(16));
-            }
-        }
-    }
-
-    @Test
-    public void testIndexedParametersAcquireOutputValueByNameErrorUseFlexibleCallableStatementFalse() throws SQLException {
-        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
-        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
-                "useFlexibleCallableStatements", "false");
-
-        try (Connection conn = DriverManager.getConnection(connectionString)) {
-            try (CallableStatement cstmt = conn.prepareCall(call)) {
-                int scale = 6;
-                double obj1 = 2015.0123;
-                double obj2 = 2015.012345;
-                int obj3 = -3;
-                float obj4 = 2015.04f;
-                int obj5 = 3;
-                String obj6 = "foo";
-                String obj7 = "b";
-                long obj8 = 2015L;
-
-                cstmt.setObject(1, obj1, Types.NUMERIC);
-                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
-                cstmt.setObject(3, obj3, Types.INTEGER);
-                cstmt.setObject(4, obj4, Types.FLOAT);
-
-                cstmt.setObject(5, obj5, Types.CHAR);
-                cstmt.setObject(6, obj6, Types.VARCHAR);
-                cstmt.setObject(7, obj7, Types.CHAR);
-                cstmt.setObject(8, obj8, Types.SMALLINT);
-
-                cstmt.registerOutParameter(9, Types.NUMERIC);
-                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
-                cstmt.registerOutParameter(11, Types.INTEGER);
-                cstmt.registerOutParameter(12, Types.FLOAT);
-
-                cstmt.registerOutParameter(13, Types.CHAR);
-                cstmt.registerOutParameter(14, Types.VARCHAR);
-                cstmt.registerOutParameter(15, Types.CHAR);
-                cstmt.registerOutParameter(16, Types.SMALLINT);
-                cstmt.execute();
-
-                assertEquals(obj1, cstmt.getDouble(9));
-                assertEquals(obj2, cstmt.getDouble(10));
-                assertEquals(obj3, cstmt.getInt(11));
-                assertEquals(obj4, cstmt.getFloat(12));
-                assertEquals(obj5, cstmt.getInt(13));
-                assertEquals(obj6, cstmt.getString(14));
-                assertEquals(obj7, cstmt.getString(15));
-                assertEquals(obj8, cstmt.getLong("o8"));
-                fail(TestResource.getResource("R_expectedFailPassed"));
-            } catch (Exception e) {
-                assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
-            }
-        }
-    }
-
-    @Test
-    public void testIndexedParametersRegisterOutputParamByNameUseFlexibleCallableStatementFalse() throws SQLException {
-        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
-        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
-                "useFlexibleCallableStatements", "false");
-
-        try (Connection conn = DriverManager.getConnection(connectionString)) {
-            try (CallableStatement cstmt = conn.prepareCall(call)) {
-                int scale = 6;
-                double obj1 = 2015.0123;
-                double obj2 = 2015.012345;
-                int obj3 = -3;
-                float obj4 = 2015.04f;
-                int obj5 = 3;
-                String obj6 = "foo";
-                String obj7 = "b";
-                long obj8 = 2015L;
-
-                cstmt.setObject(1, obj1, Types.NUMERIC);
-                cstmt.setObject(2, obj2, Types.NUMERIC, scale);
-                cstmt.setObject(3, obj3, Types.INTEGER);
-                cstmt.setObject(4, obj4, Types.FLOAT);
-
-                cstmt.setObject(5, obj5, Types.CHAR);
-                cstmt.setObject(6, obj6, Types.VARCHAR);
-                cstmt.setObject(7, obj7, Types.CHAR);
-                cstmt.setObject(8, obj8, Types.SMALLINT);
+                cstmt.setObject("i5", obj5, Types.CHAR);
+                cstmt.setObject("i6", obj6, Types.VARCHAR);
+                cstmt.setObject("i7", obj7, Types.CHAR);
+                cstmt.setObject("i8", obj8, Types.SMALLINT);
 
                 cstmt.registerOutParameter("o1", Types.NUMERIC);
-                cstmt.registerOutParameter(10, Types.NUMERIC, scale);
-                cstmt.registerOutParameter(11, Types.INTEGER);
-                cstmt.registerOutParameter(12, Types.FLOAT);
+                cstmt.registerOutParameter("o2", Types.NUMERIC, scale);
+                cstmt.registerOutParameter("o3", Types.INTEGER);
+                cstmt.registerOutParameter("o4", Types.FLOAT);
 
-                cstmt.registerOutParameter(13, Types.CHAR);
-                cstmt.registerOutParameter(14, Types.VARCHAR);
-                cstmt.registerOutParameter(15, Types.CHAR);
+                cstmt.registerOutParameter("o5", Types.CHAR);
+                cstmt.registerOutParameter("o6", Types.VARCHAR);
+                cstmt.registerOutParameter("o7", Types.CHAR);
                 cstmt.registerOutParameter(16, Types.SMALLINT);
                 cstmt.execute();
 
-                assertEquals(obj1, cstmt.getDouble(9));
-                assertEquals(obj2, cstmt.getDouble(10));
-                assertEquals(obj3, cstmt.getInt(11));
-                assertEquals(obj4, cstmt.getFloat(12));
-                assertEquals(obj5, cstmt.getInt(13));
-                assertEquals(obj6, cstmt.getString(14));
-                assertEquals(obj7, cstmt.getString(15));
+                assertEquals(obj1, cstmt.getDouble("o1"));
+                assertEquals(obj2, cstmt.getDouble("o2"));
+                assertEquals(obj3, cstmt.getInt("o3"));
+                assertEquals(obj4, cstmt.getFloat("o4"));
+                assertEquals(obj5, cstmt.getInt("o5"));
+                assertEquals(obj6, cstmt.getString("o6"));
+                assertEquals(obj7, cstmt.getString("o7"));
+                assertEquals(obj8, cstmt.getLong("o8"));
+
+                fail(TestResource.getResource("R_expectedFailPassed"));
+            }
+        } catch (Exception e) {
+            assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
+        }
+    }
+
+    @Test
+    public void useFlexibleCallableStatementFalseMainlyNamedParametersWithGettingOutputParamByIndex() {
+        String call = "{CALL " + outOfOrderSproc + " (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)}";
+        String connectionString = TestUtils.addOrOverrideProperty(getConnectionString(),
+                "useFlexibleCallableStatements", "false");
+
+        // When useFlexibleCallableStatement=false and when mainly using only named parameters, getting
+        // an output parameter by index will cause the cstmt to fail.
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            try (CallableStatement cstmt = conn.prepareCall(call)) {
+                int scale = 6;
+                double obj1 = 2015.0123;
+                double obj2 = 2015.012345;
+                int obj3 = -3;
+                float obj4 = 2015.04f;
+                int obj5 = 3;
+                String obj6 = "foo";
+                String obj7 = "b";
+                long obj8 = 2015L;
+
+                cstmt.setObject("i1", obj1, Types.NUMERIC);
+                cstmt.setObject("i2", obj2, Types.NUMERIC, scale);
+                cstmt.setObject("i3", obj3, Types.INTEGER);
+                cstmt.setObject("i4", obj4, Types.FLOAT);
+
+                cstmt.setObject("i5", obj5, Types.CHAR);
+                cstmt.setObject("i6", obj6, Types.VARCHAR);
+                cstmt.setObject("i7", obj7, Types.CHAR);
+                cstmt.setObject("i8", obj8, Types.SMALLINT);
+
+                cstmt.registerOutParameter("o1", Types.NUMERIC);
+                cstmt.registerOutParameter("o2", Types.NUMERIC, scale);
+                cstmt.registerOutParameter("o3", Types.INTEGER);
+                cstmt.registerOutParameter("o4", Types.FLOAT);
+
+                cstmt.registerOutParameter("o5", Types.CHAR);
+                cstmt.registerOutParameter("o6", Types.VARCHAR);
+                cstmt.registerOutParameter("o7", Types.CHAR);
+                cstmt.registerOutParameter("o8", Types.SMALLINT);
+                cstmt.execute();
+
+                assertEquals(obj1, cstmt.getDouble("o1"));
+                assertEquals(obj2, cstmt.getDouble("o2"));
+                assertEquals(obj3, cstmt.getInt("o3"));
+                assertEquals(obj4, cstmt.getFloat("o4"));
+                assertEquals(obj5, cstmt.getInt("o5"));
+                assertEquals(obj6, cstmt.getString("o6"));
+                assertEquals(obj7, cstmt.getString("o7"));
                 assertEquals(obj8, cstmt.getLong(16));
 
                 fail(TestResource.getResource("R_expectedFailPassed"));
-            } catch (Exception e) {
-                assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
             }
+        } catch (Exception e) {
+            assertEquals(TestResource.getResource("R_noNamedAndIndexedParameters"), e.getMessage());
         }
     }
 


### PR DESCRIPTION
These changes make it so that when `useFlexibleCallableStatements=false`, setting/registering of parameters is stricter eg. either use all index or use named parameters (no mixing of index/named parameters). The reason for this is because the exceptions/cases to using index vs. named parameters are too nuanced.