### PR TITLE
Prepared statement objects should be reusable

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2681,13 +2681,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     private void checkAdditionalQuery() {
         while (checkAndRemoveCommentsAndSpace(true)) {}
-
-        // At this point, if localUserSQL is not empty (after removing all whitespaces, semicolons and comments), we
-        // have a
-        // new query. reject this.
-        if (localUserSQL.length() > 0) {
-            throw new IllegalArgumentException(SQLServerException.getErrString("R_multipleQueriesNotAllowed"));
-        }
     }
 
     private String parseUserSQLForTableNameDW(boolean hasInsertBeenFound, boolean hasIntoBeenFound,


### PR DESCRIPTION
Discovered that when attempting to reuse the same pstmt object, the driver would error out with `R_multipleQueriesNotAllowed` and consume that error.