### PR TITLE
JDK 8 compatibility fix for vector datatype handling

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/VectorUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/VectorUtils.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.sqlserver.jdbc;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.text.MessageFormat;
@@ -56,7 +57,12 @@ class VectorUtils {
 
         ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
 
-        buffer.position(getHeaderLength()); // Skip the first 8 bytes (header)
+        /*
+         * The cast is required for JDK 8 compatibility.
+         * JDK 8 calls method Buffer.position(I)LBuffer,
+         * while in JDK 9+ calls method ByteBuffer.position(I)LByteBuffer
+         */
+        ((Buffer) buffer).position(getHeaderLength()); // Skip the first 8 bytes (header)
 
         for (int i = 0; i < objectCount; i++) {
             objectArray[i] = buffer.getFloat();


### PR DESCRIPTION
## Description
After adding [Vector datatype support #2634](https://github.com/microsoft/mssql-jdbc/pull/2634), we observed failures on JDK 8 due to a NoSuchMethodError when invoking ByteBuffer.position(int).

## Root Cause

- In JDK 8, Buffer.position(int) returns Buffer.
- In JDK 9+, ByteBuffer overrides this method to return ByteBuffer.

Directly calling ByteBuffer.position(int) caused incompatibility and resulted in NoSuchMethodError on JDK 8.

## Fix

Cast the ByteBuffer instance to Buffer before calling position().
This ensures consistent behavior across JDK 8 and newer versions.

## Testing

- Verified all vector-related tests locally.
- Confirmed successful execution on JDK 8 as well as later JDK versions.