### PR TITLE
Backport: Fixed New Type Param Definitions logic in doExecutePreparedStatement

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -646,7 +646,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     parameterNames);
             encryptionMetadataIsRetrieved = true;
             setMaxRowsAndMaxFieldSize();
-            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, true);
+            buildPreparedStrings(inOutParam, true);
         }
 
         if ((Util.shouldHonorAEForParameters(stmtColumnEncriptionSetting, connection)) && (0 < inOutParam.length)
@@ -664,7 +664,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
             // fix an issue when inserting unicode into non-encrypted nchar column using setString() and AE is on on
             // Connection
-            hasNewTypeDefinitions = buildPreparedStrings(inOutParam, true);
+            buildPreparedStrings(inOutParam, true);
         }
 
         boolean needsPrepare = true;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -81,6 +81,8 @@ public class AESetup extends AbstractTest {
             AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("JDBCEncryptedNumeric")));
     public static final String SCALE_DATE_TABLE_AE = TestUtils.escapeSingleQuotes(
             AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("JDBCEncryptedScaleDate")));
+    public static final String VARY_STRING_TABLE_AE = TestUtils
+            .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("JDBCEncryptedString")));
 
     final static char[] HEXCHARS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -40,6 +40,10 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
     static String charTable[][] = {{"Char", "char(20) COLLATE Latin1_General_BIN2"},
             {"Varchar", "varchar(50) COLLATE Latin1_General_BIN2"},};
 
+    static String stringTable[][] = {{"VarcharMax", "varchar(max)"},};
+
+    static String stringVaryLengthTable[][] = {{"VarcharMax", "varchar(max) COLLATE Latin1_General_BIN2"},};
+
     @ParameterizedTest
     @MethodSource("enclaveParams")
     public void alwaysEncrypted1(String serverName, String url, String protocol) throws Exception {
@@ -48,25 +52,26 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
                 .getConnection(AETestConnectionString + ";columnEncryptionSetting=enabled;", AEInfo);
                 Statement stmt = connection.createStatement()) {
             dropTables(stmt);
+            try {
+                createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
 
-            createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
+                populateNumericTable(connection);
+                verifyNumericTable(connection, false);
 
-            populateNumericTable(connection);
-            verifyNumericTable(connection, false);
+                dropTables(stmt);
+                createTable(DATE_TABLE_AE, cekJks, dateTable);
 
-            dropTables(stmt);
-            createTable(DATE_TABLE_AE, cekJks, dateTable);
+                populateDateTable(connection);
+                verifyDateTable(connection);
 
-            populateDateTable(connection);
-            verifyDateTable(connection);
+                dropTables(stmt);
+                createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
 
-            dropTables(stmt);
-            createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
-
-            populateNumericTableWithNull(connection);
-            verifyNumericTable(connection, true);
-
-            dropTables(stmt);
+                populateNumericTableWithNull(connection);
+                verifyNumericTable(connection, true);
+            } finally {
+                dropTables(stmt);
+            }
         }
     }
 
@@ -78,22 +83,23 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
                 .getConnection(AETestConnectionString + ";columnEncryptionSetting=enabled;", AEInfo);
                 Statement stmt = connection.createStatement()) {
             dropTables(stmt);
+            try {
+                createTable(CHAR_TABLE_AE, cekJks, charTable);
+                populateCharTable(connection);
+                verifyCharTable(connection);
 
-            createTable(CHAR_TABLE_AE, cekJks, charTable);
-            populateCharTable(connection);
-            verifyCharTable(connection);
+                dropTables(stmt);
+                createTable(DATE_TABLE_AE, cekJks, dateTable);
+                populateDateTable(connection);
+                verifyDateTable(connection);
 
-            dropTables(stmt);
-            createTable(DATE_TABLE_AE, cekJks, dateTable);
-            populateDateTable(connection);
-            verifyDateTable(connection);
-
-            dropTables(stmt);
-            createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
-            populateNumericTableSpecificSetter(connection);
-            verifyNumericTable(connection, false);
-
-            dropTables(stmt);
+                dropTables(stmt);
+                createTable(NUMERIC_TABLE_AE, cekJks, numericTable);
+                populateNumericTableSpecificSetter(connection);
+                verifyNumericTable(connection, false);
+            } finally {
+                dropTables(stmt);
+            }
         }
     }
 
@@ -225,6 +231,79 @@ public class RegressionAlwaysEncryptedTest extends AESetup {
                     assertEquals((short) 127, rs.getObject(9));
                 }
             }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testStringColumnEncryptWithVaryLength(String serverName, String url, String protocol) throws Exception {
+        setAEConnectionString(serverName, url, protocol);
+        try (Connection connection = PrepUtil
+                .getConnection(AETestConnectionString + ";columnEncryptionSetting=enabled;", AEInfo);
+                Statement stmt = connection.createStatement()) {
+            dropTables(stmt);
+
+            createTable(VARY_STRING_TABLE_AE, cekJks, stringVaryLengthTable);
+
+            try {
+                verifyStringTable(connection, false);
+            } finally {
+                dropTables(stmt);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testStringColumnEncryptWithVaryLengthClearParam(String serverName, String url,
+            String protocol) throws Exception {
+        setAEConnectionString(serverName, url, protocol);
+        try (Connection connection = PrepUtil
+                .getConnection(AETestConnectionString + ";columnEncryptionSetting=enabled;", AEInfo);
+                Statement stmt = connection.createStatement()) {
+            dropTables(stmt);
+
+            createTable(VARY_STRING_TABLE_AE, cekJks, stringVaryLengthTable);
+            try {
+                verifyStringTable(connection, true);
+            } finally {
+                dropTables(stmt);
+            }
+        }
+    }
+
+    private void verifyStringTable(Connection connection, boolean enableClearParameters) throws SQLException {
+        String sql = "insert into " + VARY_STRING_TABLE_AE + " values(?, ?, ?)";
+
+        try (PreparedStatement sqlPstmt = connection.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY, connection.getHoldability())) {
+            String data1 = "a";
+
+            if (enableClearParameters) {
+                sqlPstmt.clearParameters();
+            }
+            sqlPstmt.setString(1, data1);
+            sqlPstmt.setString(2, data1);
+            sqlPstmt.setString(3, data1);
+            sqlPstmt.executeUpdate();
+
+            String data2 = data1 + "aa";
+            if (enableClearParameters) {
+                sqlPstmt.clearParameters();
+            }
+            sqlPstmt.setString(1, data2);
+            sqlPstmt.setString(2, data2);
+            sqlPstmt.setString(3, data2);
+            sqlPstmt.executeUpdate();
+
+            String data3 = data2 + "aaa";
+            if (enableClearParameters) {
+                sqlPstmt.clearParameters();
+            }
+            sqlPstmt.setString(1, data3);
+            sqlPstmt.setString(2, data3);
+            sqlPstmt.setString(3, data3);
+            sqlPstmt.executeUpdate();
         }
     }
 


### PR DESCRIPTION
Backported PR: https://github.com/microsoft/mssql-jdbc/pull/2674

* Fixed New Type Param Definitions logic in doExecutePreparedStatement

* Added clearParameters() method in very string length insert in encrypted column while AE enabled4

* Fixed: hasNewTypeDefinitions flag is set only once in doExecutePreparedStatement(), based on the result of the first call to buildPreparedString()