### PR TITLE
Fix trustStoreType JVM property consultation in SSL connections (#2691)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1676,7 +1676,10 @@ final class TDSChannel implements Serializable {
                     .getProperty(SQLServerDriverStringProperty.TRUST_STORE_TYPE.toString());
 
             if (StringUtils.isEmpty(trustStoreType)) {
-                trustStoreType = SQLServerDriverStringProperty.TRUST_STORE_TYPE.getDefaultValue();
+                trustStoreType = System.getProperty("javax.net.ssl.trustStoreType");
+                if (StringUtils.isEmpty(trustStoreType)) {
+                    trustStoreType = SQLServerDriverStringProperty.TRUST_STORE_TYPE.getDefaultValue(); // Default to JKS if not specified
+                }
             }
 
             String serverCert = con.activeConnectionProperties


### PR DESCRIPTION
## Problem
The JDBC driver was not properly consulting the JVM system property `javax.net.ssl.trustStoreType` when the `trustStoreType` connection property was not explicitly set. This affected all SSL connection scenarios where users expected `-Djavax.net.ssl.trustStoreType=Windows-ROOT` (or other values) to be honored.

## Root Cause
The trust manager selection logic in `IOBuffer.enableSSL()` was missing the standard fallback hierarchy for `trustStoreType` resolution when entering the KeyStore loading path.

## Solution
Added comprehensive JVM system property consultation logic that follows the standard Java property resolution hierarchy:
1. Check connection property `trustStoreType`
2. If empty, check JVM system property `javax.net.ssl.trustStoreType`
3. If still empty, use default value "JKS"

## Changes
- **IOBuffer.java**: Added `System.getProperty("javax.net.ssl.trustStoreType")` fallback logic in lines 1678-1683
- Applies to all SSL connection modes: `encrypt=true`, `encrypt=strict`, login-only encryption, etc.
- Maintains backward compatibility and existing explicit property behavior

## Testing
- Verified that all encryption modes now properly respect JVM system properties
- Confirmed that explicit connection property values still take precedence
- Validated that default behavior (JKS) is preserved when neither property is set
- Tested with various trustStoreType values including Windows-ROOT, PKCS12, etc.

## Impact
- Enables Windows certificate store integration across all SSL connection types
- Restores expected Java standard property consultation behavior
- Improves compatibility with existing deployment scripts and system configurations
- No breaking changes to existing functionality

Fixes #2691