### PR TITLE
Add support for JavaType UUID

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
@@ -21,7 +21,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.EnumMap;
 import java.util.EnumSet;
-
+import java.util.UUID;
 
 enum TDSType {
     // FIXEDLEN types
@@ -476,7 +476,8 @@ enum JavaType {
     READER(Reader.class, JDBCType.LONGVARCHAR),
     // Note: Only SQLServerSQLXML SQLXML instances are accepted by this driver
     SQLXML(SQLServerSQLXML.class, JDBCType.SQLXML),
-    OBJECT(Object.class, JDBCType.UNKNOWN);
+    OBJECT(Object.class, JDBCType.UNKNOWN),
+    UUID(UUID.class, JDBCType.GUID);
 
     private final Class<?> javaClass;
     private final JDBCType jdbcTypeFromJavaType;
@@ -582,7 +583,8 @@ enum JavaType {
         TIMESTAMP(JavaType.TIMESTAMP, EnumSet.of(JDBCType.TIME, // This is needed to send nanoseconds to the driver as
                                                                 // setTime() is only milliseconds
                 JDBCType.TIMESTAMP, // This is datetime2
-                JDBCType.DATETIME, JDBCType.SMALLDATETIME));
+                JDBCType.DATETIME, JDBCType.SMALLDATETIME)),
+        UUID(JavaType.UUID, EnumSet.of(JDBCType.GUID));
 
         private final EnumSet<JDBCType> to;
         private final JavaType from;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -1888,6 +1888,15 @@ final class DTV {
                     op.execute(this, (SQLServerSQLXML) value);
                     break;
 
+                case UUID:
+                    if (null != cryptoMeta) {
+                        byte[] bArray = Util.asGuidByteArray((UUID) value);
+                        op.execute(this, bArray);
+                    } else {
+                        op.execute(this, (UUID) value);
+                    }
+                    break;
+
                 default:
                     assert false : "Unexpected JavaType: " + javaType;
                     unsupportedConversion = true;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -455,7 +455,7 @@ public class AESetup extends AbstractTest {
         String nvarchar4000 = RandomData.generateNCharTypes("4000", nullable, encrypted);
 
         String[] values = {char20.trim(), varchar50, varcharmax, nchar30, nvarchar60, nvarcharmax, Constants.UID,
-                varchar8000, nvarchar4000};
+                Constants.UID, varchar8000, nvarchar4000};
 
         return values;
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/AESetup.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.logging.LogManager;
 
 import org.junit.jupiter.api.AfterAll;
@@ -107,7 +108,8 @@ public class AESetup extends AbstractTest {
             {"NvarcharMax", "nvarchar(max) COLLATE Latin1_General_BIN2", "LONGNVARCHAR"},
             {"Uniqueidentifier", "uniqueidentifier", "GUID"},
             {"Varchar8000", "varchar(8000) COLLATE Latin1_General_BIN2", "CHAR"},
-            {"Nvarchar4000", "nvarchar(4000) COLLATE Latin1_General_BIN2", "NCHAR"},};
+            {"Nvarchar4000", "nvarchar(4000) COLLATE Latin1_General_BIN2", "NCHAR"},
+            {"UniqueidentifierString", "uniqueidentifier", "GUIDSTRING"},};
 
     static String dateTable[][] = {{"Date", "date", "DATE"}, {"Datetime2Default", "datetime2", "TIMESTAMP"},
             {"DatetimeoffsetDefault", "datetimeoffset", "DATETIMEOFFSET"}, {"TimeDefault", "time", "TIME"},
@@ -816,7 +818,7 @@ public class AESetup extends AbstractTest {
      */
     protected static void populateCharNormalCase(String[] charValues) throws SQLException {
         String sql = "insert into " + CHAR_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
-                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
+                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + "?,?,?" + ")";
 
         try (SQLServerConnection con = (SQLServerConnection) PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
@@ -852,23 +854,34 @@ public class AESetup extends AbstractTest {
                 pstmt.setNString(i, charValues[5]);
             }
 
-            // uniqueidentifier
+            // uniqueidentifier as String
             for (int i = 19; i <= 21; i++) {
                 if (null == charValues[6]) {
                     pstmt.setUniqueIdentifier(i, null);
                 } else {
-                    pstmt.setUniqueIdentifier(i, Constants.UID);
+                    pstmt.setUniqueIdentifier(i, charValues[6]);
+                }
+            }
+
+            // uniqueidentifier
+            for (int i = 22; i <= 24; i++) {
+                if (null == charValues[7]) {
+                    pstmt.setUniqueIdentifier(i, null);
+                } else {
+                    // cannot override setUniqueIdentifier to accept UUID parameter without breaking compatibility
+                    // falling back to testing UUID string parameter
+                    pstmt.setUniqueIdentifier(i, charValues[7]);
                 }
             }
 
             // varchar8000
-            for (int i = 22; i <= 24; i++) {
-                pstmt.setString(i, charValues[7]);
+            for (int i = 25; i <= 27; i++) {
+                pstmt.setString(i, charValues[8]);
             }
 
             // nvarchar4000
-            for (int i = 25; i <= 27; i++) {
-                pstmt.setNString(i, charValues[8]);
+            for (int i = 28; i <= 30; i++) {
+                pstmt.setNString(i, charValues[9]);
             }
 
             pstmt.execute();
@@ -883,7 +896,7 @@ public class AESetup extends AbstractTest {
      */
     protected static void populateCharSetObject(String[] charValues) throws SQLException {
         String sql = "insert into " + CHAR_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
-                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
+                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + "?,?,?" + ")";
 
         try (SQLServerConnection con = (SQLServerConnection) PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
@@ -919,19 +932,92 @@ public class AESetup extends AbstractTest {
                 pstmt.setObject(i, charValues[5], java.sql.Types.LONGNVARCHAR);
             }
 
-            // uniqueidentifier
+            // uniqueidentifier as String
             for (int i = 19; i <= 21; i++) {
                 pstmt.setObject(i, charValues[6], microsoft.sql.Types.GUID);
             }
 
-            // varchar8000
+            // uniqueidentifier
             for (int i = 22; i <= 24; i++) {
-                pstmt.setObject(i, charValues[7]);
+                pstmt.setObject(i, charValues[7] == null ? null : UUID.fromString(charValues[7]),
+                        microsoft.sql.Types.GUID);
+            }
+
+            // varchar8000
+            for (int i = 25; i <= 27; i++) {
+                pstmt.setObject(i, charValues[8]);
             }
 
             // nvarchar4000
+            for (int i = 28; i <= 30; i++) {
+                pstmt.setObject(i, charValues[9], java.sql.Types.NCHAR);
+            }
+
+            pstmt.execute();
+        }
+    }
+
+    /**
+     * Populate char data with null data.
+     * 
+     * @throws SQLException
+     */
+    protected static void populateCharSetObjectNull() throws SQLException {
+        String sql = "insert into " + CHAR_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
+                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
+
+        try (SQLServerConnection con = (SQLServerConnection) PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
+                        stmtColEncSetting)) {
+
+            // char
+            for (int i = 1; i <= 3; i++) {
+                pstmt.setObject(i, null, java.sql.Types.CHAR);
+            }
+
+            // varchar
+            for (int i = 4; i <= 6; i++) {
+                pstmt.setObject(i, null, java.sql.Types.VARCHAR);
+            }
+
+            // varchar(max)
+            for (int i = 7; i <= 9; i++) {
+                pstmt.setObject(i, null, java.sql.Types.LONGVARCHAR);
+            }
+
+            // nchar
+            for (int i = 10; i <= 12; i++) {
+                pstmt.setObject(i, null, java.sql.Types.NCHAR);
+            }
+
+            // nvarchar
+            for (int i = 13; i <= 15; i++) {
+                pstmt.setObject(i, null, java.sql.Types.NVARCHAR);
+            }
+
+            // nvarchar(max)
+            for (int i = 16; i <= 18; i++) {
+                pstmt.setObject(i, null, java.sql.Types.LONGNVARCHAR);
+            }
+
+            // uniqueidentifier as String
+            for (int i = 19; i <= 21; i++) {
+                pstmt.setObject(i, null, microsoft.sql.Types.GUID);
+            }
+
+            // uniqueidentifier
+            for (int i = 22; i <= 24; i++) {
+                pstmt.setObject(i, null, microsoft.sql.Types.GUID);
+            }
+
+            // varchar8000
             for (int i = 25; i <= 27; i++) {
-                pstmt.setObject(i, charValues[8], java.sql.Types.NCHAR);
+                pstmt.setObject(i, null, java.sql.Types.VARCHAR);
+            }
+
+            // nvarchar4000
+            for (int i = 28; i <= 30; i++) {
+                pstmt.setObject(i, null, java.sql.Types.NCHAR);
             }
 
             pstmt.execute();
@@ -946,7 +1032,7 @@ public class AESetup extends AbstractTest {
      */
     protected static void populateCharSetObjectWithJDBCTypes(String[] charValues) throws SQLException {
         String sql = "insert into " + CHAR_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
-                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
+                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + "?,?,?" + ")";
 
         try (SQLServerConnection con = (SQLServerConnection) PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
@@ -982,19 +1068,24 @@ public class AESetup extends AbstractTest {
                 pstmt.setObject(i, charValues[5], JDBCType.LONGNVARCHAR);
             }
 
-            // uniqueidentifier
+            // uniqueidentifier as String
             for (int i = 19; i <= 21; i++) {
                 pstmt.setObject(i, charValues[6], microsoft.sql.Types.GUID);
             }
 
-            // varchar8000
+            // uniqueidentifier
             for (int i = 22; i <= 24; i++) {
-                pstmt.setObject(i, charValues[7], JDBCType.VARCHAR);
+                pstmt.setObject(i, UUID.fromString(charValues[7]), microsoft.sql.Types.GUID);
+            }
+
+            // varchar8000
+            for (int i = 25; i <= 27; i++) {
+                pstmt.setObject(i, charValues[8], JDBCType.VARCHAR);
             }
 
             // vnarchar4000
-            for (int i = 25; i <= 27; i++) {
-                pstmt.setObject(i, charValues[8], JDBCType.NVARCHAR);
+            for (int i = 28; i <= 30; i++) {
+                pstmt.setObject(i, charValues[9], JDBCType.NVARCHAR);
             }
 
             pstmt.execute();
@@ -1008,7 +1099,7 @@ public class AESetup extends AbstractTest {
      */
     protected static void populateCharNullCase() throws SQLException {
         String sql = "insert into " + CHAR_TABLE_AE + " values( " + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?,"
-                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + ")";
+                + "?,?,?," + "?,?,?," + "?,?,?," + "?,?,?" + "?,?,?" + ")";
 
         try (SQLServerConnection con = (SQLServerConnection) PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) TestUtils.getPreparedStmt(con, sql,
@@ -1034,19 +1125,18 @@ public class AESetup extends AbstractTest {
                 pstmt.setNull(i, java.sql.Types.NVARCHAR);
             }
 
-            // uniqueidentifier
-            for (int i = 19; i <= 21; i++) {
+            // uniqueidentifier as String, uniqueidentifier
+            for (int i = 19; i <= 24; i++) {
                 pstmt.setNull(i, microsoft.sql.Types.GUID);
-
             }
 
             // varchar8000
-            for (int i = 22; i <= 24; i++) {
+            for (int i = 25; i <= 27; i++) {
                 pstmt.setNull(i, java.sql.Types.VARCHAR);
             }
 
             // nvarchar4000
-            for (int i = 25; i <= 27; i++) {
+            for (int i = 28; i <= 30; i++) {
                 pstmt.setNull(i, java.sql.Types.NVARCHAR);
             }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -700,8 +700,8 @@ public class CallableStatementTest extends AESetup {
             callableStatement.setNString(4, charValues[3]);
             callableStatement.setNString(5, charValues[4]);
             callableStatement.setNString(6, charValues[5]);
-            callableStatement.setString(7, charValues[7]);
-            callableStatement.setNString(8, charValues[8]);
+            callableStatement.setString(7, charValues[8]);
+            callableStatement.setNString(8, charValues[9]);
 
             try (SQLServerResultSet rs = (SQLServerResultSet) callableStatement.executeQuery()) {
                 rs.next();
@@ -712,8 +712,8 @@ public class CallableStatementTest extends AESetup {
                 assertEquals(rs.getString(4).trim(), charValues[3], TestResource.getResource("R_inputParamFailed"));
                 assertEquals(rs.getString(5).trim(), charValues[4], TestResource.getResource("R_inputParamFailed"));
                 assertEquals(rs.getString(6).trim(), charValues[5], TestResource.getResource("R_inputParamFailed"));
-                assertEquals(rs.getString(7).trim(), charValues[7], TestResource.getResource("R_inputParamFailed"));
-                assertEquals(rs.getString(8).trim(), charValues[8], TestResource.getResource("R_inputParamFailed"));
+                assertEquals(rs.getString(7).trim(), charValues[8], TestResource.getResource("R_inputParamFailed"));
+                assertEquals(rs.getString(8).trim(), charValues[9], TestResource.getResource("R_inputParamFailed"));
             }
         } catch (Exception e) {
             fail(e.getMessage());
@@ -1534,10 +1534,10 @@ public class CallableStatementTest extends AESetup {
             assertEquals(nvarcharValuemax, charValues[5], TestResource.getResource("R_outputParamFailed"));
 
             String varcharValue8000 = callableStatement.getString(8).trim();
-            assertEquals(varcharValue8000, charValues[7], TestResource.getResource("R_outputParamFailed"));
+            assertEquals(varcharValue8000, charValues[8], TestResource.getResource("R_outputParamFailed"));
 
             String nvarcharValue4000 = callableStatement.getNString(9).trim();
-            assertEquals(nvarcharValue4000, charValues[8], TestResource.getResource("R_outputParamFailed"));
+            assertEquals(nvarcharValue4000, charValues[9], TestResource.getResource("R_outputParamFailed"));
 
         } catch (Exception e) {
             fail(e.getMessage());
@@ -1587,10 +1587,10 @@ public class CallableStatementTest extends AESetup {
             assertEquals(nvarcharValuemax.trim(), charValues[5], TestResource.getResource("R_outputParamFailed"));
 
             String varcharValue8000 = (String) callableStatement.getObject(8);
-            assertEquals(varcharValue8000, charValues[7], TestResource.getResource("R_outputParamFailed"));
+            assertEquals(varcharValue8000, charValues[8], TestResource.getResource("R_outputParamFailed"));
 
             String nvarcharValue4000 = (String) callableStatement.getObject(9);
-            assertEquals(nvarcharValue4000, charValues[8], TestResource.getResource("R_outputParamFailed"));
+            assertEquals(nvarcharValue4000, charValues[9], TestResource.getResource("R_outputParamFailed"));
 
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
@@ -49,7 +49,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.PrepUtil;
 
 import microsoft.sql.DateTimeOffset;
-
+import java.util.UUID;
 
 /**
  * Tests Decryption and encryption of values
@@ -513,7 +513,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
 
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
-            String[] values = {null, null, null, null, null, null, null, null, null};
+            String[] values = {null, null, null, null, null, null, null, null, null, null};
 
             testChars(stmt, cekJks, charTable, values, TestCase.NORMAL, false);
         }
@@ -532,7 +532,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
 
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
-            String[] values = {null, null, null, null, null, null, null, null, null};
+            String[] values = {null, null, null, null, null, null, null, null, null, null};
 
             testChars(stmt, cekAkv, charTable, values, TestCase.SETOBJECT, false);
         }
@@ -550,7 +550,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
 
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
                 SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
-            String[] values = {null, null, null, null, null, null, null, null, null};
+            String[] values = {null, null, null, null, null, null, null, null, null, null};
 
             testChars(stmt, cekJks, charTable, values, TestCase.SETOBJECT, false);
         }
@@ -1904,9 +1904,11 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
                         case "LONGNVARCHAR":
                             pstmt.setNString(1, values[i + 1 / 3]);
                             break;
-                        case "GUID":
-                            pstmt.setUniqueIdentifier(1, null);
+                        case "GUIDSTRING":
                             pstmt.setUniqueIdentifier(1, Constants.UID);
+                            break;
+                        case "GUID":
+                            pstmt.setObject(1, UUID.fromString(Constants.UID));
                             break;
                         case "BIT":
                             if (values[i + 1 / 3].equals("null")) {
@@ -2115,7 +2117,7 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
                 populateCharSetObject(values);
                 break;
             case SETOBJECT_NULL:
-                populateDateSetObjectNull();
+                populateCharSetObjectNull();
                 break;
             case SETOBJECT_WITH_JDBCTYPES:
                 populateCharSetObjectWithJDBCTypes(values);


### PR DESCRIPTION
**Description**
This PR addresses the issue introduced by the previously merged and reverted PR: [#2324](https://github.com/microsoft/mssql-jdbc/pull/2324).

The original intent was to add support for sending UUID parameters using TDSType.GUID (0x24) over the wire, aligning with the feature request in [#1582](https://github.com/microsoft/mssql-jdbc/issues/1582).

Currently, to use this functionality, the UUID must be passed to the driver as a String with the JDBCType.GUID. Example usage:

Example:
```
st.setObject(index, myUUID.toString(), microsoft.sql.Types.GUID);
```
This PR revisits that implementation with necessary adjustments to ensure proper support and stability.

_Note: This PR incorporates the community-contributed changes from PR: [#2412](https://github.com/microsoft/mssql-jdbc/pull/2412)._