### PR TITLE
Remove exception and validation for user/password with AccessTokenCallback

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2802,13 +2802,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         && !activeConnectionProperties
                                 .getProperty(SQLServerDriverStringProperty.ACCESS_TOKEN_CALLBACK_CLASS.toString())
                                 .isEmpty();
-                if ((null != accessTokenCallback || hasAccessTokenCallbackClass) && (!activeConnectionProperties
-                        .getProperty(SQLServerDriverStringProperty.USER.toString()).isEmpty()
-                        || !activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString())
-                                .isEmpty())) {
-                    throw new SQLServerException(
-                            SQLServerException.getErrString("R_AccessTokenCallbackWithUserPassword"), null);
-                }
 
                 sPropKey = SQLServerDriverStringProperty.ACCESS_TOKEN_CALLBACK_CLASS.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
@@ -435,29 +435,8 @@ public class PooledConnectionTest extends FedauthCommon {
 
         // User/password is not required for access token callback
         AbstractTest.updateDataSource(accessTokenCallbackConnectionString, ds);
-        ds.setAccessTokenCallbackClass(AccessTokenCallbackClass.class.getName());
-        ds.setUser("user");
         SQLServerPooledConnection pc;
-
-        // Should fail with user set
-        try {
-            pc = (SQLServerPooledConnection) ds.getPooledConnection();
-            fail(TestResource.getResource("R_expectedFailPassed"));
-        } catch (SQLServerException e) {
-            assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_AccessTokenCallbackWithUserPassword")));
-        }
-
-        ds.setUser("");
-        ds.setPassword(UUID.randomUUID().toString());
-
-        // Should fail with password set
-        try {
-            pc = (SQLServerPooledConnection) ds.getPooledConnection();
-            fail(TestResource.getResource("R_expectedFailPassed"));
-        } catch (SQLServerException e) {
-            assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_AccessTokenCallbackWithUserPassword")));
-        }
-
+    
         // Should fail with invalid accessTokenCallbackClass value
         ds.setAccessTokenCallbackClass("Invalid");
         ds.setUser("");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/PooledConnectionTest.java
@@ -435,8 +435,17 @@ public class PooledConnectionTest extends FedauthCommon {
 
         // User/password is not required for access token callback
         AbstractTest.updateDataSource(accessTokenCallbackConnectionString, ds);
+
+        ds.setAccessTokenCallbackClass(AccessTokenCallbackClass.class.getName());
+        ds.setUser("user");
+        ds.setPassword(UUID.randomUUID().toString());
         SQLServerPooledConnection pc;
-    
+
+        pc = (SQLServerPooledConnection) ds.getPooledConnection();
+        try (Connection conn1 = pc.getConnection()) {
+            assertNotNull(conn1);
+        }
+
         // Should fail with invalid accessTokenCallbackClass value
         ds.setAccessTokenCallbackClass("Invalid");
         ds.setUser("");


### PR DESCRIPTION
The SQLServerConnection connectInternal() method throws the exception R_AccessTokenCallbackWithUserPassword. This logic may be too restrictive and has therefore been removed.