### PR TITLE
Revert "Properly Insert Accented Characters When Using Bulk Copy and Non-Unicode Strings"

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkBatchInsertRecord.java
@@ -7,7 +7,6 @@ package com.microsoft.sqlserver.jdbc;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.nio.charset.Charset;
 import java.sql.Types;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
@@ -35,7 +34,6 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
     private int batchParamIndex = -1;
     private List<String> columnList;
     private List<String> valueList;
-    private Charset charset;
 
     /*
      * Class name for logging.
@@ -46,10 +44,10 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
      * Constructs a SQLServerBulkBatchInsertRecord with the batch parameter, column list, value list, and encoding
      */
     SQLServerBulkBatchInsertRecord(ArrayList<Parameter[]> batchParam, ArrayList<String> columnList,
-            ArrayList<String> valueList, Charset charset, boolean columnNameCaseSensitive) throws SQLServerException {
+            ArrayList<String> valueList, String encoding, boolean columnNameCaseSensitive) throws SQLServerException {
         initLoggerResources();
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER)) {
-            loggerExternal.entering(loggerPackageName, loggerClassName, new Object[] {batchParam, charset.name()});
+            loggerExternal.entering(loggerPackageName, loggerClassName, new Object[] {batchParam, encoding});
         }
 
         if (null == batchParam) {
@@ -64,7 +62,6 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
         this.columnList = columnList;
         this.valueList = valueList;
         this.columnNameCaseSensitive = columnNameCaseSensitive;
-        this.charset = charset;
         columnMetadata = new HashMap<>();
 
         loggerExternal.exiting(loggerPackageName, loggerClassName);
@@ -196,7 +193,7 @@ class SQLServerBulkBatchInsertRecord extends SQLServerBulkRecord {
                  * If the data is already a string, return it as is.
                  */
                 if (data instanceof byte[]) {
-                    return new String((byte[]) data, charset);
+                    return new String((byte[]) data);
                 }
                 return data;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2218,8 +2218,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                         }
 
                         SQLServerBulkBatchInsertRecord batchRecord = new SQLServerBulkBatchInsertRecord(
-                                batchParamValues, bcOperationColumnList, bcOperationValueList, 
-                                connection.getDatabaseCollation().getCharset(), isDBColationCaseSensitive());
+                                batchParamValues, bcOperationColumnList, bcOperationValueList, null, isDBColationCaseSensitive());
 
                         for (int i = 1; i <= rs.getColumnCount(); i++) {
                             Column c = rs.getColumn(i);
@@ -2427,8 +2426,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                         }
 
                         SQLServerBulkBatchInsertRecord batchRecord = new SQLServerBulkBatchInsertRecord(
-                                batchParamValues, bcOperationColumnList, bcOperationValueList, 
-                                connection.getDatabaseCollation().getCharset(), isDBColationCaseSensitive());
+                                batchParamValues, bcOperationColumnList, bcOperationValueList, null, isDBColationCaseSensitive());
 
                         for (int i = 1; i <= rs.getColumnCount(); i++) {
                             Column c = rs.getColumn(i);


### PR DESCRIPTION
Reverts microsoft/mssql-jdbc#2727
This issue will be addressed in [Addressed performance issue on Bulk Copy API with batch insert #2735](https://github.com/microsoft/mssql-jdbc/pull/2735)