### PR TITLE
Perf: Check for null when getting DTV values (JDBC spec compliance - getBinaryStream /getAsciiStream will return null when the value is null)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -246,9 +246,9 @@ final class DTV {
     Object getValue(JDBCType jdbcType, int scale, InputStreamGetterArgs streamGetterArgs, Calendar cal,
             TypeInfo typeInfo, CryptoMetadata cryptoMetadata, TDSReader tdsReader,
             SQLServerStatement statement) throws SQLServerException {
-        if (null == impl){
+        if (null == impl) {
             impl = new ServerDTVImpl();
-        } else if (impl.isNull()){
+        } else if (impl.isNull()) {
             return null;
         }
         return impl.getValue(this, jdbcType, scale, streamGetterArgs, cal, typeInfo, cryptoMetadata, tdsReader,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -249,7 +249,7 @@ final class DTV {
         if (null == impl) {
             impl = new ServerDTVImpl();
         } else if (impl.isNull()) {
-        	return null;
+            return null;
         }
         return impl.getValue(this, jdbcType, scale, streamGetterArgs, cal, typeInfo, cryptoMetadata, tdsReader,
                 statement);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -246,8 +246,11 @@ final class DTV {
     Object getValue(JDBCType jdbcType, int scale, InputStreamGetterArgs streamGetterArgs, Calendar cal,
             TypeInfo typeInfo, CryptoMetadata cryptoMetadata, TDSReader tdsReader,
             SQLServerStatement statement) throws SQLServerException {
-        if (null == impl)
+        if (null == impl) {
             impl = new ServerDTVImpl();
+        } else if (impl.isNull()) {
+        	return null;
+        }
         return impl.getValue(this, jdbcType, scale, streamGetterArgs, cal, typeInfo, cryptoMetadata, tdsReader,
                 statement);
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -246,9 +246,9 @@ final class DTV {
     Object getValue(JDBCType jdbcType, int scale, InputStreamGetterArgs streamGetterArgs, Calendar cal,
             TypeInfo typeInfo, CryptoMetadata cryptoMetadata, TDSReader tdsReader,
             SQLServerStatement statement) throws SQLServerException {
-        if (null == impl) {
+        if (null == impl){
             impl = new ServerDTVImpl();
-        } else if (impl.isNull()) {
+        } else if (impl.isNull()){
             return null;
         }
         return impl.getValue(this, jdbcType, scale, streamGetterArgs, cal, typeInfo, cryptoMetadata, tdsReader,


### PR DESCRIPTION
This fix of checking for null value of a DTVImpl before calling DTVImpl::getValue has shown some perf gains in our internal benchmark.

This fix will change behavior of getBinaryStream /getAsciiStream in ResultSet to be compliant with JDBC specs:
a Java input stream that delivers the database column value as a stream of one-byte ASCII characters; if the value is SQL NULL, the value returned is null