### PR TITLE
Make enum SQLServerSortOrder become public

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSortOrder.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSortOrder.java
@@ -10,7 +10,7 @@ package com.microsoft.sqlserver.jdbc;
  * Specifies the sorting order
  *
  */
-enum SQLServerSortOrder {
+public enum SQLServerSortOrder {
     ASCENDING(0),
     DESCENDING(1),
     UNSPECIFIED(-1);


### PR DESCRIPTION
Issue #2404 

Make this enum to be public, so that people can create "SQLServerMetaData" like below:

new SQLServerMetaData("row_id", java.sql.Types.INTEGER, 0, 0, true, false, SQLServerSortOrder.Unspecified, -1)