### PR TITLE
Allow constructing a `microsoft.sql.DateTimeOffset` instance from a `java.time.OffsetDateTime` value

### DIFF
--- a/src/main/java/microsoft/sql/DateTimeOffset.java
+++ b/src/main/java/microsoft/sql/DateTimeOffset.java
@@ -78,11 +78,11 @@ public final class DateTimeOffset implements java.io.Serializable, java.lang.Com
      * @param offsetDateTime A java.time.OffsetDateTime value
      * @apiNote DateTimeOffset represents values to 100ns precision. If the java.time.OffsetDateTime instance represents
      * a value that is more precise, values in excess of the 100ns precision are rounded to the nearest
-     * multiple of 100ns.
+     * multiple of 100ns. Values within 50 nanoseconds of the next second are rounded up to the next second.
      */
     private DateTimeOffset(java.time.OffsetDateTime offsetDateTime) {
         int hundredNanos = ((offsetDateTime.getNano() + 50) / 100);
-        this.utcMillis = offsetDateTime.toEpochSecond() * 1000;
+        this.utcMillis = (offsetDateTime.toEpochSecond() * 1000) + (hundredNanos / HUNDRED_NANOS_PER_SECOND * 1000);
         this.nanos = 100 * (hundredNanos % HUNDRED_NANOS_PER_SECOND);
         this.minutesOffset = offsetDateTime.getOffset().getTotalSeconds() / 60;
     }
@@ -127,7 +127,7 @@ public final class DateTimeOffset implements java.io.Serializable, java.lang.Com
      * @return The DateTimeOffset value of the input java.time.OffsetDateTime
      * @apiNote DateTimeOffset represents values to 100ns precision. If the java.time.OffsetDateTime instance represents
      * a value that is more precise, values in excess of the 100ns precision are rounded to the nearest
-     * multiple of 100ns.
+     * multiple of 100ns. Values within 50 nanoseconds of the next second are rounded up to the next second.
      */
     public static DateTimeOffset valueOf(java.time.OffsetDateTime offsetDateTime) {
         return new DateTimeOffset(offsetDateTime);

--- a/src/main/java/microsoft/sql/DateTimeOffset.java
+++ b/src/main/java/microsoft/sql/DateTimeOffset.java
@@ -73,6 +73,21 @@ public final class DateTimeOffset implements java.io.Serializable, java.lang.Com
     }
 
     /**
+     * Constructs a DateTimeOffset from an existing java.time.OffsetDateTime
+     *
+     * @param offsetDateTime A java.time.OffsetDateTime value
+     * @apiNote DateTimeOffset represents values to 100ns precision. If the java.time.OffsetDateTime instance represents
+     * a value that is more precise, values in excess of the 100ns precision are rounded to the nearest
+     * multiple of 100ns.
+     */
+    private DateTimeOffset(java.time.OffsetDateTime offsetDateTime) {
+        int hundredNanos = ((offsetDateTime.getNano() + 50) / 100);
+        this.utcMillis = offsetDateTime.toEpochSecond() * 1000;
+        this.nanos = 100 * (hundredNanos % HUNDRED_NANOS_PER_SECOND);
+        this.minutesOffset = offsetDateTime.getOffset().getTotalSeconds() / 60;
+    }
+
+    /**
      * Converts a java.sql.Timestamp value with an integer offset to the equivalent DateTimeOffset value
      * 
      * @param timestamp
@@ -103,6 +118,19 @@ public final class DateTimeOffset implements java.io.Serializable, java.lang.Com
 
         return new DateTimeOffset(timestamp,
                 (calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET)) / (60 * 1000));
+    }
+
+    /**
+     * Directly converts a {@link java.time.OffsetDateTime} value to an equivalent {@link DateTimeOffset} value
+     *
+     * @param offsetDateTime A java.time.OffsetDateTime value
+     * @return The DateTimeOffset value of the input java.time.OffsetDateTime
+     * @apiNote DateTimeOffset represents values to 100ns precision. If the java.time.OffsetDateTime instance represents
+     * a value that is more precise, values in excess of the 100ns precision are rounded to the nearest
+     * multiple of 100ns.
+     */
+    public static DateTimeOffset valueOf(java.time.OffsetDateTime offsetDateTime) {
+        return new DateTimeOffset(offsetDateTime);
     }
 
     /** formatted value */

--- a/src/test/java/microsoft/sql/DateTimeOffsetTest.java
+++ b/src/test/java/microsoft/sql/DateTimeOffsetTest.java
@@ -1,0 +1,39 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+
+package microsoft.sql;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public class DateTimeOffsetTest {
+
+    @Test
+    @DisplayName("DateTimeOffset.valueOf(offsetDateTime) instantiates correct DateTimeOffset instances.")
+    void valueOfOffsetDateTime() {
+        int nanos = 123456789;
+        int hundredNanos = 1234568; // DateTimeOffset has a precision of 100 nanos of second
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(
+                2024,
+                2,
+                25,
+                23,
+                55,
+                6,
+                nanos,
+                ZoneOffset.ofHoursMinutes(1, 30)
+        );
+        Assertions
+                .assertEquals(
+                        offsetDateTime.withNano(hundredNanos * 100),
+                        DateTimeOffset.valueOf(offsetDateTime).getOffsetDateTime()
+                );
+    }
+
+}

--- a/src/test/java/microsoft/sql/DateTimeOffsetTest.java
+++ b/src/test/java/microsoft/sql/DateTimeOffsetTest.java
@@ -36,4 +36,16 @@ public class DateTimeOffsetTest {
                 );
     }
 
+    @Test
+    @DisplayName("DateTimeOffset.valueOf(offsetDateTime) correctly rounds up values within 50 nanoseconds of the next second.")
+    void valueOfOffsetDateTimeRounding() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.now().withNano(999999950);
+        Assertions
+                .assertEquals(
+                        offsetDateTime
+                                .withSecond(offsetDateTime.getSecond() + 1)
+                                .withNano(0),
+                        DateTimeOffset.valueOf(offsetDateTime).getOffsetDateTime()
+                );
+    }
 }


### PR DESCRIPTION
Operates similarly to existing constructor however avoids additional expense of creating Timestamp instances, and increased timezone related error potential, by directly converting java.time.OffsetDateTime instances.

Reverse of existing `DateTimeOffset.getOffsetDateTime()` method.

Rounds precision to closest 100ns matching existing semantics of `Timestamp` based constructor.