### PR TITLE
Make ibm security module optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,12 +528,12 @@
 							com.microsoft.sqlserver.jdbc.dataclassification,
 							microsoft.sql
 						</_exportcontents>
-                        <Import-Package>
-                            !microsoft.sql,
-                            com.ibm.security.auth.module;resolution:=optional,
-                            com.sun.security.auth.module;resolution:=optional,
-                            jdk.net;resolution:=optional,*
-                        </Import-Package>
+						<Import-Package>
+							!microsoft.sql,
+							com.ibm.security.auth.module;resolution:=optional,
+							com.sun.security.auth.module;resolution:=optional,
+							jdk.net;resolution:=optional,*
+						</Import-Package>
 						<Bundle-Activator>com.microsoft.sqlserver.jdbc.osgi.Activator</Bundle-Activator>
 					</instructions>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,12 @@
 							com.microsoft.sqlserver.jdbc.dataclassification,
 							microsoft.sql
 						</_exportcontents>
-						<Import-Package>!microsoft.sql,jdk.net;resolution:=optional,*</Import-Package>
+                        <Import-Package>
+                            !microsoft.sql,
+                            com.ibm.security.auth.module;resolution:=optional,
+                            com.sun.security.auth.module;resolution:=optional,
+                            jdk.net;resolution:=optional,*
+                        </Import-Package>
 						<Bundle-Activator>com.microsoft.sqlserver.jdbc.osgi.Activator</Bundle-Activator>
 					</instructions>
 				</configuration>


### PR DESCRIPTION
The change done in PR https://github.com/microsoft/mssql-jdbc/pull/2609/ got reverted in PR https://github.com/microsoft/mssql-jdbc/pull/2614.

This PR is to restore it back to address the issue reported in issue #2635 