### PR TITLE
Updated getIndexInfo() to include Columnstore indexes by using custom query.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1234,25 +1234,10 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
         * 
         * GitHub Issue: #2546 - Columnstore indexes were missing from sp_statistics results.
         */
-        SQLServerResultSet rs = null;
         PreparedStatement pstmt = (SQLServerPreparedStatement) this.connection.prepareStatement(INDEX_INFO_QUERY);
-        try {
-            pstmt.setString(1, table);
-            pstmt.setString(2, schema);
-            rs = (SQLServerResultSet) pstmt.executeQuery();
-        } catch (SQLException e) {
-            if (null != pstmt) {
-                try {
-                    pstmt.close();
-                } catch (SQLServerException ignore) {
-                    if (loggerExternal.isLoggable(Level.FINER)) {
-                        loggerExternal.finer(
-                                "getIndexInfo() threw an exception when attempting to close PreparedStatement");
-                    }
-                }
-            }
-        }
-        return rs;
+        pstmt.setString(1, table);
+        pstmt.setString(2, schema);
+        return (SQLServerResultSet) pstmt.executeQuery();
     }
 
     @Override

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -265,14 +265,14 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 
     private static final String SQL_KEYWORDS = createSqlKeyWords();
 
-    private static final String INDEX_INFO_QUERY = "SELECT db_name() AS CatalogName, " +
-    "sch.name AS SchemaName, " +
-    "t.name AS TableName, " +
-    "i.name AS IndexName, " +
-    "i.type_desc AS IndexType, " +
-    "i.is_unique AS IsUnique, " +
-    "c.name AS ColumnName, " +
-    "ic.key_ordinal AS ColumnOrder " +
+    private static final String INDEX_INFO_QUERY = "SELECT db_name() AS TABLE_CAT, " +
+    "sch.name AS TABLE_SCHEM, " +
+    "t.name AS TABLE_NAME, " +
+    "i.name AS INDEX_NAME, " +
+    "i.type_desc AS TYPE, " +
+    "i.is_unique AS NON_UNIQUE, " +
+    "c.name AS COLUMN_NAME, " +
+    "ic.key_ordinal AS ORDINAL_POSITION " +
     "FROM sys.indexes i " +
     "INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id " +
     "INNER JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id " +

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestResource.java
@@ -219,5 +219,9 @@ public final class TestResource extends ListResourceBundle {
             {"R_MInotAvailable", "Managed Identity authentication is not available"},
             {"R_sessionPropertyFailed", "Expected {0} from server for session property {1} but got {2}."},
             {"R_featureNotSupported", "{0} is not supported."},
-            {"R_MInotAvailable", "Managed Identity authentication is not available"},};
+            {"R_MInotAvailable", "Managed Identity authentication is not available"},
+            {"R_noSQLWarningsCreateTableConnection", "Expecting NO SQLWarnings from 'create table', at Connection."},
+            {"R_noSQLWarningsCreateTableStatement", "Expecting NO SQLWarnings from 'create table', at Statement."},
+            {"R_noSQLWarningsCreateIndexConnection", "Expecting NO SQLWarnings from 'create index', at Connection."},
+            {"R_noSQLWarningsCreateIndexStatement", "Expecting NO SQLWarnings from 'create index', at Statement."},};
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -36,7 +36,10 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -1095,12 +1098,161 @@ public class DatabaseMetaDataTest extends AbstractTest {
 
     @AfterAll
     public static void terminate() throws SQLException {
-        try (Statement stmt = connection.createStatement()) {
+        try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
             TestUtils.dropTableIfExists(tableName, stmt);
             TestUtils.dropFunctionIfExists(functionName, stmt);
             TestUtils.dropTableWithSchemaIfExists(tableNameWithSchema, stmt);
             TestUtils.dropProcedureWithSchemaIfExists(sprocWithSchema, stmt);
             TestUtils.dropSchemaIfExists(schema, stmt);
+        }
+    }
+
+    @Nested
+    public class DatabaseMetadataGetIndexInfoTest extends AbstractTest {
+        String tableName = AbstractSQLGenerator.escapeIdentifier("DBMetadataTestTable");
+        String col1Name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("col1"));
+        String col2Name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("col2"));
+        String col3Name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("col3"));
+
+        @BeforeEach
+        public void init() throws SQLException {
+            try (Connection con = getConnection()) {
+                con.setAutoCommit(false);
+                try (Statement stmt = con.createStatement()) {
+                    TestUtils.dropTableIfExists(tableName, stmt);
+                    String createTableSQL = "CREATE TABLE " + tableName + " (" + col1Name + " INT, " + col2Name + " INT, "
+                            + col3Name + " INT)";
+
+                    stmt.executeUpdate(createTableSQL);
+                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableConnection"));
+                    assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableStatement"));
+
+                    String createClusteredIndexSQL = "CREATE CLUSTERED INDEX IDX_Clustered ON " + tableName + "(" + col1Name
+                            + ")";
+                    stmt.executeUpdate(createClusteredIndexSQL);
+                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+                    assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
+
+                    String createNonClusteredIndexSQL = "CREATE NONCLUSTERED INDEX IDX_NonClustered ON " + tableName + "("
+                            + col2Name + ")";
+                    stmt.executeUpdate(createNonClusteredIndexSQL);
+                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+                    assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
+
+                    String createColumnstoreIndexSQL = "CREATE COLUMNSTORE INDEX IDX_Columnstore ON " + tableName + "("
+                            + col3Name + ")";
+                    stmt.executeUpdate(createColumnstoreIndexSQL);
+                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+                    assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
+                }
+                con.commit();
+            }
+        }
+
+        @AfterEach
+        public void terminate() throws SQLException {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                try {
+                    TestUtils.dropTableIfExists(tableName, stmt);
+                } catch (SQLException e) {
+                    fail(TestResource.getResource("R_unexpectedException") + e.getMessage());
+                }
+            }
+        }
+
+        @Test
+        public void testGetIndexInfo() throws SQLException {
+            ResultSet rs1, rs2 = null;
+            try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
+                String catalog = connection.getCatalog();
+                String schema = "dbo";
+                String table = "DBMetadataTestTable";
+                DatabaseMetaData dbMetadata = connection.getMetaData();
+                rs1 = dbMetadata.getIndexInfo(catalog, schema, table, false, false);
+
+                boolean hasClusteredIndex = false;
+                boolean hasNonClusteredIndex = false;
+                boolean hasColumnstoreIndex = false;
+
+                String query = "SELECT " + "    db_name() AS CatalogName, " + "    sch.name AS SchemaName, "
+                        + "    t.name AS TableName, " + "    i.name AS IndexName, " + "    i.type_desc AS IndexType, "
+                        + "    i.is_unique AS IsUnique, " + "    c.name AS ColumnName, "
+                        + "    ic.key_ordinal AS ColumnOrder " + "FROM " + "    sys.indexes i " + "INNER JOIN "
+                        + "    sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id "
+                        + "INNER JOIN " + "    sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id "
+                        + "INNER JOIN " + "    sys.tables t ON i.object_id = t.object_id " + "INNER JOIN "
+                        + "    sys.schemas sch ON t.schema_id = sch.schema_id " +
+
+                        "WHERE t.name = '" + table + "' " + "AND sch.name = '" + schema + "' " + "ORDER BY "
+                        + "    t.name, i.name, ic.key_ordinal;";
+                rs2 = stmt.executeQuery(query);
+
+                while (rs1.next() && rs2.next()) {
+                    String indexType = rs1.getString("IndexType");
+                    String indexName = rs1.getString("IndexName");
+                    String catalogName = rs1.getString("CatalogName");
+                    String schemaName = rs1.getString("SchemaName");
+                    String tableName = rs1.getString("TableName");
+                    boolean isUnique = rs1.getBoolean("IsUnique");
+                    String columnName = rs1.getString("ColumnName");
+                    int columnOrder = rs1.getInt("ColumnOrder");
+
+                    assertEquals(catalogName, rs2.getString("CatalogName"));
+                    assertEquals(schemaName, rs2.getString("SchemaName"));
+                    assertEquals(tableName, rs2.getString("TableName"));
+                    assertEquals(indexName, rs2.getString("IndexName"));
+                    assertEquals(indexType, rs2.getString("IndexType"));
+                    assertEquals(isUnique, rs2.getBoolean("IsUnique"));
+                    assertEquals(columnName, rs2.getString("ColumnName"));
+                    assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
+
+                    if (indexType.contains("COLUMNSTORE")) {
+                        hasColumnstoreIndex = true;
+                    } else if (indexType.equals("CLUSTERED")) {
+                        hasClusteredIndex = true;
+                    } else if (indexType.equals("NONCLUSTERED")) {
+                        hasNonClusteredIndex = true;
+                    }
+                }
+
+                assertTrue(hasColumnstoreIndex, "COLUMNSTORE index not found.");
+                assertTrue(hasClusteredIndex, "CLUSTERED index not found.");
+                assertTrue(hasNonClusteredIndex, "NONCLUSTERED index not found.");
+            }
+        }
+
+        @Test
+        public void testGetIndexInfoCaseSensitivity() throws SQLException {
+            ResultSet rs1, rs2 = null;
+            try (Connection connection = getConnection()) {
+                String catalog = connection.getCatalog();
+                String schema = "dbo";
+                String table = "DBMetadataTestTable";
+
+                DatabaseMetaData dbMetadata = connection.getMetaData();
+                rs1 = dbMetadata.getIndexInfo(catalog, schema, table, false, false);
+                rs2 = dbMetadata.getIndexInfo(catalog, schema, table.toUpperCase(), false, false);
+
+                while (rs1.next() && rs2.next()) {
+                    String indexType = rs1.getString("IndexType");
+                    String indexName = rs1.getString("IndexName");
+                    String catalogName = rs1.getString("CatalogName");
+                    String schemaName = rs1.getString("SchemaName");
+                    String tableName = rs1.getString("TableName");
+                    boolean isUnique = rs1.getBoolean("IsUnique");
+                    String columnName = rs1.getString("ColumnName");
+                    int columnOrder = rs1.getInt("ColumnOrder");
+
+                    assertEquals(catalogName, rs2.getString("CatalogName"));
+                    assertEquals(schemaName, rs2.getString("SchemaName"));
+                    assertEquals(tableName, rs2.getString("TableName"));
+                    assertEquals(indexName, rs2.getString("IndexName"));
+                    assertEquals(indexType, rs2.getString("IndexType"));
+                    assertEquals(isUnique, rs2.getBoolean("IsUnique"));
+                    assertEquals(columnName, rs2.getString("ColumnName"));
+                    assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1120,29 +1120,36 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 con.setAutoCommit(false);
                 try (Statement stmt = con.createStatement()) {
                     TestUtils.dropTableIfExists(tableName, stmt);
-                    String createTableSQL = "CREATE TABLE " + tableName + " (" + col1Name + " INT, " + col2Name + " INT, "
+                    String createTableSQL = "CREATE TABLE " + tableName + " (" + col1Name + " INT, " + col2Name
+                            + " INT, "
                             + col3Name + " INT)";
 
                     stmt.executeUpdate(createTableSQL);
-                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableConnection"));
+                    assertNull(connection.getWarnings(),
+                            TestResource.getResource("R_noSQLWarningsCreateTableConnection"));
                     assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateTableStatement"));
 
-                    String createClusteredIndexSQL = "CREATE CLUSTERED INDEX IDX_Clustered ON " + tableName + "(" + col1Name
+                    String createClusteredIndexSQL = "CREATE CLUSTERED INDEX IDX_Clustered ON " + tableName + "("
+                            + col1Name
                             + ")";
                     stmt.executeUpdate(createClusteredIndexSQL);
-                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+                    assertNull(connection.getWarnings(),
+                            TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
                     assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
 
-                    String createNonClusteredIndexSQL = "CREATE NONCLUSTERED INDEX IDX_NonClustered ON " + tableName + "("
+                    String createNonClusteredIndexSQL = "CREATE NONCLUSTERED INDEX IDX_NonClustered ON " + tableName
+                            + "("
                             + col2Name + ")";
                     stmt.executeUpdate(createNonClusteredIndexSQL);
-                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+                    assertNull(connection.getWarnings(),
+                            TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
                     assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
 
                     String createColumnstoreIndexSQL = "CREATE COLUMNSTORE INDEX IDX_Columnstore ON " + tableName + "("
                             + col3Name + ")";
                     stmt.executeUpdate(createColumnstoreIndexSQL);
-                    assertNull(connection.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
+                    assertNull(connection.getWarnings(),
+                            TestResource.getResource("R_noSQLWarningsCreateIndexConnection"));
                     assertNull(stmt.getWarnings(), TestResource.getResource("R_noSQLWarningsCreateIndexStatement"));
                 }
                 con.commit();
@@ -1179,7 +1186,8 @@ public class DatabaseMetaDataTest extends AbstractTest {
                         + "    i.is_unique AS IsUnique, " + "    c.name AS ColumnName, "
                         + "    ic.key_ordinal AS ColumnOrder " + "FROM " + "    sys.indexes i " + "INNER JOIN "
                         + "    sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id "
-                        + "INNER JOIN " + "    sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id "
+                        + "INNER JOIN "
+                        + "    sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id "
                         + "INNER JOIN " + "    sys.tables t ON i.object_id = t.object_id " + "INNER JOIN "
                         + "    sys.schemas sch ON t.schema_id = sch.schema_id " +
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1181,10 +1181,10 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 boolean hasNonClusteredIndex = false;
                 boolean hasColumnstoreIndex = false;
 
-                String query = "SELECT " + "    db_name() AS CatalogName, " + "    sch.name AS SchemaName, "
-                        + "    t.name AS TableName, " + "    i.name AS IndexName, " + "    i.type_desc AS IndexType, "
-                        + "    i.is_unique AS IsUnique, " + "    c.name AS ColumnName, "
-                        + "    ic.key_ordinal AS ColumnOrder " + "FROM " + "    sys.indexes i " + "INNER JOIN "
+                String query = "SELECT " + "    db_name() AS TABLE_CAT, " + "    sch.name AS TABLE_SCHEM, "
+                        + "    t.name AS TABLE_NAME, " + "    i.name AS INDEX_NAME, " + "    i.type_desc AS TYPE, "
+                        + "    i.is_unique AS NON_UNIQUE, " + "    c.name AS COLUMN_NAME, "
+                        + "    ic.key_ordinal AS ORDINAL_POSITION " + "FROM " + "    sys.indexes i " + "INNER JOIN "
                         + "    sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id "
                         + "INNER JOIN "
                         + "    sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id "
@@ -1196,23 +1196,23 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 rs2 = stmt.executeQuery(query);
 
                 while (rs1.next() && rs2.next()) {
-                    String indexType = rs1.getString("IndexType");
-                    String indexName = rs1.getString("IndexName");
-                    String catalogName = rs1.getString("CatalogName");
-                    String schemaName = rs1.getString("SchemaName");
-                    String tableName = rs1.getString("TableName");
-                    boolean isUnique = rs1.getBoolean("IsUnique");
-                    String columnName = rs1.getString("ColumnName");
-                    int columnOrder = rs1.getInt("ColumnOrder");
+                    String indexType = rs1.getString("TYPE");
+                    String indexName = rs1.getString("INDEX_NAME");
+                    String catalogName = rs1.getString("TABLE_CAT");
+                    String schemaName = rs1.getString("TABLE_SCHEM");
+                    String tableName = rs1.getString("TABLE_NAME");
+                    boolean isUnique = rs1.getBoolean("NON_UNIQUE");
+                    String columnName = rs1.getString("COLUMN_NAME");
+                    int columnOrder = rs1.getInt("ORDINAL_POSITION");
 
-                    assertEquals(catalogName, rs2.getString("CatalogName"));
-                    assertEquals(schemaName, rs2.getString("SchemaName"));
-                    assertEquals(tableName, rs2.getString("TableName"));
-                    assertEquals(indexName, rs2.getString("IndexName"));
-                    assertEquals(indexType, rs2.getString("IndexType"));
-                    assertEquals(isUnique, rs2.getBoolean("IsUnique"));
-                    assertEquals(columnName, rs2.getString("ColumnName"));
-                    assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
+                    assertEquals(catalogName, rs2.getString("TABLE_CAT"));
+                    assertEquals(schemaName, rs2.getString("TABLE_SCHEM"));
+                    assertEquals(tableName, rs2.getString("TABLE_NAME"));
+                    assertEquals(indexName, rs2.getString("INDEX_NAME"));
+                    assertEquals(indexType, rs2.getString("TYPE"));
+                    assertEquals(isUnique, rs2.getBoolean("NON_UNIQUE"));
+                    assertEquals(columnName, rs2.getString("COLUMN_NAME"));
+                    assertEquals(columnOrder, rs2.getInt("ORDINAL_POSITION"));
 
                     if (indexType.contains("COLUMNSTORE")) {
                         hasColumnstoreIndex = true;
@@ -1242,23 +1242,23 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 rs2 = dbMetadata.getIndexInfo(catalog, schema, table.toUpperCase(), false, false);
 
                 while (rs1.next() && rs2.next()) {
-                    String indexType = rs1.getString("IndexType");
-                    String indexName = rs1.getString("IndexName");
-                    String catalogName = rs1.getString("CatalogName");
-                    String schemaName = rs1.getString("SchemaName");
-                    String tableName = rs1.getString("TableName");
-                    boolean isUnique = rs1.getBoolean("IsUnique");
-                    String columnName = rs1.getString("ColumnName");
-                    int columnOrder = rs1.getInt("ColumnOrder");
+                    String indexType = rs1.getString("TYPE");
+                    String indexName = rs1.getString("INDEX_NAME");
+                    String catalogName = rs1.getString("TABLE_CAT");
+                    String schemaName = rs1.getString("TABLE_SCHEM");
+                    String tableName = rs1.getString("TABLE_NAME");
+                    boolean isUnique = rs1.getBoolean("NON_UNIQUE");
+                    String columnName = rs1.getString("COLUMN_NAME");
+                    int columnOrder = rs1.getInt("ORDINAL_POSITION");
 
-                    assertEquals(catalogName, rs2.getString("CatalogName"));
-                    assertEquals(schemaName, rs2.getString("SchemaName"));
-                    assertEquals(tableName, rs2.getString("TableName"));
-                    assertEquals(indexName, rs2.getString("IndexName"));
-                    assertEquals(indexType, rs2.getString("IndexType"));
-                    assertEquals(isUnique, rs2.getBoolean("IsUnique"));
-                    assertEquals(columnName, rs2.getString("ColumnName"));
-                    assertEquals(columnOrder, rs2.getInt("ColumnOrder"));
+                    assertEquals(catalogName, rs2.getString("TABLE_CAT"));
+                    assertEquals(schemaName, rs2.getString("TABLE_SCHEM"));
+                    assertEquals(tableName, rs2.getString("TABLE_NAME"));
+                    assertEquals(indexName, rs2.getString("INDEX_NAME"));
+                    assertEquals(indexType, rs2.getString("TYPE"));
+                    assertEquals(isUnique, rs2.getBoolean("NON_UNIQUE"));
+                    assertEquals(columnName, rs2.getString("COLUMN_NAME"));
+                    assertEquals(columnOrder, rs2.getInt("ORDINAL_POSITION"));
                 }
             }
         }


### PR DESCRIPTION
Replaced the use of the sp_statistics stored procedure with a custom query to retrieve index information as the sp_statistics procedure did not return Columnstore indexes, so a query using sys.indexes was implemented as a workaround.
This new query ensures that all index types (Clustered, NonClustered, Columnstore) are included in the result set.
Github Issue: https://github.com/microsoft/mssql-jdbc/issues/2546

