### PR TITLE
Improvement to equals in SQLServerDataTable

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ConfigurableRetryLogic.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ConfigurableRetryLogic.java
@@ -336,10 +336,10 @@ public class ConfigurableRetryLogic {
      *         if unable to read from the file
      */
     private static LinkedList<String> readFromFile(String connectionStringProperty) throws SQLServerException {
-        String filePath = getCurrentClassPath();
+        String filePath = "";
         LinkedList<String> list = new LinkedList<>();
-
         try {
+            filePath = getCurrentClassPath();
             File f = new File(filePath);
             try (BufferedReader buffer = new BufferedReader(new FileReader(f))) {
                 String readLine;
@@ -354,13 +354,22 @@ public class ConfigurableRetryLogic {
         } catch (FileNotFoundException e) {
             // If the file is not found either A) We're not using CRL OR B) the path is wrong. Do not error out, instead
             // log a message.
-            if (CONFIGURABLE_RETRY_LOGGER.isLoggable(java.util.logging.Level.FINER)) {
-                CONFIGURABLE_RETRY_LOGGER.finest("File not found at path - \"" + filePath + "\"");
+            if (CONFIGURABLE_RETRY_LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+                CONFIGURABLE_RETRY_LOGGER.fine("File not found at path - \"" + filePath + "\"");
+            }
+        } catch (InvalidPathException e) {
+            if (CONFIGURABLE_RETRY_LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+                CONFIGURABLE_RETRY_LOGGER.fine("Invalid path specified - \"" + filePath + "\"");
             }
         } catch (IOException e) {
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_errorReadingStream"));
             Object[] msgArgs = {e.getMessage() + ", from path - \"" + filePath + "\""};
             throw new SQLServerException(form.format(msgArgs), null, 0, e);
+        } catch (Exception e) {
+            // General exception handling
+            if (CONFIGURABLE_RETRY_LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+                CONFIGURABLE_RETRY_LOGGER.fine("An unexpected error occurred while reading from file: " + e.getMessage());
+            }
         }
         return list;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2195,6 +2195,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         long elapsedSeconds = 0;
         long start = System.currentTimeMillis();
+
+        // Any existing enclave session would be invalid, make sure it is invalidated.
+        // For example, if this is a session recovery reconnect.
+        //
+        invalidateEnclaveSessionCache();
         for (int connectRetryAttempt = 0, tlsRetryAttempt = 0;;) {
             try {
                 if (0 == elapsedSeconds || elapsedSeconds < loginTimeoutSeconds) {
@@ -8967,6 +8972,15 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         }
         return enclaveProvider.createEnclaveSession(this, statement, userSql, preparedTypeDefinitions, params,
                 parameterNames);
+    }
+
+    void invalidateEnclaveSessionCache() {
+        if (enclaveProvider != null) {
+            if (connectionlogger.isLoggable(Level.FINE)) {
+                connectionlogger.fine("Invalidating existing enclave session for enclave provider : " + enclaveProvider);
+            }
+            enclaveProvider.invalidateEnclaveSession();
+        }
     }
 
     boolean enclaveEstablished() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
@@ -397,9 +398,10 @@ public final class SQLServerDataTable {
                 boolean equalColumnMetadata = columnMetadata.equals(aSQLServerDataTable.columnMetadata);
                 boolean equalColumnNames = columnNames.equals(aSQLServerDataTable.columnNames);
                 boolean equalRowData = compareRows(aSQLServerDataTable.rows);
+                boolean equalTvpName = Objects.equals(tvpName, aSQLServerDataTable.tvpName);
 
                 return (rowCount == aSQLServerDataTable.rowCount && columnCount == aSQLServerDataTable.columnCount
-                        && tvpName == aSQLServerDataTable.tvpName && equalColumnMetadata && equalColumnNames
+                        && equalTvpName && equalColumnMetadata && equalColumnNames
                         && equalRowData);
             }
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -275,8 +276,12 @@ public final class SQLServerDataTable {
 
                     // java.sql.Date, java.sql.Time and java.sql.Timestamp are subclass of java.util.Date
                     if (val instanceof java.util.Date || val instanceof microsoft.sql.DateTimeOffset
-                            || val instanceof OffsetDateTime || val instanceof OffsetTime)
+                            || val instanceof OffsetTime)
                         rowValues[key] = val.toString();
+                    else if (val instanceof OffsetDateTime)
+                        // avoid calling OffsetDateTime#toString() because when there are no seconds we would get
+                        // a format which is incompatible with the server - see LocalTime#toString()
+                        rowValues[key] = ((OffsetDateTime)val).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
                     else
                         rowValues[key] = val;
                     break;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -73,6 +73,8 @@ public final class SQLServerException extends java.sql.SQLException {
     // Built-in function '%.*ls' in impersonation context is not supported in this version of SQL Server.
     static final int IMPERSONATION_CONTEXT_NOT_SUPPORTED = 40529;
 
+    static final int INVAID_ENCLAVE_SESSION_HANDLE_ERROR = 33195;
+
     // Facility for driver-specific error codes
     static final int DRIVER_ERROR_NONE = 0;
     static final int DRIVER_ERROR_FROM_DATABASE = 2;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -687,6 +687,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                 startResults();
                 getNextResult(true);
             } catch (SQLException e) {
+                if (connection.isAEv2() && (e.getErrorCode() == SQLServerException.INVAID_ENCLAVE_SESSION_HANDLE_ERROR)) {
+                    //If the exception received is as below then just invalidate the cache 
+                    //code = '33195', SQL state = 'S0001': Internal enclave error. Enclave was provided with an invalid session handle. For more information, contact Customer Support Services..
+                    //
+                    connection.invalidateEnclaveSessionCache();
+                }
                 if (retryBasedOnFailedReuseOfCachedHandle(e, attempt, needsPrepare, false)) {
                     continue;
                 } else if (!inRetry && connection.doesServerSupportEnclaveRetry()) {
@@ -3119,6 +3125,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                         assert numBatchesExecuted == numBatchesPrepared;
                     }
                 } catch (SQLException e) {
+                    if (connection.isAEv2() && (e.getErrorCode() == SQLServerException.INVAID_ENCLAVE_SESSION_HANDLE_ERROR)) {
+                        //If the exception received is as below then just invalidate the cache 
+                        //code = '33195', SQL state = 'S0001': Internal enclave error. Enclave was provided with an invalid session handle. For more information, contact Customer Support Services..
+                        //
+                        connection.invalidateEnclaveSessionCache();
+                    }
                     if (retryBasedOnFailedReuseOfCachedHandle(e, attempt, needsPrepare, true)
                             && connection.isStatementPoolingEnabled()) {
                         // Reset number of batches prepared.

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -111,4 +111,21 @@ public class SQLServerDataTableTest {
         table.setTvpName("TVP_HashCode");
         return table;
     }
+
+    @Test()
+    public void testEqualsTvp() throws SQLServerException {
+        SQLServerDataTable a = new SQLServerDataTable();
+        SQLServerDataTable b = new SQLServerDataTable();
+
+        assert (a.equals(b));
+
+        a.setTvpName("test");
+        b.setTvpName(new String("test"));
+
+        assert (a.equals(b));
+
+        a.setTvpName("test");
+        b.setTvpName(new String("test2"));
+        assert (!a.equals(b));
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -26,19 +29,25 @@ public class SQLServerDataTableTest {
         SQLServerDataTable table = new SQLServerDataTable();
         SQLServerDataColumn a = new SQLServerDataColumn("foo", Types.VARCHAR);
         SQLServerDataColumn b = new SQLServerDataColumn("bar", Types.INTEGER);
+        SQLServerDataColumn c = new SQLServerDataColumn("baz", Types.TIMESTAMP_WITH_TIMEZONE);
 
         table.addColumnMetadata(a);
         table.addColumnMetadata(b);
-        assertEquals(2, table.getColumnMetadata().size());
+        table.addColumnMetadata(c);
+        assertEquals(3, table.getColumnMetadata().size());
 
         table.clear();
         assertEquals(0, table.getColumnMetadata().size());
 
         table.addColumnMetadata(a);
         table.addColumnMetadata(b);
-        assertEquals(2, table.getColumnMetadata().size());
+        table.addColumnMetadata(c);
+        assertEquals(3, table.getColumnMetadata().size());
     }
 
+    /*
+     * * Test for hashCode and equals methods of SQLServerDataColumn and SQLServerDataTable.
+     */
     @Test
     public void testHashCodes() throws SQLServerException {
         // Test Null field values for SQLServerDataColumn
@@ -66,13 +75,14 @@ public class SQLServerDataTableTest {
         assert (a.equals(aClone));
 
         SQLServerDataColumn b = new SQLServerDataColumn("bar", Types.DECIMAL);
-        SQLServerDataTable table = createTable(a, b);
+        SQLServerDataColumn c = new SQLServerDataColumn("baz", Types.TIMESTAMP_WITH_TIMEZONE);
+        SQLServerDataTable table = createTable(a, b, c);
 
         // Test consistent generation of hashCode
         assert (table.hashCode() == table.hashCode());
         assert (table.equals(table));
 
-        SQLServerDataTable tableClone = createTable(aClone, b);
+        SQLServerDataTable tableClone = createTable(aClone, b, c);
 
         // Test for different instances generating same hashCode for same data
         assert (table.hashCode() == tableClone.hashCode());
@@ -82,21 +92,22 @@ public class SQLServerDataTableTest {
         assert (a.hashCode() != b.hashCode());
         assert (!a.equals(b));
 
-        SQLServerDataColumn c = new SQLServerDataColumn("bar", Types.FLOAT);
+        SQLServerDataColumn bb = new SQLServerDataColumn("bar", Types.FLOAT);
         table.clear();
-        table = createTable(a, c);
+        table = createTable(a, bb, c);
 
         // Test for non equal hashCodes
         assert (table.hashCode() != tableClone.hashCode());
         assert (!table.equals(tableClone));
     }
 
-    private SQLServerDataTable createTable(SQLServerDataColumn a, SQLServerDataColumn b) throws SQLServerException {
+    private SQLServerDataTable createTable(SQLServerDataColumn a, SQLServerDataColumn b, SQLServerDataColumn c) throws SQLServerException {
         SQLServerDataTable table = new SQLServerDataTable();
         table.addColumnMetadata(a);
         table.addColumnMetadata(b);
-        table.addRow("Hello", new BigDecimal(1.5));
-        table.addRow("World", new BigDecimal(5.5));
+        table.addColumnMetadata(c);
+        table.addRow("Hello", new BigDecimal(1.5), OffsetDateTime.parse("1977-07-24T12:34+02:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        table.addRow("World", new BigDecimal(5.5), OffsetDateTime.parse("1977-07-24T12:34:56+02:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
         table.setTvpName("TVP_HashCode");
         return table;
     }


### PR DESCRIPTION
Noticed that it was using == on strings in the equals function for SQLServerDataTable.  (I didn't experience a bug as a result of it) Is it intended to check the memory location? 