### PR TITLE
Remove maximum time testing from CRL

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
@@ -506,9 +506,9 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
                     (e.getMessage().toLowerCase()
                             .contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase()))
                             || (TestUtils.getProperty(connectionString, "msiClientId") != null && e.getMessage()
-                            .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
+                                    .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
                             || ((isSqlAzure() || isSqlAzureDW()) && e.getMessage().toLowerCase()
-                            .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
+                                    .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
                     e.getMessage());
         }
 
@@ -523,9 +523,9 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
                     (e.getMessage().toLowerCase()
                             .contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase()))
                             || (TestUtils.getProperty(connectionString, "msiClientId") != null && e.getMessage()
-                            .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
+                                    .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
                             || ((isSqlAzure() || isSqlAzureDW()) && e.getMessage().toLowerCase()
-                            .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
+                                    .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
                     e.getMessage());
 
             if (e.getMessage().toLowerCase().contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase())) {
@@ -546,9 +546,9 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
                     (e.getMessage().toLowerCase()
                             .contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase()))
                             || (TestUtils.getProperty(connectionString, "msiClientId") != null && e.getMessage()
-                            .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
+                                    .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
                             || ((isSqlAzure() || isSqlAzureDW()) && e.getMessage().toLowerCase()
-                            .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
+                                    .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
                     e.getMessage());
 
             if (e.getMessage().toLowerCase().contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase())) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
@@ -56,7 +56,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
     /**
      * Test that the SQLServerConnection methods getRetryExec and setRetryExec correctly get the existing retryExec, and
      * set the retryExec connection parameter respectively.
-     *
+     * 
      * @throws Exception
      *         if an exception occurs
      */
@@ -108,7 +108,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that statement retry with prepared statements correctly retries given the provided retryExec rule.
-     *
+     * 
      * @throws Exception
      *         if unable to connect or execute against db
      */
@@ -133,7 +133,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that statement retry with callable statements correctly retries given the provided retryExec rule.
-     *
+     * 
      * @throws Exception
      *         if unable to connect or execute against db
      */
@@ -158,7 +158,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that statement retry with SQL server statements correctly retries given the provided retryExec rule.
-     *
+     * 
      * @throws Exception
      *         if unable to connect or execute against db
      */
@@ -391,7 +391,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid retry error correctly fail.
-     *
+     * 
      * @throws Exception
      *         for the invalid parameter
      */
@@ -414,7 +414,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid retry count correctly fail.
-     *
+     * 
      * @throws Exception
      *         for the invalid parameter
      */
@@ -437,7 +437,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid initial retry time correctly fail.
-     *
+     * 
      * @throws Exception
      *         for the invalid parameter
      */
@@ -460,7 +460,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid operand correctly fail.
-     *
+     * 
      * @throws Exception
      *         for the invalid parameter
      */
@@ -475,7 +475,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid retry change correctly fail.
-     *
+     * 
      * @throws Exception
      *         for the invalid parameter
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
@@ -56,7 +56,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
     /**
      * Test that the SQLServerConnection methods getRetryExec and setRetryExec correctly get the existing retryExec, and
      * set the retryExec connection parameter respectively.
-     * 
+     *
      * @throws Exception
      *         if an exception occurs
      */
@@ -108,7 +108,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that statement retry with prepared statements correctly retries given the provided retryExec rule.
-     * 
+     *
      * @throws Exception
      *         if unable to connect or execute against db
      */
@@ -133,7 +133,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that statement retry with callable statements correctly retries given the provided retryExec rule.
-     * 
+     *
      * @throws Exception
      *         if unable to connect or execute against db
      */
@@ -158,7 +158,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that statement retry with SQL server statements correctly retries given the provided retryExec rule.
-     * 
+     *
      * @throws Exception
      *         if unable to connect or execute against db
      */
@@ -223,8 +223,8 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that the correct number of retries are happening for all statement scenarios. Tests are expected to take
-     * a minimum of the sum of whatever has been defined for the waiting intervals, and maximum of the previous sum
-     * plus some amount of time to account for test environment slowness.
+     * a minimum of the sum of whatever has been defined for the waiting intervals. Maximum is not tested due to the
+     * unpredictable factor of slowness that can be applied to these tests.
      */
     @Test
     public void statementTimingTests() {
@@ -253,8 +253,6 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
             totalTime = System.currentTimeMillis() - timerStart;
             assertTrue(totalTime > TimeUnit.SECONDS.toMillis(5),
                     "total time: " + totalTime + ", expected minimum time: " + TimeUnit.SECONDS.toMillis(5));
-            assertTrue(totalTime < TimeUnit.SECONDS.toMillis(15),
-                    "total time: " + totalTime + ", expected maximum time: " + TimeUnit.SECONDS.toMillis(15));
         }
 
         timerStart = System.currentTimeMillis();
@@ -268,8 +266,6 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
             totalTime = System.currentTimeMillis() - timerStart;
             assertTrue(totalTime > TimeUnit.SECONDS.toMillis(2),
                     "total time: " + totalTime + ", expected minimum time: " + TimeUnit.SECONDS.toMillis(8));
-            assertTrue(totalTime < TimeUnit.SECONDS.toMillis(18),
-                    "total time: " + totalTime + ", expected maximum time: " + TimeUnit.SECONDS.toMillis(18));
         }
 
         timerStart = System.currentTimeMillis();
@@ -283,8 +279,6 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
             totalTime = System.currentTimeMillis() - timerStart;
             assertTrue(totalTime > TimeUnit.SECONDS.toMillis(3),
                     "total time: " + totalTime + ", expected minimum time: " + TimeUnit.SECONDS.toMillis(10));
-            assertTrue(totalTime < TimeUnit.SECONDS.toMillis(20),
-                    "total time: " + totalTime + ", expected maximum time: " + TimeUnit.SECONDS.toMillis(20));
         }
     }
 
@@ -397,7 +391,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid retry error correctly fail.
-     * 
+     *
      * @throws Exception
      *         for the invalid parameter
      */
@@ -420,7 +414,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid retry count correctly fail.
-     * 
+     *
      * @throws Exception
      *         for the invalid parameter
      */
@@ -443,7 +437,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid initial retry time correctly fail.
-     * 
+     *
      * @throws Exception
      *         for the invalid parameter
      */
@@ -466,7 +460,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid operand correctly fail.
-     * 
+     *
      * @throws Exception
      *         for the invalid parameter
      */
@@ -481,7 +475,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that rules with an invalid retry change correctly fail.
-     * 
+     *
      * @throws Exception
      *         for the invalid parameter
      */
@@ -496,14 +490,13 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
     /**
      * Tests that the correct number of retries are happening for all connection scenarios. Tests are expected to take
-     * a minimum of the sum of whatever has been defined for the waiting intervals, and maximum of the previous sum
-     * plus some amount of time to account for test environment slowness.
+     * a minimum of the sum of whatever has been defined for the waiting intervals. Maximum is not tested due to the
+     * unpredictable factor of slowness that can be applied to these tests.
      */
     @Test
     public void connectionTimingTest() {
         long totalTime;
         long timerStart = System.currentTimeMillis();
-        long expectedMaxTime = 10;
 
         // No retries since CRL rules override, expected time ~1 second
         try {
@@ -513,22 +506,14 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
                     (e.getMessage().toLowerCase()
                             .contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase()))
                             || (TestUtils.getProperty(connectionString, "msiClientId") != null && e.getMessage()
-                                    .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
+                            .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
                             || ((isSqlAzure() || isSqlAzureDW()) && e.getMessage().toLowerCase()
-                                    .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
+                            .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
                     e.getMessage());
-
-            if (e.getMessage().toLowerCase().contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase())) {
-                // Only check the timing if the correct error, "cannot open database", is returned.
-                totalTime = System.currentTimeMillis() - timerStart;
-                assertTrue(totalTime < TimeUnit.SECONDS.toMillis(expectedMaxTime),
-                        "total time: " + totalTime + ", expected time: " + TimeUnit.SECONDS.toMillis(expectedMaxTime));
-            }
         }
 
         timerStart = System.currentTimeMillis();
         long expectedMinTime = 10;
-        expectedMaxTime = 35;
 
         // (0s attempt + 0s attempt + 10s wait + 0s attempt) = expected 10s execution time
         try {
@@ -538,16 +523,14 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
                     (e.getMessage().toLowerCase()
                             .contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase()))
                             || (TestUtils.getProperty(connectionString, "msiClientId") != null && e.getMessage()
-                                    .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
+                            .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
                             || ((isSqlAzure() || isSqlAzureDW()) && e.getMessage().toLowerCase()
-                                    .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
+                            .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
                     e.getMessage());
 
             if (e.getMessage().toLowerCase().contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase())) {
                 // Only check the timing if the correct error, "cannot open database", is returned.
                 totalTime = System.currentTimeMillis() - timerStart;
-                assertTrue(totalTime < TimeUnit.SECONDS.toMillis(expectedMaxTime), "total time: " + totalTime
-                        + ", expected max time: " + TimeUnit.SECONDS.toMillis(expectedMaxTime));
                 assertTrue(totalTime > TimeUnit.SECONDS.toMillis(expectedMinTime), "total time: " + totalTime
                         + ", expected min time: " + TimeUnit.SECONDS.toMillis(expectedMinTime));
             }
@@ -563,16 +546,14 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
                     (e.getMessage().toLowerCase()
                             .contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase()))
                             || (TestUtils.getProperty(connectionString, "msiClientId") != null && e.getMessage()
-                                    .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
+                            .toLowerCase().contains(TestResource.getResource("R_loginFailedMI").toLowerCase()))
                             || ((isSqlAzure() || isSqlAzureDW()) && e.getMessage().toLowerCase()
-                                    .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
+                            .contains(TestResource.getResource("R_connectTimedOut").toLowerCase())),
                     e.getMessage());
 
             if (e.getMessage().toLowerCase().contains(TestResource.getResource("R_cannotOpenDatabase").toLowerCase())) {
                 // Only check the timing if the correct error, "cannot open database", is returned.
                 totalTime = System.currentTimeMillis() - timerStart;
-                assertTrue(totalTime < TimeUnit.SECONDS.toMillis(expectedMaxTime), "total time: " + totalTime
-                        + ", expected max time: " + TimeUnit.SECONDS.toMillis(expectedMaxTime));
                 assertTrue(totalTime > TimeUnit.SECONDS.toMillis(expectedMinTime), "total time: " + totalTime
                         + ", expected min time: " + TimeUnit.SECONDS.toMillis(expectedMinTime));
             }


### PR DESCRIPTION
Remove testing that the execution time is below a maximum for CRL. Minimum testing is required, as this tells us if a retry actually happened, but maximum can be affected by factors outside the feature and test and can not be reliably tested.