### PR TITLE
Fixed isRecoveryAliveAndConnDead() to ensure connection be dead

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResiliencyUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ResiliencyUtils.java
@@ -34,7 +34,7 @@ final class ResiliencyUtils {
 
     private static final String[] ON_OFF = new String[] {"ON", "OFF"};
     static final String alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    static final int checkRecoveryAliveInterval = 500;
+    static final int checkRecoveryAliveInterval = 15000; // SQLServerConnection.maxIdleMillis is 15000
 
     private ResiliencyUtils() {};
 


### PR DESCRIPTION
Fixed isRecoveryAliveAndConnDead() method to ensure connection should be dead.