### PR TITLE
Improvement to equals in SQLServerDataTable

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataTable.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
@@ -397,9 +398,10 @@ public final class SQLServerDataTable {
                 boolean equalColumnMetadata = columnMetadata.equals(aSQLServerDataTable.columnMetadata);
                 boolean equalColumnNames = columnNames.equals(aSQLServerDataTable.columnNames);
                 boolean equalRowData = compareRows(aSQLServerDataTable.rows);
+                boolean equalTvpName = Objects.equals(tvpName, aSQLServerDataTable.tvpName);
 
                 return (rowCount == aSQLServerDataTable.rowCount && columnCount == aSQLServerDataTable.columnCount
-                        && tvpName == aSQLServerDataTable.tvpName && equalColumnMetadata && equalColumnNames
+                        && equalTvpName && equalColumnMetadata && equalColumnNames
                         && equalRowData);
             }
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/SQLServerDataTableTest.java
@@ -101,6 +101,23 @@ public class SQLServerDataTableTest {
         assert (!table.equals(tableClone));
     }
 
+    @Test()
+    public void testEqualsTvp() throws SQLServerException {
+        SQLServerDataTable a = new SQLServerDataTable();
+        SQLServerDataTable b = new SQLServerDataTable();
+
+        assert (a.equals(b));
+
+        a.setTvpName("test");
+        b.setTvpName(new String("test"));
+
+        assert (a.equals(b));
+
+        a.setTvpName("test");
+        b.setTvpName(new String("test2"));
+        assert (!a.equals(b));
+    }
+
     private SQLServerDataTable createTable(SQLServerDataColumn a, SQLServerDataColumn b, SQLServerDataColumn c) throws SQLServerException {
         SQLServerDataTable table = new SQLServerDataTable();
         table.addColumnMetadata(a);


### PR DESCRIPTION
Noticed that it was using == on strings in the equals function for SQLServerDataTable. (I didn't experience a bug as a result of it) Is it intended to check the memory location?