### PR TITLE
Update batch insert for bulk copy operation to handle string correctly when sendStringParametersAsUnicode is set to false

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
@@ -181,13 +181,24 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
                 return null;
             }
 
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR: {
+                /*
+                 * If string data comes in as a byte array through setString (and sendStringParametersAsUnicode = false)
+                 * through Bulk Copy for Batch Insert API, convert the byte array to a string.
+                 * If the data is already a string, return it as is.
+                 */
+                if (data instanceof byte[]) {
+                    return new String((byte[]) data);
+                }
+                return data;
+            }
+
             case Types.DATE:
             case Types.CHAR:
-            case Types.NCHAR:
             case Types.VARCHAR:
-            case Types.NVARCHAR:
             case Types.LONGVARCHAR:
-            case Types.LONGNVARCHAR:
             case Types.CLOB:
             default: {
                 // The string is copied as is.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
@@ -181,6 +181,9 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
                 return null;
             }
 
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
             case Types.NCHAR:
             case Types.NVARCHAR:
             case Types.LONGNVARCHAR: {
@@ -196,9 +199,6 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
             }
 
             case Types.DATE:
-            case Types.CHAR:
-            case Types.VARCHAR:
-            case Types.LONGVARCHAR:
             case Types.CLOB:
             default: {
                 // The string is copied as is.

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -1186,66 +1186,99 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
     }
 
     /**
-     * Test batch insert using bulk copy with string value when setSendStringParametersAsUnicode is true.
+     * Test batch insert using bulk copy with string values when setSendStringParametersAsUnicode is true.
      */
     @Test
     public void testBulkInsertStringWhenSentAsUnicode() throws Exception {
-        String createTableSQL = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString) + " (" +
-                "StateCode NVARCHAR(50) NOT NULL" + ")";
         String insertSQL = "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString)
-                + " (StateCode) VALUES (?)";
-        String selectSQL = "SELECT StateCode FROM " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString);
+                + " (charCol, varcharCol, longvarcharCol, ncharCol, nvarcharCol, longnvarcharCol) VALUES (?, ?, ?, ?, ?, ?)";
+
+        String selectSQL = "SELECT charCol, varcharCol, longvarcharCol, ncharCol, nvarcharCol, longnvarcharCol FROM "
+                + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString);
 
         try (Connection connection = PrepUtil.getConnection(
                 connectionString + ";useBulkCopyForBatchInsert=true;sendStringParametersAsUnicode=true;");
                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement(insertSQL);
                 Statement stmt = (SQLServerStatement) connection.createStatement()) {
 
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableNameBulkString), stmt);
-            stmt.execute(createTableSQL);
+            getCreateTableWithStringData();
 
-            pstmt.setString(1, "OH");
+            pstmt.setString(1, "CHAR_VAL");
+            pstmt.setString(2, "VARCHAR_VALUE");
+            pstmt.setString(3, "LONGVARCHAR_VALUE_WITH_MORE_TEXT");
+            pstmt.setString(4, "NCHAR_VAL");
+            pstmt.setString(5, "NVARCHAR_VALUE");
+            pstmt.setString(6, "LONGNVARCHAR_VALUE_WITH_UNICODE_TEXT");
             pstmt.addBatch();
             pstmt.executeBatch();
 
             // Validate inserted data
             try (ResultSet rs = stmt.executeQuery(selectSQL)) {
                 assertTrue(rs.next(), "Expected at least one row in result set");
-                assertEquals("OH", rs.getString("StateCode"));
+                assertEquals("CHAR_VAL", rs.getString("charCol"));
+                assertEquals("VARCHAR_VALUE", rs.getString("varcharCol"));
+                assertEquals("LONGVARCHAR_VALUE_WITH_MORE_TEXT", rs.getString("longvarcharCol"));
+                assertEquals("NCHAR_VAL", rs.getString("ncharCol"));
+                assertEquals("NVARCHAR_VALUE", rs.getString("nvarcharCol"));
+                assertEquals("LONGNVARCHAR_VALUE_WITH_UNICODE_TEXT", rs.getString("longnvarcharCol"));
                 assertFalse(rs.next());
             }
         }
     }
 
     /**
-     * Test batch insert using bulk copy with string value when setSendStringParametersAsUnicode is false.
+     * Test batch insert using bulk copy with string values when setSendStringParametersAsUnicode is false.
      */
     @Test
     public void testBulkInsertStringWhenNotSentAsUnicode() throws Exception {
-        String createTableSQL = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString) + " (" +
-                "StateCode NVARCHAR(50) NOT NULL" + ")";
         String insertSQL = "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString)
-                + " (StateCode) VALUES (?)";
-        String selectSQL = "SELECT StateCode FROM " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString);
+                + " (charCol, varcharCol, longvarcharCol, ncharCol, nvarcharCol, longnvarcharCol) VALUES (?, ?, ?, ?, ?, ?)";
+
+        String selectSQL = "SELECT charCol, varcharCol, longvarcharCol, ncharCol, nvarcharCol, longnvarcharCol FROM "
+                + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString);
 
         try (Connection connection = PrepUtil.getConnection(
                 connectionString + ";useBulkCopyForBatchInsert=true;sendStringParametersAsUnicode=false;");
                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement(insertSQL);
                 Statement stmt = (SQLServerStatement) connection.createStatement()) {
 
-            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableNameBulkString), stmt);
-            stmt.execute(createTableSQL);
+            getCreateTableWithStringData();
 
-            pstmt.setString(1, "OH");
+            pstmt.setString(1, "CHAR_VAL");
+            pstmt.setString(2, "VARCHAR_VALUE");
+            pstmt.setString(3, "LONGVARCHAR_VALUE_WITH_MORE_TEXT");
+            pstmt.setString(4, "NCHAR_VAL");
+            pstmt.setString(5, "NVARCHAR_VALUE");
+            pstmt.setString(6, "LONGNVARCHAR_VALUE_WITH_UNICODE_TEXT");
             pstmt.addBatch();
             pstmt.executeBatch();
 
             // Validate inserted data
             try (ResultSet rs = stmt.executeQuery(selectSQL)) {
                 assertTrue(rs.next(), "Expected at least one row in result set");
-                assertEquals("OH", rs.getString("StateCode"));
+                assertEquals("CHAR_VAL", rs.getString("charCol"));
+                assertEquals("VARCHAR_VALUE", rs.getString("varcharCol"));
+                assertEquals("LONGVARCHAR_VALUE_WITH_MORE_TEXT", rs.getString("longvarcharCol"));
+                assertEquals("NCHAR_VAL", rs.getString("ncharCol"));
+                assertEquals("NVARCHAR_VALUE", rs.getString("nvarcharCol"));
+                assertEquals("LONGNVARCHAR_VALUE_WITH_UNICODE_TEXT", rs.getString("longnvarcharCol"));
                 assertFalse(rs.next());
             }
+        }
+    }
+
+    private void getCreateTableWithStringData() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableNameBulkString), stmt);
+            String createTableSQL = "CREATE TABLE " + AbstractSQLGenerator.escapeIdentifier(tableNameBulkString) + " (" +
+                    "charCol CHAR(8) NOT NULL, " +
+                    "varcharCol VARCHAR(50) NOT NULL, " +
+                    "longvarcharCol VARCHAR(MAX) NOT NULL, " +
+                    "ncharCol NCHAR(9) NOT NULL, " +
+                    "nvarcharCol NVARCHAR(50) NOT NULL, " +
+                    "longnvarcharCol NVARCHAR(MAX) NOT NULL" + ")";
+
+            stmt.execute(createTableSQL);
         }
     }
 


### PR DESCRIPTION
## Description


This PR addresses GitHub reported issue : [Bulk copy for batch insert destroys data without error #2669](https://github.com/microsoft/mssql-jdbc/issues/2669)

When inserting string data using batch insert for bulk copy with below combinations:

```
- useBulkCopyForBatchInsert=true
- sendStringParametersAsUnicode=false
```

The data is inserted in byte array format. 

**Expected behavior**
Select StateCode from states -> "OH"

**Actual behavior**
Select StateCode from states; -> "[B@4b01d9e4"


## Root cause

The issue occurs because:
- When sendStringParametersAsUnicode=false, the setString() method stores parameter values as byte arrays in the DTV (Data Type Value) objects.
- During bulk copy batch insert, the SQLServerBulkBatchInsertRecord.convertValue() method retrieves these raw byte arrays from the parameter DTVs
- The method was missing logic to detect and convert byte arrays back to strings for string-type columns


## Testing
Added comprehensive test cases in BatchExecutionWithBulkCopyTest.java:

- testBulkInsertStringWhenSentAsUnicode():
Tests bulk insert with sendStringParametersAsUnicode=true (default behavior). Validates that string data is inserted correctly as Unicode

- testBulkInsertStringWhenNotSentAsUnicode():
Tests bulk insert with sendStringParametersAsUnicode=false (issue scenario)
Validates that byte arrays are properly converted back to strings