### PR TITLE
correct processing of OffsetDateTime in SQLServerDataTable 

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -275,8 +276,12 @@ public final class SQLServerDataTable {
 
                     // java.sql.Date, java.sql.Time and java.sql.Timestamp are subclass of java.util.Date
                     if (val instanceof java.util.Date || val instanceof microsoft.sql.DateTimeOffset
-                            || val instanceof OffsetDateTime || val instanceof OffsetTime)
+                            || val instanceof OffsetTime)
                         rowValues[key] = val.toString();
+                    else if (val instanceof OffsetDateTime)
+                        // avoid calling OffsetDateTime#toString() because when there are no seconds we would get
+                        // a format which is incompatible with the server - see LocalTime#toString()
+                        rowValues[key] = ((OffsetDateTime)val).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
                     else
                         rowValues[key] = val;
                     break;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -45,6 +45,9 @@ public class SQLServerDataTableTest {
         assertEquals(3, table.getColumnMetadata().size());
     }
 
+    /*
+     * * Test for hashCode and equals methods of SQLServerDataColumn and SQLServerDataTable.
+     */
     @Test
     public void testHashCodes() throws SQLServerException {
         // Test Null field values for SQLServerDataColumn

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -26,17 +29,20 @@ public class SQLServerDataTableTest {
         SQLServerDataTable table = new SQLServerDataTable();
         SQLServerDataColumn a = new SQLServerDataColumn("foo", Types.VARCHAR);
         SQLServerDataColumn b = new SQLServerDataColumn("bar", Types.INTEGER);
+        SQLServerDataColumn c = new SQLServerDataColumn("baz", Types.TIMESTAMP_WITH_TIMEZONE);
 
         table.addColumnMetadata(a);
         table.addColumnMetadata(b);
-        assertEquals(2, table.getColumnMetadata().size());
+        table.addColumnMetadata(c);
+        assertEquals(3, table.getColumnMetadata().size());
 
         table.clear();
         assertEquals(0, table.getColumnMetadata().size());
 
         table.addColumnMetadata(a);
         table.addColumnMetadata(b);
-        assertEquals(2, table.getColumnMetadata().size());
+        table.addColumnMetadata(c);
+        assertEquals(3, table.getColumnMetadata().size());
     }
 
     @Test
@@ -66,13 +72,14 @@ public class SQLServerDataTableTest {
         assert (a.equals(aClone));
 
         SQLServerDataColumn b = new SQLServerDataColumn("bar", Types.DECIMAL);
-        SQLServerDataTable table = createTable(a, b);
+        SQLServerDataColumn c = new SQLServerDataColumn("baz", Types.TIMESTAMP_WITH_TIMEZONE);
+        SQLServerDataTable table = createTable(a, b, c);
 
         // Test consistent generation of hashCode
         assert (table.hashCode() == table.hashCode());
         assert (table.equals(table));
 
-        SQLServerDataTable tableClone = createTable(aClone, b);
+        SQLServerDataTable tableClone = createTable(aClone, b, c);
 
         // Test for different instances generating same hashCode for same data
         assert (table.hashCode() == tableClone.hashCode());
@@ -82,21 +89,22 @@ public class SQLServerDataTableTest {
         assert (a.hashCode() != b.hashCode());
         assert (!a.equals(b));
 
-        SQLServerDataColumn c = new SQLServerDataColumn("bar", Types.FLOAT);
+        SQLServerDataColumn bb = new SQLServerDataColumn("bar", Types.FLOAT);
         table.clear();
-        table = createTable(a, c);
+        table = createTable(a, bb, c);
 
         // Test for non equal hashCodes
         assert (table.hashCode() != tableClone.hashCode());
         assert (!table.equals(tableClone));
     }
 
-    private SQLServerDataTable createTable(SQLServerDataColumn a, SQLServerDataColumn b) throws SQLServerException {
+    private SQLServerDataTable createTable(SQLServerDataColumn a, SQLServerDataColumn b, SQLServerDataColumn c) throws SQLServerException {
         SQLServerDataTable table = new SQLServerDataTable();
         table.addColumnMetadata(a);
         table.addColumnMetadata(b);
-        table.addRow("Hello", new BigDecimal(1.5));
-        table.addRow("World", new BigDecimal(5.5));
+        table.addColumnMetadata(c);
+        table.addRow("Hello", new BigDecimal(1.5), OffsetDateTime.parse("1977-07-24T12:34+02:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        table.addRow("World", new BigDecimal(5.5), OffsetDateTime.parse("1977-07-24T12:34:56+02:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
         table.setTvpName("TVP_HashCode");
         return table;
     }


### PR DESCRIPTION
When OffsetDateTime contains zero seconds, calling toString() produces the following format: 2025-04-26T19:42+02:00 (without seconds) which is rejected by the server with the message "Conversion failed when converting date and/or time from character string." (SQL Error: 241, SQLState: S0001)