### PR TITLE
Updated getIndexInfo() to include Columnstore indexes by using custom query.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2446,7 +2446,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != sPropValue)
                     validateMaxSQLLoginName(sPropKey, sPropValue);
                 else
-                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.DEFAULT_APP_NAME);
+                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.constructedAppName);
 
                 sPropKey = SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -170,7 +170,7 @@ public class SQLServerDataSource
     @Override
     public String getApplicationName() {
         return getStringProperty(connectionProps, SQLServerDriverStringProperty.APPLICATION_NAME.toString(),
-                SQLServerDriverStringProperty.APPLICATION_NAME.getDefaultValue());
+                SQLServerDriver.constructedAppName);
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1197,39 +1197,31 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         }
     }
 
-    private static final String[] getIndexInfoColumnNames = { /* 1 */ TABLE_CAT, /* 2 */ TABLE_SCHEM,
-            /* 3 */ TABLE_NAME, /* 4 */ NON_UNIQUE, /* 5 */ INDEX_QUALIFIER, /* 6 */ INDEX_NAME, /* 7 */ TYPE,
-            /* 8 */ ORDINAL_POSITION, /* 9 */ COLUMN_NAME, /* 10 */ ASC_OR_DESC, /* 11 */ CARDINALITY, /* 12 */ PAGES,
-            /* 13 */ FILTER_CONDITION};
-
     @Override
     public java.sql.ResultSet getIndexInfo(String cat, String schema, String table, boolean unique,
-            boolean approximate) throws SQLServerException, SQLTimeoutException {
+            boolean approximate) throws SQLServerException, SQLTimeoutException, SQLException {
         if (loggerExternal.isLoggable(Level.FINER) && Util.isActivityTraceOn()) {
             loggerExternal.finer(toString() + ACTIVITY_ID + ActivityCorrelator.getCurrent().toString());
         }
         checkClosed();
-        /*
-         * sp_statistics [ @table_name = ] 'table_name' [ , [ @table_owner = ] 'owner' ] [ , [ @table_qualifier = ]
-         * 'qualifier' ] [ , [ @index_name = ] 'index_name' ] [ , [ @is_unique = ] 'is_unique' ] [ , [ @accuracy = ]
-         * 'accuracy' ]
-         */
-        String[] arguments = new String[6];
-        arguments[0] = table;
-        arguments[1] = schema;
-        arguments[2] = cat;
-        // use default for index name
-        arguments[3] = "%"; // index name % is default
-        if (unique)
-            arguments[4] = "Y"; // is_unique
-        else
-            arguments[4] = "N";
-        if (approximate)
-            arguments[5] = "Q";
-        else
-            arguments[5] = "E";
-        return getResultSetWithProvidedColumnNames(cat, CallableHandles.SP_STATISTICS, arguments,
-                getIndexInfoColumnNames);
+        String query = "SELECT " +
+                "db_name() AS CatalogName, " +
+                "sch.name AS SchemaName, " +
+                "t.name AS TableName, " +
+                "i.name AS IndexName, " +
+                "i.type_desc AS IndexType, " +
+                "i.is_unique AS IsUnique, " +
+                "c.name AS ColumnName, " +
+                "ic.key_ordinal AS ColumnOrder " +
+                "FROM sys.indexes i " +
+                "INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id " +
+                "INNER JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id " +
+                "INNER JOIN sys.tables t ON i.object_id = t.object_id " +
+                "INNER JOIN sys.schemas sch ON t.schema_id = sch.schema_id " +
+                "WHERE t.name = '" + table + "' " +
+                "AND sch.name = '" + schema + "' " +
+                "ORDER BY t.name, i.name, ic.key_ordinal";
+        return getResultSetFromInternalQueries(cat, query);
     }
 
     @Override

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -731,7 +731,32 @@ public final class SQLServerDriver implements java.sql.Driver {
     static final String AUTH_DLL_NAME = "mssql-jdbc_auth-" + SQLJdbcVersion.MAJOR + "." + SQLJdbcVersion.MINOR + "."
             + SQLJdbcVersion.PATCH + "." + Util.getJVMArchOnWindows() + SQLJdbcVersion.RELEASE_EXT;
     static final String DEFAULT_APP_NAME = "Microsoft JDBC Driver for SQL Server";
+    static final String APP_NAME_TEMPLATE = "Microsoft JDBC - %s, %s - %s";
+    static final String constructedAppName;
+    static {
+        constructedAppName = getAppName();
+    }
 
+    /**
+     * Constructs the application name using system properties for OS, platform, and architecture.
+     * If any of the properties cannot be fetched, it falls back to the default application name.
+     * Format -> Microsoft JDBC - {OS}, {Platform} - {architecture}
+     *
+     * @return the constructed application name or the default application name if properties are not available
+     */
+    static String getAppName() {
+        String osName = System.getProperty("os.name", "");
+        String osArch = System.getProperty("os.arch", "");
+        String javaVmName = System.getProperty("java.vm.name", "");
+        String javaVmVersion = System.getProperty("java.vm.version", "");
+        String platform = javaVmName.isEmpty() || javaVmVersion.isEmpty() ? "" : javaVmName + " " + javaVmVersion;
+
+        if (osName.isEmpty() && platform.isEmpty() && osArch.isEmpty()) {
+            return DEFAULT_APP_NAME;
+        }
+        return String.format(APP_NAME_TEMPLATE, osName, platform, osArch);
+    }
+    
     private static final String[] TRUE_FALSE = {"true", "false"};
 
     private static final SQLServerDriverPropertyInfo[] DRIVER_PROPERTIES = {
@@ -741,7 +766,7 @@ public final class SQLServerDriver implements java.sql.Driver {
                     SQLServerDriverStringProperty.APPLICATION_INTENT.getDefaultValue(), false,
                     new String[] {ApplicationIntent.READ_ONLY.toString(), ApplicationIntent.READ_WRITE.toString()}),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.APPLICATION_NAME.toString(),
-                    SQLServerDriverStringProperty.APPLICATION_NAME.getDefaultValue(), false, null),
+            		SQLServerDriverStringProperty.APPLICATION_NAME.getDefaultValue(), false, null),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.COLUMN_ENCRYPTION.toString(),
                     SQLServerDriverStringProperty.COLUMN_ENCRYPTION.getDefaultValue(), false,
                     new String[] {ColumnEncryptionSetting.DISABLED.toString(),
@@ -1028,6 +1053,9 @@ public final class SQLServerDriver implements java.sql.Driver {
                 drLogger.finer("Error registering driver: " + e);
             }
         }
+        if (loggerExternal.isLoggable(Level.FINE)) {
+            loggerExternal.log(Level.FINE, "Application Name: " + SQLServerDriver.constructedAppName);
+        }
     }
 
     // Check for jdk.net.ExtendedSocketOptions to set TCP keep-alive options for idle connection resiliency
@@ -1266,6 +1294,7 @@ public final class SQLServerDriver implements java.sql.Driver {
         Properties connectProperties = parseAndMergeProperties(url, suppliedProperties);
         if (connectProperties != null) {
             result = DriverJDBCVersion.getSQLServerConnection(toString());
+            connectProperties.setProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString(), SQLServerDriver.constructedAppName);
             result.connect(connectProperties, null);
         }
         loggerExternal.exiting(getClassNameLogging(), "connect", result);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -1294,7 +1294,9 @@ public final class SQLServerDriver implements java.sql.Driver {
         Properties connectProperties = parseAndMergeProperties(url, suppliedProperties);
         if (connectProperties != null) {
             result = DriverJDBCVersion.getSQLServerConnection(toString());
-            connectProperties.setProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString(), SQLServerDriver.constructedAppName);
+            if (connectProperties.getProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString()) == null) {
+                connectProperties.setProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString(), SQLServerDriver.constructedAppName);
+            }   
             result.connect(connectProperties, null);
         }
         loggerExternal.exiting(getClassNameLogging(), "connect", result);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -242,7 +242,7 @@ public class SQLServerDriverTest extends AbstractTest {
              Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT app_name()")) {
             if (rs.next()) {
-                assertEquals(SQLServerDriver.constructedAppName, rs.getString(1));
+                assertEquals("0123456789012345678901234567890123456789012345678901234567890123456789012345678901234589012345678901234567890123456789012345678", rs.getString(1));
             }
         } catch (SQLException e) {
             fail(e.getMessage());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -212,6 +212,44 @@ public class SQLServerDriverTest extends AbstractTest {
     }
 
     /**
+     * test application name by executing select app_name()
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testApplicationNameUsingApp_Name() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(connectionString);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT app_name()")) {
+            if (rs.next()) {
+                assertEquals(SQLServerDriver.constructedAppName, rs.getString(1));
+            }
+        } catch (SQLException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * test application name by executing select app_name()
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testAppNameWithSpecifiedApplicationName() throws SQLException {
+        String url = connectionString + ";applicationName={0123456789012345678901234567890123456789012345678901234567890123456789012345678901234589012345678901234567890123456789012345678}";
+
+        try (Connection conn = DriverManager.getConnection(url);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT app_name()")) {
+            if (rs.next()) {
+                assertEquals(SQLServerDriver.constructedAppName, rs.getString(1));
+            }
+        } catch (SQLException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
      * test application name when system properties are empty
      * 
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -2,6 +2,8 @@ package com.microsoft.sqlserver.jdbc;
 
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
@@ -189,5 +191,41 @@ public class SQLServerDriverTest extends AbstractTest {
                         TestResource.getResource("R_valuesAreDifferent"));
             }
         }
+    }
+    
+    /**
+     * test application name
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testApplicationName() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(connectionString);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT program_name FROM sys.dm_exec_sessions WHERE session_id = @@SPID")) {
+            if (rs.next()) {
+                assertEquals(SQLServerDriver.constructedAppName, rs.getString("program_name"));
+            }
+        } catch (SQLException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * test application name when system properties are empty
+     * 
+     */
+    @Test
+    public void testGetAppName() {
+        String appName = SQLServerDriver.getAppName();
+        assertNotNull(appName, "Application name should not be null");
+        assertFalse(appName.isEmpty(), "Application name should not be empty");
+
+        System.setProperty("os.name", "");
+        System.setProperty("os.arch", "");
+        System.setProperty("java.vm.name", "");
+        System.setProperty("java.vm.version", "");
+        String defaultAppName = SQLServerDriver.getAppName();
+        assertEquals(SQLServerDriver.DEFAULT_APP_NAME, defaultAppName, "Application name should be the default one");
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -216,5 +216,9 @@ public final class TestResource extends ListResourceBundle {
             {"R_expectedClassDoesNotMatchActualClass",
                     "Expected column class {0} does not match actual column class {1} for column {2}."},
             {"R_loginFailedMI", "Login failed for user '<token-identified principal>'"},
-            {"R_MInotAvailable", "Managed Identity authentication is not available"},};
+            {"R_MInotAvailable", "Managed Identity authentication is not available"},
+            {"R_noSQLWarningsCreateTableConnection", "Expecting NO SQLWarnings from 'create table', at Connection."},
+            {"R_noSQLWarningsCreateTableStatement", "Expecting NO SQLWarnings from 'create table', at Statement."},
+            {"R_noSQLWarningsCreateIndexConnection", "Expecting NO SQLWarnings from 'create index', at Connection."},
+            {"R_noSQLWarningsCreateIndexStatement", "Expecting NO SQLWarnings from 'create index', at Statement."},};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetadataGetIndexInfoTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetadataGetIndexInfoTest.java
@@ -25,9 +25,9 @@ import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 public class DatabaseMetadataGetIndexInfoTest extends AbstractTest {
 
 	private static String tableName = AbstractSQLGenerator.escapeIdentifier("DBMetadataTestTable");
-	private static String col1Name = AbstractSQLGenerator.escapeIdentifier("p1");
-	private static String col2Name = AbstractSQLGenerator.escapeIdentifier("p2");
-	private static String col3Name = AbstractSQLGenerator.escapeIdentifier("p3");
+	private static String col1Name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("col1"));
+    private static String col2Name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("col2"));
+    private static String col3Name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("col3"));
 
 	@BeforeAll
 	public static void setupTests() throws Exception {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetadataGetIndexInfoTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetadataGetIndexInfoTest.java
@@ -1,0 +1,174 @@
+package com.microsoft.sqlserver.jdbc.databasemetadata;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.jdbc.TestResource;
+import com.microsoft.sqlserver.jdbc.TestUtils;
+import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
+
+public class DatabaseMetadataGetIndexInfoTest extends AbstractTest {
+
+	private static String tableName = AbstractSQLGenerator.escapeIdentifier("DBMetadataTestTable");
+    private static String col1Name = AbstractSQLGenerator.escapeIdentifier("p1");
+    private static String col2Name = AbstractSQLGenerator.escapeIdentifier("p2");
+    private static String col3Name = AbstractSQLGenerator.escapeIdentifier( "p3");
+    
+    @BeforeAll
+    public static void setupTests() throws Exception {
+        setConnection();
+    }
+    
+    @BeforeEach
+    public void init() throws Exception {
+        try (Connection con = getConnection()) {
+            con.setAutoCommit(false);
+            try (Statement stmt = con.createStatement()) {
+            	TestUtils.dropTableIfExists(tableName, stmt);
+            	String createTableSQL = "CREATE TABLE " + tableName + " (" +
+                        col1Name + " INT, " +
+                        col2Name + " INT, " +
+                        col3Name + " INT)";
+            	
+            	stmt.executeUpdate(createTableSQL);
+            	assertNull(connection.getWarnings(), "Expecting NO SQLWarnings from 'create table', at Connection.");
+            	assertNull(stmt.getWarnings(), "Expecting NO SQLWarnings from 'create table', at Statement.");
+                
+                String createClusteredIndexSQL = "CREATE CLUSTERED INDEX IDX_Clustered ON " + tableName + "(" + col1Name + ")";
+    			stmt.executeUpdate(createClusteredIndexSQL);
+    			assertNull(connection.getWarnings(), "Expecting NO SQLWarnings from 'create index', at Connection.");
+                assertNull(stmt.getWarnings(), "Expecting NO SQLWarnings from 'create index', at Statement.");
+    			
+    			String createNonClusteredIndexSQL = "CREATE NONCLUSTERED INDEX IDX_NonClustered ON " + tableName + "(" + col2Name + ")";
+    			stmt.executeUpdate(createNonClusteredIndexSQL);
+    			assertNull(connection.getWarnings(), "Expecting NO SQLWarnings from 'create index', at Connection.");
+                assertNull(stmt.getWarnings(), "Expecting NO SQLWarnings from 'create index', at Statement.");
+                
+                String createColumnstoreIndexSQL = "CREATE COLUMNSTORE INDEX IDX_Columnstore ON " + tableName + "(" + col3Name + ")";
+    			stmt.executeUpdate(createColumnstoreIndexSQL);
+            	assertNull(connection.getWarnings(), "Expecting NO SQLWarnings from 'create index', at Connection.");
+                assertNull(stmt.getWarnings(), "Expecting NO SQLWarnings from 'create index', at Statement.");
+            }
+            con.commit();
+        }
+    }
+    
+    @AfterEach
+    public void terminate() throws Exception {
+        try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+            try {
+                TestUtils.dropTableIfExists(tableName, stmt);
+            } catch (SQLException e) {
+                fail(TestResource.getResource("R_unexpectedException") + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testGetIndexInfo() throws SQLException, SQLServerException {
+        ResultSet rs1, rs2 = null;
+        try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
+            String catalog = connection.getCatalog();
+            String schema = "dbo";
+            String table = "DBMetadataTestTable";
+            DatabaseMetaData dbMetadata = connection.getMetaData();
+			rs1 = dbMetadata.getIndexInfo(catalog, schema, table, false, false);
+
+			boolean hasClusteredIndex = false;
+            boolean hasNonClusteredIndex = false;
+            boolean hasColumnstoreIndex = false;
+            
+			String query = 
+		                "SELECT " +
+		                "    db_name() AS CatalogName, " +
+		                "    sch.name AS SchemaName, " +
+		                "    t.name AS TableName, " +
+		                "    i.name AS IndexName, " +
+		                "    i.type_desc AS IndexType, " +
+		                "    i.is_unique AS IsUnique, " +
+		                "    c.name AS ColumnName, " +
+		                "    ic.key_ordinal AS ColumnOrder " +
+		                "FROM " +
+		                "    sys.indexes i " +
+		                "INNER JOIN " +
+		                "    sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id " +
+		                "INNER JOIN " +
+		                "    sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id " +
+		                "INNER JOIN " +
+		                "    sys.tables t ON i.object_id = t.object_id " +
+		                "INNER JOIN " +
+		                "    sys.schemas sch ON t.schema_id = sch.schema_id " +
+		
+		                "WHERE t.name = '" + table + "' " +
+		                      "AND sch.name = '" + schema + "' " +
+		                "ORDER BY " +
+		                "    t.name, i.name, ic.key_ordinal;";
+			rs2 = stmt.executeQuery(query);
+			
+            while (rs1.next() && rs2.next()) {
+                String indexType = rs1.getString("IndexType");
+                String indexName = rs1.getString("IndexName");
+                
+                assertEquals(rs1.getString("CatalogName"), rs2.getString("CatalogName"));
+                assertEquals(rs1.getString("SchemaName"), rs2.getString("SchemaName"));
+                assertEquals(rs1.getString("TableName"), rs2.getString("TableName"));
+                assertEquals(indexName, rs2.getString("IndexName"));
+                assertEquals(indexType, rs2.getString("IndexType"));
+                assertEquals(rs1.getString("IsUnique"), rs2.getString("IsUnique"));
+                assertEquals(rs1.getString("ColumnName"), rs2.getString("ColumnName"));
+                assertEquals(rs1.getString("ColumnOrder"), rs2.getString("ColumnOrder"));
+
+                if (indexType.contains("COLUMNSTORE")) {
+                    hasColumnstoreIndex = true;
+                } else if (indexType.equals("CLUSTERED")) {
+                    hasClusteredIndex = true;
+                } else if (indexType.equals("NONCLUSTERED")) {
+                    hasNonClusteredIndex = true;
+                }
+            }
+
+            assertTrue(hasColumnstoreIndex, "COLUMNSTORE index not found.");
+            assertTrue(hasClusteredIndex, "CLUSTERED index not found.");
+            assertTrue(hasNonClusteredIndex, "NONCLUSTERED index not found.");
+        }
+    }
+    
+    @Test
+    public void testGetIndexInfoCaseSensitivity() throws SQLException, SQLServerException {
+        ResultSet rs1, rs2 = null;
+        try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
+            String catalog = connection.getCatalog();
+            String schema = "dbo";
+            String table = "DBMetadataTestTable";
+            
+            DatabaseMetaData dbMetadata = connection.getMetaData();
+			rs1 = dbMetadata.getIndexInfo(catalog, schema, table, false, false);
+			rs2 = dbMetadata.getIndexInfo(catalog, schema, table.toUpperCase(), false, false);
+
+			while (rs1.next() && rs2.next()) {
+                String indexType = rs1.getString("IndexType");
+                String indexName = rs1.getString("IndexName");
+                
+                assertEquals(rs1.getString("CatalogName"), rs2.getString("CatalogName"));
+                assertEquals(rs1.getString("SchemaName"), rs2.getString("SchemaName"));
+                assertEquals(rs1.getString("TableName"), rs2.getString("TableName"));
+                assertEquals(indexName, rs2.getString("IndexName"));
+                assertEquals(indexType, rs2.getString("IndexType"));
+                assertEquals(rs1.getString("IsUnique"), rs2.getString("IsUnique"));
+                assertEquals(rs1.getString("ColumnName"), rs2.getString("ColumnName"));
+                assertEquals(rs1.getString("ColumnOrder"), rs2.getString("ColumnOrder"));
+            }
+        }
+    }
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetadataGetIndexInfoTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetadataGetIndexInfoTest.java
@@ -25,166 +25,153 @@ import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 public class DatabaseMetadataGetIndexInfoTest extends AbstractTest {
 
 	private static String tableName = AbstractSQLGenerator.escapeIdentifier("DBMetadataTestTable");
-    private static String col1Name = AbstractSQLGenerator.escapeIdentifier("p1");
-    private static String col2Name = AbstractSQLGenerator.escapeIdentifier("p2");
-    private static String col3Name = AbstractSQLGenerator.escapeIdentifier("p3");
-    
-    @BeforeAll
-    public static void setupTests() throws Exception {
-        setConnection();
-    }
-    
-    @BeforeEach
-    public void init() throws SQLException {
-        try (Connection con = getConnection()) {
-            con.setAutoCommit(false);
-            try (Statement stmt = con.createStatement()) {
-            	TestUtils.dropTableIfExists(tableName, stmt);
-            	String createTableSQL = "CREATE TABLE " + tableName + " (" +
-                        col1Name + " INT, " +
-                        col2Name + " INT, " +
-                        col3Name + " INT)";
-            	
-            	stmt.executeUpdate(createTableSQL);
-            	assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableConnection"));
-            	assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableStatement"));
-                
-                String createClusteredIndexSQL = "CREATE CLUSTERED INDEX IDX_Clustered ON " + tableName + "(" + col1Name + ")";
-    			stmt.executeUpdate(createClusteredIndexSQL);
-    			assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
-                assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
-    			
-    			String createNonClusteredIndexSQL = "CREATE NONCLUSTERED INDEX IDX_NonClustered ON " + tableName + "(" + col2Name + ")";
-    			stmt.executeUpdate(createNonClusteredIndexSQL);
-    			assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
-                assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
-                
-                String createColumnstoreIndexSQL = "CREATE COLUMNSTORE INDEX IDX_Columnstore ON " + tableName + "(" + col3Name + ")";
-    			stmt.executeUpdate(createColumnstoreIndexSQL);
-    			assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
-                assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
-            }
-            con.commit();
-        }
-    }
-    
-    @AfterEach
-    public void terminate() throws SQLException {
-        try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
-            try {
-                TestUtils.dropTableIfExists(tableName, stmt);
-            } catch (SQLException e) {
-                fail(TestResource.getResource("R_unexpectedException") + e.getMessage());
-            }
-        }
-    }
+	private static String col1Name = AbstractSQLGenerator.escapeIdentifier("p1");
+	private static String col2Name = AbstractSQLGenerator.escapeIdentifier("p2");
+	private static String col3Name = AbstractSQLGenerator.escapeIdentifier("p3");
 
-    @Test
-    public void testGetIndexInfo() throws SQLException {
-        ResultSet rs1, rs2 = null;
-        try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
-            String catalog = connection.getCatalog();
-            String schema = "dbo";
-            String table = "DBMetadataTestTable";
-            DatabaseMetaData dbMetadata = connection.getMetaData();
+	@BeforeAll
+	public static void setupTests() throws Exception {
+		setConnection();
+	}
+
+	@BeforeEach
+	public void init() throws SQLException {
+		try (Connection con = getConnection()) {
+			con.setAutoCommit(false);
+			try (Statement stmt = con.createStatement()) {
+				TestUtils.dropTableIfExists(tableName, stmt);
+				String createTableSQL = "CREATE TABLE " + tableName + " (" + col1Name + " INT, " + col2Name + " INT, "
+						+ col3Name + " INT)";
+
+				stmt.executeUpdate(createTableSQL);
+				assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableConnection"));
+				assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableStatement"));
+
+				String createClusteredIndexSQL = "CREATE CLUSTERED INDEX IDX_Clustered ON " + tableName + "(" + col1Name
+						+ ")";
+				stmt.executeUpdate(createClusteredIndexSQL);
+				assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+				assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
+
+				String createNonClusteredIndexSQL = "CREATE NONCLUSTERED INDEX IDX_NonClustered ON " + tableName + "("
+						+ col2Name + ")";
+				stmt.executeUpdate(createNonClusteredIndexSQL);
+				assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+				assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
+
+				String createColumnstoreIndexSQL = "CREATE COLUMNSTORE INDEX IDX_Columnstore ON " + tableName + "("
+						+ col3Name + ")";
+				stmt.executeUpdate(createColumnstoreIndexSQL);
+				assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+				assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
+			}
+			con.commit();
+		}
+	}
+
+	@AfterEach
+	public void terminate() throws SQLException {
+		try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+			try {
+				TestUtils.dropTableIfExists(tableName, stmt);
+			} catch (SQLException e) {
+				fail(TestResource.getResource("R_unexpectedException") + e.getMessage());
+			}
+		}
+	}
+
+	@Test
+	public void testGetIndexInfo() throws SQLException {
+		ResultSet rs1, rs2 = null;
+		try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
+			String catalog = connection.getCatalog();
+			String schema = "dbo";
+			String table = "DBMetadataTestTable";
+			DatabaseMetaData dbMetadata = connection.getMetaData();
 			rs1 = dbMetadata.getIndexInfo(catalog, schema, table, false, false);
 
 			boolean hasClusteredIndex = false;
-            boolean hasNonClusteredIndex = false;
-            boolean hasColumnstoreIndex = false;
-            
-			String query = 
-		                "SELECT " +
-		                "    db_name() AS CatalogName, " +
-		                "    sch.name AS SchemaName, " +
-		                "    t.name AS TableName, " +
-		                "    i.name AS IndexName, " +
-		                "    i.type_desc AS IndexType, " +
-		                "    i.is_unique AS IsUnique, " +
-		                "    c.name AS ColumnName, " +
-		                "    ic.key_ordinal AS ColumnOrder " +
-		                "FROM " +
-		                "    sys.indexes i " +
-		                "INNER JOIN " +
-		                "    sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id " +
-		                "INNER JOIN " +
-		                "    sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id " +
-		                "INNER JOIN " +
-		                "    sys.tables t ON i.object_id = t.object_id " +
-		                "INNER JOIN " +
-		                "    sys.schemas sch ON t.schema_id = sch.schema_id " +
-		
-		                "WHERE t.name = '" + table + "' " +
-		                      "AND sch.name = '" + schema + "' " +
-		                "ORDER BY " +
-		                "    t.name, i.name, ic.key_ordinal;";
+			boolean hasNonClusteredIndex = false;
+			boolean hasColumnstoreIndex = false;
+
+			String query = "SELECT " + "    db_name() AS CatalogName, " + "    sch.name AS SchemaName, "
+					+ "    t.name AS TableName, " + "    i.name AS IndexName, " + "    i.type_desc AS IndexType, "
+					+ "    i.is_unique AS IsUnique, " + "    c.name AS ColumnName, "
+					+ "    ic.key_ordinal AS ColumnOrder " + "FROM " + "    sys.indexes i " + "INNER JOIN "
+					+ "    sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id "
+					+ "INNER JOIN " + "    sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id "
+					+ "INNER JOIN " + "    sys.tables t ON i.object_id = t.object_id " + "INNER JOIN "
+					+ "    sys.schemas sch ON t.schema_id = sch.schema_id " +
+
+					"WHERE t.name = '" + table + "' " + "AND sch.name = '" + schema + "' " + "ORDER BY "
+					+ "    t.name, i.name, ic.key_ordinal;";
 			rs2 = stmt.executeQuery(query);
-			
-            while (rs1.next() && rs2.next()) {
-                String indexType = rs1.getString("IndexType");
-                String indexName = rs1.getString("IndexName");
-                String catalogName = rs1.getString("CatalogName");
-                String schemaName = rs1.getString("SchemaName");
-                String tableName = rs1.getString("TableName");
-                boolean isUnique = rs1.getBoolean("IsUnique");
-                String columnName = rs1.getString("ColumnName");
-                int columnOrder = rs1.getInt("ColumnOrder");
-                
-                assertEquals(catalogName, rs2.getString("CatalogName"));
-                assertEquals(schemaName, rs2.getString("SchemaName"));
-                assertEquals(tableName, rs2.getString("TableName"));
-                assertEquals(indexName, rs2.getString("IndexName"));
-                assertEquals(indexType, rs2.getString("IndexType"));
-                assertEquals(isUnique, rs2.getBoolean("IsUnique"));
-                assertEquals(columnName, rs2.getString("ColumnName"));
-                assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
 
-                if (indexType.contains("COLUMNSTORE")) {
-                    hasColumnstoreIndex = true;
-                } else if (indexType.equals("CLUSTERED")) {
-                    hasClusteredIndex = true;
-                } else if (indexType.equals("NONCLUSTERED")) {
-                    hasNonClusteredIndex = true;
-                }
-            }
+			while (rs1.next() && rs2.next()) {
+				String indexType = rs1.getString("IndexType");
+				String indexName = rs1.getString("IndexName");
+				String catalogName = rs1.getString("CatalogName");
+				String schemaName = rs1.getString("SchemaName");
+				String tableName = rs1.getString("TableName");
+				boolean isUnique = rs1.getBoolean("IsUnique");
+				String columnName = rs1.getString("ColumnName");
+				int columnOrder = rs1.getInt("ColumnOrder");
 
-            assertTrue(hasColumnstoreIndex, "COLUMNSTORE index not found.");
-            assertTrue(hasClusteredIndex, "CLUSTERED index not found.");
-            assertTrue(hasNonClusteredIndex, "NONCLUSTERED index not found.");
-        }
-    }
-    
-    @Test
-    public void testGetIndexInfoCaseSensitivity() throws SQLException {
-        ResultSet rs1, rs2 = null;
-        try (Connection connection = getConnection()) {
-            String catalog = connection.getCatalog();
-            String schema = "dbo";
-            String table = "DBMetadataTestTable";
-            
-            DatabaseMetaData dbMetadata = connection.getMetaData();
+				assertEquals(catalogName, rs2.getString("CatalogName"));
+				assertEquals(schemaName, rs2.getString("SchemaName"));
+				assertEquals(tableName, rs2.getString("TableName"));
+				assertEquals(indexName, rs2.getString("IndexName"));
+				assertEquals(indexType, rs2.getString("IndexType"));
+				assertEquals(isUnique, rs2.getBoolean("IsUnique"));
+				assertEquals(columnName, rs2.getString("ColumnName"));
+				assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
+
+				if (indexType.contains("COLUMNSTORE")) {
+					hasColumnstoreIndex = true;
+				} else if (indexType.equals("CLUSTERED")) {
+					hasClusteredIndex = true;
+				} else if (indexType.equals("NONCLUSTERED")) {
+					hasNonClusteredIndex = true;
+				}
+			}
+
+			assertTrue(hasColumnstoreIndex, "COLUMNSTORE index not found.");
+			assertTrue(hasClusteredIndex, "CLUSTERED index not found.");
+			assertTrue(hasNonClusteredIndex, "NONCLUSTERED index not found.");
+		}
+	}
+
+	@Test
+	public void testGetIndexInfoCaseSensitivity() throws SQLException {
+		ResultSet rs1, rs2 = null;
+		try (Connection connection = getConnection()) {
+			String catalog = connection.getCatalog();
+			String schema = "dbo";
+			String table = "DBMetadataTestTable";
+
+			DatabaseMetaData dbMetadata = connection.getMetaData();
 			rs1 = dbMetadata.getIndexInfo(catalog, schema, table, false, false);
 			rs2 = dbMetadata.getIndexInfo(catalog, schema, table.toUpperCase(), false, false);
 
 			while (rs1.next() && rs2.next()) {
-                String indexType = rs1.getString("IndexType");
-                String indexName = rs1.getString("IndexName");
-                String catalogName = rs1.getString("CatalogName");
-                String schemaName = rs1.getString("SchemaName");
-                String tableName = rs1.getString("TableName");
-                boolean isUnique = rs1.getBoolean("IsUnique");
-                String columnName = rs1.getString("ColumnName");
-                int columnOrder = rs1.getInt("ColumnOrder");
-                
-                assertEquals(catalogName, rs2.getString("CatalogName"));
-                assertEquals(schemaName, rs2.getString("SchemaName"));
-                assertEquals(tableName, rs2.getString("TableName"));
-                assertEquals(indexName, rs2.getString("IndexName"));
-                assertEquals(indexType, rs2.getString("IndexType"));
-                assertEquals(isUnique, rs2.getBoolean("IsUnique"));
-                assertEquals(columnName, rs2.getString("ColumnName"));
-                assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
-            }
-        }
-    }
+				String indexType = rs1.getString("IndexType");
+				String indexName = rs1.getString("IndexName");
+				String catalogName = rs1.getString("CatalogName");
+				String schemaName = rs1.getString("SchemaName");
+				String tableName = rs1.getString("TableName");
+				boolean isUnique = rs1.getBoolean("IsUnique");
+				String columnName = rs1.getString("ColumnName");
+				int columnOrder = rs1.getInt("ColumnOrder");
+
+				assertEquals(catalogName, rs2.getString("CatalogName"));
+				assertEquals(schemaName, rs2.getString("SchemaName"));
+				assertEquals(tableName, rs2.getString("TableName"));
+				assertEquals(indexName, rs2.getString("IndexName"));
+				assertEquals(indexType, rs2.getString("IndexType"));
+				assertEquals(isUnique, rs2.getBoolean("IsUnique"));
+				assertEquals(columnName, rs2.getString("ColumnName"));
+				assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
+			}
+		}
+	}
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -13,8 +13,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.sql.BatchUpdateException;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
@@ -122,6 +124,25 @@ public class PreparedStatementTest extends AbstractTest {
                 ps.executeUpdate(); // Takes sp_prepare path
                 ps.executeUpdate();
             }
+        }
+    }
+    
+    @Test
+    void testDatabaseQueryMetaData() throws SQLException {
+        try (Connection connection = getConnection()) {
+            try (SQLServerPreparedStatement stmt = (SQLServerPreparedStatement) connection.prepareStatement(
+                    "select 1 as \"any questions ???\"")) {
+                ResultSetMetaData metaData = stmt.getMetaData();
+                String actualLabel = metaData.getColumnLabel(1);
+                String actualName = metaData.getColumnName(1);
+
+                String expected = "any questions ???";
+                assertEquals(expected, actualLabel, "Column label should match the expected value");
+                assertEquals(expected, actualName, "Column name should match the expected value");
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            fail("SQLException occurred during test: " + e.getMessage());
         }
     }
 
@@ -927,5 +948,5 @@ public class PreparedStatementTest extends AbstractTest {
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName5), stmt);
         }
     }
-
+    
 }


### PR DESCRIPTION
Replaced the use of the sp_statistics stored procedure with a custom query to retrieve index information as the sp_statistics procedure did not return Columnstore indexes, so a query using sys.indexes was implemented as a workaround.
This new query ensures that all index types (Clustered, NonClustered, Columnstore) are included in the result set.
Github Issue: https://github.com/microsoft/mssql-jdbc/issues/2546