### PR TITLE
Update FedAuth tests to use ManagedIdentity

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ConcurrentLoginTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ConcurrentLoginTest.java
@@ -10,7 +10,6 @@ import java.sql.Connection;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.microsoft.sqlserver.jdbc.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,6 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.fedAuth)
-@Tag(Constants.requireSecret)
 public class ConcurrentLoginTest extends FedauthCommon {
 
     final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ConnectionEncryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ConnectionEncryptionTest.java
@@ -11,7 +11,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.MessageFormat;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,7 +28,6 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.fedAuth)
-@Tag(Constants.requireSecret)
 public class ConnectionEncryptionTest extends FedauthCommon {
 
     static String charTable = TestUtils.escapeSingleQuotes(

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/ErrorMessageTest.java
@@ -25,7 +25,6 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.fedAuth)
-@Tag(Constants.requireSecret)
 public class ErrorMessageTest extends FedauthCommon {
 
     String badUserName = "abc" + azureUserName;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -42,7 +42,6 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.fedAuth)
-@Tag(Constants.requireSecret)
 public class FedauthTest extends FedauthCommon {
     static String charTable = TestUtils
             .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("JDBC_FedAuthTest")));
@@ -286,6 +285,7 @@ public class FedauthTest extends FedauthCommon {
      */
     @Deprecated
     @Test
+    @Tag(Constants.requireSecret)
     public void testAADServicePrincipalAuthDeprecated() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
                 + SqlAuthentication.ActiveDirectoryServicePrincipal + ";AADSecurePrincipalId=" + applicationClientID
@@ -308,6 +308,7 @@ public class FedauthTest extends FedauthCommon {
      * encryption.
      */
     @Test
+    @Tag(Constants.requireSecret)
     public void testAADServicePrincipalAuth() {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
                 + SqlAuthentication.ActiveDirectoryServicePrincipal + ";Username=" + applicationClientID + ";Password="
@@ -326,6 +327,7 @@ public class FedauthTest extends FedauthCommon {
     }
 
     @Test
+    @Tag(Constants.requireSecret)
     public void testAADServicePrincipalAuthFailureOnSubsequentConnectionsWithInvalidatedTokenCacheWithInvalidSecret() throws Exception {
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
                 + SqlAuthentication.ActiveDirectoryServicePrincipal + ";Username=" + applicationClientID + ";Password="
@@ -364,6 +366,7 @@ public class FedauthTest extends FedauthCommon {
     }
 
     @Test
+    @Tag(Constants.requireSecret)
     public void testAADServicePrincipalCertAuthFailureOnSubsequentConnectionsWithInvalidatedTokenCacheWithInvalidPassword() throws Exception {
         // Should succeed on valid cert field values
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
@@ -389,6 +392,7 @@ public class FedauthTest extends FedauthCommon {
      * Test invalid connection property combinations when using AAD Service Principal Authentication.
      */
     @Test
+    @Tag(Constants.requireSecret)
     public void testAADServicePrincipalAuthWrong() {
         String baseUrl = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
                 + SqlAuthentication.ActiveDirectoryServicePrincipal + ";";
@@ -426,6 +430,7 @@ public class FedauthTest extends FedauthCommon {
      * encryption.
      */
     @Test
+    @Tag(Constants.requireSecret)
     public void testAADServicePrincipalCertAuth() {
         // certificate from AKV has no password
         String url = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
@@ -449,6 +454,7 @@ public class FedauthTest extends FedauthCommon {
      * Test invalid connection property combinations when using AAD Service Principal Certificate Authentication.
      */
     @Test
+    @Tag(Constants.requireSecret)
     public void testAADServicePrincipalCertAuthWrong() {
         String baseUrl = "jdbc:sqlserver://" + azureServer + ";database=" + azureDatabase + ";authentication="
                 + SqlAuthentication.ActiveDirectoryServicePrincipalCertificate + ";userName="

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthTest.java
@@ -494,23 +494,6 @@ public class FedauthTest extends FedauthCommon {
         try (Connection conn1 = DriverManager.getConnection(cs)) {}
     }
 
-    @Test
-    public void testAccessTokenCache() {
-        try {
-            SilentParameters silentParameters = SilentParameters.builder(Collections.singleton(spn + "/.default"))
-                    .build();
-
-            // this will fail if not cached
-            CompletableFuture<IAuthenticationResult> future = fedauthClientApp.acquireTokenSilently(silentParameters);
-            IAuthenticationResult authenticationResult = future.get();
-            assertNotNull(authenticationResult.accessToken());
-            assertTrue(authenticationResult.accessToken().equals(accessToken), accessToken);
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
-
-    }
-
     private static void validateException(String url, String resourceKey) {
         try (Connection conn = DriverManager.getConnection(url)) {
             fail(TestResource.getResource("R_expectedFailPassed"));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthWithAE.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/fedauth/FedauthWithAE.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
+import com.azure.identity.ManagedIdentityCredential;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerColumnEncryptionAzureKeyVaultProvider;
 import com.microsoft.sqlserver.jdbc.SQLServerColumnEncryptionJavaKeyStoreProvider;
@@ -37,7 +39,6 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.fedAuth)
-@Tag(Constants.requireSecret)
 public class FedauthWithAE extends FedauthCommon {
 
     static String cmkName1 = Constants.CMK_NAME + "fedauthAE1";
@@ -282,16 +283,17 @@ public class FedauthWithAE extends FedauthCommon {
 
     private SQLServerColumnEncryptionKeyStoreProvider setupKeyStoreProvider_AKV() throws SQLServerException {
         SQLServerConnection.unregisterColumnEncryptionKeyStoreProviders();
-        return registerAKVProvider(
-                new SQLServerColumnEncryptionAzureKeyVaultProvider(applicationClientID, applicationKey));
+        return registerAKVProvider();
     }
 
-    private SQLServerColumnEncryptionKeyStoreProvider registerAKVProvider(
-            SQLServerColumnEncryptionKeyStoreProvider provider) throws SQLServerException {
-        Map<String, SQLServerColumnEncryptionKeyStoreProvider> map1 = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
-        map1.put(provider.getName(), provider);
-        SQLServerConnection.registerColumnEncryptionKeyStoreProviders(map1);
-        return provider;
+    private SQLServerColumnEncryptionKeyStoreProvider registerAKVProvider() throws SQLServerException {
+        Map<String, SQLServerColumnEncryptionKeyStoreProvider> map = new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
+        ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+                .clientId(akvProviderManagedClientId).build();
+        akvProvider = new SQLServerColumnEncryptionAzureKeyVaultProvider(credential);
+        map.put(Constants.AZURE_KEY_VAULT_NAME, akvProvider);
+        SQLServerConnection.registerColumnEncryptionKeyStoreProviders(map);
+        return akvProvider;
     }
 
     private void createCMK(String cmkName, String keyStoreName, String keyPath, Statement stmt) throws SQLException {


### PR DESCRIPTION
this re-enables all fedauth tests other than ones which specifically require secrets which will still use the requireSecret tag