### PR TITLE
Add support for TDSType.GUID (#1582)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -57,6 +57,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -4782,6 +4783,31 @@ final class TDSWriter {
 
         byte[] val = DDC.convertBigDecimalToBytes(bdValue, nScale);
         writeBytes(val, 0, val.length);
+    }
+
+    /**
+     * Append a UUID in RPC transmission format.
+     *
+     * @param sName
+     *        the optional parameter name
+     * @param uuidValue
+     *        the data value
+     * @param bOut
+     *        boolean true if the data value is being registered as an output parameter
+     */
+    void writeRPCUUID(String sName, UUID uuidValue, boolean bOut) throws SQLServerException {
+        writeRPCNameValType(sName, bOut, TDSType.GUID);
+
+        if (uuidValue == null) {
+            writeByte((byte) 0);
+
+        } else {
+            writeByte((byte) 0x10);  // maximum length = 16
+            writeByte((byte) 0x10);  // length = 16
+
+            byte[] val = Util.asGuidByteArray(uuidValue);
+            writeBytes(val, 0, val.length);
+        }
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -4800,6 +4800,7 @@ final class TDSWriter {
 
         if (uuidValue == null) {
             writeByte((byte) 0);
+            writeByte((byte) 0);
 
         } else {
             writeByte((byte) 0x10);  // maximum length = 16

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -22,6 +22,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.UUID;
 
 
 /**
@@ -1122,6 +1123,10 @@ final class Parameter {
         }
 
         void execute(DTV dtv, Boolean booleanValue) throws SQLServerException {
+            setTypeDefinition(dtv);
+        }
+
+        void execute(DTV dtv, UUID uuidValue) throws SQLServerException {
             setTypeDefinition(dtv);
         }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -99,6 +99,8 @@ abstract class DTVExecuteOp {
 
     abstract void execute(DTV dtv, Boolean booleanValue) throws SQLServerException;
 
+    abstract void execute(DTV dtv, UUID uuidValue) throws SQLServerException;
+
     abstract void execute(DTV dtv, byte[] byteArrayValue) throws SQLServerException;
 
     abstract void execute(DTV dtv, Blob blobValue) throws SQLServerException;
@@ -291,6 +293,9 @@ final class DTV {
         }
 
         void execute(DTV dtv, String strValue) throws SQLServerException {
+            if (dtv.getJdbcType() == JDBCType.GUID) {
+                tdsWriter.writeRPCUUID(name, UUID.fromString(strValue), isOutParam);
+            }
             tdsWriter.writeRPCStringUnicode(name, strValue, isOutParam, collation, dtv.isNonPLP);
         }
 
@@ -1126,6 +1131,10 @@ final class DTV {
             tdsWriter.writeRPCBit(name, booleanValue, isOutParam);
         }
 
+        void execute(DTV dtv, UUID uuidValue) throws SQLServerException {
+            tdsWriter.writeRPCUUID(name, uuidValue, isOutParam);
+        }
+
         void execute(DTV dtv, byte[] byteArrayValue) throws SQLServerException {
             if (null != cryptoMeta) {
                 tdsWriter.writeRPCNameValType(name, isOutParam, TDSType.BIGVARBINARY);
@@ -1537,8 +1546,11 @@ final class DTV {
                 case VARCHAR:
                 case LONGVARCHAR:
                 case CLOB:
-                case GUID:
                     op.execute(this, (byte[]) null);
+                    break;
+
+                case GUID:
+                    op.execute(this, (UUID) null);
                     break;
 
                 case TINYINT:
@@ -1619,7 +1631,7 @@ final class DTV {
                             byte[] bArray = Util.asGuidByteArray((UUID) value);
                             op.execute(this, bArray);
                         } else {
-                            op.execute(this, String.valueOf(value));
+                            op.execute(this, UUID.fromString(String.valueOf(value)));
                         }
                     } else if (JDBCType.SQL_VARIANT == jdbcType) {
                         op.execute(this, String.valueOf(value));
@@ -2193,6 +2205,8 @@ final class AppDTVImpl extends DTVImpl {
         void execute(DTV dtv, Short shortValue) throws SQLServerException {}
 
         void execute(DTV dtv, Boolean booleanValue) throws SQLServerException {}
+
+        void execute(DTV dtv, UUID uuidValue) throws SQLServerException {}
 
         void execute(DTV dtv, byte[] byteArrayValue) throws SQLServerException {}
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -295,8 +295,9 @@ final class DTV {
         void execute(DTV dtv, String strValue) throws SQLServerException {
             if (dtv.getJdbcType() == JDBCType.GUID) {
                 tdsWriter.writeRPCUUID(name, UUID.fromString(strValue), isOutParam);
+            } else {
+                tdsWriter.writeRPCStringUnicode(name, strValue, isOutParam, collation, dtv.isNonPLP);
             }
-            tdsWriter.writeRPCStringUnicode(name, strValue, isOutParam, collation, dtv.isNonPLP);
         }
 
         void execute(DTV dtv, Clob clobValue) throws SQLServerException {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
@@ -1,0 +1,96 @@
+package com.microsoft.sqlserver.jdbc.datatypes;
+
+import com.microsoft.sqlserver.jdbc.RandomUtil;
+import com.microsoft.sqlserver.jdbc.SQLServerResultSet;
+import com.microsoft.sqlserver.jdbc.TestUtils;
+import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import microsoft.sql.Types;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/*
+ * This test is for testing the serialisation of String as microsoft.sql.Types.GUID
+ */
+@RunWith(JUnitPlatform.class)
+public class GuidTest extends AbstractTest {
+
+    final static String tableName = RandomUtil.getIdentifier("GuidTestTable");
+    final static String escapedTableName = AbstractSQLGenerator.escapeIdentifier(tableName);
+
+    @BeforeAll
+    public static void setupTests() throws Exception {
+        setConnection();
+    }
+
+    /*
+     * Test UUID conversions
+     */
+    @Test
+    public void testGuid() throws Exception {
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+
+            // Create the test table
+            TestUtils.dropTableIfExists(escapedTableName, stmt);
+
+            String query = "create table " + escapedTableName
+                    + " (uuid uniqueidentifier, id int IDENTITY primary key)";
+            stmt.executeUpdate(query);
+
+            UUID uuid = UUID.randomUUID();
+            String uuidString = uuid.toString();
+            int id = 1;
+
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO " + escapedTableName
+                    + " VALUES(?) SELECT * FROM " + escapedTableName + " where id = ?")) {
+
+                pstmt.setObject(1, uuidString, Types.GUID);
+                pstmt.setObject(2, id++);
+                pstmt.execute();
+                pstmt.getMoreResults();
+                try (SQLServerResultSet rs = (SQLServerResultSet) pstmt.getResultSet()) {
+                    rs.next();
+                    assertEquals(uuid, UUID.fromString(rs.getUniqueIdentifier(1)));
+                }
+
+                // Test NULL GUFID
+                pstmt.setObject(1, null, Types.GUID);
+                pstmt.setObject(2, id++);
+                pstmt.execute();
+                pstmt.getMoreResults();
+                try (SQLServerResultSet rs = (SQLServerResultSet) pstmt.getResultSet()) {
+                    rs.next();
+                    String s = rs.getUniqueIdentifier(1);
+                    assertNull(s);
+                    assertTrue(rs.wasNull());
+                }
+
+                // Test Illegal GUFID
+                try {
+                    pstmt.setObject(1, "garbage", Types.GUID);
+                    fail("Must throw an IllegalArgumentException for this illegal UUID");
+                } catch (IllegalArgumentException e) {
+                    assertEquals("Invalid UUID string: garbage", e.getMessage());
+                }
+            }
+        } finally {
+            try (Statement stmt = connection.createStatement()) {
+                TestUtils.dropTableIfExists(escapedTableName, stmt);
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
@@ -2,6 +2,7 @@ package com.microsoft.sqlserver.jdbc.datatypes;
 
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerResultSet;
+import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
@@ -66,7 +67,7 @@ public class GuidTest extends AbstractTest {
                     assertEquals(uuid, UUID.fromString(rs.getUniqueIdentifier(1)));
                 }
 
-                // Test NULL GUFID
+                // Test NULL GUID
                 pstmt.setObject(1, null, Types.GUID);
                 pstmt.setObject(2, id++);
                 pstmt.execute();
@@ -78,10 +79,10 @@ public class GuidTest extends AbstractTest {
                     assertTrue(rs.wasNull());
                 }
 
-                // Test Illegal GUFID
+                // Test Illegal GUID
                 try {
                     pstmt.setObject(1, "garbage", Types.GUID);
-                    fail("Must throw an IllegalArgumentException for this illegal UUID");
+                    fail(TestResource.getResource("R_expectedFailPassed"));
                 } catch (IllegalArgumentException e) {
                     assertEquals("Invalid UUID string: garbage", e.getMessage());
                 }


### PR DESCRIPTION
This PR intends to provide support for sending UUID parameters as `TDSType.GUID (0x24)` on the wire and (hopefully) implements feature request #1582. 
It currently requires the Java parameter be given to the driver as `String` with `JDBCType.GUID`, i.e. :
```
st.setObject(index, myUUID.toString(), microsoft.sql.Types.GUID);
```
