### PR TITLE
Backport: Increased the max noOfRedirections and updated the message. (#2659)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3642,7 +3642,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         // indicates the no of times the connection was routed to a different server
         int noOfRedirections = 0;
-
+        int maxNoOfRedirections = 10;
         // Only three ways out of this loop:
         // 1) Successfully connected
         // 2) Parser threw exception while main timer was expired
@@ -3716,9 +3716,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                 .fine(toString() + " Connection open - redirection count: " + noOfRedirections);
                     }
 
-                    if (noOfRedirections > 1) {
-                        String msg = SQLServerException.getErrString("R_multipleRedirections");
-                        terminate(SQLServerException.DRIVER_ERROR_UNSUPPORTED_CONFIG, msg);
+                    if (noOfRedirections > maxNoOfRedirections) {
+                        MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_multipleRedirections"));
+                        Object[] msgArgs = {maxNoOfRedirections};
+                        terminate(SQLServerException.DRIVER_ERROR_UNSUPPORTED_CONFIG, form.format(msgArgs));
                     }
 
                     // close tds channel

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -41,7 +41,7 @@ public final class SQLServerResource extends ListResourceBundle {
         // LOCALIZE THIS
         {"R_timedOutBeforeRouting", "The timeout expired before connecting to the routing destination."},
         {"R_invalidRoutingInfo", "Unexpected routing information received. Please check your connection properties and SQL Server configuration."},
-        {"R_multipleRedirections", "Two or more redirections have occurred. Only one redirection per login attempt is allowed."},
+        {"R_multipleRedirections", "Too many redirections have occurred. Only {0} redirections per login is allowed."},
         {"R_dbMirroringWithMultiSubnetFailover", "Connecting to a mirrored SQL Server instance using the multiSubnetFailover connection property is not supported."},
         {"R_dbMirroringWithReadOnlyIntent", "Connecting to a mirrored SQL Server instance using the ApplicationIntent ReadOnly connection property is not supported."},
         {"R_ipAddressLimitWithMultiSubnetFailover", "Connecting with the multiSubnetFailover connection property to a SQL Server instance configured with more than {0} IP addresses is not supported."},


### PR DESCRIPTION
Backported PR: https://github.com/microsoft/mssql-jdbc/pull/2659

Fabric has introduced a feature that can cause clients to be redirected more than once. The JDBC driver currently limits connections to one redirection.

Describe the preferred solution
M.D.SqlClient has increased their limit to 10 redirections. Other drivers should follow suit and not error until redirection attempts exceed 10.