### PR TITLE
Backport: Make ibm security module optional (#2636)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,12 @@
 							com.microsoft.sqlserver.jdbc.dataclassification,
 							microsoft.sql
 						</_exportcontents>
-						<Import-Package>!microsoft.sql,jdk.net;resolution:=optional,*</Import-Package>
+						<Import-Package>
+							!microsoft.sql,
+							com.ibm.security.auth.module;resolution:=optional,
+							com.sun.security.auth.module;resolution:=optional,
+							jdk.net;resolution:=optional,*
+						</Import-Package>
 						<Bundle-Activator>com.microsoft.sqlserver.jdbc.osgi.Activator</Bundle-Activator>
 					</instructions>
 				</configuration>


### PR DESCRIPTION
Backported PR: https://github.com/microsoft/mssql-jdbc/pull/2636

* Make ibm security module optional

* Formatted the change