### PR TITLE
pom.xml: use newer bundle plugin 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.1</version>
+				<version>6.0.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>


### PR DESCRIPTION
If compiling with maven/new JDK the generated OSGi metadata contains a require osgi.ee=UNKNOWN requirement, since the older bnd version does not know about the new Java profile. Updating to latest bundle plugin does also bring a new bnd version which has not this issue.

Alternative: provide `<_runee>Java-xx</_runee>` instruction.

X-Signed-Off: Bernd Eckenfels <b.eckenfels@seeburger.de>