### PR TITLE
[FIX] PreparedStatement.executeBatch() When the Insert Sql Column Name Case Mismatch, Throws BatchUpdateException "Unable to retrieve column metadata."

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
@@ -84,7 +84,9 @@ final class SQLCollation implements java.io.Serializable {
      * @return
      */
     boolean getIsCaseSensitive() {
-        return sortOrderIndex.get(this.sortId).name.contains("_CS_");
+        SortOrder sortOrder = sortOrderIndex.get(this.sortId);
+        // consider case-insensitive if no SortOrder entry
+        return sortOrder != null && sortOrder.name.contains("_CS_");
     }
 
     boolean isEqual(SQLCollation col) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLCollation.java
@@ -78,6 +78,15 @@ final class SQLCollation implements java.io.Serializable {
         return this.sortId;
     }
 
+    /**
+     * return collation is case-sensitive or not
+     *
+     * @return
+     */
+    boolean getIsCaseSensitive() {
+        return sortOrderIndex.get(this.sortId).name.contains("_CS_");
+    }
+
     boolean isEqual(SQLCollation col) {
         return (col != null && col.info == info && col.sortId == sortId);
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
@@ -44,7 +44,7 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
      * Constructs a SQLServerBulkBatchInsertRecord with the batch parameter, column list, value list, and encoding
      */
     SQLServerBulkBatchInsertRecord(ArrayList<Parameter[]> batchParam, ArrayList<String> columnList,
-            ArrayList<String> valueList, String encoding) throws SQLServerException {
+            ArrayList<String> valueList, String encoding, boolean columnNameCaseSensitive) throws SQLServerException {
         initLoggerResources();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER)) {
             loggerExternal.entering(loggerPackageName, loggerClassName, new Object[] {batchParam, encoding});
@@ -61,6 +61,7 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
         this.batchParam = batchParam;
         this.columnList = columnList;
         this.valueList = valueList;
+        this.columnNameCaseSensitive = columnNameCaseSensitive;
         columnMetadata = new HashMap<>();
 
         loggerExternal.exiting(loggerPackageName, loggerClassName);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkRecord.java
@@ -64,6 +64,8 @@ abstract class SQLServerBulkRecord implements ISQLServerBulkRecord {
      */
     protected transient DateTimeFormatter timeFormatter = null;
 
+    protected boolean columnNameCaseSensitive = false;
+
     /*
      * Logger
      */
@@ -153,7 +155,10 @@ abstract class SQLServerBulkRecord implements ISQLServerBulkRecord {
                 // duplicate check is not performed in case of same
                 // positionInTable value
                 if (null != entry && entry.getKey() != positionInTable && null != entry.getValue()
-                        && colName.trim().equalsIgnoreCase(entry.getValue().columnName)) {
+                        && (this.columnNameCaseSensitive
+                        ? colName.trim().equals(entry.getValue().columnName)
+                        : colName.trim().equalsIgnoreCase(entry.getValue().columnName)
+                )) {
                     throw new SQLServerException(SQLServerException.getErrString("R_BulkDataDuplicateColumn"), null);
                 }
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2213,7 +2213,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                                 // connection contains database name
                                 boolean isCaseSensitive = connection.getDatabaseCollation().getIsCaseSensitive();
                                 int columnIndex;
-                                columnIndex = bcOperationColumnList.indexOf(c.getColumnName());
                                 if (isCaseSensitive) {
                                     columnIndex = bcOperationColumnList.indexOf(c.getColumnName());
                                 } else {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2210,11 +2210,19 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                                 jdbctype = ti.getSSType().getJDBCType().getIntValue();
                             }
                             if (null != bcOperationColumnList && !bcOperationColumnList.isEmpty()) {
-                                // find index ignore case
+                                // connection contains database name
+                                boolean isCaseSensitive = connection.getDatabaseCollation().getIsCaseSensitive();
+                                // bcOperationTableName contains database name, may be not equal to connection
                                 int columnIndex = -1;
-                                for (int opi = 0; opi < bcOperationColumnList.size(); opi++) {
-                                    if (bcOperationColumnList.get(opi).equalsIgnoreCase(c.getColumnName())) {
-                                        columnIndex = opi;
+                                if (isCaseSensitive) {
+                                    columnIndex = bcOperationColumnList.indexOf(c.getColumnName());
+                                } else {
+                                    // find index ignore case
+                                    for (int opi = 0; opi < bcOperationColumnList.size(); opi++) {
+                                        if (bcOperationColumnList.get(opi).equalsIgnoreCase(c.getColumnName())) {
+                                            columnIndex = opi;
+                                            break;
+                                        }
                                     }
                                 }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2265,9 +2265,8 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     }
                 }
             } catch (SQLException e) {
-                throw e;
                 // throw a BatchUpdateException with the given error message, and return null for the updateCounts.
-                //throw new BatchUpdateException(e.getMessage(), null, 0, null);
+                throw new BatchUpdateException(e.getMessage(), null, 0, null);
             } catch (IllegalArgumentException e) {
                 // If we fail with IllegalArgumentException, fall back to the original batch insert logic.
                 if (getStatementLogger().isLoggable(java.util.logging.Level.FINE)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2210,7 +2210,14 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                                 jdbctype = ti.getSSType().getJDBCType().getIntValue();
                             }
                             if (null != bcOperationColumnList && !bcOperationColumnList.isEmpty()) {
-                                int columnIndex = bcOperationColumnList.indexOf(c.getColumnName());
+                                // find index ignore case
+                                int columnIndex = -1;
+                                for (int opi = 0; opi < bcOperationColumnList.size(); opi++) {
+                                    if (bcOperationColumnList.get(opi).equalsIgnoreCase(c.getColumnName())) {
+                                        columnIndex = opi;
+                                    }
+                                }
+
                                 if (columnIndex > -1) {
                                     columnMappings.put(columnIndex + 1, i);
                                     batchRecord.addColumnMetadata(columnIndex + 1, c.getColumnName(), jdbctype,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2193,7 +2193,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                         }
 
                         SQLServerBulkBatchInsertRecord batchRecord = new SQLServerBulkBatchInsertRecord(
-                                batchParamValues, bcOperationColumnList, bcOperationValueList, null);
+                                batchParamValues, bcOperationColumnList, bcOperationValueList, null, connection.getDatabaseCollation().getIsCaseSensitive());
 
                         for (int i = 1; i <= rs.getColumnCount(); i++) {
                             Column c = rs.getColumn(i);
@@ -2212,12 +2212,13 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                             if (null != bcOperationColumnList && !bcOperationColumnList.isEmpty()) {
                                 // connection contains database name
                                 boolean isCaseSensitive = connection.getDatabaseCollation().getIsCaseSensitive();
-                                // bcOperationTableName contains database name, may be not equal to connection
-                                int columnIndex = -1;
+                                int columnIndex;
+                                columnIndex = bcOperationColumnList.indexOf(c.getColumnName());
                                 if (isCaseSensitive) {
                                     columnIndex = bcOperationColumnList.indexOf(c.getColumnName());
                                 } else {
                                     // find index ignore case
+                                    columnIndex = -1;
                                     for (int opi = 0; opi < bcOperationColumnList.size(); opi++) {
                                         if (bcOperationColumnList.get(opi).equalsIgnoreCase(c.getColumnName())) {
                                             columnIndex = opi;
@@ -2264,8 +2265,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     }
                 }
             } catch (SQLException e) {
+                throw e;
                 // throw a BatchUpdateException with the given error message, and return null for the updateCounts.
-                throw new BatchUpdateException(e.getMessage(), null, 0, null);
+                //throw new BatchUpdateException(e.getMessage(), null, 0, null);
             } catch (IllegalArgumentException e) {
                 // If we fail with IllegalArgumentException, fall back to the original batch insert logic.
                 if (getStatementLogger().isLoggable(java.util.logging.Level.FINE)) {
@@ -2401,7 +2403,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                         }
 
                         SQLServerBulkBatchInsertRecord batchRecord = new SQLServerBulkBatchInsertRecord(
-                                batchParamValues, bcOperationColumnList, bcOperationValueList, null);
+                                batchParamValues, bcOperationColumnList, bcOperationValueList, null, connection.getDatabaseCollation().getIsCaseSensitive());
 
                         for (int i = 1; i <= rs.getColumnCount(); i++) {
                             Column c = rs.getColumn(i);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
@@ -571,26 +571,6 @@ public class BatchExecutionTest extends AbstractTest {
     }
 
     @Test
-    public void testExecuteBatchColumnCaseMatching() throws Exception {
-        // Insert Timestamp using prepared statement when useBulkCopyForBatchInsert=true
-        try (Connection con = DriverManager.getConnection(connectionString
-                + ";useBulkCopyForBatchInsert=true;sendTemporalDataTypesAsStringForBulkCopy=false;")) {
-            try (Statement statement = con.createStatement()) {
-                TestUtils.dropTableIfExists(caseSensitiveTable, statement);
-                String createSql = "CREATE TABLE" + caseSensitiveTable + " (c1 varchar(10))";
-                statement.execute(createSql);
-            }
-            try (PreparedStatement preparedStatement = con.prepareStatement("INSERT INTO " + caseSensitiveTable + "(c1) VALUES(?)")) {
-                preparedStatement.setObject(1, "value1");
-                preparedStatement.addBatch();
-                preparedStatement.setObject(1, "value2");
-                preparedStatement.addBatch();
-                preparedStatement.executeBatch();
-            }
-        }
-    }
-
-    @Test
     public void testExecuteBatchColumnCaseMismatch() throws Exception {
         // Insert Timestamp using prepared statement when useBulkCopyForBatchInsert=true
         try (Connection con = DriverManager.getConnection(connectionString

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.microsoft.sqlserver.jdbc.*;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
@@ -72,6 +72,8 @@ public class BatchExecutionTest extends AbstractTest {
             .escapeIdentifier(RandomUtil.getIdentifier("timestamptable1"));
     private static String timestampTable2 = AbstractSQLGenerator
             .escapeIdentifier(RandomUtil.getIdentifier("timestamptable2"));
+    private static String caseSensitiveTable = AbstractSQLGenerator
+            .escapeIdentifier(RandomUtil.getIdentifier("caseSensitiveTable"));
 
     /**
      * This tests the updateCount when the error query does cause a SQL state HY008.
@@ -570,16 +572,15 @@ public class BatchExecutionTest extends AbstractTest {
 
     @Test
     public void testExecuteBatchColumnCaseMatching() throws Exception {
-        String varcharTable1 = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("varchartable1"));
         // Insert Timestamp using prepared statement when useBulkCopyForBatchInsert=true
         try (Connection con = DriverManager.getConnection(connectionString
                 + ";useBulkCopyForBatchInsert=true;sendTemporalDataTypesAsStringForBulkCopy=false;")) {
             try (Statement statement = con.createStatement()) {
-                TestUtils.dropTableIfExists(varcharTable1, statement);
-                String createSql = "CREATE TABLE" + varcharTable1 + " (c1 varchar(10))";
+                TestUtils.dropTableIfExists(caseSensitiveTable, statement);
+                String createSql = "CREATE TABLE" + caseSensitiveTable + " (c1 varchar(10))";
                 statement.execute(createSql);
             }
-            try (PreparedStatement preparedStatement = con.prepareStatement("INSERT INTO " + varcharTable1 + "(c1) VALUES(?)")) {
+            try (PreparedStatement preparedStatement = con.prepareStatement("INSERT INTO " + caseSensitiveTable + "(c1) VALUES(?)")) {
                 preparedStatement.setObject(1, "value1");
                 preparedStatement.addBatch();
                 preparedStatement.setObject(1, "value2");
@@ -591,17 +592,16 @@ public class BatchExecutionTest extends AbstractTest {
 
     @Test
     public void testExecuteBatchColumnCaseMismatch() throws Exception {
-        String varcharTable1 = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("varchartable1"));
         // Insert Timestamp using prepared statement when useBulkCopyForBatchInsert=true
         try (Connection con = DriverManager.getConnection(connectionString
                 + ";useBulkCopyForBatchInsert=true;sendTemporalDataTypesAsStringForBulkCopy=false;")) {
             try (Statement statement = con.createStatement()) {
-                TestUtils.dropTableIfExists(varcharTable1, statement);
-                String createSql = "CREATE TABLE" + varcharTable1 + " (c1 varchar(10))";
+                TestUtils.dropTableIfExists(caseSensitiveTable, statement);
+                String createSql = "CREATE TABLE" + caseSensitiveTable + " (c1 varchar(10))";
                 statement.execute(createSql);
             }
             // upper case C1
-            try (PreparedStatement preparedStatement = con.prepareStatement("INSERT INTO " + varcharTable1 + "(C1) VALUES(?)")) {
+            try (PreparedStatement preparedStatement = con.prepareStatement("INSERT INTO " + caseSensitiveTable + "(C1) VALUES(?)")) {
                 preparedStatement.setObject(1, "value1");
                 preparedStatement.addBatch();
                 preparedStatement.setObject(1, "value2");
@@ -882,6 +882,7 @@ public class BatchExecutionTest extends AbstractTest {
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(ctstable4), stmt);
             TestUtils.dropTableIfExists(timestampTable1, stmt);
             TestUtils.dropTableIfExists(timestampTable2, stmt);
+            TestUtils.dropTableIfExists(caseSensitiveTable, stmt);
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/BatchExecutionTest.java
@@ -606,13 +606,7 @@ public class BatchExecutionTest extends AbstractTest {
                 preparedStatement.addBatch();
                 preparedStatement.setObject(1, "value2");
                 preparedStatement.addBatch();
-                try {
-                    preparedStatement.executeBatch();
-                    fail("Should have failed");
-                } catch (Exception ex) {
-                    assertInstanceOf(SQLServerException.class, ex);
-                    assertEquals("Unable to retrieve column metadata.", ex.getMessage());
-                }
+                preparedStatement.executeBatch();
             }
         }
     }


### PR DESCRIPTION
fix https://github.com/microsoft/mssql-jdbc/issues/2588 [BUG] PreparedStatement.executeBatch() When the Insert Sql Column Name Case Mismatch, Throws BatchUpdateException "Unable to retrieve column metadata."