### PR TITLE
Updated fedauth error tests

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
@@ -397,7 +397,8 @@ public class ErrorMessageTest extends FedauthCommon {
                     && e.getCause().getCause().getMessage().toLowerCase().contains("invalid username or password")
                     || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY)
                     || e.getCause().getCause().getMessage().contains(ERR_FAULT_ID3342)
-                    || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
+                    || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED)
+                    || e.getMessage().contains(ERR_FAULT_AUTH_FAIL));
         }
     }
 
@@ -424,7 +425,8 @@ public class ErrorMessageTest extends FedauthCommon {
                     && e.getCause().getCause().getMessage().toLowerCase().contains("invalid username or password")
                     || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY)
                     || e.getCause().getCause().getMessage().contains(ERR_FAULT_ID3342)
-                    || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
+                    || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED)
+                    || e.getMessage().contains(ERR_FAULT_AUTH_FAIL));
         }
     }
 
@@ -445,7 +447,8 @@ public class ErrorMessageTest extends FedauthCommon {
                     && e.getCause().getCause().getMessage().toLowerCase().contains("invalid username or password")
                     || e.getCause().getCause().getMessage().contains(ERR_MSG_SIGNIN_TOO_MANY)
                     || e.getCause().getCause().getMessage().contains(ERR_FAULT_ID3342)
-                    || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED));
+                    || e.getMessage().contains(ERR_MSG_REQUEST_THROTTLED)
+                    || e.getMessage().contains(ERR_FAULT_AUTH_FAIL));
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthCommon.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthCommon.java
@@ -128,6 +128,7 @@ public class FedauthCommon extends AbstractTest {
     static final String ERR_MSG_HAS_BEEN_CLOSED = TestResource.getResource("R_hasBeenClosed");
     static final String ERR_MSG_SIGNIN_TOO_MANY = TestResource.getResource("R_signinTooManyTimes");
     static final String ERR_FAULT_ID3342 = "FaultMessage: ID3242";
+    static final String ERR_FAULT_AUTH_FAIL = "FaultMessage: Authentication Failure";
     static final String ERR_MSG_NOT_AUTH_AND_IS = TestUtils.R_BUNDLE
             .getString("R_SetAuthenticationWhenIntegratedSecurityTrue");
     static final String ERR_MSG_NOT_AUTH_AND_USER_PASSWORD = TestUtils.R_BUNDLE


### PR DESCRIPTION
Internal pipelines are failing because the error message returned from failed AAD password auth has changed. Updated tests.