### PR TITLE
Use Re-entrant locks instead of synchronized blocks to make driver loom friendly

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1440,8 +1440,13 @@ final class TDSChannel implements Serializable {
         }
 
         @Override
-        public synchronized int getReceiveBufferSize() throws SocketException {
-            return tdsChannel.tcpSocket.getReceiveBufferSize();
+        public int getReceiveBufferSize() throws SocketException {
+            tdsChannelLock.lock();
+            try {
+                return tdsChannel.tcpSocket.getReceiveBufferSize();
+            } finally {
+                tdsChannelLock.unlock();
+            }
         }
 
         @Override
@@ -1455,8 +1460,13 @@ final class TDSChannel implements Serializable {
         }
 
         @Override
-        public synchronized int getSendBufferSize() throws SocketException {
-            return tdsChannel.tcpSocket.getSendBufferSize();
+        public int getSendBufferSize() throws SocketException {
+            tdsChannelLock.lock();
+            try {
+                return tdsChannel.tcpSocket.getSendBufferSize();
+            } finally {
+                tdsChannelLock.unlock();
+            }
         }
 
         @Override
@@ -1465,8 +1475,13 @@ final class TDSChannel implements Serializable {
         }
 
         @Override
-        public synchronized int getSoTimeout() throws SocketException {
-            return tdsChannel.tcpSocket.getSoTimeout();
+        public int getSoTimeout() throws SocketException {
+            tdsChannelLock.lock();
+            try {
+                return tdsChannel.tcpSocket.getSoTimeout();
+            } finally {
+                tdsChannelLock.unlock();
+            }
         }
 
         @Override
@@ -1536,21 +1551,36 @@ final class TDSChannel implements Serializable {
         // Ignore calls to methods that would otherwise allow the SSL socket
         // to directly manipulate the underlying TCP socket
         @Override
-        public synchronized void close() throws IOException {
-            if (logger.isLoggable(Level.FINER))
-                logger.finer(logContext + " Ignoring close");
+        public void close() throws IOException {
+            tdsChannelLock.lock();
+            try {
+                if (logger.isLoggable(Level.FINER))
+                    logger.finer(logContext + " Ignoring close");
+            } finally {
+                tdsChannelLock.unlock();
+            }
         }
 
         @Override
-        public synchronized void setReceiveBufferSize(int size) throws SocketException {
-            if (logger.isLoggable(Level.FINER))
-                logger.finer(toString() + " Ignoring setReceiveBufferSize size:" + size);
+        public void setReceiveBufferSize(int size) throws SocketException {
+            tdsChannelLock.lock();
+            try {
+                if (logger.isLoggable(Level.FINER))
+                    logger.finer(toString() + " Ignoring setReceiveBufferSize size:" + size);
+            } finally {
+                tdsChannelLock.unlock();
+            }
         }
 
         @Override
-        public synchronized void setSendBufferSize(int size) throws SocketException {
-            if (logger.isLoggable(Level.FINER))
-                logger.finer(toString() + " Ignoring setSendBufferSize size:" + size);
+        public void setSendBufferSize(int size) throws SocketException {
+            tdsChannelLock.lock();
+            try {
+                if (logger.isLoggable(Level.FINER))
+                    logger.finer(toString() + " Ignoring setSendBufferSize size:" + size);
+            } finally {
+                tdsChannelLock.unlock();
+            }
         }
 
         @Override
@@ -1566,8 +1596,13 @@ final class TDSChannel implements Serializable {
         }
 
         @Override
-        public synchronized void setSoTimeout(int timeout) throws SocketException {
-            tdsChannel.tcpSocket.setSoTimeout(timeout);
+        public void setSoTimeout(int timeout) throws SocketException {
+            tdsChannelLock.lock();
+            try {
+                tdsChannel.tcpSocket.setSoTimeout(timeout);
+            } finally {
+                tdsChannelLock.unlock();
+            }
         }
 
         @Override


### PR DESCRIPTION
Loom project: https://openjdk.java.net/projects/loom/

Using synchronized keyword pins the virtual thread on the platform thread degrading the performance. Using ReentrantLock should prevent it from happening.

Sample code:
```
void foo() {
  synchronized(this) {
     ... // performs IO or something blocking
  }
}
```
With code like:
```
// loom friendly ...

private final Lock lock = new ReentrantLock();

void foo() {
  lock.lock();
  try {
     ... // performs IO or something blocking
  } finally {
     lock.unlock();
  }
}
```