### PR TITLE
Backport: Fixed session recovery for Azure SQL DB in redirect mode connected

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -7199,20 +7199,15 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
         LogonProcessor logonProcessor = new LogonProcessor(authentication);
         TDSReader tdsReader;
+        sessionRecovery.setConnectionRecoveryPossible(false);
         do {
             tdsReader = logonCommand.startResponse();
-            sessionRecovery.setConnectionRecoveryPossible(false);
             TDSParser.parse(tdsReader, logonProcessor);
         } while (!logonProcessor.complete(logonCommand, tdsReader));
 
-        if (sessionRecovery.isReconnectRunning() && !sessionRecovery.isConnectionRecoveryPossible()) {
-            if (connectionlogger.isLoggable(Level.WARNING)) {
-                connectionlogger.warning(this.toString()
-                        + "SessionRecovery feature extension ack was not sent by the server during reconnection.");
-            }
-            terminate(SQLServerException.DRIVER_ERROR_INVALID_TDS,
-                    SQLServerException.getErrString("R_crClientNoRecoveryAckFromLogin"));
-        }
+        connectionReconveryCheck(sessionRecovery.isReconnectRunning(), sessionRecovery.isConnectionRecoveryPossible(),
+                routingInfo);
+
         if (connectRetryCount > 0 && !sessionRecovery.isReconnectRunning()) {
             sessionRecovery.getSessionStateTable().setOriginalCatalog(sCatalog);
             sessionRecovery.getSessionStateTable().setOriginalCollation(databaseCollation);
@@ -7220,6 +7215,17 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         }
     }
 
+    private void connectionReconveryCheck(boolean isReconnectRunning, boolean isConnectionRecoveryPossible,
+                    ServerPortPlaceHolder routingDetails) throws SQLServerException {
+        if (isReconnectRunning && !isConnectionRecoveryPossible && routingDetails == null) {
+            if (connectionlogger.isLoggable(Level.WARNING)) {
+                connectionlogger.warning(this.toString()
+                        + "SessionRecovery feature extension ack was not sent by the server during reconnection.");
+            }
+            terminate(SQLServerException.DRIVER_ERROR_INVALID_TDS,
+                    SQLServerException.getErrString("R_crClientNoRecoveryAckFromLogin"));
+        }
+    }
     /* --------------- JDBC 3.0 ------------- */
 
     /**


### PR DESCRIPTION
Backported PR: https://github.com/microsoft/mssql-jdbc/pull/2668

* In case of federated authentication request, do not terminate the connection to resolve Fed auth connection resiliency issue

* In place of serverSupportsDNSCaching, routingInfo value is a better choice to take decision on connection termination. If endpoint is routed then no need to terminate the current connection.

* Added mock test for connectionReconveryCheck() method ---------