### PR TITLE
Update getProcedureColumns() and getFunctionColumns() to return name without numbered prefixes

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1130,6 +1130,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                 rs.getColumn(9).setFilter(new ZeroFixupFilter());
                 rs.getColumn(17).setFilter(new ZeroFixupFilter());
             }
+            rs.getColumn(3).setFilter(new ColumnNameFilter());
         }
         return rs;
     }
@@ -2948,14 +2949,14 @@ class ZeroFixupFilter extends IntColumnFilter {
 }
 
 /**
- * Provides filter to remove numbered prefixes from procedure names.
+ * Provides filter to remove numbered prefixes from procedure and function names.
  */
 class ColumnNameFilter extends ColumnFilter {
     @Override
     public Object apply(Object value, JDBCType asJDBCType) throws SQLServerException {
         if (value instanceof String) {
             String name = (String) value;
-            int idx = name.indexOf(';');
+            int idx = name.lastIndexOf(';');
             return (idx > 0) ? name.substring(0, idx) : name;
         }
         return value;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1648,6 +1648,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                 rs.getColumn(9).setFilter(new ZeroFixupFilter());
                 rs.getColumn(17).setFilter(new ZeroFixupFilter());
             }
+            rs.getColumn(3).setFilter(new ColumnNameFilter());
         }
         return rs;
     }
@@ -2946,6 +2947,20 @@ class ZeroFixupFilter extends IntColumnFilter {
     }
 }
 
+/**
+ * Provides filter to remove numbered prefixes from procedure names.
+ */
+class ColumnNameFilter extends ColumnFilter {
+    @Override
+    public Object apply(Object value, JDBCType asJDBCType) throws SQLServerException {
+        if (value instanceof String) {
+            String name = (String) value;
+            int idx = name.indexOf(';');
+            return (idx > 0) ? name.substring(0, idx) : name;
+        }
+        return value;
+    }
+}
 
 /**
  * Converts one value to another solely based on the column integer value. Apply to integer columns only

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1438,46 +1438,6 @@ public class DatabaseMetaDataTest extends AbstractTest {
         }
     }
 
-    @Test
-    public void testGetProcedureColumns() throws SQLException {
-        try (Connection conn = getConnection()) {
-            DatabaseMetaData databaseMetaData = conn.getMetaData();
-            String catalog = null; // Specify catalog if needed
-            String schemaPattern = null; // Specify schema pattern if needed
-            String procedureNamePattern = "%"; // Use '%' to match all procedures
-            String columnNamePattern = "%"; // Use '%' to match all columns
-
-            try (ResultSet rs = databaseMetaData.getProcedureColumns(catalog, schemaPattern, procedureNamePattern,
-                    columnNamePattern)) {
-                System.out.println("Procedure Columns:");
-                System.out.println("--------------------------------------------------");
-                int count = 0;
-                while (rs.next()) {
-                    count++;
-                    String procedureCatalog = rs.getString("PROCEDURE_CAT");
-                    String procedureSchema = rs.getString("PROCEDURE_SCHEM");
-                    String procedureName = rs.getString("PROCEDURE_NAME");
-                    String columnName = rs.getString("COLUMN_NAME");
-                    int columnType = rs.getInt("COLUMN_TYPE");
-                    int dataType = rs.getInt("DATA_TYPE");
-                    String typeName = rs.getString("TYPE_NAME");
-                    int precision = rs.getInt("PRECISION");
-                    int length = rs.getInt("LENGTH");
-                    int scale = rs.getInt("SCALE");
-                    int radix = rs.getInt("RADIX");
-                    int nullable = rs.getInt("NULLABLE");
-                    String remarks = rs.getString("REMARKS");
-
-                    System.out.printf(
-                            "Catalog: %s, Schema: %s, Procedure: %s, Column: %s, Column Type: %d, Data Type: %d, Type Name: %s, Precision: %d, Length: %d, Scale: %d, Radix: %d, Nullable: %d, Remarks: %s%n",
-                            procedureCatalog, procedureSchema, procedureName, columnName, columnType, dataType,
-                            typeName, precision, length, scale, radix, nullable, remarks);
-                }
-                System.out.printf("Total Procedure Columns Found: %d%n", count);
-            }
-        }
-    }
-
     /**
      * Test procedure columns retrieval with validation.
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1438,6 +1438,46 @@ public class DatabaseMetaDataTest extends AbstractTest {
         }
     }
 
+    @Test
+    public void testGetProcedureColumns() throws SQLException {
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+            String catalog = null; // Specify catalog if needed
+            String schemaPattern = null; // Specify schema pattern if needed
+            String procedureNamePattern = "%"; // Use '%' to match all procedures
+            String columnNamePattern = "%"; // Use '%' to match all columns
+
+            try (ResultSet rs = databaseMetaData.getProcedureColumns(catalog, schemaPattern, procedureNamePattern,
+                    columnNamePattern)) {
+                System.out.println("Procedure Columns:");
+                System.out.println("--------------------------------------------------");
+                int count = 0;
+                while (rs.next()) {
+                    count++;
+                    String procedureCatalog = rs.getString("PROCEDURE_CAT");
+                    String procedureSchema = rs.getString("PROCEDURE_SCHEM");
+                    String procedureName = rs.getString("PROCEDURE_NAME");
+                    String columnName = rs.getString("COLUMN_NAME");
+                    int columnType = rs.getInt("COLUMN_TYPE");
+                    int dataType = rs.getInt("DATA_TYPE");
+                    String typeName = rs.getString("TYPE_NAME");
+                    int precision = rs.getInt("PRECISION");
+                    int length = rs.getInt("LENGTH");
+                    int scale = rs.getInt("SCALE");
+                    int radix = rs.getInt("RADIX");
+                    int nullable = rs.getInt("NULLABLE");
+                    String remarks = rs.getString("REMARKS");
+
+                    System.out.printf(
+                            "Catalog: %s, Schema: %s, Procedure: %s, Column: %s, Column Type: %d, Data Type: %d, Type Name: %s, Precision: %d, Length: %d, Scale: %d, Radix: %d, Nullable: %d, Remarks: %s%n",
+                            procedureCatalog, procedureSchema, procedureName, columnName, columnType, dataType,
+                            typeName, precision, length, scale, radix, nullable, remarks);
+                }
+                System.out.printf("Total Procedure Columns Found: %d%n", count);
+            }
+        }
+    }
+
     @BeforeAll
     public static void setupTable() throws Exception {
         setConnection();


### PR DESCRIPTION
## Description
This PR addresses GitHub reported issue : [Cannot relate procedures to procedure columns (same with functions) #2739](https://github.com/microsoft/mssql-jdbc/issues/2739)

Post fixing the issue [Use sys.all_objects for accurate function and procedure filtering #2705](https://github.com/microsoft/mssql-jdbc/pull/2705) : where both DatabaseMetadata.getProcedures and DatabaseMetadata.getFunctions returns correct result. With this change object names got updated as mentioned below:
```
Old behaviour: sp_testProc;1
New behaviour: sp_testProc
```

So, DatabaseMetadata.getProcedureColumns and DatabaseMetadata.getFunctionColumns should also return similar pattern.
Currently it returns the resultset where procedure and function names were appended with a numbered suffix (;1).

As per the [documentation](https://learn.microsoft.com/en-us/previous-versions/sql/sql-server-2008/ms187926(v=sql.100)?redirectedfrom=MSDN#:~:text=This%20feature%20will%20be%20removed%20in%20a%20future%20version%20of%20Microsoft%20SQL%20Server.%20Avoid%20using%20this%20feature%20in%20new%20development%20work%2C%20and%20plan%20to%20modify%20applications%20that%20currently%20use%20this%20feature.) : “Numbered procedures are deprecated. Avoid using them in new development work, and plan to modify applications that currently use them.”

## Fix
Updated the implementation of getProcedureColumns() and getFunctionColumns() to filter out numbered suffixes from procedure/function names.
This ensures that the returned column metadata reflects only the expected procedure/function names.

## Testing
- Manual testing: Verified locally with custom scripts to ensure that getProcedureColumns() and getFunctionColumns() return accurate object names without numbered suffixes.
- Automated tests: Added testGetProcedureColumnsWithValidation and testGetFunctionColumnsWithValidation to confirm that procedure and function column names are correctly validated.
