### PR TITLE
Re-added support for stored procedure 'exec' escape syntax in CallableStatements

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -2064,7 +2064,8 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
 
     private void writeColumnToTdsWriter(TDSWriter tdsWriter, int bulkPrecision, int bulkScale, int bulkJdbcType,
             boolean bulkNullable, // should it be destNullable instead?
-            int srcColOrdinal, int destColOrdinal, boolean isStreaming, Object colValue, Calendar cal) throws SQLServerException {
+            int srcColOrdinal, int destColOrdinal, boolean isStreaming, Object colValue,
+            Calendar cal) throws SQLServerException {
         SSType destSSType = destColumnMetadata.get(destColOrdinal).ssType;
 
         bulkPrecision = validateSourcePrecision(bulkPrecision, bulkJdbcType,
@@ -2987,8 +2988,8 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
     /**
      * Reads the given column from the result set current row and writes the data to tdsWriter.
      */
-    private void writeColumn(TDSWriter tdsWriter, int srcColOrdinal, int destColOrdinal,
-            Object colValue, Calendar cal) throws SQLServerException {
+    private void writeColumn(TDSWriter tdsWriter, int srcColOrdinal, int destColOrdinal, Object colValue,
+            Calendar cal) throws SQLServerException {
         String destName = destColumnMetadata.get(destColOrdinal).columnName;
         int srcPrecision, srcScale, destPrecision, srcJdbcType;
         SSType destSSType = null;
@@ -3640,8 +3641,8 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                 // Loop for each destination column. The mappings is a many to one mapping
                 // where multiple source columns can be mapped to one destination column.
                 for (ColumnMapping columnMapping : columnMappings) {
-                    writeColumn(tdsWriter, columnMapping.sourceColumnOrdinal, columnMapping.destinationColumnOrdinal, null,
-                            null // cell
+                    writeColumn(tdsWriter, columnMapping.sourceColumnOrdinal, columnMapping.destinationColumnOrdinal,
+                            null, null // cell
                     // value is
                     // retrieved
                     // inside

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -133,6 +133,16 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      */
     private boolean useBulkCopyForBatchInsert;
 
+    /**
+     * Regex for JDBC 'call' escape syntax
+     */
+    private static final Pattern callEscapePattern = Pattern.compile("^\\s*(?i)\\{(\\s*\\??\\s*=?\\s*)call (.+)\\s*\\(?\\?*,?\\)?\\s*}\\s*$");
+
+    /**
+     * Regex for 'exec' escape syntax
+     */
+    private static final Pattern execEscapePattern = Pattern.compile("^\\s*(?i)(?:exec|execute)\\b");
+
     /** Returns the prepared statement SQL */
     @Override
     public String toString() {
@@ -1246,13 +1256,11 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     }
 
     private boolean isExecEscapeSyntax(String sql) {
-        Pattern pattern = Pattern.compile("^\\s*(?i)(?:exec|execute)\\b");
-        return pattern.matcher(sql).find();
+        return execEscapePattern.matcher(sql).find();
     }
 
     private boolean isCallEscapeSyntax(String sql) {
-        Pattern pattern = Pattern.compile("^\\s*(?i)\\{(\\s*\\?\\s*=\\s*)call (.+)?\\s*\\(?\\?+,?\\)?\\s*}\\s*$");
-        return pattern.matcher(sql).find();
+        return callEscapePattern.matcher(sql).find();
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -1251,7 +1251,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     }
 
     private boolean isCallEscapeSyntax(String sql) {
-        Pattern pattern = Pattern.compile("^\\s*(?i)\\{call (.+)\\s*\\(?\\?+,?\\)?\\s*}\\s*$");
+        Pattern pattern = Pattern.compile("^\\s*(?i)\\{(\\s*\\?\\s*=\\s*)call (.+)?\\s*\\(?\\?+,?\\)?\\s*}\\s*$");
         return pattern.matcher(sql).find();
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -70,6 +70,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     /** Processed SQL statement text, may not be same as what user initially passed. */
     final String userSQL;
 
+    /** Unprocessed SQL statement text, should tbe same as what user initially passed. */
+    final String userSQLUnprocessed;
+
     /** Parameter positions in processed SQL statement text. */
     final int[] userSQLParamPositions;
 
@@ -253,6 +256,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         procedureName = parsedSQL.procedureName;
         bReturnValueSyntax = parsedSQL.bReturnValueSyntax;
         userSQL = parsedSQL.processedSQL;
+        userSQLUnprocessed = sql;
         userSQLParamPositions = parsedSQL.parameterPositions;
         initParams(userSQLParamPositions.length);
         useBulkCopyForBatchInsert = conn.getUseBulkCopyForBatchInsert();
@@ -1210,7 +1214,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      */
     boolean callRPCDirectly(Parameter[] params) throws SQLServerException {
         int paramCount = SQLServerConnection.countParams(userSQL);
-        return (null != procedureName && paramCount != 0 && !isTVPType(params));
+        return (null != procedureName && paramCount != 0 && !isTVPType(params) && !isExecCommand());
     }
 
     /**
@@ -1228,6 +1232,11 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             }
         }
         return false;
+    }
+
+    private boolean isExecCommand() {
+        String command = userSQLUnprocessed.split(" ")[0].toLowerCase();
+        return command.equals("exec") || command.equals("execute");
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -136,7 +136,8 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     /**
      * Regex for JDBC 'call' escape syntax
      */
-    private static final Pattern callEscapePattern = Pattern.compile("^\\s*(?i)\\{(\\s*\\??\\s*=?\\s*)call (.+)\\s*\\(?\\?*,?\\)?\\s*}\\s*$");
+    private static final Pattern callEscapePattern = Pattern
+            .compile("^\\s*(?i)\\{(\\s*\\??\\s*=?\\s*)call (.+)\\s*\\(?\\?*,?\\)?\\s*}\\s*$");
 
     /**
      * Regex for 'exec' escape syntax
@@ -1235,7 +1236,8 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         // 4. Compliant CALL escape syntax
         // If isExecEscapeSyntax is true, EXEC escape syntax is used then use prior behaviour to
         // execute the procedure
-        return (null != procedureName && paramCount != 0 && !isTVPType(params) && isCallEscapeSyntax && !isExecEscapeSyntax);
+        return (null != procedureName && paramCount != 0 && !isTVPType(params) && isCallEscapeSyntax
+                && !isExecEscapeSyntax);
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1069,11 +1069,26 @@ public class CallableStatementTest extends AbstractTest {
 
     @Test
     public void testExecuteSystemStoredProcedureNamedParametersAndIndexedParameterNoResultset() throws SQLException {
-        String call = "EXEC sp_getapplock @Resource=?, @LockTimeout='0', @LockMode='Exclusive', @LockOwner='Session'";
+        String call0 = "EXEC sp_getapplock @Resource=?, @LockTimeout='0', @LockMode='Exclusive', @LockOwner='Session'";
+        String call1 = "\rEXEC\r\rsp_getapplock @Resource=?, @LockTimeout='0', @LockMode='Exclusive', @LockOwner='Session'";
+        String call2 = "  EXEC   sp_getapplock @Resource=?, @LockTimeout='0', @LockMode='Exclusive', @LockOwner='Session'";
+        String call3 = "\tEXEC\t\t\tsp_getapplock @Resource=?, @LockTimeout='0', @LockMode='Exclusive', @LockOwner='Session'";
 
-        try (CallableStatement cstmt = connection.prepareCall(call)) {
-            cstmt.setString(1, "Resource-" + UUID.randomUUID());
-            cstmt.execute();
+        try (CallableStatement cstmt0 = connection.prepareCall(call0);
+                CallableStatement cstmt1 = connection.prepareCall(call1);
+                CallableStatement cstmt2 = connection.prepareCall(call2);
+                CallableStatement cstmt3 = connection.prepareCall(call3);) {
+            cstmt0.setString(1, "Resource-" + UUID.randomUUID());
+            cstmt0.execute();
+
+            cstmt1.setString(1, "Resource-" + UUID.randomUUID());
+            cstmt1.execute();
+
+            cstmt2.setString(1, "Resource-" + UUID.randomUUID());
+            cstmt2.execute();
+
+            cstmt3.setString(1, "Resource-" + UUID.randomUUID());
+            cstmt3.execute();
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -81,7 +81,7 @@ public class CallableStatementTest extends AbstractTest {
 
     /**
      * Setup before test
-     * 
+     *
      * @throws SQLException
      */
     @BeforeAll
@@ -201,7 +201,7 @@ public class CallableStatementTest extends AbstractTest {
 
     /**
      * Tests CallableStatement.getString() with uniqueidentifier parameter
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -226,7 +226,7 @@ public class CallableStatementTest extends AbstractTest {
 
     /**
      * test for setNull(index, varchar) to behave as setNull(index, nvarchar) when SendStringParametersAsUnicode is true
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -302,7 +302,7 @@ public class CallableStatementTest extends AbstractTest {
 
     /**
      * Tests getObject(n, java.time.OffsetDateTime.class) and getObject(n, java.time.OffsetTime.class).
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -332,7 +332,7 @@ public class CallableStatementTest extends AbstractTest {
 
     /**
      * recognize parameter names with and without leading '@'
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1067,9 +1067,36 @@ public class CallableStatementTest extends AbstractTest {
         }
     }
 
+    @Test
+    public void testExecuteSystemStoredProcedureNamedParametersNoResultset() throws SQLException {
+        // Uppercase 'EXEC' command test
+        String call = "EXEC sp_getapplock @Resource=?, @LockTimeout='60', @LockMode='Exclusive', @LockOwner='Session'";
+
+        try (CallableStatement cstmt = connection.prepareCall(call)) {
+            cstmt.setString(1, "resource");
+            cstmt.execute();
+        }
+    }
+
+    @Test
+    public void testExecuteSystemStoredProcedureNamedParametersResultSet() throws SQLException {
+        // Lowercase 'exec' command test
+        String call = "exec sp_sproc_columns_100 ?, @ODBCVer=3, @fUsePattern=0";
+
+        try (CallableStatement cstmt = connection.prepareCall(call)) {
+            cstmt.setString(1, "sp_getapplock");
+
+            try (ResultSet rs = cstmt.executeQuery()) {
+                while (rs.next()) {
+                    assertTrue("Failed -- ResultSet was not returned.", !rs.getString(4).isEmpty());
+                }
+            }
+        }
+    }
+
     /**
      * Cleanup after test
-     * 
+     *
      * @throws SQLException
      */
     @AfterAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1115,14 +1115,14 @@ public class CallableStatementTest extends AbstractTest {
             serverName = rs.getString(1);
         }
 
-        String[] sprocs = {"EXEC sp_column_privileges ?", "EXECUTE sp_serveroption @@SERVERNAME, ?, TRUE",
+        String[] sprocs = {"EXEC sp_column_privileges ?",
                 "exec sp_catalogs ?", "execute sp_column_privileges ?", "EXEC sp_column_privileges_ex ?",
                 "EXECUTE sp_columns ?", "exec sp_columns_ex ?", "execute sp_datatype_info ?",
                 "EXEC sp_sproc_columns ?", "EXECUTE sp_server_info ?", "exec sp_special_columns ?",
                 "execute sp_statistics ?", "EXEC sp_table_privileges ?", "EXECUTE sp_table_privileges_ex ?",
                 "exec sp_tables ?", "execute sp_tables_ex ?"};
 
-        Object[] params = {testTableName, "DATA ACCESS", serverName, testTableName, serverName,
+        Object[] params = {testTableName, serverName, testTableName, serverName,
                 testTableName, serverName, integer, "sp_column_privileges", integer, testTableName,
                 testTableName, testTableName, serverName, testTableName, serverName};
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1069,10 +1069,10 @@ public class CallableStatementTest extends AbstractTest {
 
     @Test
     public void testExecuteSystemStoredProcedureNamedParametersAndIndexedParameterNoResultset() throws SQLException {
-        String call = "EXEC sp_getapplock @Resource=?, @LockTimeout='60', @LockMode='Exclusive', @LockOwner='Session'";
+        String call = "EXEC sp_getapplock @Resource=?, @LockTimeout='0', @LockMode='Exclusive', @LockOwner='Session'";
 
         try (CallableStatement cstmt = connection.prepareCall(call)) {
-            cstmt.setString(1, "resource");
+            cstmt.setString(1, "Resource-" + UUID.randomUUID());
             cstmt.execute();
         }
     }
@@ -1096,12 +1096,10 @@ public class CallableStatementTest extends AbstractTest {
     public void testExecSystemStoredProcedureNoIndexedParametersResultSet() throws SQLException {
         String call = "execute sp_sproc_columns_100 sp_getapplock, @ODBCVer=3, @fUsePattern=0";
 
-        try (CallableStatement cstmt = connection.prepareCall(call)) {
-
-            try (ResultSet rs = cstmt.executeQuery()) {
-                while (rs.next()) {
-                    assertTrue(TestResource.getResource("R_resultSetEmpty"), !rs.getString(4).isEmpty());
-                }
+        try (CallableStatement cstmt = connection.prepareCall(call);
+                ResultSet rs = cstmt.executeQuery()) {
+            while (rs.next()) {
+                assertTrue(TestResource.getResource("R_resultSetEmpty"), !rs.getString(4).isEmpty());
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1117,13 +1117,16 @@ public class CallableStatementTest extends AbstractTest {
             serverName = rs.getString(1);
         }
 
-        String[] sprocs = {"EXEC sp_column_privileges ?", "EXECUTE sp_serveroption @@SERVERNAME, ?, TRUE", "exec sp_catalogs ?",
-                "execute sp_column_privileges ?", "EXEC sp_column_privileges_ex ?", "EXECUTE sp_columns ?", "exec sp_columns_ex ?",
-                "execute sp_datatype_info ?", "EXEC sp_sproc_columns ?", "EXECUTE sp_server_info ?", "exec sp_special_columns ?",
-                "execute sp_statistics ?", "EXEC sp_table_privileges ?", "EXECUTE sp_table_privileges_ex ?", "exec sp_tables ?", "execute sp_tables_ex ?"};
+        String[] sprocs = {"EXEC sp_column_privileges ?", "EXECUTE sp_serveroption @@SERVERNAME, ?, TRUE",
+                "exec sp_catalogs ?", "execute sp_column_privileges ?", "EXEC sp_column_privileges_ex ?",
+                "EXECUTE sp_columns ?", "exec sp_columns_ex ?", "execute sp_datatype_info ?",
+                "EXEC sp_sproc_columns ?", "EXECUTE sp_server_info ?", "exec sp_special_columns ?",
+                "execute sp_statistics ?", "EXEC sp_table_privileges ?", "EXECUTE sp_table_privileges_ex ?",
+                "exec sp_tables ?", "execute sp_tables_ex ?"};
 
         Object[] params = {testTableName, "DATA ACCESS", serverName, testTableName, serverName,
-                testTableName, serverName, integer, "sp_column_privileges", integer, testTableName, testTableName, testTableName, serverName, testTableName, serverName};
+                testTableName, serverName, integer, "sp_column_privileges", integer, testTableName,
+                testTableName, testTableName, serverName, testTableName, serverName};
 
         int paramIndex = 0;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1069,7 +1069,6 @@ public class CallableStatementTest extends AbstractTest {
 
     @Test
     public void testExecuteSystemStoredProcedureNamedParametersNoResultset() throws SQLException {
-        // Uppercase 'EXEC' command test
         String call = "EXEC sp_getapplock @Resource=?, @LockTimeout='60', @LockMode='Exclusive', @LockOwner='Session'";
 
         try (CallableStatement cstmt = connection.prepareCall(call)) {
@@ -1080,11 +1079,24 @@ public class CallableStatementTest extends AbstractTest {
 
     @Test
     public void testExecuteSystemStoredProcedureNamedParametersResultSet() throws SQLException {
-        // Lowercase 'exec' command test
         String call = "exec sp_sproc_columns_100 ?, @ODBCVer=3, @fUsePattern=0";
 
         try (CallableStatement cstmt = connection.prepareCall(call)) {
             cstmt.setString(1, "sp_getapplock");
+
+            try (ResultSet rs = cstmt.executeQuery()) {
+                while (rs.next()) {
+                    assertTrue("Failed -- ResultSet was not returned.", !rs.getString(4).isEmpty());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testExecuteSystemStoredProcedureNoNamedParametersResultSet() throws SQLException {
+        String call = "execute sp_sproc_columns_100 sp_getapplock, @ODBCVer=3, @fUsePattern=0";
+
+        try (CallableStatement cstmt = connection.prepareCall(call)) {
 
             try (ResultSet rs = cstmt.executeQuery()) {
                 while (rs.next()) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1111,8 +1111,7 @@ public class CallableStatementTest extends AbstractTest {
     public void testExecSystemStoredProcedureNoIndexedParametersResultSet() throws SQLException {
         String call = "execute sp_sproc_columns_100 sp_getapplock, @ODBCVer=3, @fUsePattern=0";
 
-        try (CallableStatement cstmt = connection.prepareCall(call);
-                ResultSet rs = cstmt.executeQuery()) {
+        try (CallableStatement cstmt = connection.prepareCall(call); ResultSet rs = cstmt.executeQuery()) {
             while (rs.next()) {
                 assertTrue(TestResource.getResource("R_resultSetEmpty"), !rs.getString(4).isEmpty());
             }
@@ -1130,15 +1129,13 @@ public class CallableStatementTest extends AbstractTest {
             serverName = rs.getString(1);
         }
 
-        String[] sprocs = {"EXEC sp_column_privileges ?",
-                "exec sp_catalogs ?", "execute sp_column_privileges ?", "EXEC sp_column_privileges_ex ?",
-                "EXECUTE sp_columns ?", "execute sp_datatype_info ?",
+        String[] sprocs = {"EXEC sp_column_privileges ?", "exec sp_catalogs ?", "execute sp_column_privileges ?",
+                "EXEC sp_column_privileges_ex ?", "EXECUTE sp_columns ?", "execute sp_datatype_info ?",
                 "EXEC sp_sproc_columns ?", "EXECUTE sp_server_info ?", "exec sp_special_columns ?",
                 "execute sp_statistics ?", "EXEC sp_table_privileges ?", "exec sp_tables ?"};
 
-        Object[] params = {testTableName, serverName, testTableName, serverName,
-                testTableName, integer, "sp_column_privileges", integer, testTableName,
-                testTableName, testTableName, testTableName};
+        Object[] params = {testTableName, serverName, testTableName, serverName, testTableName, integer,
+                "sp_column_privileges", integer, testTableName, testTableName, testTableName, testTableName};
 
         int paramIndex = 0;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1086,7 +1086,7 @@ public class CallableStatementTest extends AbstractTest {
 
             try (ResultSet rs = cstmt.executeQuery()) {
                 while (rs.next()) {
-                    assertTrue("Failed -- ResultSet was not returned.", !rs.getString(4).isEmpty());
+                    assertTrue(TestResource.getResource("R_resultSetEmpty"), !rs.getString(4).isEmpty());
                 }
             }
         }
@@ -1100,7 +1100,7 @@ public class CallableStatementTest extends AbstractTest {
 
             try (ResultSet rs = cstmt.executeQuery()) {
                 while (rs.next()) {
-                    assertTrue("Failed -- ResultSet was not returned.", !rs.getString(4).isEmpty());
+                    assertTrue(TestResource.getResource("R_resultSetEmpty"), !rs.getString(4).isEmpty());
                 }
             }
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1117,14 +1117,13 @@ public class CallableStatementTest extends AbstractTest {
 
         String[] sprocs = {"EXEC sp_column_privileges ?",
                 "exec sp_catalogs ?", "execute sp_column_privileges ?", "EXEC sp_column_privileges_ex ?",
-                "EXECUTE sp_columns ?", "exec sp_columns_ex ?", "execute sp_datatype_info ?",
+                "EXECUTE sp_columns ?", "execute sp_datatype_info ?",
                 "EXEC sp_sproc_columns ?", "EXECUTE sp_server_info ?", "exec sp_special_columns ?",
-                "execute sp_statistics ?", "EXEC sp_table_privileges ?", "EXECUTE sp_table_privileges_ex ?",
-                "exec sp_tables ?", "execute sp_tables_ex ?"};
+                "execute sp_statistics ?", "EXEC sp_table_privileges ?", "exec sp_tables ?"};
 
         Object[] params = {testTableName, serverName, testTableName, serverName,
-                testTableName, serverName, integer, "sp_column_privileges", integer, testTableName,
-                testTableName, testTableName, serverName, testTableName, serverName};
+                testTableName, integer, "sp_column_privileges", integer, testTableName,
+                testTableName, testTableName, testTableName};
 
         int paramIndex = 0;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
@@ -170,7 +170,7 @@ public class BatchExecutionTest extends AbstractTest {
     public void testValidTimezonesDstTimestampBatchInsertWithBulkCopy() throws Exception {
         Calendar gmtCal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
 
-        for (String tzId: TimeZone.getAvailableIDs()) {
+        for (String tzId : TimeZone.getAvailableIDs()) {
             TimeZone.setDefault(TimeZone.getTimeZone(tzId));
 
             long ms = 1696127400000L; // DST
@@ -191,8 +191,8 @@ public class BatchExecutionTest extends AbstractTest {
             }
 
             // Insert Timestamp using bulkcopy for batch insert
-            try (Connection con = DriverManager.getConnection(
-                    connectionString + ";useBulkCopyForBatchInsert=true;sendTemporalDataTypesAsStringForBulkCopy=false;");
+            try (Connection con = DriverManager.getConnection(connectionString
+                    + ";useBulkCopyForBatchInsert=true;sendTemporalDataTypesAsStringForBulkCopy=false;");
                     PreparedStatement pstmt = con.prepareStatement("INSERT INTO " + timestampTable1 + " VALUES(?)")) {
 
                 Timestamp timestamp = new Timestamp(ms);
@@ -235,8 +235,9 @@ public class BatchExecutionTest extends AbstractTest {
         long ms = 1578743412000L;
 
         // Insert Timestamp using prepared statement when useBulkCopyForBatchInsert=true
-        try (Connection con = DriverManager.getConnection(connectionString
-                + ";useBulkCopyForBatchInsert=true;sendTemporalDataTypesAsStringForBulkCopy=false;"); Statement stmt = con.createStatement();
+        try (Connection con = DriverManager.getConnection(
+                connectionString + ";useBulkCopyForBatchInsert=true;sendTemporalDataTypesAsStringForBulkCopy=false;");
+                Statement stmt = con.createStatement();
                 PreparedStatement pstmt = con.prepareStatement("INSERT INTO " + timestampTable2 + " VALUES(?)")) {
 
             TestUtils.dropTableIfExists(timestampTable2, stmt);


### PR DESCRIPTION
Prior to 12.6.0, all cstmts calls were wrapped int T-SQL sp_executesql, sp_prepexec etc.. calls before being sent off to the server. Doing so means the raw/unprocessed user's sql was passed into these T-SQL calls as parameter values and so the driver was able to execute "EXEC" calls against the server eg. `EXEC sp_columns_100 ?,?,?,?....`.

For example:
```
exec sp_executesql N'EXEC sp_getapplock @Resource=@P0, @LockTimeout='3600000', @LockMode='Exclusive', @LockOwner='Session',N'@P0 nvarchar(4000)',N'testParamValue'
```

This PR enables this prior behaviour again. 

https://github.com/microsoft/mssql-jdbc/issues/2323