### PR TITLE
Backport: Invalidate enclave session during connection recovery and when an invalid session handle error is returned

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2189,6 +2189,11 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         long elapsedSeconds = 0;
         long start = System.currentTimeMillis();
+
+        // Any existing enclave session would be invalid, make sure it is invalidated.
+        // For example, if this is a session recovery reconnect.
+        //
+        invalidateEnclaveSessionCache();
         for (int connectRetryAttempt = 0, tlsRetryAttempt = 0;;) {
             try {
                 if (0 == elapsedSeconds || elapsedSeconds < loginTimeoutSeconds) {
@@ -8911,6 +8916,15 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         }
         return enclaveProvider.createEnclaveSession(this, statement, userSql, preparedTypeDefinitions, params,
                 parameterNames);
+    }
+
+    void invalidateEnclaveSessionCache() {
+        if (enclaveProvider != null) {
+            if (connectionlogger.isLoggable(Level.FINE)) {
+                connectionlogger.fine("Invalidating existing enclave session for enclave provider : " + enclaveProvider);
+            }
+            enclaveProvider.invalidateEnclaveSession();
+        }
     }
 
     boolean enclaveEstablished() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -73,6 +73,8 @@ public final class SQLServerException extends java.sql.SQLException {
     // Built-in function '%.*ls' in impersonation context is not supported in this version of SQL Server.
     static final int IMPERSONATION_CONTEXT_NOT_SUPPORTED = 40529;
 
+    static final int INVAID_ENCLAVE_SESSION_HANDLE_ERROR = 33195;
+
     // Facility for driver-specific error codes
     static final int DRIVER_ERROR_NONE = 0;
     static final int DRIVER_ERROR_FROM_DATABASE = 2;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -687,6 +687,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                 startResults();
                 getNextResult(true);
             } catch (SQLException e) {
+                if (connection.isAEv2() && (e.getErrorCode() == SQLServerException.INVAID_ENCLAVE_SESSION_HANDLE_ERROR)) {
+                    //If the exception received is as below then just invalidate the cache 
+                    //code = '33195', SQL state = 'S0001': Internal enclave error. Enclave was provided with an invalid session handle. For more information, contact Customer Support Services..
+                    //
+                    connection.invalidateEnclaveSessionCache();
+                }
                 if (retryBasedOnFailedReuseOfCachedHandle(e, attempt, needsPrepare, false)) {
                     continue;
                 } else if (!inRetry && connection.doesServerSupportEnclaveRetry()) {
@@ -3119,6 +3125,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                         assert numBatchesExecuted == numBatchesPrepared;
                     }
                 } catch (SQLException e) {
+                    if (connection.isAEv2() && (e.getErrorCode() == SQLServerException.INVAID_ENCLAVE_SESSION_HANDLE_ERROR)) {
+                        //If the exception received is as below then just invalidate the cache 
+                        //code = '33195', SQL state = 'S0001': Internal enclave error. Enclave was provided with an invalid session handle. For more information, contact Customer Support Services..
+                        //
+                        connection.invalidateEnclaveSessionCache();
+                    }
                     if (retryBasedOnFailedReuseOfCachedHandle(e, attempt, needsPrepare, true)
                             && connection.isStatementPoolingEnabled()) {
                         // Reset number of batches prepared.


### PR DESCRIPTION
Backported PR: https://github.com/microsoft/mssql-jdbc/pull/2638

* Invalidate existing enclave session in during (re)connect

* Added check on logging level

* Added a speculative fix to invalidate enclaveCache on error 33195

* Moved error checking in PreparedStatement doExecute methods

* Added trade for invalidation

* Directly call invalidateEnclaveSessionCache from reconnect