### PR TITLE
Driver cuts out the question mark from columns labels (aliases)

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -13,8 +13,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.sql.BatchUpdateException;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
@@ -122,6 +124,25 @@ public class PreparedStatementTest extends AbstractTest {
                 ps.executeUpdate(); // Takes sp_prepare path
                 ps.executeUpdate();
             }
+        }
+    }
+    
+    @Test
+    void testDatabaseQueryMetaData() throws SQLException {
+        try (Connection connection = getConnection()) {
+            try (var stmt = connection.prepareStatement(
+                    "select 1 as \"any questions ???\"")) {
+                ResultSetMetaData metaData = stmt.getMetaData();
+                String actualLabel = metaData.getColumnLabel(1);
+                String actualName = metaData.getColumnName(1);
+
+                String expected = "any questions ???";
+                assertEquals(expected, actualLabel, "Column label should match the expected value");
+                assertEquals(expected, actualName, "Column name should match the expected value");
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            fail("SQLException occurred during test: " + e.getMessage());
         }
     }
 
@@ -927,5 +948,4 @@ public class PreparedStatementTest extends AbstractTest {
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName5), stmt);
         }
     }
-
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -130,7 +130,7 @@ public class PreparedStatementTest extends AbstractTest {
     @Test
     void testDatabaseQueryMetaData() throws SQLException {
         try (Connection connection = getConnection()) {
-            try (var stmt = connection.prepareStatement(
+            try (SQLServerPreparedStatement stmt = (SQLServerPreparedStatement) connection.prepareStatement(
                     "select 1 as \"any questions ???\"")) {
                 ResultSetMetaData metaData = stmt.getMetaData();
                 String actualLabel = metaData.getColumnLabel(1);
@@ -948,4 +948,5 @@ public class PreparedStatementTest extends AbstractTest {
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName5), stmt);
         }
     }
+    
 }


### PR DESCRIPTION
https://github.com/microsoft/mssql-jdbc/issues/2535 - Enhance error handling in buildExecuteMetaData method to handle SQLServerException more robustly.