### PR TITLE
Improvement to equals in SQLServerDataTable

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -9,8 +9,16 @@ import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -394,7 +394,7 @@ public final class SQLServerDataTable {
                 boolean equalRowData = compareRows(aSQLServerDataTable.rows);
 
                 return (rowCount == aSQLServerDataTable.rowCount && columnCount == aSQLServerDataTable.columnCount
-                        && tvpName == aSQLServerDataTable.tvpName && equalColumnMetadata && equalColumnNames
+                        && tvpName.equals(aSQLServerDataTable.tvpName) && equalColumnMetadata && equalColumnNames
                         && equalRowData);
             }
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -9,15 +9,8 @@ import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -392,7 +385,7 @@ public final class SQLServerDataTable {
                 boolean equalColumnMetadata = columnMetadata.equals(aSQLServerDataTable.columnMetadata);
                 boolean equalColumnNames = columnNames.equals(aSQLServerDataTable.columnNames);
                 boolean equalRowData = compareRows(aSQLServerDataTable.rows);
-                boolean equalTvpName = tvpName.equals(aSQLServerDataTable.tvpName);
+                boolean equalTvpName = Objects.equals(tvpName, aSQLServerDataTable.tvpName);
 
                 return (rowCount == aSQLServerDataTable.rowCount && columnCount == aSQLServerDataTable.columnCount
                         && equalTvpName && equalColumnMetadata && equalColumnNames && equalRowData);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -392,10 +392,10 @@ public final class SQLServerDataTable {
                 boolean equalColumnMetadata = columnMetadata.equals(aSQLServerDataTable.columnMetadata);
                 boolean equalColumnNames = columnNames.equals(aSQLServerDataTable.columnNames);
                 boolean equalRowData = compareRows(aSQLServerDataTable.rows);
+                boolean equalTvpName = tvpName.equals(aSQLServerDataTable.tvpName);
 
                 return (rowCount == aSQLServerDataTable.rowCount && columnCount == aSQLServerDataTable.columnCount
-                        && tvpName.equals(aSQLServerDataTable.tvpName) && equalColumnMetadata && equalColumnNames
-                        && equalRowData);
+                        && equalTvpName && equalColumnMetadata && equalColumnNames && equalRowData);
             }
         }
         return false;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -91,6 +91,21 @@ public class SQLServerDataTableTest {
         assert (!table.equals(tableClone));
     }
 
+    @Test()
+    public void testEqualsTvp() throws SQLServerException {
+        SQLServerDataTable sqlServerDataTable = new SQLServerDataTable();
+        sqlServerDataTable.setTvpName("test");
+
+        SQLServerDataTable sqlServerDataTable1 = new SQLServerDataTable();
+        sqlServerDataTable1.setTvpName(new String("test"));
+
+        assert (sqlServerDataTable.equals(sqlServerDataTable1));
+
+        sqlServerDataTable.setTvpName("test");
+        sqlServerDataTable1.setTvpName(new String("test2"));
+        assert (!sqlServerDataTable.equals(sqlServerDataTable1));
+    }
+
     private SQLServerDataTable createTable(SQLServerDataColumn a, SQLServerDataColumn b) throws SQLServerException {
         SQLServerDataTable table = new SQLServerDataTable();
         table.addColumnMetadata(a);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -94,9 +94,11 @@ public class SQLServerDataTableTest {
     @Test()
     public void testEqualsTvp() throws SQLServerException {
         SQLServerDataTable a = new SQLServerDataTable();
-        a.setTvpName("test");
-
         SQLServerDataTable b = new SQLServerDataTable();
+
+        assert (a.equals(b));
+
+        a.setTvpName("test");
         b.setTvpName(new String("test"));
 
         assert (a.equals(b));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -93,17 +93,17 @@ public class SQLServerDataTableTest {
 
     @Test()
     public void testEqualsTvp() throws SQLServerException {
-        SQLServerDataTable sqlServerDataTable = new SQLServerDataTable();
-        sqlServerDataTable.setTvpName("test");
+        SQLServerDataTable a = new SQLServerDataTable();
+        a.setTvpName("test");
 
-        SQLServerDataTable sqlServerDataTable1 = new SQLServerDataTable();
-        sqlServerDataTable1.setTvpName(new String("test"));
+        SQLServerDataTable b = new SQLServerDataTable();
+        b.setTvpName(new String("test"));
 
-        assert (sqlServerDataTable.equals(sqlServerDataTable1));
+        assert (a.equals(b));
 
-        sqlServerDataTable.setTvpName("test");
-        sqlServerDataTable1.setTvpName(new String("test2"));
-        assert (!sqlServerDataTable.equals(sqlServerDataTable1));
+        a.setTvpName("test");
+        b.setTvpName(new String("test2"));
+        assert (!a.equals(b));
     }
 
     private SQLServerDataTable createTable(SQLServerDataColumn a, SQLServerDataColumn b) throws SQLServerException {


### PR DESCRIPTION
Noticed that it was using == on strings in the equals function for SQLServerDataTable. (I didn't experience a bug as a result of it) Is it intended to check the memory location?