### PR TITLE
Fix issue#2745

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -2289,7 +2289,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     @Override
     public boolean supportsIntegrityEnhancementFacility() throws SQLServerException {
         checkClosed();
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
If the driver supports primary key and foreign key relationships then normally it should respond `true` regarding the `DatabaseMetaData.supportsIntegrityEnhancementFacility()` method.