### PR TITLE
Add new trusted AKV URLs for FR and DE

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionAzureKeyVaultProvider.java
@@ -1000,10 +1000,18 @@ public class SQLServerColumnEncryptionAzureKeyVaultProvider extends SQLServerCol
             trustedEndpoints.add("vault.azure.cn");
             trustedEndpoints.add("vault.usgovcloudapi.net");
             trustedEndpoints.add("vault.microsoftazure.de");
+            trustedEndpoints.add("vault.cloudapi.microsoft.scloud"); // USSec
+            trustedEndpoints.add("vault.cloudapi.eaglex.ic.gov"); //USNat
+            trustedEndpoints.add("vault.sovcloud-api.fr"); // France (Blue)
+            trustedEndpoints.add("vault.sovcloud-api.de"); // Germany (Delos)
             trustedEndpoints.add("managedhsm.azure.net");
             trustedEndpoints.add("managedhsm.azure.cn");
             trustedEndpoints.add("managedhsm.usgovcloudapi.net");
             trustedEndpoints.add("managedhsm.microsoftazure.de");
+            trustedEndpoints.add("managedhsm.cloudapi.microsoft.scloud");
+            trustedEndpoints.add("managedhsm.cloudapi.eaglex.ic.gov");
+            trustedEndpoints.add("managedhsm.sovcloud-api.fr");
+            trustedEndpoints.add("managedhsm.sovcloud-api.de");
         }
         return trustedEndpoints;
     }


### PR DESCRIPTION
Description:
Added 4 new trusted AKV URLs and their Managed HSM counterparts:

vault.cloudapi.microsoft.scloud
vault.cloudapi.eaglex.ic.gov
vault.sovcloud-api.fr
vault.sovcloud-api.de