### PR TITLE
Addressed and suppressed CodeQL warnings with explanatory comments in the JDBC codebase.

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/KeyStoreProviderCommon.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KeyStoreProviderCommon.java
@@ -126,7 +126,7 @@ class KeyStoreProviderCommon {
             CertificateDetails certificateDetails) throws SQLServerException {
         byte[] plainCEK = null;
         try {
-            Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
+            Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding"); // CodeQL [SM03796] Required for an external standard: Always Encrypted only supports encrypting column encryption keys with RSA_OAEP(SHA1) (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             rsa.init(Cipher.DECRYPT_MODE, certificateDetails.privateKey);
             rsa.update(cipherText);
             plainCEK = rsa.doFinal();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
@@ -602,7 +602,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
      *         if key is invalid
      */
     private byte[] hmacMD5(final byte[] key, final byte[] data) throws InvalidKeyException {
-        SecretKeySpec keySpec = new SecretKeySpec(key, "HmacMD5");
+        SecretKeySpec keySpec = new SecretKeySpec(key, "HmacMD5"); // CodeQL [SM05136] HmacMD5 is required for NTLM support
         context.mac.init(keySpec);
         return context.mac.doFinal(data);
     }
@@ -822,7 +822,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
              * MIC is calculated by using a 0 MIC then hmacMD5 of session key and concat of the 3 msgs
              */
             if (null != context.timestamp && 0 < context.timestamp.length) {
-                SecretKeySpec keySpec = new SecretKeySpec(context.sessionBaseKey, "HmacMD5");
+                SecretKeySpec keySpec = new SecretKeySpec(context.sessionBaseKey, "HmacMD5"); // CodeQL [SM05136] HmacMD5 is required for NTLM support
                 context.mac.init(keySpec);
                 context.mac.update(context.negotiateMsg);
                 context.mac.update(context.challengeMsg);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCertificateUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCertificateUtils.java
@@ -422,7 +422,7 @@ final class SQLServerCertificateUtils {
             buffer.get(key);
 
             if (encrypted) {
-                MessageDigest digest = MessageDigest.getInstance("SHA1");
+                MessageDigest digest = MessageDigest.getInstance("SHA1"); // CodeQL [SM05136] Required for backwards compatibility reading of old private keys
                 digest.update(salt);
                 if (null != keyPass) {
                     digest.update(keyPass.getBytes());
@@ -482,7 +482,7 @@ final class SQLServerCertificateUtils {
 
     private static byte[] getSecretKeyFromHash(byte[] originalKey,
             byte[] keyHash) throws GeneralSecurityException, SQLServerException {
-        SecretKey key = new SecretKeySpec(keyHash, 0, 16, RC4_ALG);
+        SecretKey key = new SecretKeySpec(keyHash, 0, 16, RC4_ALG); // CodeQL [SM05136] Required for backwards compatibility reading of old private keys
         byte[] decrypted = decryptSecretKey(key, originalKey);
         if (startsWithMagic(decrypted)) {
             return decrypted;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
@@ -368,7 +368,7 @@ public class SQLServerColumnEncryptionJavaKeyStoreProvider extends SQLServerColu
     private byte[] encryptRSAOAEP(byte[] plainText, CertificateDetails certificateDetails) throws SQLServerException {
         byte[] cipherText = null;
         try {
-            Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
+            Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding"); // CodeQL [SM03796] Required for an external standard: Always Encrypted only supports encrypting column encryption keys with RSA_OAEP(SHA1) (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             rsa.init(Cipher.ENCRYPT_MODE, certificateDetails.certificate.getPublicKey());
             rsa.update(plainText);
             cipherText = rsa.doFinal();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SecureStringUtil.java
@@ -85,8 +85,8 @@ final class SecureStringUtil {
             secretKey = new SecretKeySpec(keygen.generateKey().getEncoded(), "AES");
 
             // get ciphers for encryption/decryption
-            encryptCipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
-            decryptCipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            encryptCipher = Cipher.getInstance(CIPHER_TRANSFORMATION); // This cipher is used appropriately in a short-lived, in-memory scenario, with each nonce only used once for encryption.
+            decryptCipher = Cipher.getInstance(CIPHER_TRANSFORMATION); // This cipher is used appropriately in a short-lived, in-memory scenario, with each nonce only used once for encryption.
         } catch (Exception e) {
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_SecureStringInitFailed"));
             Object[] msgArgs = {e.getMessage()};


### PR DESCRIPTION
Description
CodeQL static analysis raised warnings for certain cryptographic algorithms and usages in the JDBC driver codebase. These warnings were triggered in files supporting NTLM authentication, Always Encrypted, legacy private key handling, and secure in-memory string encryption. However, these usages are intentional and required for compatibility with SQL Server features, industry standards, and appropriate security contexts.

Resolution details:
This PR adds CodeQL suppression comments to the affected lines of code. These suppressions are justified and documented to ensure clarity and maintain compliance with external standards or backward compatibility. No functional code changes were made. The updates are as follows:
1. NTLMAuthentication.java (lines 605, 825)
Suppression added for use of HmacMD5 algorithm, which is required for NTLM support.
// CodeQL [SM05136] HmacMD5 is required for NTLM support
2. KeyStoreProviderCommon.java (line 129)
Suppression added for use of RSA_OAEP with SHA1, which is mandated by SQL Server for Always Encrypted.
// CodeQL [SM03796] Required for an external standard: Always Encrypted only supports encrypting column encryption keys with RSA_OAEP(SHA1) (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
3. SQLServerCertificateUtils.java (lines 425, 485)
Suppressions added to maintain backward compatibility with older private key formats.
// CodeQL [SM05136] Required for backwards compatibility reading of old private keys
4. SQLServerColumnEncryptionJavaKeyStoreProvider.java (line 371)
Suppression added for RSA_OAEP(SHA1) usage required by Always Encrypted.
// CodeQL [SM03796] Required for an external standard: Always Encrypted only supports encrypting column encryption keys with RSA_OAEP(SHA1) (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
5. SecureStringUtil.java (lines 88, 89)
Suppressions added for the use of AES/GCM/NoPadding, which is a modern and secure cipher.
// This cipher is used appropriately in a short-lived, in-memory scenario, with each nonce only used once for encryption.

Testing
No functional changes were made; therefore, no new tests were added. Existing test coverage remains valid, and this change is limited to documentation-only suppressions to pass CodeQL analysis while preserving required functionality.