### PR TITLE
Handled sp_prepexec call for Column encryption enabled

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -68,7 +68,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     private String preparedTypeDefinitions;
     
     /** Cached preparedTypeDefinitions in case of multiple time calls of buildPreparedStrings method*/
-    private String preparedTypeDefinitionsCache;
+    private String preparedTypeDefinitionsPrev;
 
     /** Processed SQL statement text, may not be same as what user initially passed. */
     final String userSQL;
@@ -436,8 +436,8 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     private boolean buildPreparedStrings(Parameter[] params, boolean renewDefinition, boolean isInternalEncryptionQuery) throws SQLServerException {
         String newTypeDefinitions = buildParamTypeDefinitions(params, renewDefinition);
 
-        if(connection.isAEv2() && renewDefinition && !isInternalEncryptionQuery && null != preparedTypeDefinitionsCache) {
-           preparedTypeDefinitions = preparedTypeDefinitionsCache; 
+        if(connection.isAEv2() && renewDefinition && !isInternalEncryptionQuery && null != preparedTypeDefinitionsPrev) {
+           preparedTypeDefinitions = preparedTypeDefinitionsPrev; 
         }
 
         if (null != preparedTypeDefinitions && newTypeDefinitions.equalsIgnoreCase(preparedTypeDefinitions))
@@ -450,7 +450,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             preparedSQL = preparedSQL + IDENTITY_QUERY;
 
         if(connection.isAEv2() && !renewDefinition && !isInternalEncryptionQuery) {
-           preparedTypeDefinitionsCache = preparedTypeDefinitions; 
+           preparedTypeDefinitionsPrev = preparedTypeDefinitions; 
         }
         return true;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -66,6 +66,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     /** The prepared type definitions */
     private String preparedTypeDefinitions;
+    
+    /** Cached preparedTypeDefinitions in case of multiple time calls of buildPreparedStrings method*/
+    private String preparedTypeDefinitionsCache;
 
     /** Processed SQL statement text, may not be same as what user initially passed. */
     final String userSQL;
@@ -430,18 +433,25 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      * Determines whether the statement needs to be reprepared based on a change in any of the type definitions of any
      * of the parameters due to changes in scale, length, etc., and, if so, sets the new type definition string.
      */
-    private boolean buildPreparedStrings(Parameter[] params, boolean renewDefinition) throws SQLServerException {
+    private boolean buildPreparedStrings(Parameter[] params, boolean renewDefinition, boolean isInternalEncryptionQuery) throws SQLServerException {
         String newTypeDefinitions = buildParamTypeDefinitions(params, renewDefinition);
+
+        if(connection.isAEv2() && renewDefinition && !isInternalEncryptionQuery && null != preparedTypeDefinitionsCache) {
+           preparedTypeDefinitions = preparedTypeDefinitionsCache; 
+        }
+
         if (null != preparedTypeDefinitions && newTypeDefinitions.equalsIgnoreCase(preparedTypeDefinitions))
             return false;
 
         preparedTypeDefinitions = newTypeDefinitions;
 
-        /* Replace the parameter marker '?' with the param numbers @p1, @p2 etc */
         preparedSQL = connection.replaceParameterMarkers(userSQL, userSQLParamPositions, params, bReturnValueSyntax);
         if (bRequestedGeneratedKeys)
             preparedSQL = preparedSQL + IDENTITY_QUERY;
 
+        if(connection.isAEv2() && !renewDefinition && !isInternalEncryptionQuery) {
+           preparedTypeDefinitionsCache = preparedTypeDefinitions; 
+        }
         return true;
     }
 
@@ -638,7 +648,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         boolean hasNewTypeDefinitions = true;
         boolean inRetry = false; // Used to indicate if this execution is a retry
         if (!encryptionMetadataIsRetrieved) {
-            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, false);
+            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, false, isInternalEncryptionQuery);
         }
 
         if (connection.isAEv2() && !isInternalEncryptionQuery) {
@@ -646,7 +656,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     parameterNames);
             encryptionMetadataIsRetrieved = true;
             setMaxRowsAndMaxFieldSize();
-            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, true);
+            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, true, isInternalEncryptionQuery);
         }
 
         if ((Util.shouldHonorAEForParameters(stmtColumnEncriptionSetting, connection)) && (0 < inOutParam.length)
@@ -664,7 +674,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
             // fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is on on
             // Connection
-            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, true);
+            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, true, isInternalEncryptionQuery);
         }
 
         boolean needsPrepare = true;
@@ -2943,7 +2953,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             System.arraycopy(paramValues, 0, batchParam, 0, paramValues.length);
 
             boolean hasExistingTypeDefinitions = preparedTypeDefinitions != null;
-            boolean hasNewTypeDefinitions = buildPreparedStrings(batchParam, false);
+            boolean hasNewTypeDefinitions = buildPreparedStrings(batchParam, false, isInternalEncryptionQuery);
 
             if ((0 == numBatchesExecuted) && !isInternalEncryptionQuery && connection.isAEv2()
                     && !encryptionMetadataIsRetrieved) {
@@ -2955,7 +2965,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                  * fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is on
                  * one Connection
                  */
-                buildPreparedStrings(batchParam, true);
+                buildPreparedStrings(batchParam, true, isInternalEncryptionQuery);
 
                 /*
                  * Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the
@@ -2976,7 +2986,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                  * fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is on
                  * one Connection
                  */
-                buildPreparedStrings(batchParam, true);
+                buildPreparedStrings(batchParam, true, isInternalEncryptionQuery);
 
                 /*
                  * Save the crypto metadata retrieved for the first batch. We will re-use these for the rest of the

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -81,6 +81,8 @@ public class AESetup extends AbstractTest {
             AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("JDBCEncryptedNumeric")));
     public static final String SCALE_DATE_TABLE_AE = TestUtils.escapeSingleQuotes(
             AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("JDBCEncryptedScaleDate")));
+    public static final String VARY_STRING_TABLE_AE = TestUtils.escapeSingleQuotes(
+            AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("JDBCEncryptedString")));
 
     final static char[] HEXCHARS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -50,25 +50,27 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
                 .getConnection(AETestConnectionString + ";columnEncryptionSetting=enabled;", AEInfo);
                 Statement stmt = connection.createStatement()) {
             dropTables(stmt);
+            try {        
+                createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
 
-            createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
+                populateNumericTable(connection);
+                verifyNumericTable(connection, false);
 
-            populateNumericTable(connection);
-            verifyNumericTable(connection, false);
+                dropTables(stmt);
+                createTable(DATE_TABLE_AE, cekJks, dateTable);
 
-            dropTables(stmt);
-            createTable(DATE_TABLE_AE, cekJks, dateTable);
+                populateDateTable(connection);
+                verifyDateTable(connection);
 
-            populateDateTable(connection);
-            verifyDateTable(connection);
+                dropTables(stmt);
+                createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
 
-            dropTables(stmt);
-            createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
-
-            populateNumericTableWithNull(connection);
-            verifyNumericTable(connection, true);
-
-            dropTables(stmt);
+                populateNumericTableWithNull(connection);
+                verifyNumericTable(connection, true);
+               
+            } finally {
+                dropTables(stmt);
+            }
         }
     }
 
@@ -80,22 +82,23 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
                 .getConnection(AETestConnectionString + ";columnEncryptionSetting=enabled;", AEInfo);
                 Statement stmt = connection.createStatement()) {
             dropTables(stmt);
+            try{
+                createTable(CHAR_TABLE_AE, cekJks, charTable);
+                populateCharTable(connection);
+                verifyCharTable(connection);
 
-            createTable(CHAR_TABLE_AE, cekJks, charTable);
-            populateCharTable(connection);
-            verifyCharTable(connection);
+                dropTables(stmt);
+                createTable(DATE_TABLE_AE, cekJks, dateTable);
+                populateDateTable(connection);
+                verifyDateTable(connection);
 
-            dropTables(stmt);
-            createTable(DATE_TABLE_AE, cekJks, dateTable);
-            populateDateTable(connection);
-            verifyDateTable(connection);
-
-            dropTables(stmt);
-            createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
-            populateNumericTableSpecificSetter(connection);
-            verifyNumericTable(connection, false);
-
-            dropTables(stmt);
+                dropTables(stmt);
+                createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
+                populateNumericTableSpecificSetter(connection);
+                verifyNumericTable(connection, false);
+            } finally {
+                dropTables(stmt);
+            }
         }
     }
 
@@ -241,7 +244,11 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
 
             createTable(VARY_STRING_TABLE_AE, cekJks, stringTable);
 
-            verifyStringTable(connection);
+            try {
+                verifyStringTable(connection);
+            } finally {
+                dropTables(stmt);
+            }
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -37,6 +37,8 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
 
     };
 
+    static String stringTable[][] = {{"VarcharMax", "varchar(max)"},};
+
     static String charTable[][] = {{"Char", "char(20) COLLATE Latin1_General_BIN2"},
             {"Varchar", "varchar(50) COLLATE Latin1_General_BIN2"},};
 
@@ -228,9 +230,43 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testStringColumnEncryptWithVaryLength(String serverName, String url, String protocol) throws Exception {
+        setAEConnectionString(serverName, url, protocol);
+        try (Connection connection = PrepUtil
+                .getConnection(AETestConnectionString + ";columnEncryptionSetting=enabled;", AEInfo);
+                Statement stmt = connection.createStatement()) {
+            dropTables(stmt);
+
+            createTable(VARY_STRING_TABLE_AE, cekJks, stringTable);
+
+            verifyStringTable(connection);
+        }
+    }
+
+    private void verifyStringTable(Connection connection) throws SQLException {
+        String sql = "insert into " + VARY_STRING_TABLE_AE + " values(?, ?)";
+        try (PreparedStatement sqlPstmt = connection.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY, connection.getHoldability())) {
+                String data1 ="a"; 
+                sqlPstmt.setString(1, data1);
+                sqlPstmt.executeUpdate();
+              
+                String data2 =  data1 + "aa";
+                sqlPstmt.setString(1, data2);
+                sqlPstmt.executeUpdate();
+              
+                String data3 =  data2 + "aaa";
+                sqlPstmt.setString(1, data3);
+                sqlPstmt.executeUpdate();
+        }
+    }
+
     public static void dropTables(Statement stmt) throws SQLException {
         TestUtils.dropTableIfExists(DATE_TABLE_AE, stmt);
         TestUtils.dropTableIfExists(CHAR_TABLE_AE, stmt);
         TestUtils.dropTableIfExists(NUMERIC_TABLE_AE, stmt);
+        TestUtils.dropTableIfExists(VARY_STRING_TABLE_AE, stmt);
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -255,19 +255,25 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
     }
 
     private void verifyStringTable(Connection connection) throws SQLException {
-        String sql = "insert into " + VARY_STRING_TABLE_AE + " values(?, ?)";
+        String sql = "insert into " + VARY_STRING_TABLE_AE + " values(?, ?, ?)";
         try (PreparedStatement sqlPstmt = connection.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_READ_ONLY, connection.getHoldability())) {
                 String data1 ="a"; 
                 sqlPstmt.setString(1, data1);
+                sqlPstmt.setString(2, data1);
+                sqlPstmt.setString(3, data1);
                 sqlPstmt.executeUpdate();
               
                 String data2 =  data1 + "aa";
                 sqlPstmt.setString(1, data2);
+                sqlPstmt.setString(2, data2);
+                sqlPstmt.setString(3, data2);
                 sqlPstmt.executeUpdate();
               
                 String data3 =  data2 + "aaa";
                 sqlPstmt.setString(1, data3);
+                sqlPstmt.setString(2, data3);
+                sqlPstmt.setString(3, data3);
                 sqlPstmt.executeUpdate();
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -42,6 +42,8 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
     static String charTable[][] = {{"Char", "char(20) COLLATE Latin1_General_BIN2"},
             {"Varchar", "varchar(50) COLLATE Latin1_General_BIN2"},};
 
+    static String stringVaryLengthTable[][] = {{"VarcharMax", "varchar(max) COLLATE Latin1_General_BIN2"},};
+        
     @ParameterizedTest
     @MethodSource("enclaveParams")
     public void alwaysEncrypted1(String serverName, String url, String protocol) throws Exception {
@@ -242,7 +244,7 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
                 Statement stmt = connection.createStatement()) {
             dropTables(stmt);
 
-            createTable(VARY_STRING_TABLE_AE, cekJks, stringTable);
+            createTable(VARY_STRING_TABLE_AE, cekJks, stringVaryLengthTable);
 
             try {
                 verifyStringTable(connection);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementMockTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementMockTest.java
@@ -62,15 +62,15 @@ public class SQLServerPreparedStatementMockTest extends AbstractTest {
         boolean renewDefinition = false;
         boolean isInternalEncryptionQuery = false;
         
-        // On the first invocation, buildPreparedStringsMethod() sets the preparedTypeDefinitionsCache field.
+        // On the first invocation, buildPreparedStringsMethod() sets the preparedTypeDefinitionsPrev field.
         buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
-        // Use reflection to access the private field 'preparedTypeDefinitionsCache'
-        Field cacheFieldPreparedTypeDefinitionsCache = SQLServerPreparedStatement.class.getDeclaredField("preparedTypeDefinitionsCache");
-        cacheFieldPreparedTypeDefinitionsCache.setAccessible(true);
+        // Use reflection to access the private field 'preparedTypeDefinitionsPrev'
+        Field cacheFieldpreparedTypeDefinitionsPrev = SQLServerPreparedStatement.class.getDeclaredField("preparedTypeDefinitionsPrev");
+        cacheFieldpreparedTypeDefinitionsPrev.setAccessible(true);
         // Validate that the field is now non-null
-        assertNotNull(cacheFieldPreparedTypeDefinitionsCache.get(preparedStatement), "The preparedTypeDefinitionsCache should not be null.");
+        assertNotNull(cacheFieldpreparedTypeDefinitionsPrev.get(preparedStatement), "The preparedTypeDefinitionsPrev should not be null.");
 
-        // On the second invocation, buildPreparedStringsMethod() resets preparedTypeDefinitions using the value from preparedTypeDefinitionsCache,
+        // On the second invocation, buildPreparedStringsMethod() resets preparedTypeDefinitions using the value from preparedTypeDefinitionsPrev,
         // and returns true, which triggers sp_prepexec since the prepared statement definition has changed.
         renewDefinition = true;
         isInternalEncryptionQuery = false;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementMockTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementMockTest.java
@@ -21,7 +21,7 @@ import com.microsoft.sqlserver.testframework.AbstractTest;
 
 
 @RunWith(JUnitPlatform.class)
-public class SQLServerPreparedStatementTest extends AbstractTest {
+public class SQLServerPreparedStatementMockTest extends AbstractTest {
 
     /**
      * This test case helps track the insertion process and ensures that encrypted columns can handle string values of varying sizes correctly.
@@ -63,7 +63,7 @@ public class SQLServerPreparedStatementTest extends AbstractTest {
         boolean isInternalEncryptionQuery = false;
         
         // On the first invocation, buildPreparedStringsMethod() sets the preparedTypeDefinitionsCache field.
-        result = (boolean) buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
+        buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
         // Use reflection to access the private field 'preparedTypeDefinitionsCache'
         Field cacheFieldPreparedTypeDefinitionsCache = SQLServerPreparedStatement.class.getDeclaredField("preparedTypeDefinitionsCache");
         cacheFieldPreparedTypeDefinitionsCache.setAccessible(true);
@@ -76,9 +76,9 @@ public class SQLServerPreparedStatementTest extends AbstractTest {
         isInternalEncryptionQuery = false;
         when(params[0].getTypeDefinition(any(), any())).thenReturn("varchar(3)");
         // Invoke the private method
-        result = (boolean) buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
+        boolean needsPrepareCall = (boolean) buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
         // Validate that the field is now null
-        assertTrue(result, "buildPreparedStrings() should return true");
+        assertTrue(needsPrepareCall, "buildPreparedStrings() should return true");
     }
     
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementTest.java
@@ -1,0 +1,82 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.testframework.AbstractTest;
+
+
+@RunWith(JUnitPlatform.class)
+public class SQLServerPreparedStatementTest extends AbstractTest {
+
+    /**
+     * This test case helps track the insertion process and ensures that encrypted columns can handle string values of varying sizes correctly.
+     * @throws Exception
+     */
+    @Test
+    public void testBuildPreparedStringsForVaryLength() throws Exception {
+        // Create a mock of SQLServerConnection
+        SQLServerConnection mockConnection = mock(SQLServerConnection.class);
+
+        // Define the behavior of isAEv2()
+        when(mockConnection.isAEv2()).thenReturn(true);
+
+        // Call the method and assert the result
+        boolean result = mockConnection.isAEv2();
+        assertTrue(result, "isAEv2() should return true");
+
+        // Create a mock or real instance of SQLServerPreparedStatement
+        SQLServerPreparedStatement preparedStatement = mock(SQLServerPreparedStatement.class);
+
+        // Use reflection to set the private 'connection' field in SQLServerPreparedStatement
+        Field connectionField = SQLServerStatement.class.getDeclaredField("connection");
+        connectionField.setAccessible(true);
+        connectionField.set(preparedStatement, mockConnection);
+
+        // Use reflection to access the private method
+        Method buildPreparedStringsMethod = SQLServerPreparedStatement.class.getDeclaredMethod(
+                "buildPreparedStrings", Parameter[].class, boolean.class, boolean.class);
+        buildPreparedStringsMethod.setAccessible(true);
+
+        // Prepare the required parameters
+        Parameter[] params = new Parameter[1];
+        params[0] = mock(Parameter.class); // Mock a Parameter object
+        
+        // Mock behavior for dependent methods (if needed)
+        when(params[0].getTypeDefinition(any(), any())).thenReturn("varchar(1)");
+
+        boolean renewDefinition = false;
+        boolean isInternalEncryptionQuery = false;
+        // First invocation buildPreparedStringsMethod() method which will set the preparedTypeDefinitionsCache field
+        result = (boolean) buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
+        // Use reflection to access the private field 'preparedTypeDefinitionsCache'
+        Field cacheFieldPreparedTypeDefinitionsCache = SQLServerPreparedStatement.class.getDeclaredField("preparedTypeDefinitionsCache");
+        cacheFieldPreparedTypeDefinitionsCache.setAccessible(true);
+        // Validate that the field is now non-null
+        assertNotNull(cacheFieldPreparedTypeDefinitionsCache.get(preparedStatement), "The preparedTypeDefinitionsCache should not be null.");
+
+        // Scond invocation buildPreparedStringsMethod() method which will reset the preparedTypeDefinitions with preparedTypeDefinitionsCache value and return true   
+        renewDefinition = true;
+        isInternalEncryptionQuery = false;
+        when(params[0].getTypeDefinition(any(), any())).thenReturn("varchar(3)");
+        // Invoke the private method
+        result = (boolean) buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
+        // Validate that the field is now null
+        assertTrue(result, "buildPreparedStrings() should return true");
+    }
+    
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatementTest.java
@@ -61,7 +61,8 @@ public class SQLServerPreparedStatementTest extends AbstractTest {
 
         boolean renewDefinition = false;
         boolean isInternalEncryptionQuery = false;
-        // First invocation buildPreparedStringsMethod() method which will set the preparedTypeDefinitionsCache field
+        
+        // On the first invocation, buildPreparedStringsMethod() sets the preparedTypeDefinitionsCache field.
         result = (boolean) buildPreparedStringsMethod.invoke(preparedStatement, params, renewDefinition, isInternalEncryptionQuery);
         // Use reflection to access the private field 'preparedTypeDefinitionsCache'
         Field cacheFieldPreparedTypeDefinitionsCache = SQLServerPreparedStatement.class.getDeclaredField("preparedTypeDefinitionsCache");
@@ -69,7 +70,8 @@ public class SQLServerPreparedStatementTest extends AbstractTest {
         // Validate that the field is now non-null
         assertNotNull(cacheFieldPreparedTypeDefinitionsCache.get(preparedStatement), "The preparedTypeDefinitionsCache should not be null.");
 
-        // Scond invocation buildPreparedStringsMethod() method which will reset the preparedTypeDefinitions with preparedTypeDefinitionsCache value and return true   
+        // On the second invocation, buildPreparedStringsMethod() resets preparedTypeDefinitions using the value from preparedTypeDefinitionsCache,
+        // and returns true, which triggers sp_prepexec since the prepared statement definition has changed.
         renewDefinition = true;
         isInternalEncryptionQuery = false;
         when(params[0].getTypeDefinition(any(), any())).thenReturn("varchar(3)");


### PR DESCRIPTION
**Description:**
- The incident involved unexpected behavior when inserting strings using Always Encrypted with Secure Enclaves in Azure SQL DB.
- Unexpected insert results when using Always Encrypted.
- Subsequent inserts into encrypted columns fail after initial successful inserts.
- Issue in details at code level:
The buildPreparedStrings method compares the last prepared statement with the current one to be executed. If both statements are identical, it signals that calling sp_prepexec is unnecessary. Otherwise, sp_prepexec will be invoked later in the driver's execution flow. However, multiple calls to buildPreparedStrings overwrite the preparedTypeDefinitions variable, which stores the current prepared statement. As a result, repeated invocations can lead to the loss of the original statement, affecting the logic that determines whether sp_prepexec should be called with updated data types and lengths.

- Resolution details:
Within the buildPreparedStrings method, the preparedTypeDefinitions variable is cached in preparedTypeDefinitionsPrev to prevent it from being overwritten. If isAEv2() is enabled, renewDefinition is false, and isInternalEncryptionQuery is true, then the driver caches the preparedTypeDefinitions value into preparedTypeDefinitionsPrev. In subsequent calls to buildPreparedStrings, if isAEv2() is still enabled, renewDefinition is true, and isInternalEncryptionQuery is false, the driver restores preparedTypeDefinitions from the cached preparedTypeDefinitionsPrev. This caching mechanism prevents the loss of the original statement and ensures the correct signal is returned regarding whether to invoke sp_prepexec.

**Issues:**
https://portal.microsofticm.com/imp/v5/incidents/details/619317008/summary

**Testing**
- Configure the SQL database with encryption enabled and create a table with column-level encryption. Below manual test method works well.
```
Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
try (Connection conn = DriverManager.getConnection(url)) {
    try (PreparedStatement pstmt = conn.prepareStatement("insert into t1 values(?)")) {
        String data2 ="a"; 
        pstmt.setString(1, data2);
        pstmt.executeUpdate();
        String data3 =  data2 + "aa";
        pstmt.setString(1, data3);
        pstmt.executeUpdate();
        String data4 =  data3 + "aaa";
        pstmt.setString(1, data4);
        pstmt.executeUpdate();
    } catch (SQLException e) {
        e.printStackTrace();  
    }
} 

```
- Mocked the above use case via Mockito framework in the test case testBuildPreparedStringsForVaryLength()