### PR TITLE
Add support for TDSType.GUID (fix) (#1582)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -57,6 +57,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -4782,6 +4783,32 @@ final class TDSWriter {
 
         byte[] val = DDC.convertBigDecimalToBytes(bdValue, nScale);
         writeBytes(val, 0, val.length);
+    }
+
+    /**
+     * Append a UUID in RPC transmission format.
+     *
+     * @param sName
+     *        the optional parameter name
+     * @param uuidValue
+     *        the data value
+     * @param bOut
+     *        boolean true if the data value is being registered as an output parameter
+     */
+    void writeRPCUUID(String sName, UUID uuidValue, boolean bOut) throws SQLServerException {
+        writeRPCNameValType(sName, bOut, TDSType.GUID);
+
+        if (uuidValue == null) {
+            writeByte((byte) 0);
+            writeByte((byte) 0);
+
+        } else {
+            writeByte((byte) 0x10);  // maximum length = 16
+            writeByte((byte) 0x10);  // length = 16
+
+            byte[] val = Util.asGuidByteArray(uuidValue);
+            writeBytes(val, 0, val.length);
+        }
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -22,6 +22,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.UUID;
 
 
 /**
@@ -1122,6 +1123,10 @@ final class Parameter {
         }
 
         void execute(DTV dtv, Boolean booleanValue) throws SQLServerException {
+            setTypeDefinition(dtv);
+        }
+
+        void execute(DTV dtv, UUID uuidValue) throws SQLServerException {
             setTypeDefinition(dtv);
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
@@ -1,0 +1,97 @@
+package com.microsoft.sqlserver.jdbc.datatypes;
+
+import com.microsoft.sqlserver.jdbc.RandomUtil;
+import com.microsoft.sqlserver.jdbc.SQLServerResultSet;
+import com.microsoft.sqlserver.jdbc.TestResource;
+import com.microsoft.sqlserver.jdbc.TestUtils;
+import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import microsoft.sql.Types;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/*
+ * This test is for testing the serialisation of String as microsoft.sql.Types.GUID
+ */
+@RunWith(JUnitPlatform.class)
+public class GuidTest extends AbstractTest {
+
+    final static String tableName = RandomUtil.getIdentifier("GuidTestTable");
+    final static String escapedTableName = AbstractSQLGenerator.escapeIdentifier(tableName);
+
+    @BeforeAll
+    public static void setupTests() throws Exception {
+        setConnection();
+    }
+
+    /*
+     * Test UUID conversions
+     */
+    @Test
+    public void testGuid() throws Exception {
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+
+            // Create the test table
+            TestUtils.dropTableIfExists(escapedTableName, stmt);
+
+            String query = "create table " + escapedTableName
+                    + " (uuid uniqueidentifier, id int IDENTITY primary key)";
+            stmt.executeUpdate(query);
+
+            UUID uuid = UUID.randomUUID();
+            String uuidString = uuid.toString();
+            int id = 1;
+
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO " + escapedTableName
+                    + " VALUES(?) SELECT * FROM " + escapedTableName + " where id = ?")) {
+
+                pstmt.setObject(1, uuidString, Types.GUID);
+                pstmt.setObject(2, id++);
+                pstmt.execute();
+                pstmt.getMoreResults();
+                try (SQLServerResultSet rs = (SQLServerResultSet) pstmt.getResultSet()) {
+                    rs.next();
+                    assertEquals(uuid, UUID.fromString(rs.getUniqueIdentifier(1)));
+                }
+
+                // Test NULL GUID
+                pstmt.setObject(1, null, Types.GUID);
+                pstmt.setObject(2, id++);
+                pstmt.execute();
+                pstmt.getMoreResults();
+                try (SQLServerResultSet rs = (SQLServerResultSet) pstmt.getResultSet()) {
+                    rs.next();
+                    String s = rs.getUniqueIdentifier(1);
+                    assertNull(s);
+                    assertTrue(rs.wasNull());
+                }
+
+                // Test Illegal GUID
+                try {
+                    pstmt.setObject(1, "garbage", Types.GUID);
+                    fail(TestResource.getResource("R_expectedFailPassed"));
+                } catch (IllegalArgumentException e) {
+                    assertEquals("Invalid UUID string: garbage", e.getMessage());
+                }
+            }
+        } finally {
+            try (Statement stmt = connection.createStatement()) {
+                TestUtils.dropTableIfExists(escapedTableName, stmt);
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
+import com.microsoft.sqlserver.testframework.Constants;
 /*
  * This test is for testing the serialisation of String as microsoft.sql.Types.GUID
  */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
@@ -8,6 +8,7 @@ import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import microsoft.sql.Types;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/GuidTest.java
@@ -41,6 +41,7 @@ public class GuidTest extends AbstractTest {
      * Test UUID conversions
      */
     @Test
+    @Tag(Constants.xAzureSQLDW)
     public void testGuid() throws Exception {
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
 


### PR DESCRIPTION
This is a fix for the merged and reverted PR #2324.

The original PR intends to provide support for sending UUID parameters as `TDSType.GUID (0x24)` on the wire and (hopefully) implements feature request #1582. 
It currently requires the Java parameter be given to the driver as `String` with `JDBCType.GUID`, i.e. :
```
st.setObject(index, myUUID.toString(), microsoft.sql.Types.GUID);
```
