### PR TITLE
Addressed performance issue on Bulk Copy API with batch insert

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
@@ -189,18 +189,7 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
             case Types.LONGVARCHAR:
             case Types.NCHAR:
             case Types.NVARCHAR:
-            case Types.LONGNVARCHAR: {
-                /*
-                 * If string data comes in as a byte array through setString (and sendStringParametersAsUnicode = false)
-                 * through Bulk Copy for Batch Insert API, convert the byte array to a string.
-                 * If the data is already a string, return it as is.
-                 */
-                if (data instanceof byte[]) {
-                    return new String((byte[]) data, charset);
-                }
-                return data;
-            }
-
+            case Types.LONGNVARCHAR:
             case Types.DATE:
             case Types.CLOB:
             default: {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -2064,7 +2064,7 @@ final class AppDTVImpl extends DTVImpl {
             // SSType (i.e. VARCHAR vs. TEXT/VARCHAR(max)) is based on the exact length of
             // the MBCS value (in bytes).
             // If useBulkCopyForBatchInsert is true, conversion to byte array is not done due to performance
-            else if ((con.getUseBulkCopyForBatchInsert() == false) && null != collation && (JDBCType.CHAR == type || JDBCType.VARCHAR == type
+            else if (!con.getUseBulkCopyForBatchInsert() && null != collation && (JDBCType.CHAR == type || JDBCType.VARCHAR == type
                     || JDBCType.LONGVARCHAR == type || JDBCType.CLOB == type)) {
                 byte[] nativeEncoding = null;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -2063,7 +2063,8 @@ final class AppDTVImpl extends DTVImpl {
             // then do the conversion now so that the decision to use a "short" or "long"
             // SSType (i.e. VARCHAR vs. TEXT/VARCHAR(max)) is based on the exact length of
             // the MBCS value (in bytes).
-            else if (null != collation && (JDBCType.CHAR == type || JDBCType.VARCHAR == type
+            // If useBulkCopyForBatchInsert is true, conversion to byte array is not done due to performance
+            else if ((con.getUseBulkCopyForBatchInsert() == false) && null != collation && (JDBCType.CHAR == type || JDBCType.VARCHAR == type
                     || JDBCType.LONGVARCHAR == type || JDBCType.CLOB == type)) {
                 byte[] nativeEncoding = null;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -1435,11 +1435,11 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
 
             // Attempt unsupported INSERT-SELECT query for bulk copy api
             String insertSelectSQL = "INSERT INTO " + tableNameDestination + " SELECT * FROM " + tableNameSource
-                    + " WHERE id = ?";
+                    + " WHERE value = ?";
 
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
                     .prepareStatement(insertSelectSQL)) {
-                pstmt.setInt(1, 1);
+                pstmt.setString(1, "TestValue1");
                 pstmt.addBatch();
                 pstmt.executeBatch(); // This should fall back to normal execution flow
             }


### PR DESCRIPTION
## Description

A GitHub issue was raised highlighting a performance degradation in the Bulk Copy API when using batch inserts
[Pre-release 13.1 is slower #2732](https://github.com/microsoft/mssql-jdbc/issues/2732)

The original issue reported was [Bulk copy for batch insert destroys data without error #2669](https://github.com/microsoft/mssql-jdbc/issues/2669)
This occurred when inserting string data using the following settings:
```
- useBulkCopyForBatchInsert=true
- sendStringParametersAsUnicode=false
```
Under these conditions, data was inserted in byte array format rather than as readable strings.

Expected behavior
Select StateCode from states -> "OH"

Actual behavior
Select StateCode from states; -> "[B@4b01d9e4"

On top of this a new issue was reported [Accented characters saved incorrectly in database when using useBulkCopyForBatchInsert=true and sendStringParametersAsUnicode=false #2721](https://github.com/microsoft/mssql-jdbc/issues/2721).
When inserting data using useBulkCopyForBatchInsert=true and sendStringParametersAsUnicode=false, names with accented characters were saved incorrectly in the database.

## Root Cause
When inserting string data using batch insert for bulk copy with below combinations:

```
- useBulkCopyForBatchInsert=true
- sendStringParametersAsUnicode=false
```
[Fix#2704](https://github.com/microsoft/mssql-jdbc/pull/2704) and [Fix#2727](https://github.com/microsoft/mssql-jdbc/pull/2727) introduced a performance slowdown because of unnecessary conversion from byte array back to string during the bulk copy batch insert operation.

## Fix
Modified the logic to avoid sending data as a byte array in the first place when useBulkCopyForBatchInsert=true. As data inserted to destination table is being taken from dtv.value which is byte array.
Post this fix performance has improved significantly.

## Testing
- Added test cases for all combinations of useBulkCopyForBatchInsert and sendStringParametersAsUnicode to validate data insertion (including Unicode and accented characters) without performance degradation.
- Added a test case to simulate an unsupported INSERT-SELECT batch insert with useBulkCopyForBatchInsert=true and sendStringParametersAsUnicode=false, verifying that the fallback to normal execution occurs and the data is inserted correctly.