### PR TITLE
Fixed getSchemas catalog filtering logic and added test case to validate built-in schema handling (#2639)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1561,8 +1561,11 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             else
                 s += " where ";
             s += schemaName + " in " + constSchemas;
-        } else if (null != schemaPattern)
+        } else if (null != schemaPattern) {
             s += " where " + schemaName + " like ?  ";
+        } else if (null != catalog && catalog.length() != 0) {
+            s += " where " + schemaName + " not in " + constSchemas;
+        }
 
         s += " order by 2, 1";
         if (logger.isLoggable(java.util.logging.Level.FINE)) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1036,6 +1036,8 @@ public class DatabaseMetaDataTest extends AbstractTest {
     }
 
     @Test
+    @Tag(Constants.xAzureSQLDW)
+    @Tag(Constants.xAzureSQLDB)
     void testGetSchemasWithAndWithoutCatalog() throws Exception {
         String dbName = "TestDb_GetSchemas_Inline";
         String schemaName = "TestSchema123";

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1052,7 +1052,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
             stmt.executeUpdate("IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '" + schemaName + "') EXEC('CREATE SCHEMA " + schemaName + "')");
         
 
-            ResultSet rs = connection.getMetaData().getSchemas("TestDb", null );
+            ResultSet rs = connection.getMetaData().getSchemas(dbName, null );
             while (rs.next()) {
                 String schema = rs.getString("TABLE_SCHEM");
                 String catalog = rs.getString("TABLE_CATALOG");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1038,9 +1038,10 @@ public class DatabaseMetaDataTest extends AbstractTest {
     @Test
     @Tag(Constants.xAzureSQLDW)
     @Tag(Constants.xAzureSQLDB)
-    void testGetSchemasWithAndWithoutCatalog() throws Exception {
-        String dbName = "TestDb_GetSchemas_Inline";
-        String schemaName = "TestSchema123";
+    public void testGetSchemasWithAndWithoutCatalog() throws SQLException {
+        UUID id = UUID.randomUUID();
+        String dbName = "GetSchemas" + id;
+        String schemaName = "TestSchema" + id;
         String[] constSchemas = {
             "dbo", "guest", "INFORMATION_SCHEMA", "sys", "db_owner", "db_accessadmin",
             "db_securityadmin", "db_ddladmin", "db_backupoperator", "db_datareader",
@@ -1049,10 +1050,10 @@ public class DatabaseMetaDataTest extends AbstractTest {
 
         try (Connection connection = getConnection();
             Statement stmt = connection.createStatement()) {
-
-            stmt.executeUpdate("IF DB_ID('" + dbName + "') IS NULL CREATE DATABASE " + dbName);
-            stmt.executeUpdate("IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '" + schemaName + "') EXEC('CREATE SCHEMA " + schemaName + "')");
-        
+            TestUtils.dropDatabaseIfExists(dbName, connectionString);
+            stmt.execute(String.format("CREATE DATABASE [%s]", dbName));
+            stmt.execute(String.format("USE [%s]", dbName));
+            stmt.execute(String.format("CREATE SCHEMA [%s]", schemaName));
 
             ResultSet rs = connection.getMetaData().getSchemas(dbName, null );
             while (rs.next()) {
@@ -1063,7 +1064,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 assertNotNull(catalog, "TABLE_CATALOG should not be null for schema '" + schema + "' when catalog is specified");
             }
 
-            rs = connection.getMetaData().getSchemas(null, null );
+            rs = connection.getMetaData().getSchemas(null, null);
             while (rs.next()) {
                 String schema = rs.getString("TABLE_SCHEM");
                 String catalog = rs.getString("TABLE_CATALOG");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1074,12 +1074,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 }
             }
         } finally {
-            try (Connection connection = getConnection();
-                 Statement stmt = connection.createStatement()) {
-                stmt.executeUpdate("USE master");
-                stmt.executeUpdate("ALTER DATABASE " + dbName + " SET SINGLE_USER WITH ROLLBACK IMMEDIATE");
-                stmt.executeUpdate("DROP DATABASE " + dbName);
-            }
+            TestUtils.dropDatabaseIfExists(dbName, connectionString);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1076,6 +1076,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
         } finally {
             try (Connection connection = getConnection();
                  Statement stmt = connection.createStatement()) {
+                stmt.executeUpdate("USE master");
                 stmt.executeUpdate("ALTER DATABASE " + dbName + " SET SINGLE_USER WITH ROLLBACK IMMEDIATE");
                 stmt.executeUpdate("DROP DATABASE " + dbName);
             }


### PR DESCRIPTION
Github Issue: https://github.com/microsoft/mssql-jdbc/issues/2639 
Fixed incorrect filtering behavior in DatabaseMetaData.getSchemas when a specific catalog name is provided. Previously, the driver returned system/predefined schemas with a null catalog even when a catalog was specified, violating the JDBC specification. This update ensures that only schemas belonging to the specified catalog are returned, and system schemas without a catalog are properly excluded from the result set.