### PR TITLE
Added scenarios to validate existing behaviour of getFunctions(), getProcedures(), getFunctionColumns() and getProcedureColumns() APIs

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -425,10 +425,30 @@ public final class TestUtils {
                 "IF OBJECT_ID('" + tableNameWithSchema + "', 'U') IS NOT NULL DROP TABLE " + tableNameWithSchema + ";");
     }
 
+    /**
+     * Drops a procedure with schema if it exists.
+     *
+     * @param procedureWithSchema
+     * @param stmt
+     * @throws SQLException
+     */
     public static void dropProcedureWithSchemaIfExists(String procedureWithSchema,
             java.sql.Statement stmt) throws SQLException {
         stmt.execute("IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'" + procedureWithSchema
                 + "') AND type in (N'P', N'PC')) DROP PROCEDURE " + procedureWithSchema + ";");
+    }
+
+    /**
+     * Drops a function with schema if it exists.
+     *
+     * @param functionWithSchema
+     * @param stmt
+     * @throws SQLException
+     */
+    public static void dropFunctionWithSchemaIfExists(String functionWithSchema,
+            java.sql.Statement stmt) throws SQLException {
+        stmt.execute("IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'" + functionWithSchema
+                + "') AND type in (N'FN', N'IF', N'TF')) DROP FUNCTION " + functionWithSchema + ";");
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -29,8 +29,10 @@ import java.sql.Types;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -1345,4 +1347,344 @@ public class DatabaseMetaDataTest extends AbstractTest {
             }
         }
     }
+
+    private void setupProcedures(String schemaName, String proc1, String proc1Body,
+            String proc2, String proc2Body) throws SQLException {
+        String escapedSchema = AbstractSQLGenerator.escapeIdentifier(schemaName);
+        String escapedProc1 = AbstractSQLGenerator.escapeIdentifier(proc1);
+        String escapedProc2 = AbstractSQLGenerator.escapeIdentifier(proc2);
+
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(
+                    "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '" + schemaName + "') " +
+                            "EXEC('CREATE SCHEMA " + escapedSchema + "')");
+
+            stmt.executeUpdate("IF OBJECT_ID('" + schemaName + "." + proc1 + "', 'P') IS NOT NULL " +
+                    "DROP PROCEDURE " + escapedSchema + "." + escapedProc1);
+            stmt.executeUpdate("CREATE PROCEDURE " + escapedSchema + "." + escapedProc1 + " " + proc1Body);
+
+            stmt.executeUpdate("IF OBJECT_ID('" + schemaName + "." + proc2 + "', 'P') IS NOT NULL " +
+                    "DROP PROCEDURE " + escapedSchema + "." + escapedProc2);
+            stmt.executeUpdate("CREATE PROCEDURE " + escapedSchema + "." + escapedProc2 + " " + proc2Body);
+        }
+    }
+
+    private void setupFunctions(String schemaName, String func1, String func1Body,
+            String func2, String func2Body) throws SQLException {
+        String escapedSchema = AbstractSQLGenerator.escapeIdentifier(schemaName);
+        String escapedFunc1 = AbstractSQLGenerator.escapeIdentifier(func1);
+        String escapedFunc2 = AbstractSQLGenerator.escapeIdentifier(func2);
+
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(
+                    "IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '" + schemaName + "') " +
+                            "EXEC('CREATE SCHEMA " + escapedSchema + "')");
+
+            stmt.executeUpdate("IF OBJECT_ID('" + schemaName + "." + func1 + "', 'FN') IS NOT NULL " +
+                    "DROP FUNCTION " + escapedSchema + "." + escapedFunc1);
+            stmt.executeUpdate("CREATE FUNCTION " + escapedSchema + "." + escapedFunc1 + " " + func1Body);
+
+            stmt.executeUpdate("IF OBJECT_ID('" + schemaName + "." + func2 + "', 'FN') IS NOT NULL " +
+                    "DROP FUNCTION " + escapedSchema + "." + escapedFunc2);
+            stmt.executeUpdate("CREATE FUNCTION " + escapedSchema + "." + escapedFunc2 + " " + func2Body);
+        }
+    }
+
+    /**
+     * Test to verify getProcedures() metadata structure and PROCEDURE_TYPE values
+     * getProcedures() internally calls sp_stored_procedures and PROCEDURE_TYPE is returned as 2 always
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testGetProceduresMetadataValidation() throws SQLException {
+        String schemaName = "test_schema" + uuid;
+        String proc1 = "sp_test1" + uuid;
+        String proc2 = "sp_test2" + uuid;
+
+        setupProcedures(schemaName,
+                proc1, "AS BEGIN SELECT 1; END",
+                proc2, "@val INT AS BEGIN SELECT @val * 2; END");
+
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData metaData = conn.getMetaData();
+            String[] expectedCols = {
+                    "PROCEDURE_CAT", "PROCEDURE_SCHEM", "PROCEDURE_NAME", "NUM_INPUT_PARAMS",
+                    "NUM_OUTPUT_PARAMS", "NUM_RESULT_SETS", "REMARKS", "PROCEDURE_TYPE"
+            };
+
+            try (ResultSet rs = metaData.getProcedures(null, schemaName, "sp_test%")) {
+                ResultSetMetaData rsMeta = rs.getMetaData();
+                assertEquals(expectedCols.length, rsMeta.getColumnCount());
+
+                for (int i = 1; i <= rsMeta.getColumnCount(); i++) {
+                    assertEquals(expectedCols[i - 1], rsMeta.getColumnName(i));
+                }
+
+                boolean foundProcedure = false;
+                int rowCount = 0;
+                while (rs.next() && rowCount < 5) {
+                    foundProcedure = true;
+                    rowCount++;
+
+                    // Verify required fields are not null/empty
+                    assertNotNull(rs.getString("PROCEDURE_CAT"));
+                    assertNotNull(rs.getString("PROCEDURE_SCHEM"));
+                    assertNotNull(rs.getString("PROCEDURE_NAME"));
+
+                    // Verify PROCEDURE_TYPE - should be 2
+                    int procedureType = rs.getInt("PROCEDURE_TYPE");
+                    assertEquals(2, procedureType);
+
+                    // Verify parameter counts are -1 (unknown) as per JDBC spec
+                    assertEquals(-1, rs.getInt("NUM_INPUT_PARAMS"));
+                    assertEquals(-1, rs.getInt("NUM_OUTPUT_PARAMS"));
+                    assertEquals(-1, rs.getInt("NUM_RESULT_SETS"));
+                }
+
+                assertTrue(foundProcedure, "At least one procedure should be found in schema");
+                System.out.println("Verified " + rowCount + " procedures with PROCEDURE_TYPE = 2");
+
+            }
+        } finally {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropProcedureWithSchemaIfExists(schemaName + "." + proc1, stmt);
+                TestUtils.dropProcedureWithSchemaIfExists(schemaName + "." + proc2, stmt);
+
+                TestUtils.dropSchemaIfExists(schemaName, stmt);
+            }
+        }
+    }
+
+    /**
+     * Test to verify getFunctions() metadata structure and FUNCTION_TYPE values
+     * getFunctions() internally calls sp_stored_functions and FUNCTION_TYPE is returned as 2 always
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testGetFunctionsMetadataValidation() throws SQLException {
+        String schemaName = "test_schema" + uuid;
+        String func1 = "fn_test1" + uuid;
+        String func2 = "fn_test2" + uuid;
+
+        setupFunctions(schemaName,
+                func1, "() RETURNS INT AS BEGIN RETURN 42; END",
+                func2, "(@val INT) RETURNS INT AS BEGIN RETURN @val * 2; END");
+
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData metaData = conn.getMetaData();
+            String[] expectedCols = {
+                    "FUNCTION_CAT", "FUNCTION_SCHEM", "FUNCTION_NAME", "NUM_INPUT_PARAMS",
+                    "NUM_OUTPUT_PARAMS", "NUM_RESULT_SETS", "REMARKS", "FUNCTION_TYPE"
+            };
+
+            try (ResultSet rs = metaData.getFunctions(null, schemaName, "fn_test%")) {
+                ResultSetMetaData rsMeta = rs.getMetaData();
+                assertEquals(expectedCols.length, rsMeta.getColumnCount());
+                for (int i = 1; i <= rsMeta.getColumnCount(); i++) {
+                    assertEquals(expectedCols[i - 1], rsMeta.getColumnName(i));
+                }
+
+                boolean foundFunction = false;
+                int rowCount = 0;
+                while (rs.next() && rowCount < 5) {
+                    foundFunction = true;
+                    rowCount++;
+
+                    // Verify required fields are not null/empty
+                    assertNotNull(rs.getString("FUNCTION_CAT"));
+                    assertNotNull(rs.getString("FUNCTION_SCHEM"));
+                    assertNotNull(rs.getString("FUNCTION_NAME"));
+
+                    // Verify FUNCTION_TYPE - should be 2
+                    int functionType = rs.getInt("FUNCTION_TYPE");
+                    assertEquals(2, functionType);
+
+                    // Verify parameter counts are -1 (unknown) as per JDBC spec
+                    assertEquals(-1, rs.getInt("NUM_INPUT_PARAMS"));
+                    assertEquals(-1, rs.getInt("NUM_OUTPUT_PARAMS"));
+                    assertEquals(-1, rs.getInt("NUM_RESULT_SETS"));
+                }
+
+                assertTrue(foundFunction, "At least one function should be found in schema");
+                System.out.println("Verified " + rowCount + " functions with FUNCTION_TYPE = 2");
+
+            }
+        } finally {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropFunctionWithSchemaIfExists(schemaName + "." + func1, stmt);
+                TestUtils.dropFunctionWithSchemaIfExists(schemaName + "." + func2, stmt);
+
+                TestUtils.dropSchemaIfExists(schemaName, stmt);
+            }
+        }
+    }
+
+    /**
+     * Test to verify getProcedures() with controlled data using specific procedures
+     * getProcedures() internally calls sp_stored_procedures and PROCEDURE_NAME is returned with numbered suffix always
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testGetProceduresWithData() throws SQLException {
+        String schemaName = "test_Schema" + uuid;
+        String proc1 = "sproc_test1" + uuid;
+        String proc2 = "sproc_test2" + uuid;
+
+        setupProcedures(schemaName,
+                proc1, "AS BEGIN SELECT 1; END",
+                proc2, "@val INT AS BEGIN SELECT @val * 2; END");
+
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData metaData = conn.getMetaData();
+            try (ResultSet rs = metaData.getProcedures(null, schemaName, "sproc_test%")) {
+                Set<String> foundProcedures = new HashSet<>();
+                while (rs.next()) {
+                    foundProcedures.add(rs.getString("PROCEDURE_NAME"));
+                    assertEquals(2, rs.getInt("PROCEDURE_TYPE"));
+                }
+                assertEquals(new HashSet<>(Arrays.asList(proc1 + ";1", proc2 + ";1")), foundProcedures);
+            }
+        } finally {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropProcedureWithSchemaIfExists(schemaName + "." + proc1, stmt);
+                TestUtils.dropProcedureWithSchemaIfExists(schemaName + "." + proc2, stmt);
+
+                TestUtils.dropSchemaIfExists(schemaName, stmt);
+            }
+        }
+    }
+
+    /**
+     * Test to verify getFunctions() with controlled data using specific functions
+     * getFunctions() internally calls sp_stored_functions and FUNCTION_NAME is returned with numbered suffix always
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testGetFunctionsWithData() throws SQLException {
+        String schemaName = "test_Schema" + uuid;
+        String func1 = "function_test1" + uuid;
+        String func2 = "function_test2" + uuid;
+
+        setupFunctions(schemaName,
+                func1, "() RETURNS INT AS BEGIN RETURN 42; END",
+                func2, "(@val INT) RETURNS INT AS BEGIN RETURN @val * 2; END");
+
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData metaData = conn.getMetaData();
+            try (ResultSet rs = metaData.getFunctions(null, schemaName, "function_test%")) {
+                Set<String> foundFunctions = new HashSet<>();
+                while (rs.next()) {
+                    foundFunctions.add(rs.getString("FUNCTION_NAME"));
+                    assertEquals(2, rs.getInt("FUNCTION_TYPE"));
+                }
+                assertEquals(new HashSet<>(Arrays.asList(func1 + ";0", func2 + ";0")), foundFunctions);
+            }
+        } finally {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropFunctionWithSchemaIfExists(schemaName + "." + func1, stmt);
+                TestUtils.dropFunctionWithSchemaIfExists(schemaName + "." + func2, stmt);
+
+                TestUtils.dropSchemaIfExists(schemaName, stmt);
+            }
+        }
+    }
+
+    /**
+     * Test procedure columns retrieval with validation.
+     * Internally calls sp_sproc_columns which returns numbered procedures
+     */
+    @Test
+    public void testGetProcedureColumnsWithValidation() throws SQLException {
+        String schemaName = "test_Schema" + uuid;
+        String proc1 = "sproc_test1" + uuid;
+        String proc2 = "sproc_test2" + uuid;
+
+        // Setup procedures
+        setupProcedures(schemaName,
+                proc1, "@val INT AS BEGIN SELECT @val * 2; END",
+                proc2, "@val INT AS BEGIN SELECT @val * 2; END");
+
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+
+            // Fetch procedure columns
+            try (ResultSet rs = databaseMetaData.getProcedureColumns(null, schemaName, "%", "%")) {
+                int count = 0;
+                while (rs.next()) {
+                    String procedureName = rs.getString("PROCEDURE_NAME");
+                    String schema = rs.getString("PROCEDURE_SCHEM");
+
+                    // Validate procedure name
+                    assertTrue(procedureName.equals(proc1 + ";1") || procedureName.equals(proc2 + ";1"),
+                            "Unexpected procedure name: " + procedureName);
+
+                    // Validate schema name
+                    assertEquals(schemaName, schema, "Schema name does not match");
+
+                    count++;
+                }
+
+                assertEquals(2, count, "Unexpected number of procedures found");
+            }
+        } finally {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropProcedureWithSchemaIfExists(schemaName + "." + proc1, stmt);
+                TestUtils.dropProcedureWithSchemaIfExists(schemaName + "." + proc2, stmt);
+
+                TestUtils.dropSchemaIfExists(schemaName, stmt);
+            }
+        }
+    }
+
+    /**
+     * Test function columns retrieval with validation.
+     * Internally calls sp_sproc_columns which returns numbered functions
+     */
+    @Test
+    public void testGetFunctionColumnsWithValidation() throws SQLException {
+        String schemaName = "test_Schema" + uuid;
+        String func1 = "function_test1" + uuid;
+        String func2 = "function_test2" + uuid;
+
+        // Setup functions
+        setupFunctions(schemaName,
+                func1, "() RETURNS INT AS BEGIN RETURN 42; END",
+                func2, "() RETURNS INT AS BEGIN RETURN 42; END");
+
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+
+            // Fetch function columns
+            try (ResultSet rs = databaseMetaData.getFunctionColumns(null, schemaName, "%", "%")) {
+                int count = 0;
+                while (rs.next()) {
+                    String functionName = rs.getString("FUNCTION_NAME");
+                    String schema = rs.getString("FUNCTION_SCHEM");
+
+                    // Validate function name
+                    assertTrue(functionName.equals(func1 + ";0") || functionName.equals(func2 + ";0"),
+                            "Unexpected function name: " + functionName);
+
+                    // Validate schema name
+                    assertEquals(schemaName, schema, "Schema name does not match");
+
+                    count++;
+                }
+
+                assertEquals(2, count, "Unexpected number of functions found");
+            }
+        } finally {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropFunctionWithSchemaIfExists(schemaName + "." + func1, stmt);
+                TestUtils.dropFunctionWithSchemaIfExists(schemaName + "." + func2, stmt);
+
+                TestUtils.dropSchemaIfExists(schemaName, stmt);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Description

- getFunctions() and getProcedures() internally call sp_stored_procedures, which always returns the object type as 2 and the object name as a numbered procedure.
- Similarly, getFunctionColumns() and getProcedureColumns() rely on sp_sproc_columns, which also returns numbered procedures.

This behavior is consistent with how the server returns the values.

## Testing
Added test scenarios for the above APIs to validate and cover the expected results