### PR TITLE
issue#2537 - Fix for SQLServerConnection infinite loop

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -7598,7 +7598,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     }
 
     /** request started flag */
-    private boolean requestStarted = false;
+    private volatile boolean requestStarted = false;
 
     /** original database autocommit mode */
     private boolean originalDatabaseAutoCommitMode;
@@ -7640,7 +7640,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     private volatile SQLWarning originalSqlWarnings;
 
     /** open statements */
-    private volatile List<ISQLServerStatement> openStatements;
+    private List<ISQLServerStatement> openStatements;
 
     /** original usesFmtOnly flag */
     private boolean originalUseFmtOnly;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -7741,8 +7741,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != openStatements) {
                     while (!openStatements.isEmpty()) {
                         Statement st = openStatements.get(0);
-                        st.close();
-                        removeOpenStatement((SQLServerStatement) st);
+                        try {
+                            st.close();
+                        } finally {
+                            removeOpenStatement((SQLServerStatement) st);
+                        }
                     }
                 }
                 requestStarted = false;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -7640,7 +7640,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     private volatile SQLWarning originalSqlWarnings;
 
     /** open statements */
-    private List<ISQLServerStatement> openStatements;
+    private volatile List<ISQLServerStatement> openStatements;
 
     /** original usesFmtOnly flag */
     private boolean originalUseFmtOnly;
@@ -7740,9 +7740,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 sqlWarnings = originalSqlWarnings;
                 if (null != openStatements) {
                     while (!openStatements.isEmpty()) {
-                        try (Statement st = openStatements.get(0)) {}
+                        Statement st = openStatements.get(0);
+                        st.close();
+                        removeOpenStatement((SQLServerStatement) st);
                     }
-                    openStatements.clear();
                 }
                 requestStarted = false;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -541,7 +541,7 @@ public class SQLServerStatement implements ISQLServerStatement {
     /**
      * True is the statement is closed
      */
-    boolean bIsClosed;
+    volatile boolean bIsClosed;
 
     /**
      * True if the user requested to driver to generate insert keys


### PR DESCRIPTION
Description:

Based on issue analysis 

"Could be looping infinitely because bIsClosed could be true. bIsClosed could have been set to true earlier somewhere."

we are improving the infinite loop to close all statements present in openStatements , remove them from it explicitly and terminate.
 
Also, it looks like this could be happening as connections/statements are being used across threads based on the issue description.
 
bIsClosed and openStatements are not volatile, and as a result a thread creating statements while under a request ( started using beginRequest) may add them in openStatements list, with some other thread closing them but not removing from openStatements just due to that thread having read a stale value(null) of openStatements( and other combinations of issues of this sort). Hence, we are making bIsClosed and openStatements volatile.


Testing:

- All unit tests passed
- The existing test RequestBoundaryMethodsTest specifically validates this code path.