### PR TITLE
[Backport] Clear prepared statement cache when resetting statement pool connection (2361)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1794,6 +1794,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     final void resetPooledConnection() {
         tdsChannel.resetPooledConnection();
         initResettableValues();
+
+        // reset prepared statement handle cache
+        if (null != preparedStatementHandleCache) {
+            preparedStatementHandleCache.clear();
+        }
     }
 
     /**


### PR DESCRIPTION
Backport a fix to make sure the prepared statement cache is cleared when resetting statement pool connection (#2361).