### PR TITLE
Introduced timeouts for MSAL calls.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6110,7 +6110,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         }
 
         while (true) {
-        	int millisecondsRemaining = timerRemaining(timerExpire);
+            int millisecondsRemaining = timerRemaining(timerExpire);
             if (authenticationString.equalsIgnoreCase(SqlAuthentication.ACTIVE_DIRECTORY_PASSWORD.toString())) {
                 fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthToken(fedAuthInfo, user,
                         activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString()),

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6126,12 +6126,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
                 if (null != managedIdentityClientId && !managedIdentityClientId.isEmpty()) {
                     fedAuthToken = SQLServerSecurityUtility.getManagedIdentityCredAuthToken(fedAuthInfo.spn,
-                            managedIdentityClientId);
+                            managedIdentityClientId, millisecondsRemaining);
                     break;
                 }
 
                 fedAuthToken = SQLServerSecurityUtility.getManagedIdentityCredAuthToken(fedAuthInfo.spn,
-                        activeConnectionProperties.getProperty(SQLServerDriverStringProperty.MSI_CLIENT_ID.toString()));
+                        activeConnectionProperties.getProperty(SQLServerDriverStringProperty.MSI_CLIENT_ID.toString()), millisecondsRemaining);
 
                 // Break out of the retry loop in successful case.
                 break;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6110,10 +6110,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         }
 
         while (true) {
+        	int millisecondsRemaining = timerRemaining(timerExpire);
             if (authenticationString.equalsIgnoreCase(SqlAuthentication.ACTIVE_DIRECTORY_PASSWORD.toString())) {
                 fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthToken(fedAuthInfo, user,
                         activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString()),
-                        authenticationString);
+                        authenticationString, millisecondsRemaining);
 
                 // Break out of the retry loop in successful case.
                 break;
@@ -6141,12 +6142,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (aadPrincipalID != null && !aadPrincipalID.isEmpty() && aadPrincipalSecret != null
                         && !aadPrincipalSecret.isEmpty()) {
                     fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal(fedAuthInfo, aadPrincipalID,
-                            aadPrincipalSecret, authenticationString);
+                            aadPrincipalSecret, authenticationString, millisecondsRemaining);
                 } else {
                     fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal(fedAuthInfo,
                             activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString()),
                             activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString()),
-                            authenticationString);
+                            authenticationString, millisecondsRemaining);
                 }
 
                 // Break out of the retry loop in successful case.
@@ -6159,7 +6160,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString()),
                         servicePrincipalCertificate,
                         activeConnectionProperties.getProperty(SQLServerDriverStringProperty.PASSWORD.toString()),
-                        servicePrincipalCertificateKey, servicePrincipalCertificatePassword, authenticationString);
+                        servicePrincipalCertificateKey, servicePrincipalCertificatePassword, authenticationString, millisecondsRemaining);
 
                 // Break out of the retry loop in successful case.
                 break;
@@ -6194,7 +6195,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             throw new SQLServerException(form.format(msgArgs), null);
                         }
 
-                        int millisecondsRemaining = timerRemaining(timerExpire);
+                        millisecondsRemaining = timerRemaining(timerExpire);
                         if (ActiveDirectoryAuthentication.GET_ACCESS_TOKEN_TRANSIENT_ERROR != errorCategory
                                 || timerHasExpired(timerExpire) || (fedauthSleepInterval >= millisecondsRemaining)) {
 
@@ -6240,7 +6241,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         Object[] msgArgs = {SQLServerDriver.AUTH_DLL_NAME, authenticationString};
                         throw new SQLServerException(form.format(msgArgs), null, 0, null);
                     }
-                    fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenIntegrated(fedAuthInfo, authenticationString);
+                    fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenIntegrated(fedAuthInfo, authenticationString, millisecondsRemaining);
                 }
                 // Break out of the retry loop in successful case.
                 break;
@@ -6248,7 +6249,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     .equalsIgnoreCase(SqlAuthentication.ACTIVE_DIRECTORY_INTERACTIVE.toString())) {
                 // interactive flow
                 fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenInteractive(fedAuthInfo, user,
-                        authenticationString);
+                        authenticationString, millisecondsRemaining);
 
                 // Break out of the retry loop in successful case.
                 break;
@@ -6258,12 +6259,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
                 if (null != managedIdentityClientId && !managedIdentityClientId.isEmpty()) {
                     fedAuthToken = SQLServerSecurityUtility.getDefaultAzureCredAuthToken(fedAuthInfo.spn,
-                            managedIdentityClientId);
+                            managedIdentityClientId, millisecondsRemaining);
                     break;
                 }
 
                 fedAuthToken = SQLServerSecurityUtility.getDefaultAzureCredAuthToken(fedAuthInfo.spn,
-                        activeConnectionProperties.getProperty(SQLServerDriverStringProperty.MSI_CLIENT_ID.toString()));
+                        activeConnectionProperties.getProperty(SQLServerDriverStringProperty.MSI_CLIENT_ID.toString()), millisecondsRemaining);
 
                 break;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -134,7 +134,7 @@ class SQLServerMSAL4JUtils {
         } catch (MalformedURLException | ExecutionException e) {
             throw getCorrectedException(e, user, authenticationString);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);         
+            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } finally {
             lock.unlock();
             executorService.shutdown();
@@ -201,7 +201,7 @@ class SQLServerMSAL4JUtils {
         } catch (MalformedURLException | ExecutionException e) {
             throw getCorrectedException(e, aadPrincipalID, authenticationString);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);         
+            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } finally {
             lock.unlock();
             executorService.shutdown();
@@ -469,7 +469,7 @@ class SQLServerMSAL4JUtils {
         } catch (MalformedURLException | URISyntaxException | ExecutionException e) {
             throw getCorrectedException(e, user, authenticationString);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);        
+            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } finally {
             lock.unlock();
             executorService.shutdown();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -394,7 +394,7 @@ class SQLServerMSAL4JUtils {
             //
             isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
-        	final PublicClientApplication pca = PublicClientApplication
+            final PublicClientApplication pca = PublicClientApplication
                     .builder(ActiveDirectoryAuthentication.JDBC_FEDAUTH_CLIENT_ID).executorService(executorService)
                     .setTokenCacheAccessAspect(PersistentTokenCacheAccessAspect.getInstance())
                     .authority(fedAuthInfo.stsurl).build();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -320,6 +320,8 @@ class SQLServerMSAL4JUtils {
             // this includes all certificate exceptions
             throw new SQLServerException(SQLServerException.getErrString("R_readCertError") + e.getMessage(), null, 0,
                     null);
+        } catch (TimeoutException e) {
+            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } catch (Exception e) {
             throw getCorrectedException(e, aadPrincipalID, authenticationString);
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -145,7 +145,7 @@ class SQLServerMSAL4JUtils {
         } catch (MalformedURLException | ExecutionException e) {
             throw getCorrectedException(e, user, authenticationString);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
+            throw getCorrectedException(new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e), user, authenticationString);
         } finally {
             if (isSemAcquired) {
                 sem.release();
@@ -223,7 +223,7 @@ class SQLServerMSAL4JUtils {
         } catch (MalformedURLException | ExecutionException e) {
             throw getCorrectedException(e, aadPrincipalID, authenticationString);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
+            throw getCorrectedException(new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e), aadPrincipalID, authenticationString);
         } finally {
             if (isSemAcquired) {
                 sem.release();
@@ -354,7 +354,7 @@ class SQLServerMSAL4JUtils {
             throw new SQLServerException(SQLServerException.getErrString("R_readCertError") + e.getMessage(), null, 0,
                     null);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
+            throw getCorrectedException(new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e), aadPrincipalID, authenticationString);
         } catch (Exception e) {
             throw getCorrectedException(e, aadPrincipalID, authenticationString);
 
@@ -420,7 +420,7 @@ class SQLServerMSAL4JUtils {
         } catch (IOException | ExecutionException e) {
             throw getCorrectedException(e, user, authenticationString);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
+            throw getCorrectedException(new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e), user, authenticationString);
         } finally {
             if (isSemAcquired) {
                 sem.release();
@@ -526,7 +526,7 @@ class SQLServerMSAL4JUtils {
         } catch (MalformedURLException | URISyntaxException | ExecutionException e) {
             throw getCorrectedException(e, user, authenticationString);
         } catch (TimeoutException e) {
-            throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
+            throw getCorrectedException(new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e), user, authenticationString);
         } finally {
             if (isSemAcquired) {
                 sem.release();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -90,7 +90,7 @@ class SQLServerMSAL4JUtils {
             logger.finest(LOGCONTEXT + authenticationString + ": get FedAuth token for user: " + user);
         }
 
-        boolean semAcquired = false;
+        boolean isSemAcquired = false;
         try {
             //
             //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
@@ -100,7 +100,7 @@ class SQLServerMSAL4JUtils {
             //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
             //to get their tokens at the same time, stressing the auth endpoint.
             //
-            semAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             String hashedSecret = getHashedSecret(new String[] {fedAuthInfo.stsurl, user, password});
             PersistentTokenCacheAccessAspect persistentTokenCacheAccessAspect = TOKEN_CACHE_MAP.getEntry(user,
@@ -147,7 +147,7 @@ class SQLServerMSAL4JUtils {
         } catch (TimeoutException e) {
             throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } finally {
-            if (semAcquired) {
+            if (isSemAcquired) {
                 sem.release();
             }
             executorService.shutdown();
@@ -168,7 +168,7 @@ class SQLServerMSAL4JUtils {
         Set<String> scopes = new HashSet<>();
         scopes.add(scope);
         
-        boolean semAcquired = false;
+        boolean isSemAcquired = false;
         try {
             //
             //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
@@ -178,7 +178,7 @@ class SQLServerMSAL4JUtils {
             //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
             //to get their tokens at the same time, stressing the auth endpoint.
             //
-            semAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             String hashedSecret = getHashedSecret(
                     new String[] {fedAuthInfo.stsurl, aadPrincipalID, aadPrincipalSecret});
@@ -225,7 +225,7 @@ class SQLServerMSAL4JUtils {
         } catch (TimeoutException e) {
             throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } finally {
-            if (semAcquired) {
+            if (isSemAcquired) {
                 sem.release();
             }
             executorService.shutdown();
@@ -248,7 +248,7 @@ class SQLServerMSAL4JUtils {
         Set<String> scopes = new HashSet<>();
         scopes.add(scope);
 
-        boolean semAcquired = false;
+        boolean isSemAcquired = false;
         try {
             //
             //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
@@ -258,7 +258,7 @@ class SQLServerMSAL4JUtils {
             //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
             //to get their tokens at the same time, stressing the auth endpoint.
             //
-            semAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             String hashedSecret = getHashedSecret(new String[] {fedAuthInfo.stsurl, aadPrincipalID, certFile,
                     certPassword, certKey, certKeyPassword});
@@ -359,7 +359,7 @@ class SQLServerMSAL4JUtils {
             throw getCorrectedException(e, aadPrincipalID, authenticationString);
 
         } finally {
-            if (semAcquired) {
+            if (isSemAcquired) {
                 sem.release();
             }
             executorService.shutdown();
@@ -382,7 +382,7 @@ class SQLServerMSAL4JUtils {
                     + "realm name:" + kerberosPrincipal.getRealm());
         }
 
-        boolean semAcquired = false;
+        boolean isSemAcquired = false;
         try {
             //
             //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
@@ -392,7 +392,7 @@ class SQLServerMSAL4JUtils {
             //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
             //to get their tokens at the same time, stressing the auth endpoint.
             //
-            semAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
         	final PublicClientApplication pca = PublicClientApplication
                     .builder(ActiveDirectoryAuthentication.JDBC_FEDAUTH_CLIENT_ID).executorService(executorService)
@@ -422,7 +422,7 @@ class SQLServerMSAL4JUtils {
         } catch (TimeoutException e) {
             throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } finally {
-            if (semAcquired) {
+            if (isSemAcquired) {
                 sem.release();
             }
             executorService.shutdown();
@@ -437,7 +437,7 @@ class SQLServerMSAL4JUtils {
             logger.finer(LOGCONTEXT + authenticationString + ": get FedAuth token interactive for user: " + user);
         }
 
-        boolean semAcquired = false;
+        boolean isSemAcquired = false;
         try {
             //
             //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
@@ -447,7 +447,7 @@ class SQLServerMSAL4JUtils {
             //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
             //to get their tokens at the same time, stressing the auth endpoint.
             //
-            semAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             PublicClientApplication pca = PublicClientApplication
                     .builder(ActiveDirectoryAuthentication.JDBC_FEDAUTH_CLIENT_ID).executorService(executorService)
@@ -528,7 +528,7 @@ class SQLServerMSAL4JUtils {
         } catch (TimeoutException e) {
             throw new SQLServerException(SQLServerException.getErrString("R_connectionTimedOut"), e);
         } finally {
-            if (semAcquired) {
+            if (isSemAcquired) {
                 sem.release();
             }
             executorService.shutdown();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -65,7 +65,7 @@ class SQLServerMSAL4JUtils {
     static final String REDIRECTURI = "http://localhost";
     static final String SLASH_DEFAULT = "/.default";
     static final String ACCESS_TOKEN_EXPIRE = "access token expires: ";
-
+    static final long TOKEN_WAIT_DURATION_MS = 20000;
     private static final TokenCacheMap TOKEN_CACHE_MAP = new TokenCacheMap();
 
     private final static String LOGCONTEXT = "MSAL version "
@@ -117,7 +117,7 @@ class SQLServerMSAL4JUtils {
                     .builder(Collections.singleton(fedAuthInfo.spn + SLASH_DEFAULT), user, password.toCharArray())
                     .build());
 
-            final IAuthenticationResult authenticationResult = future.get(millisecondsRemaining, TimeUnit.MILLISECONDS);
+            final IAuthenticationResult authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             if (logger.isLoggable(Level.FINER)) {
                 logger.finer(
@@ -184,7 +184,7 @@ class SQLServerMSAL4JUtils {
 
             final CompletableFuture<IAuthenticationResult> future = clientApplication
                     .acquireToken(ClientCredentialParameters.builder(scopes).build());
-            final IAuthenticationResult authenticationResult = future.get(millisecondsRemaining, TimeUnit.MILLISECONDS);
+            final IAuthenticationResult authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             if (logger.isLoggable(Level.FINER)) {
                 logger.finer(
@@ -302,7 +302,7 @@ class SQLServerMSAL4JUtils {
 
             final CompletableFuture<IAuthenticationResult> future = clientApplication
                     .acquireToken(ClientCredentialParameters.builder(scopes).build());
-            final IAuthenticationResult authenticationResult = future.get(millisecondsRemaining, TimeUnit.MILLISECONDS);
+            final IAuthenticationResult authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             if (logger.isLoggable(Level.FINER)) {
                 logger.finer(
@@ -357,7 +357,7 @@ class SQLServerMSAL4JUtils {
                     .acquireToken(IntegratedWindowsAuthenticationParameters
                             .builder(Collections.singleton(fedAuthInfo.spn + SLASH_DEFAULT), user).build());
 
-            final IAuthenticationResult authenticationResult = future.get(millisecondsRemaining, TimeUnit.MILLISECONDS);
+            final IAuthenticationResult authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             if (logger.isLoggable(Level.FINER)) {
                 logger.finer(
@@ -439,7 +439,7 @@ class SQLServerMSAL4JUtils {
             }
 
             if (null != future) {
-                authenticationResult = future.get(millisecondsRemaining, TimeUnit.MILLISECONDS);
+                authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
             } else {
                 // acquire token interactively with system browser
                 if (logger.isLoggable(Level.FINEST)) {
@@ -451,7 +451,7 @@ class SQLServerMSAL4JUtils {
                         .loginHint(user).scopes(Collections.singleton(fedAuthInfo.spn + SLASH_DEFAULT)).build();
 
                 future = pca.acquireToken(parameters);
-                authenticationResult = future.get(millisecondsRemaining, TimeUnit.MILLISECONDS);
+                authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
             }
 
             if (logger.isLoggable(Level.FINER)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
@@ -344,7 +344,7 @@ class SQLServerSecurityUtility {
      * @throws SQLServerException
      */
     static SqlAuthenticationToken getManagedIdentityCredAuthToken(String resource,
-            String managedIdentityClientId) throws SQLServerException {
+            String managedIdentityClientId, long millisecondsRemaining) throws SQLServerException {
 
         if (logger.isLoggable(java.util.logging.Level.FINEST)) {
             logger.finest("Getting Managed Identity authentication token for: " + managedIdentityClientId);
@@ -383,7 +383,7 @@ class SQLServerSecurityUtility {
 
         SqlAuthenticationToken sqlFedAuthToken = null;
 
-        Optional<AccessToken> accessTokenOptional = mic.getToken(tokenRequestContext).blockOptional();
+        Optional<AccessToken> accessTokenOptional = mic.getToken(tokenRequestContext).timeout(Duration.of(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), ChronoUnit.MILLIS)).blockOptional();
 
         if (!accessTokenOptional.isPresent()) {
             throw new SQLServerException(SQLServerException.getErrString("R_ManagedIdentityTokenAcquisitionFail"),
@@ -467,7 +467,7 @@ class SQLServerSecurityUtility {
 
         SqlAuthenticationToken sqlFedAuthToken = null;
 
-        Optional<AccessToken> accessTokenOptional = dac.getToken(tokenRequestContext).blockOptional(Duration.of(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), ChronoUnit.MILLIS));
+        Optional<AccessToken> accessTokenOptional = dac.getToken(tokenRequestContext).timeout(Duration.of(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), ChronoUnit.MILLIS)).blockOptional();
 
         if (!accessTokenOptional.isPresent()) {
             throw new SQLServerException(SQLServerException.getErrString("R_ManagedIdentityTokenAcquisitionFail"),

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
@@ -58,7 +58,7 @@ class SQLServerSecurityUtility {
 
     private static final Lock CREDENTIAL_LOCK = new ReentrantLock();
 
-	private static final int TOKEN_WAIT_DURATION_MS = 0;
+	private static final int TOKEN_WAIT_DURATION_MS = 20000;
 
     private SQLServerSecurityUtility() {
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
@@ -58,6 +58,8 @@ class SQLServerSecurityUtility {
 
     private static final Lock CREDENTIAL_LOCK = new ReentrantLock();
 
+	private static final int TOKEN_WAIT_DURATION_MS = 0;
+
     private SQLServerSecurityUtility() {
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));
     }
@@ -465,7 +467,7 @@ class SQLServerSecurityUtility {
 
         SqlAuthenticationToken sqlFedAuthToken = null;
 
-        Optional<AccessToken> accessTokenOptional = dac.getToken(tokenRequestContext).blockOptional(Duration.of(millisecondsRemaining, ChronoUnit.MILLIS));
+        Optional<AccessToken> accessTokenOptional = dac.getToken(tokenRequestContext).blockOptional(Duration.of(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), ChronoUnit.MILLIS));
 
         if (!accessTokenOptional.isPresent()) {
             throw new SQLServerException(SQLServerException.getErrString("R_ManagedIdentityTokenAcquisitionFail"),

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSecurityUtility.java
@@ -8,6 +8,8 @@ package com.microsoft.sqlserver.jdbc;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Optional;
@@ -408,7 +410,7 @@ class SQLServerSecurityUtility {
      * @throws SQLServerException
      */
     static SqlAuthenticationToken getDefaultAzureCredAuthToken(String resource,
-            String managedIdentityClientId) throws SQLServerException {
+            String managedIdentityClientId, int millisecondsRemaining) throws SQLServerException {
         String intellijKeepassPath = System.getenv(INTELLIJ_KEEPASS_PASS);
         String[] additionallyAllowedTenants = getAdditonallyAllowedTenants();
 
@@ -463,7 +465,7 @@ class SQLServerSecurityUtility {
 
         SqlAuthenticationToken sqlFedAuthToken = null;
 
-        Optional<AccessToken> accessTokenOptional = dac.getToken(tokenRequestContext).blockOptional();
+        Optional<AccessToken> accessTokenOptional = dac.getToken(tokenRequestContext).blockOptional(Duration.of(millisecondsRemaining, ChronoUnit.MILLIS));
 
         if (!accessTokenOptional.isPresent()) {
             throw new SQLServerException(SQLServerException.getErrString("R_ManagedIdentityTokenAcquisitionFail"),

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -42,6 +42,7 @@ import org.junit.runner.RunWith;
 
 import com.microsoft.aad.msal4j.TokenCache;
 import com.microsoft.aad.msal4j.TokenCacheAccessContext;
+import com.microsoft.sqlserver.jdbc.SQLServerConnection.SqlFedAuthInfo;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
@@ -50,6 +51,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 
 @RunWith(JUnitPlatform.class)
 public class SQLServerConnectionTest extends AbstractTest {
+	
     // If no retry is done, the function should at least exit in 5 seconds
     static int threshHoldForNoRetryInMilliseconds = 5000;
     static int loginTimeOutInSeconds = 10;
@@ -1321,4 +1323,34 @@ public class SQLServerConnectionTest extends AbstractTest {
             assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_errorServerName")));
         }
     }
+    
+
+    @Test
+    public void testGetSqlFedAuthTokenFailure() throws SQLException {
+        try (Connection conn = getConnection()){
+        	SqlFedAuthInfo fedAuthInfo = ((SQLServerConnection) conn).new SqlFedAuthInfo();
+        	fedAuthInfo.spn = "https://database.windows.net/";
+        	fedAuthInfo.stsurl = "https://login.windows.net/xxx";
+        	SqlAuthenticationToken fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthToken(fedAuthInfo, "xxx",
+                    "xxx",SqlAuthentication.ACTIVE_DIRECTORY_PASSWORD.toString(), 0);
+        	fail("Expected the test to throw SQLServerException");
+        } catch (SQLServerException e) {
+        	//test pass
+        }        
+    }
+
+
+    @Test
+    public void testGetSqlFedAuthTokenPrincipalFailure() throws SQLException {
+        try (Connection conn = getConnection()){
+        	SqlFedAuthInfo fedAuthInfo = ((SQLServerConnection) conn).new SqlFedAuthInfo();
+        	fedAuthInfo.spn = "https://database.windows.net/";
+        	fedAuthInfo.stsurl = "https://login.windows.net/xxx";
+        	SqlAuthenticationToken fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal(fedAuthInfo, "xxx",
+                    "xxx",SqlAuthentication.ACTIVE_DIRECTORY_SERVICE_PRINCIPAL.toString(), 0);
+        	fail("Expected the test to throw SQLServerException");
+        } catch (SQLServerException e) {
+    	}        
+    }
+    
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -1332,25 +1332,42 @@ public class SQLServerConnectionTest extends AbstractTest {
         	fedAuthInfo.spn = "https://database.windows.net/";
         	fedAuthInfo.stsurl = "https://login.windows.net/xxx";
         	SqlAuthenticationToken fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthToken(fedAuthInfo, "xxx",
-                    "xxx",SqlAuthentication.ACTIVE_DIRECTORY_PASSWORD.toString(), 0);
-        	fail("Expected the test to throw SQLServerException");
+                    "xxx",SqlAuthentication.ACTIVE_DIRECTORY_PASSWORD.toString(), 10);
+        	fail(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (SQLServerException e) {
         	//test pass
+        	assertEquals(e.getMessage(), SQLServerException.getErrString("R_connectionTimedOut"), "Expected Timeout Exception was not thrown");
         }        
     }
 
-
     @Test
-    public void testGetSqlFedAuthTokenPrincipalFailure() throws SQLException {
+    public void testGetSqlFedAuthTokenFailureNoWaiting() throws SQLException {
         try (Connection conn = getConnection()){
         	SqlFedAuthInfo fedAuthInfo = ((SQLServerConnection) conn).new SqlFedAuthInfo();
         	fedAuthInfo.spn = "https://database.windows.net/";
         	fedAuthInfo.stsurl = "https://login.windows.net/xxx";
-        	SqlAuthenticationToken fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal(fedAuthInfo, "xxx",
-                    "xxx",SqlAuthentication.ACTIVE_DIRECTORY_SERVICE_PRINCIPAL.toString(), 0);
-        	fail("Expected the test to throw SQLServerException");
+        	SqlAuthenticationToken fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthToken(fedAuthInfo, "xxx",
+                    "xxx",SqlAuthentication.ACTIVE_DIRECTORY_PASSWORD.toString(), 0);
+        	fail(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (SQLServerException e) {
-    	}        
+        	//test pass
+        	assertEquals(e.getMessage(), SQLServerException.getErrString("R_connectionTimedOut"), "Expected Timeout Exception was not thrown");
+        }        
     }
-    
+
+    @Test
+    public void testGetSqlFedAuthTokenFailureNagativeWaiting() throws SQLException {
+        try (Connection conn = getConnection()){
+        	SqlFedAuthInfo fedAuthInfo = ((SQLServerConnection) conn).new SqlFedAuthInfo();
+        	fedAuthInfo.spn = "https://database.windows.net/";
+        	fedAuthInfo.stsurl = "https://login.windows.net/xxx";
+        	SqlAuthenticationToken fedAuthToken = SQLServerMSAL4JUtils.getSqlFedAuthToken(fedAuthInfo, "xxx",
+                    "xxx",SqlAuthentication.ACTIVE_DIRECTORY_PASSWORD.toString(), -1);
+        	fail(TestResource.getResource("R_expectedExceptionNotThrown"));
+        } catch (SQLServerException e) {
+        	//test pass
+        	assertEquals(e.getMessage(), SQLServerException.getErrString("R_connectionTimedOut"), "Expected Timeout Exception was not thrown");
+        }        
+    }
+
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerConnectionTest.java
@@ -1336,7 +1336,7 @@ public class SQLServerConnectionTest extends AbstractTest {
         	fail(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (SQLServerException e) {
         	//test pass
-        	assertEquals(e.getMessage(), SQLServerException.getErrString("R_connectionTimedOut"), "Expected Timeout Exception was not thrown");
+            assertTrue(e.getMessage().contains(SQLServerException.getErrString("R_connectionTimedOut")), "Expected Timeout Exception was not thrown");
         }        
     }
 
@@ -1351,7 +1351,7 @@ public class SQLServerConnectionTest extends AbstractTest {
         	fail(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (SQLServerException e) {
         	//test pass
-        	assertEquals(e.getMessage(), SQLServerException.getErrString("R_connectionTimedOut"), "Expected Timeout Exception was not thrown");
+            assertTrue(e.getMessage().contains(SQLServerException.getErrString("R_connectionTimedOut")), "Expected Timeout Exception was not thrown");
         }        
     }
 
@@ -1366,7 +1366,7 @@ public class SQLServerConnectionTest extends AbstractTest {
         	fail(TestResource.getResource("R_expectedExceptionNotThrown"));
         } catch (SQLServerException e) {
         	//test pass
-        	assertEquals(e.getMessage(), SQLServerException.getErrString("R_connectionTimedOut"), "Expected Timeout Exception was not thrown");
+            assertTrue(e.getMessage().contains(SQLServerException.getErrString("R_connectionTimedOut")), "Expected Timeout Exception was not thrown");
         }        
     }
 


### PR DESCRIPTION
Description:

Calls to MSAL authentication library done from the Java driver code use future.get(), potentially leading to hangs in case the library does not receive timely response from the server. All these calls done as part of getFedAuthToken need to have timeouts imposed. The timeout period is calculated based on remaining time wrt login timeout, and passed to future.get(<timeout>, <timeunit>) calls with this fix.

Tests:
- Existing unit tests pass on local build
- All ADO tests passed
- Added new tests