### PR TITLE
In case of federated authentication request, do not terminate the con…

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -7258,7 +7258,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             TDSParser.parse(tdsReader, logonProcessor);
         } while (!logonProcessor.complete(logonCommand, tdsReader));
 
-        if (sessionRecovery.isReconnectRunning() && !sessionRecovery.isConnectionRecoveryPossible()) {
+        if (sessionRecovery.isReconnectRunning() && (!sessionRecovery.isConnectionRecoveryPossible() && !federatedAuthenticationRequested)) {
             if (connectionlogger.isLoggable(Level.WARNING)) {
                 connectionlogger.warning(this.toString()
                         + "SessionRecovery feature extension ack was not sent by the server during reconnection.");


### PR DESCRIPTION
**Description**:
The incident involves a connectivity issue where the customer, using the JDBC driver version 10 and latest main branch with Azure Active Directory Interactive authentication, encounters a warning during reconnection attempts. The error message indicates that the session recovery feature extension acknowledgment was not sent by the server. The issue arises after the SPID is killed, leading to failures in the recovery logic of the driver. Although SQL Authentication works without issues, the AAD token cannot be reused successfully after disconnection, which complicates the reconnection process.

**Issues**:
https://portal.microsofticm.com/imp/v5/incidents/details/627286523/summary