### PR TITLE
Adding OS, architecture and runtime details to applicationName

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2623,7 +2623,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != sPropValue)
                     validateMaxSQLLoginName(sPropKey, sPropValue);
                 else
-                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.DEFAULT_APP_NAME);
+                    activeConnectionProperties.setProperty(sPropKey, SQLServerDriver.constructedAppName);
 
                 sPropKey = SQLServerDriverBooleanProperty.LAST_UPDATE_COUNT.toString();
                 sPropValue = activeConnectionProperties.getProperty(sPropKey);
@@ -6905,7 +6905,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         String appName = activeConnectionProperties
                 .getProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString());
                 String interfaceLibName = "Microsoft JDBC Driver " + SQLJdbcVersion.MAJOR + "." + SQLJdbcVersion.MINOR;
-        //String interfaceLibName = SQLServerDriver.constructedAppName;
         String databaseName = activeConnectionProperties
                 .getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -170,7 +170,7 @@ public class SQLServerDataSource
     @Override
     public String getApplicationName() {
         return getStringProperty(connectionProps, SQLServerDriverStringProperty.APPLICATION_NAME.toString(),
-        SQLServerDriverStringProperty.APPLICATION_NAME.getDefaultValue());
+        SQLServerDriver.constructedAppName);
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -204,7 +204,7 @@ public class SQLServerDriverTest extends AbstractTest {
              Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT program_name FROM sys.dm_exec_sessions WHERE session_id = @@SPID")) {
             if (rs.next()) {
-                assertEquals(SQLServerDriverStringProperty.APPLICATION_NAME.getDefaultValue(), rs.getString("program_name"));
+                assertEquals(SQLServerDriver.constructedAppName, rs.getString("program_name"));
             }
         } catch (SQLException e) {
             fail(e.getMessage());
@@ -216,54 +216,55 @@ public class SQLServerDriverTest extends AbstractTest {
      * 
      * @throws SQLException
      */
-    // @Test
-    // public void testApplicationNameUsingApp_Name() throws SQLException {
-    //     try (Connection conn = DriverManager.getConnection(connectionString);
-    //          Statement stmt = conn.createStatement();
-    //          ResultSet rs = stmt.executeQuery("SELECT app_name()")) {
-    //         if (rs.next()) {
-    //             assertEquals(SQLServerDriver.constructedAppName, rs.getString(1));
-    //         }
-    //     } catch (SQLException e) {
-    //         fail(e.getMessage());
-    //     }
-    // }
+    @Test
+    public void testApplicationNameUsingApp_Name() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(connectionString);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT app_name()")) {
+            if (rs.next()) {
+                assertEquals(SQLServerDriver.constructedAppName, rs.getString(1));
+            }
+        } catch (SQLException e) {
+            fail(e.getMessage());
+        }
+    }
 
     /**
      * test application name by executing select app_name()
      * 
      * @throws SQLException
      */
-    // @Test
-    // public void testAppNameWithSpecifiedApplicationName() throws SQLException {
-    //     String url = connectionString + ";applicationName={0123456789012345678901234567890123456789012345678901234567890123456789012345678901234589012345678901234567890123456789012345678}";
+    @Test
+    public void testAppNameWithSpecifiedApplicationName() throws SQLException {
+        String url = connectionString + ";applicationName={0123456789012345678901234567890123456789012345678901234567890123456789012345678901234589012345678901234567890123456789012345678}";
 
-    //     try (Connection conn = DriverManager.getConnection(url);
-    //          Statement stmt = conn.createStatement();
-    //          ResultSet rs = stmt.executeQuery("SELECT app_name()")) {
-    //         if (rs.next()) {
-    //             assertEquals("0123456789012345678901234567890123456789012345678901234567890123456789012345678901234589012345678901234567890123456789012345678", rs.getString(1));
-    //         }
-    //     } catch (SQLException e) {
-    //         fail(e.getMessage());
-    //     }
-    // }
+        try (Connection conn = DriverManager.getConnection(url);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT app_name()")) {
+            if (rs.next()) {
+                assertEquals("0123456789012345678901234567890123456789012345678901234567890123456789012345678901234589012345678901234567890123456789012345678", rs.getString(1));
+            }
+        } catch (SQLException e) {
+            fail(e.getMessage());
+        }
+    }
 
     /**
      * test application name when system properties are empty
      * 
      */
-    // @Test
-    // public void testGetAppName() {
-    //     String appName = SQLServerDriver.getAppName();
-    //     assertNotNull(appName, "Application name should not be null");
-    //     assertFalse(appName.isEmpty(), "Application name should not be empty");
+    @Test
+    public void testGetAppName() {
+        String appName = SQLServerDriver.getAppName();
+        assertNotNull(appName, "Application name should not be null");
+        assertFalse(appName.isEmpty(), "Application name should not be empty");
 
-    //     System.setProperty("os.name", "");
-    //     System.setProperty("os.arch", "");
-    //     System.setProperty("java.vm.name", "");
-    //     System.setProperty("java.vm.version", "");
-    //     String defaultAppName = SQLServerDriver.getAppName();
-    //     assertEquals(SQLServerDriver.DEFAULT_APP_NAME, defaultAppName, "Application name should be the default one");
-    // }
+        System.setProperty("os.name", "");
+        System.setProperty("os.arch", "");
+        System.setProperty("os.version", "");
+        System.setProperty("java.vm.name", "");
+        System.setProperty("java.vm.version", "");
+        String defaultAppName = SQLServerDriver.getAppName();
+        assertEquals(SQLServerDriver.DEFAULT_APP_NAME, defaultAppName, "Application name should be the default one");
+    }
 }


### PR DESCRIPTION
By enhancing telemetry for SQL drivers, we can achieve a more nuanced understanding of the operating environments in use. This capability enables us to make strategic decisions about testing and support, ultimately improving our efficiency and reducing costs. Adopting a structured approach to telemetry collection will ensure we gather the most relevant and useful data, facilitating continuous improvement in our processes. 

Format 
{Driver Name}|{OS Type}|{Process Architecture}|{OS Details}|{Runtime Details} 

Maximum lengths (in Unicode characters) for each field are: 
Driver Name - 16 
OS Type - 10 
Process Architecture - 10 
OS Details - 44 
Runtime Details - 44 