### PR TITLE
Capture Client Guest OS and architecture in JDBC

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2446,7 +2446,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != sPropValue)
                     validateMaxSQLLoginName(sPropKey, sPropValue);
                 else
-                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.DEFAULT_APP_NAME);
+                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.APP_NAME);
 
                 sPropKey = SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2446,7 +2446,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != sPropValue)
                     validateMaxSQLLoginName(sPropKey, sPropValue);
                 else
-                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.APP_NAME);
+                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.getAppName());
 
                 sPropKey = SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2446,7 +2446,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != sPropValue)
                     validateMaxSQLLoginName(sPropKey, sPropValue);
                 else
-                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.contructedAppName);
+                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.constructedAppName);
 
                 sPropKey = SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2446,7 +2446,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != sPropValue)
                     validateMaxSQLLoginName(sPropKey, sPropValue);
                 else
-                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.getAppName());
+                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.contructedAppName);
 
                 sPropKey = SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -732,6 +732,10 @@ public final class SQLServerDriver implements java.sql.Driver {
             + SQLJdbcVersion.PATCH + "." + Util.getJVMArchOnWindows() + SQLJdbcVersion.RELEASE_EXT;
     static final String DEFAULT_APP_NAME = "Microsoft JDBC Driver for SQL Server";
     static final String APP_NAME_TEMPLATE = "Microsoft JDBC - %s, %s - %s";
+    static final String contructedAppName;
+    static {
+        contructedAppName = getAppName();
+    }
 
     /**
      * Constructs the application name using system properties for OS, platform, and architecture.
@@ -1050,7 +1054,7 @@ public final class SQLServerDriver implements java.sql.Driver {
             }
         }
         if (loggerExternal.isLoggable(Level.FINE)) {
-            loggerExternal.log(Level.FINE, "Application Name: " + SQLServerDriver.getAppName());
+            loggerExternal.log(Level.FINE, "Application Name: " + SQLServerDriver.contructedAppName);
         }
     }
 
@@ -1290,7 +1294,7 @@ public final class SQLServerDriver implements java.sql.Driver {
         Properties connectProperties = parseAndMergeProperties(url, suppliedProperties);
         if (connectProperties != null) {
             result = DriverJDBCVersion.getSQLServerConnection(toString());
-            connectProperties.setProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString(), getAppName());
+            connectProperties.setProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString(), SQLServerDriver.contructedAppName);
             result.connect(connectProperties, null);
         }
         loggerExternal.exiting(getClassNameLogging(), "connect", result);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -563,7 +563,7 @@ enum PrepareMethod {
 
 enum SQLServerDriverStringProperty {
     APPLICATION_INTENT("applicationIntent", ApplicationIntent.READ_WRITE.toString()),
-    APPLICATION_NAME("applicationName", ""),
+    APPLICATION_NAME("applicationName", SQLServerDriver.DEFAULT_APP_NAME),
     PREPARE_METHOD("prepareMethod", PrepareMethod.PREPEXEC.toString()),
     DATABASE_NAME("databaseName", ""),
     FAILOVER_PARTNER("failoverPartner", ""),
@@ -762,7 +762,7 @@ public final class SQLServerDriver implements java.sql.Driver {
                     SQLServerDriverStringProperty.APPLICATION_INTENT.getDefaultValue(), false,
                     new String[] {ApplicationIntent.READ_ONLY.toString(), ApplicationIntent.READ_WRITE.toString()}),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.APPLICATION_NAME.toString(),
-                    "", false, null),
+            		SQLServerDriverStringProperty.APPLICATION_NAME.getDefaultValue(), false, null),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.COLUMN_ENCRYPTION.toString(),
                     SQLServerDriverStringProperty.COLUMN_ENCRYPTION.getDefaultValue(), false,
                     new String[] {ColumnEncryptionSetting.DISABLED.toString(),

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -732,9 +732,9 @@ public final class SQLServerDriver implements java.sql.Driver {
             + SQLJdbcVersion.PATCH + "." + Util.getJVMArchOnWindows() + SQLJdbcVersion.RELEASE_EXT;
     static final String DEFAULT_APP_NAME = "Microsoft JDBC Driver for SQL Server";
     static final String APP_NAME_TEMPLATE = "Microsoft JDBC - %s, %s - %s";
-    static final String contructedAppName;
+    static final String constructedAppName;
     static {
-        contructedAppName = getAppName();
+        constructedAppName = getAppName();
     }
 
     /**
@@ -1054,7 +1054,7 @@ public final class SQLServerDriver implements java.sql.Driver {
             }
         }
         if (loggerExternal.isLoggable(Level.FINE)) {
-            loggerExternal.log(Level.FINE, "Application Name: " + SQLServerDriver.contructedAppName);
+            loggerExternal.log(Level.FINE, "Application Name: " + SQLServerDriver.constructedAppName);
         }
     }
 
@@ -1294,7 +1294,7 @@ public final class SQLServerDriver implements java.sql.Driver {
         Properties connectProperties = parseAndMergeProperties(url, suppliedProperties);
         if (connectProperties != null) {
             result = DriverJDBCVersion.getSQLServerConnection(toString());
-            connectProperties.setProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString(), SQLServerDriver.contructedAppName);
+            connectProperties.setProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString(), SQLServerDriver.constructedAppName);
             result.connect(connectProperties, null);
         }
         loggerExternal.exiting(getClassNameLogging(), "connect", result);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -745,17 +745,12 @@ public final class SQLServerDriver implements java.sql.Driver {
         String osArch = System.getProperty("os.arch", "");
         String javaVmName = System.getProperty("java.vm.name", "");
         String javaVmVersion = System.getProperty("java.vm.version", "");
-
         String platform = javaVmName.isEmpty() || javaVmVersion.isEmpty() ? "" : javaVmName + " " + javaVmVersion;
 
-        String appName = String.format(APP_NAME_TEMPLATE, osName, platform, osArch);
-        
-        // If all values are empty, return the default app name
         if (osName.isEmpty() && platform.isEmpty() && osArch.isEmpty()) {
             return DEFAULT_APP_NAME;
         }
-        return appName;
-
+        return String.format(APP_NAME_TEMPLATE, osName, platform, osArch);
     }
     
     private static final String[] TRUE_FALSE = {"true", "false"};
@@ -1054,9 +1049,8 @@ public final class SQLServerDriver implements java.sql.Driver {
                 drLogger.finer("Error registering driver: " + e);
             }
         }
-        if (loggerExternal.isLoggable(Level.INFO)) {
-            String appName = getAppName();
-            loggerExternal.log(Level.INFO, "Application Name: " + appName);
+        if (loggerExternal.isLoggable(Level.FINE)) {
+            loggerExternal.log(Level.FINE, "Application Name: " + SQLServerDriver.getAppName());
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -1240,6 +1240,21 @@ public final class SQLServerDriver implements java.sql.Driver {
             "java.specification.version", "java.class.path", "java.class.version", "java.runtime.name",
             "java.runtime.version", "java.vendor", "java.version", "java.vm.name", "java.vm.vendor", "java.vm.version",
             "java.vm.specification.vendor", "java.vm.specification.version", "os.name", "os.version", "os.arch"};
+    
+    /**
+     * This method retrieves the OS name and architecture using Java system properties
+     * and logs this information.
+     */
+    private void logClientOSAndArchInfo() {
+        try {
+            String osName = System.getProperty("os.name");
+            String osArch = System.getProperty("os.arch");
+            
+            loggerExternal.log(Level.FINE, "Client OS: " + osName + ", Architecture: " + osArch);
+        } catch (Exception e) {
+            loggerExternal.warning("Unable to capture client OS and architecture information.");
+        }
+    }
 
     @Override
     public java.sql.Connection connect(String url, Properties suppliedProperties) throws SQLServerException {
@@ -1251,6 +1266,7 @@ public final class SQLServerDriver implements java.sql.Driver {
                     "Microsoft JDBC Driver " + SQLJdbcVersion.MAJOR + "." + SQLJdbcVersion.MINOR + "."
                             + SQLJdbcVersion.PATCH + "." + SQLJdbcVersion.BUILD + SQLJdbcVersion.RELEASE_EXT
                             + " for SQL Server");
+            logClientOSAndArchInfo();
             if (loggerExternal.isLoggable(Level.FINER)) {
                 for (String propertyKeyName : systemPropertiesToLog) {
                     String propertyValue = System.getProperty(propertyKeyName);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -2,6 +2,8 @@ package com.microsoft.sqlserver.jdbc;
 
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
@@ -207,5 +209,23 @@ public class SQLServerDriverTest extends AbstractTest {
         } catch (SQLException e) {
             fail(e.getMessage());
         }
+    }
+
+    /**
+     * test application name when system properties are empty
+     * 
+     */
+    @Test
+    public void testGetAppName() {
+        String appName = SQLServerDriver.getAppName();
+        assertNotNull(appName, "Application name should not be null");
+        assertFalse(appName.isEmpty(), "Application name should not be empty");
+
+        System.setProperty("os.name", "");
+        System.setProperty("os.arch", "");
+        System.setProperty("java.vm.name", "");
+        System.setProperty("java.vm.version", "");
+        String defaultAppName = SQLServerDriver.getAppName();
+        assertEquals(SQLServerDriver.DEFAULT_APP_NAME, defaultAppName, "Application name should be the default one");
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -202,7 +202,7 @@ public class SQLServerDriverTest extends AbstractTest {
              Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT program_name FROM sys.dm_exec_sessions WHERE session_id = @@SPID")) {
             if (rs.next()) {
-                assertEquals(SQLServerDriver.getAppName(), rs.getString("program_name"));
+                assertEquals(SQLServerDriver.contructedAppName, rs.getString("program_name"));
             }
         } catch (SQLException e) {
             fail(e.getMessage());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -190,4 +190,22 @@ public class SQLServerDriverTest extends AbstractTest {
             }
         }
     }
+    
+    /**
+     * test application name
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testApplicationName() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(connectionString);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT program_name FROM sys.dm_exec_sessions WHERE session_id = @@SPID")) {
+            if (rs.next()) {
+                assertEquals(SQLServerDriver.getAppName(), rs.getString("program_name"));
+            }
+        } catch (SQLException e) {
+            fail(e.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -204,7 +204,7 @@ public class SQLServerDriverTest extends AbstractTest {
              Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT program_name FROM sys.dm_exec_sessions WHERE session_id = @@SPID")) {
             if (rs.next()) {
-                assertEquals(SQLServerDriver.contructedAppName, rs.getString("program_name"));
+                assertEquals(SQLServerDriver.constructedAppName, rs.getString("program_name"));
             }
         } catch (SQLException e) {
             fail(e.getMessage());


### PR DESCRIPTION
Use case: Update the application name to "Microsoft JDBC - {OS}, {Platform} - {architecture}"

