### PR TITLE
Fixed exception type to SQLFeatureNotSupported

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -22,6 +22,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLPermission;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
@@ -7467,7 +7468,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     @Override
     public void releaseSavepoint(Savepoint savepoint) throws SQLException {
         loggerExternal.entering(loggingClassName, "releaseSavepoint", savepoint);
-        SQLServerException.throwNotSupportedException(this, null);
+        MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_featureNotSupported"));
+        Object[] msgArgs = {"releaseSavepoint"};
+        throw new SQLFeatureNotSupportedException(form.format(msgArgs));
     }
 
     final private Savepoint setNamedSavepoint(String sName) throws SQLServerException {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -218,5 +218,6 @@ public final class TestResource extends ListResourceBundle {
             {"R_loginFailedMI", "Login failed for user '<token-identified principal>'"},
             {"R_MInotAvailable", "Managed Identity authentication is not available"},
             {"R_sessionPropertyFailed", "Expected {0} from server for session property {1} but got {2}."},
-            {"R_featureNotSupported", "{0} is not supported."},};
+            {"R_featureNotSupported", "{0} is not supported."},
+            {"R_MInotAvailable", "Managed Identity authentication is not available"},};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -217,5 +217,6 @@ public final class TestResource extends ListResourceBundle {
                     "Expected column class {0} does not match actual column class {1} for column {2}."},
             {"R_loginFailedMI", "Login failed for user '<token-identified principal>'"},
             {"R_MInotAvailable", "Managed Identity authentication is not available"},
-            {"R_sessionPropertyFailed", "Expected {0} from server for session property {1} but got {2}."},};
+            {"R_sessionPropertyFailed", "Expected {0} from server for session property {1} but got {2}."},
+            {"R_featureNotSupported", "{0} is not supported."},};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.text.MessageFormat;
 
+import com.microsoft.sqlserver.jdbc.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,6 @@ import org.junit.runner.RunWith;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerSavepoint;
 import com.microsoft.sqlserver.jdbc.TestResource;
-import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.text.MessageFormat;
 
 import com.microsoft.sqlserver.jdbc.TestUtils;
@@ -136,4 +137,21 @@ public class SavepointTest extends AbstractTest {
             } catch (SQLException e) {}
         }
     }
+
+    /**
+     * Test releaseSavepoint.
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testReleaseSavepoint() throws SQLException {
+        try (Connection connection = getConnection()) {
+            try {
+                connection.releaseSavepoint(null);
+            } catch (SQLException e) {
+                assertTrue(e instanceof SQLFeatureNotSupportedException);
+            }
+        }
+    }
+
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.sqlserver.jdbc.unit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,7 +14,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.text.MessageFormat;
 
-import com.microsoft.sqlserver.jdbc.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -149,7 +149,13 @@ public class SavepointTest extends AbstractTest {
             try {
                 connection.releaseSavepoint(null);
             } catch (SQLException e) {
-                assertTrue(e instanceof SQLFeatureNotSupportedException);
+                assertEquals(e.getClass(), SQLFeatureNotSupportedException.class, "Expected exception type " + SQLFeatureNotSupportedException.class.getName() + ", but received " + e.getClass().getName());
+
+                MessageFormat form = new MessageFormat(TestResource.getResource("R_featureNotSupported"));
+                Object[] msgArgs = {"releaseSavepoint"};
+                String expectedExceptionMsg = form.format(msgArgs);
+                String receivedExceptionMsg = e.getMessage();
+                assertEquals(expectedExceptionMsg, receivedExceptionMsg, "Expected exception message " + expectedExceptionMsg + ", but received " + receivedExceptionMsg);;
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/SavepointTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerSavepoint;
 import com.microsoft.sqlserver.jdbc.TestResource;
+import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 
@@ -151,11 +152,7 @@ public class SavepointTest extends AbstractTest {
             } catch (SQLException e) {
                 assertEquals(e.getClass(), SQLFeatureNotSupportedException.class, "Expected exception type " + SQLFeatureNotSupportedException.class.getName() + ", but received " + e.getClass().getName());
 
-                MessageFormat form = new MessageFormat(TestResource.getResource("R_featureNotSupported"));
-                Object[] msgArgs = {"releaseSavepoint"};
-                String expectedExceptionMsg = form.format(msgArgs);
-                String receivedExceptionMsg = e.getMessage();
-                assertEquals(expectedExceptionMsg, receivedExceptionMsg, "Expected exception message " + expectedExceptionMsg + ", but received " + receivedExceptionMsg);;
+                assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_featureNotSupported")));
             }
         }
     }


### PR DESCRIPTION
Fixed exception type to SQLfeatureNotSupported as per the the java.sql.Connection API doc: https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#releaseSavepoint-java.sql.Savepoint-

Testing:
- Build and unit tests pass
- Added new unit test for testing this exception
-