### PR TITLE
Execute stored procedures directly for RPC calls

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -216,7 +216,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         }
 
         if (inOutParam[i - 1].isReturnValue() && bReturnValueSyntax && !isCursorable(executeMethod) && !isTVPType
-                && returnValueStatus != userDefinedFunctionReturnStatus) {
+                && returnValueStatus != USER_DEFINED_FUNCTION_RETURN_STATUS) {
             return inOutParam[i - 1];
         }
 
@@ -364,7 +364,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         OutParamHandler outParamHandler = new OutParamHandler();
 
         if (bReturnValueSyntax && (nOutParamsAssigned == 0) && !isCursorable(executeMethod) && !isTVPType
-                && callRPCDirectly(inOutParam) && returnValueStatus != userDefinedFunctionReturnStatus) {
+                && callRPCDirectly(inOutParam) && returnValueStatus != USER_DEFINED_FUNCTION_RETURN_STATUS) {
             nOutParamsAssigned++;
         }
 
@@ -413,7 +413,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 outParamIndex = outParamHandler.srv.getOrdinalOrLength();
 
                 if (bReturnValueSyntax && !isCursorable(executeMethod) && !isTVPType && callRPCDirectly(inOutParam)
-                        && returnValueStatus != userDefinedFunctionReturnStatus) {
+                        && returnValueStatus != USER_DEFINED_FUNCTION_RETURN_STATUS) {
                     outParamIndex++;
                 } else {
                     // Statements need to have their out param indices adjusted by the number
@@ -423,7 +423,11 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
                 if ((outParamIndex < 0 || outParamIndex >= inOutParam.length)
                         || (!inOutParam[outParamIndex].isOutput())) {
-                    if (outParamHandler.srv.getStatus() == userDefinedFunctionReturnStatus) {
+
+                    // For RPC calls with out parameters, the initial return value token will indicate
+                    // it being a RPC. In such case, consume the token as it does not contain the out parameter
+                    // value. The subsequent token will have the value.
+                    if (outParamHandler.srv.getStatus() == USER_DEFINED_FUNCTION_RETURN_STATUS) {
                         continue;
                     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -423,13 +423,13 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
 
                 if ((outParamIndex < 0 || outParamIndex >= inOutParam.length)
                         || (!inOutParam[outParamIndex].isOutput())) {
+                    if (outParamHandler.srv.getStatus() == userDefinedFunctionReturnStatus) {
+                        continue;
+                    }
+
                     if (getStatementLogger().isLoggable(java.util.logging.Level.INFO)) {
                         getStatementLogger().info(toString() + " Unexpected outParamIndex: " + outParamIndex
                                 + "; adjustment: " + outParamIndexAdjustment);
-                    }
-
-                    if (outParamHandler.srv.getStatus() == 2) {
-                        continue;
                     }
 
                     connection.throwInvalidTDS();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -269,7 +269,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             // the response stream.
             for (int index = 0; index < inOutParam.length; ++index) {
                 if (index != outParamIndex && inOutParam[index].isValueGotten()) {
-                    assert inOutParam[index].isOutput();
                     inOutParam[index].resetOutputValue();
                 }
             }
@@ -428,6 +427,11 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                         getStatementLogger().info(toString() + " Unexpected outParamIndex: " + outParamIndex
                                 + "; adjustment: " + outParamIndexAdjustment);
                     }
+
+                    if (outParamHandler.srv.getStatus() == 2) {
+                        continue;
+                    }
+
                     connection.throwInvalidTDS();
                 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -77,9 +77,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     // flag whether is call escape syntax
     private boolean isCallEscapeSyntax;
 
-    // flag whether is four part syntax
-    private boolean isFourPartSyntax;
-
     /** Parameter positions in processed SQL statement text. */
     final int[] userSQLParamPositions;
 
@@ -148,11 +145,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      * Regex for 'exec' escape syntax
      */
     private static final Pattern execEscapePattern = Pattern.compile("^\\s*(?i)(?:exec|execute)\\b");
-
-    /**
-     * Regex for four part syntax
-     */
-    private static final Pattern fourPartSyntaxPattern = Pattern.compile("(.+)\\.(.+)\\.(.+)\\.(.+)");
 
     /** Returns the prepared statement SQL */
     @Override
@@ -290,7 +282,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         userSQL = parsedSQL.processedSQL;
         isExecEscapeSyntax = isExecEscapeSyntax(sql);
         isCallEscapeSyntax = isCallEscapeSyntax(sql);
-        isFourPartSyntax = isFourPartSyntax(sql);
         userSQLParamPositions = parsedSQL.parameterPositions;
         initParams(userSQLParamPositions.length);
         useBulkCopyForBatchInsert = conn.getUseBulkCopyForBatchInsert();
@@ -1258,10 +1249,8 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         // 4. Compliant CALL escape syntax
         // If isExecEscapeSyntax is true, EXEC escape syntax is used then use prior behaviour of
         // wrapping call to execute the procedure
-        // If isFourPartSyntax is true, sproc is being executed against linked server, then
-        // use prior behaviour of wrapping call to execute procedure
         return (null != procedureName && paramCount != 0 && !isTVPType(params) && isCallEscapeSyntax
-                && !isExecEscapeSyntax && !isFourPartSyntax);
+                && !isExecEscapeSyntax);
     }
 
     /**
@@ -1287,10 +1276,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     private boolean isCallEscapeSyntax(String sql) {
         return callEscapePattern.matcher(sql).find();
-    }
-
-    private boolean isFourPartSyntax(String sql) {
-        return fourPartSyntaxPattern.matcher(sql).find();
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -72,7 +72,7 @@ public class SQLServerStatement implements ISQLServerStatement {
     /** Check if statement contains TVP Type */
     boolean isTVPType = false;
 
-    static int userDefinedFunctionReturnStatus = 2;
+    protected static final int USER_DEFINED_FUNCTION_RETURN_STATUS = 2;
 
     final boolean getIsResponseBufferingAdaptive() {
         return isResponseBufferingAdaptive;
@@ -1676,7 +1676,7 @@ public class SQLServerStatement implements ISQLServerStatement {
                 // in which case we need to stop parsing and let CallableStatement take over.
                 // A RETVALUE token appearing in the execution results, but before any RETSTATUS
                 // token, is a TEXTPTR return value that should be ignored.
-                if (moreResults && null == procedureRetStatToken && status != userDefinedFunctionReturnStatus) {
+                if (moreResults && null == procedureRetStatToken && status != USER_DEFINED_FUNCTION_RETURN_STATUS) {
                     Parameter p = new Parameter(
                             Util.shouldHonorAEForParameters(stmtColumnEncriptionSetting, connection));
                     p.skipRetValStatus(tdsReader);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/StreamRetValue.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/StreamRetValue.java
@@ -18,8 +18,12 @@ final class StreamRetValue extends StreamPacket {
      */
     private int ordinalOrLength;
 
-    final int getOrdinalOrLength() {
+    int getOrdinalOrLength() {
         return ordinalOrLength;
+    }
+
+    int getStatus() {
+        return status;
     }
 
     /*

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1156,7 +1156,6 @@ public class CallableStatementTest extends AbstractTest {
         String table = "serverList";
 
         try (Statement stmt = connection.createStatement()) {
-            stmt.execute("EXEC sp_droplinkedsrvlogin @rmtsrvname='" + linkedServer + "', @localLogin=NULL;");
             stmt.execute("IF OBJECT_ID(N'" + table + "') IS NOT NULL DROP TABLE " + table);
             stmt.execute("CREATE TABLE " + table
                     + " (serverName varchar(100),network varchar(100),serverStatus varchar(4000), id int, collation varchar(100), connectTimeout int, queryTimeout int)");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1156,6 +1156,7 @@ public class CallableStatementTest extends AbstractTest {
         String table = "serverList";
 
         try (Statement stmt = connection.createStatement()) {
+            stmt.execute("EXEC sp_droplinkedsrvlogin @rmtsrvname='" + linkedServer + "', @localLogin=NULL;");
             stmt.execute("IF OBJECT_ID(N'" + table + "') IS NOT NULL DROP TABLE " + table);
             stmt.execute("CREATE TABLE " + table
                     + " (serverName varchar(100),network varchar(100),serverStatus varchar(4000), id int, collation varchar(100), connectTimeout int, queryTimeout int)");
@@ -1187,6 +1188,9 @@ public class CallableStatementTest extends AbstractTest {
                 Statement stmt = linkedServerConnection.createStatement()) {
             stmt.execute(
                     "create or alter procedure dbo.TestAdd(@Num1 int, @Num2 int, @Result int output) as begin set @Result = @Num1 + @Num2; end;");
+
+            stmt.execute(
+                    "create or alter procedure dbo.TestReturn(@Num1 int) as select @Num1 return @Num1*3  ");
         }
 
         try (CallableStatement cstmt = connection
@@ -1210,6 +1214,14 @@ public class CallableStatementTest extends AbstractTest {
             cstmt.registerOutParameter(3, Types.INTEGER);
             cstmt.execute();
             assertEquals(sum, cstmt.getInt(3));
+        }
+
+        try (CallableStatement cstmt = connection.prepareCall("{? = call [" + linkedServer + "].master.dbo.TestReturn(?)}")) {
+            int expected = 15;
+            cstmt.registerOutParameter(1, java.sql.Types.INTEGER);
+            cstmt.setInt(2, 5);
+            cstmt.execute();
+            assertEquals(expected, cstmt.getInt(3));
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1188,8 +1188,7 @@ public class CallableStatementTest extends AbstractTest {
             stmt.execute(
                     "create or alter procedure dbo.TestAdd(@Num1 int, @Num2 int, @Result int output) as begin set @Result = @Num1 + @Num2; end;");
 
-            stmt.execute(
-                    "create or alter procedure dbo.TestReturn(@Num1 int) as select @Num1 return @Num1*3  ");
+            stmt.execute("create or alter procedure dbo.TestReturn(@Num1 int) as select @Num1 return @Num1*3  ");
         }
 
         try (CallableStatement cstmt = connection
@@ -1215,7 +1214,8 @@ public class CallableStatementTest extends AbstractTest {
             assertEquals(sum, cstmt.getInt(3));
         }
 
-        try (CallableStatement cstmt = connection.prepareCall("{? = call [" + linkedServer + "].master.dbo.TestReturn(?)}")) {
+        try (CallableStatement cstmt = connection
+                .prepareCall("{? = call [" + linkedServer + "].master.dbo.TestReturn(?)}")) {
             int expected = 15;
             cstmt.registerOutParameter(1, java.sql.Types.INTEGER);
             cstmt.setInt(2, 5);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -1221,7 +1221,7 @@ public class CallableStatementTest extends AbstractTest {
             cstmt.registerOutParameter(1, java.sql.Types.INTEGER);
             cstmt.setInt(2, 5);
             cstmt.execute();
-            assertEquals(expected, cstmt.getInt(3));
+            assertEquals(expected, cstmt.getInt(1));
         }
     }
 


### PR DESCRIPTION
RPC calls were falling back to old logic of being wrapped in sp_executesql calls to execute. With the PR, moving forward, RPC calls are also directly executed.