### PR TITLE
Fix Byte Buddy dependency scope for unit testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy</artifactId>
 			<version>1.15.11</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
**Issue**
One of the recently added testing dependencies (Byte Buddy 1.15.11) was left with the default compile scope instead of <scope>test</scope>. This resulted in the ~8.1 MB jar being included in runtime artifacts.

**Resolution**
Updated the POM to set the scope to test for the missed dependency.

**Validation:**
- `mvn dependency:tree` now shows Byte Buddy only under `test` scope
