### PR TITLE
[Backport] Clear prepared statement handle before reconnect (2364)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ReconnectListener.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ReconnectListener.java
@@ -1,0 +1,15 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc;
+
+/**
+ * This functional interface represents a listener which is called before a reconnect of {@link SQLServerConnection}.
+ */
+@FunctionalInterface
+public interface ReconnectListener {
+
+    void beforeReconnect();
+
+}

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1756,6 +1756,19 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return pooledConnectionParent;
     }
 
+    /**
+     * List of listeners which are called before reconnecting.
+     */
+    private List<ReconnectListener> reconnectListeners = new ArrayList<>();
+
+    public void registerBeforeReconnectListener(ReconnectListener reconnectListener) {
+        reconnectListeners.add(reconnectListener);
+    }
+
+    public void removeBeforeReconnectListener(ReconnectListener reconnectListener) {
+        reconnectListeners.remove(reconnectListener);
+    }
+
     SQLServerConnection(String parentInfo) {
         int connectionID = nextConnectionID(); // sequential connection id
         traceID = "ConnectionID:" + connectionID;
@@ -4346,6 +4359,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                 if (null != preparedStatementHandleCache) {
                                     preparedStatementHandleCache.clear();
                                 }
+
+                                this.reconnectListeners.forEach(ReconnectListener::beforeReconnect);
 
                                 if (loggerResiliency.isLoggable(Level.FINE)) {
                                     loggerResiliency.fine(toString()

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -209,6 +209,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     private Vector<CryptoMetadata> cryptoMetaBatch = new Vector<>();
 
     /**
+     * Listener to clear the {@link SQLServerPreparedStatement#prepStmtHandle} and
+     * {@link SQLServerPreparedStatement#cachedPreparedStatementHandle} before reconnecting.
+     */
+    private ReconnectListener clearPrepStmtHandleOnReconnectListener;
+
+    /**
      * Constructs a SQLServerPreparedStatement.
      * 
      * @param conn
@@ -227,6 +233,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     SQLServerPreparedStatement(SQLServerConnection conn, String sql, int nRSType, int nRSConcur,
             SQLServerStatementColumnEncryptionSetting stmtColEncSetting) throws SQLServerException {
         super(conn, nRSType, nRSConcur, stmtColEncSetting);
+
+        clearPrepStmtHandleOnReconnectListener = this::clearPrepStmtHandle;
+        connection.registerBeforeReconnectListener(clearPrepStmtHandleOnReconnectListener);
 
         if (null == sql) {
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_NullValue"));
@@ -262,6 +271,8 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      * Closes the prepared statement's prepared handle.
      */
     private void closePreparedHandle() {
+        connection.removeBeforeReconnectListener(clearPrepStmtHandleOnReconnectListener);
+
         if (!hasPreparedStatementHandle())
             return;
 
@@ -3533,5 +3544,13 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                 SQLServerException.getErrString("R_cannotTakeArgumentsPreparedOrCallable"));
         Object[] msgArgs = {"addBatch()"};
         throw new SQLServerException(this, form.format(msgArgs), null, 0, false);
+    }
+
+    private void clearPrepStmtHandle() {
+        prepStmtHandle = 0;
+        cachedPreparedStatementHandle = null;
+        if (getStatementLogger().isLoggable(Level.FINER)) {
+            getStatementLogger().finer(toString() + " cleared cachedPrepStmtHandle!");
+        }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
@@ -525,6 +525,8 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
         verifiedMethodNames.add("setUseFlexibleCallableStatements");
         verifiedMethodNames.add("getCalcBigDecimalPrecision");
         verifiedMethodNames.add("setCalcBigDecimalPrecision");
+        verifiedMethodNames.add("registerBeforeReconnectListener");
+        verifiedMethodNames.add("removeBeforeReconnectListener");
         return verifiedMethodNames;
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -6,18 +6,27 @@
 package com.microsoft.sqlserver.jdbc.resiliency;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.UUID;
 
 import javax.sql.PooledConnection;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
@@ -26,10 +35,6 @@ import com.microsoft.sqlserver.jdbc.SQLServerPooledConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
 import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 
@@ -364,6 +369,99 @@ public class BasicConnectionTest extends AbstractTest {
                 pstmt.execute();
             }
             assertEquals(0, con.getDiscardedServerPreparedStatementCount());
+        }
+    }
+
+    @Test
+    public void testPreparedStatementHandleOfStatementShouldBeCleared() throws SQLException {
+        try (SQLServerConnection con = (SQLServerConnection) ResiliencyUtils.getConnection(connectionString)) {
+            int cacheSize = 2;
+            String query = String.format("/*testPreparedStatementHandleOfStatementShouldBeCleared%s*/SELECT 1; -- ",
+                    UUID.randomUUID().toString());
+
+            // enable caching
+            con.setDisableStatementPooling(false);
+            con.setStatementPoolingCacheSize(cacheSize);
+            con.setServerPreparedStatementDiscardThreshold(cacheSize);
+
+            List<SQLServerPreparedStatement> statements = new LinkedList<>();
+
+            // add statements to fill cache
+            for (int i = 0; i < cacheSize + 1; ++i) {
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con.prepareStatement(query + i);
+                pstmt.execute();
+                pstmt.execute();
+                pstmt.execute();
+                pstmt.getMoreResults();
+                statements.add(pstmt);
+            }
+
+            // handle of the prepared statement should be set
+            assertNotEquals(0, statements.get(1).getPreparedStatementHandle());
+
+            ResiliencyUtils.killConnection(con, connectionString, 1);
+
+            // call first statement to trigger reconnect
+            statements.get(0).execute();
+
+            // handle of the other statements should be cleared after reconnect
+            assertEquals(0, statements.get(1).getPreparedStatementHandle());
+        }
+    }
+
+    @Test
+    public void testPreparedStatementShouldNotUseWrongHandleAfterReconnect() throws SQLException {
+        try (SQLServerConnection con = (SQLServerConnection) ResiliencyUtils.getConnection(connectionString)) {
+            int cacheSize = 3;
+            String queryOne = "select * from sys.sysusers where name=?;";
+            String queryTwo = "select * from sys.sysusers where name=? and uid=?;";
+            String queryThree = "select * from sys.sysusers where name=? and uid=? and islogin=?";
+
+            String parameterOne = "name";
+            int parameterUid = 0;
+            int parameterIsLogin = 0;
+
+            // enable caching
+            con.setDisableStatementPooling(false);
+            con.setStatementPoolingCacheSize(cacheSize);
+            con.setServerPreparedStatementDiscardThreshold(cacheSize);
+
+            List<PreparedStatement> statements = new LinkedList<>();
+
+            PreparedStatement ps = con.prepareStatement(queryOne);
+            ps.setString(1, parameterOne);
+            statements.add(ps);
+
+            ps = con.prepareStatement(queryTwo);
+            ps.setString(1, parameterOne);
+            ps.setInt(2, parameterUid);
+            statements.add(ps);
+
+            ps = con.prepareStatement(queryThree);
+            ps.setString(1, parameterOne);
+            ps.setInt(2, parameterUid);
+            ps.setInt(3, parameterIsLogin);
+            statements.add(ps);
+
+            // add new statements to fill cache
+            for (PreparedStatement preparedStatement : statements) {
+                preparedStatement.execute();
+                preparedStatement.execute();
+                preparedStatement.execute();
+                preparedStatement.getMoreResults();
+            }
+
+            ResiliencyUtils.killConnection(con, connectionString, 1);
+
+            // call statements in reversed order, in order to force the statement to use the wrong handle
+            // first execute triggers a reconnect
+            Collections.reverse(statements);
+            for (PreparedStatement preparedStatement : statements) {
+                preparedStatement.execute();
+                preparedStatement.execute();
+                preparedStatement.execute();
+                preparedStatement.getMoreResults();
+            }
         }
     }
 


### PR DESCRIPTION
Backport the user-submitted fix for clearing prepared statement handle before reconnect (#2364).