### PR TITLE
Backport : Enable vector test to run only in AzureDB

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/VectorUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/VectorUtils.java
@@ -56,7 +56,7 @@ class VectorUtils {
 
         ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
 
-        buffer.position(getHeaderLength()); // Skip the first 8 bytes (header)
+        ((java.nio.Buffer) buffer).position(getHeaderLength()); // Skip the first 8 bytes (header)
 
         for (int i = 0; i < objectCount; i++) {
             objectArray[i] = buffer.getFloat();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/VectorUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/VectorUtils.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.sqlserver.jdbc;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.text.MessageFormat;
@@ -56,7 +57,12 @@ class VectorUtils {
 
         ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
 
-        ((java.nio.Buffer) buffer).position(getHeaderLength()); // Skip the first 8 bytes (header)
+        /*
+         * The cast is required for JDK 8 compatibility.
+         * JDK 8 calls method Buffer.position(I)LBuffer,
+         * while in JDK 9+ calls method ByteBuffer.position(I)LByteBuffer
+         */
+        ((Buffer) buffer).position(getHeaderLength()); // Skip the first 8 bytes (header)
 
         for (int i = 0; i < objectCount; i++) {
             objectArray[i] = buffer.getFloat();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -44,12 +44,12 @@ import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.DBConnection;
 import com.microsoft.sqlserver.testframework.DBResultSet;
 import com.microsoft.sqlserver.testframework.DBStatement;
 import com.microsoft.sqlserver.testframework.DBTable;
-import com.microsoft.sqlserver.testframework.VectorTag;
 import com.microsoft.sqlserver.testframework.sqlType.SqlType;
 
 import microsoft.sql.Vector;
@@ -621,7 +621,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      * BulkCopyCSVTestInputWithVector.csv file
      */
     @Test
-    @VectorTag
+    @AzureDB
     public void testBulkCopyVectorFromCSV() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFile;
@@ -698,7 +698,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      * BulkCopyCSVTestInputWithMultipleVectorColumn.csv file
      */
     @Test
-    @VectorTag
+    @AzureDB
     public void testBulkCopyVectorFromCSVWithMultipleColumns() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFileWithMultipleColumn;
@@ -765,7 +765,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      * BulkCopyCSVTestWithMultipleVectorColumnWithPipeDelimiter.csv file
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorFromCSVWithMultipleColumnsWithPipeDelimiter() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFileWithMultipleColumnWithPipeDelimiter;
@@ -832,7 +832,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      * metadata.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorFromCSVWithIncorrectDimension() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFile;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -49,6 +49,7 @@ import com.microsoft.sqlserver.testframework.DBConnection;
 import com.microsoft.sqlserver.testframework.DBResultSet;
 import com.microsoft.sqlserver.testframework.DBStatement;
 import com.microsoft.sqlserver.testframework.DBTable;
+import com.microsoft.sqlserver.testframework.VectorTag;
 import com.microsoft.sqlserver.testframework.sqlType.SqlType;
 
 import microsoft.sql.Vector;
@@ -620,7 +621,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      * BulkCopyCSVTestInputWithVector.csv file
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @VectorTag
     public void testBulkCopyVectorFromCSV() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFile;
@@ -697,7 +698,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      * BulkCopyCSVTestInputWithMultipleVectorColumn.csv file
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @VectorTag
     public void testBulkCopyVectorFromCSVWithMultipleColumns() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFileWithMultipleColumn;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -622,6 +622,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorFromCSV() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFile;
@@ -699,6 +700,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorFromCSVWithMultipleColumns() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFileWithMultipleColumn;
@@ -766,6 +768,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorFromCSVWithMultipleColumnsWithPipeDelimiter() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFileWithMultipleColumnWithPipeDelimiter;
@@ -833,6 +836,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorFromCSVWithIncorrectDimension() throws SQLException {
         String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"));
         String fileName = filePath + vectorInputCsvFile;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
@@ -42,6 +42,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.DBConnection;
 import com.microsoft.sqlserver.testframework.DBStatement;
@@ -161,7 +162,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with a single Vector row.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVector() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -586,7 +587,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * to destination table with VECTOR column.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyTableToTableJsonToVector() throws Exception {
         String srcTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testSrcJsonTable"));
         String dstTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testDstVectorTable"));
@@ -661,7 +662,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with null Vector data.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorNull() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -708,7 +709,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * incompatible with vector".
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorUsingBulkCopySourceAsVarBinary() {
         String varbinaryTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVarbinaryTable"));
@@ -769,7 +770,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * incompatible with varbinary(max)".
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorUsingBulkCopyDestinationAsVarBinary() {
         String vectorTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVectorTable"));
         String varbinaryTable = TestUtils
@@ -836,7 +837,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * The operation should succeed, and the data should be validated.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorUsingBulkCopySourceAsVarchar() {
         String varcharTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVarcharTable"));
         String vectorTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVectorTable"));
@@ -903,7 +904,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * The operation should succeed, and the data should be validated.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorUsingBulkCopyDestinationAsVarchar() {
         String vectorTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVectorTable"));
         String varcharTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVarcharTable"));
@@ -973,7 +974,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * The operation should fail with an error: "The vector dimensions 3 and 4 do not match."
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyVectorWithMismatchedDimensions() {
         String srcTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testSrcTable"));
         String desTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testDesTable"));
@@ -1031,7 +1032,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with a large number of records to check performance.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testBulkCopyPerformance() throws SQLException {
         String tableName = AbstractSQLGenerator.escapeIdentifier("srcTable");
         // For testing, we can use a smaller set of records to avoid long execution time

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
@@ -163,6 +163,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVector() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -588,6 +589,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyTableToTableJsonToVector() throws Exception {
         String srcTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testSrcJsonTable"));
         String dstTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testDstVectorTable"));
@@ -663,6 +665,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorNull() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -710,6 +713,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorUsingBulkCopySourceAsVarBinary() {
         String varbinaryTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVarbinaryTable"));
@@ -771,6 +775,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorUsingBulkCopyDestinationAsVarBinary() {
         String vectorTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVectorTable"));
         String varbinaryTable = TestUtils
@@ -838,6 +843,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorUsingBulkCopySourceAsVarchar() {
         String varcharTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVarcharTable"));
         String vectorTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVectorTable"));
@@ -905,6 +911,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorUsingBulkCopyDestinationAsVarchar() {
         String vectorTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVectorTable"));
         String varcharTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testVarcharTable"));
@@ -975,6 +982,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyVectorWithMismatchedDimensions() {
         String srcTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testSrcTable"));
         String desTable = TestUtils.escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier("testDesTable"));
@@ -1033,6 +1041,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testBulkCopyPerformance() throws SQLException {
         String tableName = AbstractSQLGenerator.escapeIdentifier("srcTable");
         // For testing, we can use a smaller set of records to avoid long execution time

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -56,6 +56,7 @@ import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
@@ -1091,7 +1092,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testVectorMetaData() throws SQLException {
         String vectorTableName = RandomUtil.getIdentifier("vectorTable");
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1093,6 +1093,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testVectorMetaData() throws SQLException {
         String vectorTableName = RandomUtil.getIdentifier("vectorTable");
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
@@ -29,7 +29,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
-import com.microsoft.sqlserver.testframework.VectorTag;
+import com.microsoft.sqlserver.testframework.AzureDB;
 
 import microsoft.sql.Vector;
 import microsoft.sql.Vector.VectorDimensionType;
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test Vector Data Type")
-@VectorTag
+@AzureDB
 public class VectorTest extends AbstractTest {
 
     private static final String tableName = RandomUtil.getIdentifier("VECTOR_Test");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
@@ -16,6 +16,7 @@ import java.sql.Statement;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -30,6 +31,7 @@ import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.AzureDB;
+import com.microsoft.sqlserver.testframework.Constants;
 
 import microsoft.sql.Vector;
 import microsoft.sql.Vector.VectorDimensionType;
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test Vector Data Type")
 @AzureDB
+@Tag(Constants.vectorTest)
 public class VectorTest extends AbstractTest {
 
     private static final String tableName = RandomUtil.getIdentifier("VECTOR_Test");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
@@ -16,7 +16,6 @@ import java.sql.Statement;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -30,7 +29,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
-import com.microsoft.sqlserver.testframework.Constants;
+import com.microsoft.sqlserver.testframework.VectorTag;
 
 import microsoft.sql.Vector;
 import microsoft.sql.Vector.VectorDimensionType;
@@ -45,13 +44,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test Vector Data Type")
-@Tag(Constants.xSQLv11)
-@Tag(Constants.xSQLv12)
-@Tag(Constants.xSQLv14)
-@Tag(Constants.xSQLv15)
-@Tag(Constants.xSQLv16)
-@Tag(Constants.xAzureSQLDW)
-@Tag(Constants.xAzureSQLMI)
+@VectorTag
 public class VectorTest extends AbstractTest {
 
     private static final String tableName = RandomUtil.getIdentifier("VECTOR_Test");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/VectorTest.java
@@ -45,7 +45,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test Vector Data Type")
-@Tag(Constants.vectorTest)
+@Tag(Constants.xSQLv11)
+@Tag(Constants.xSQLv12)
+@Tag(Constants.xSQLv14)
+@Tag(Constants.xSQLv15)
+@Tag(Constants.xSQLv16)
+@Tag(Constants.xAzureSQLDW)
+@Tag(Constants.xAzureSQLMI)
 public class VectorTest extends AbstractTest {
 
     private static final String tableName = RandomUtil.getIdentifier("VECTOR_Test");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -54,6 +54,7 @@ import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.PrepUtil;
 
@@ -1266,7 +1267,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      * Test inserting vector data using prepared statement with bulk copy enabled.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testInsertVectorWithBulkCopy() throws Exception {
         String tableName = RandomUtil.getIdentifier("BulkCopyVectorTest");
         String sqlString = "insert into " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (vectorCol) values (?)";
@@ -1304,7 +1305,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      * Test inserting null vector data using prepared statement with bulk copy enabled.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testInsertNullVectorWithBulkCopy() throws Exception {
         String tableName = RandomUtil.getIdentifier("BulkCopyVectorTest");
         String sqlString = "insert into " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (vectorCol) values (?)";
@@ -1343,7 +1344,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      * Test inserting vector data using prepared statement with bulk copy enabled for performance.
      */
     @Test
-    @Tag(Constants.vectorTest)
+    @AzureDB
     public void testInsertWithBulkCopyPerformance() throws SQLException {
         String tableName = AbstractSQLGenerator.escapeIdentifier("BulkCopyVectorPerformanceTest");
         // For testing, we can use a smaller set of records to avoid long execution time

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -1268,6 +1268,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testInsertVectorWithBulkCopy() throws Exception {
         String tableName = RandomUtil.getIdentifier("BulkCopyVectorTest");
         String sqlString = "insert into " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (vectorCol) values (?)";
@@ -1306,6 +1307,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testInsertNullVectorWithBulkCopy() throws Exception {
         String tableName = RandomUtil.getIdentifier("BulkCopyVectorTest");
         String sqlString = "insert into " + AbstractSQLGenerator.escapeIdentifier(tableName) + " (vectorCol) values (?)";
@@ -1345,6 +1347,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      */
     @Test
     @AzureDB
+    @Tag(Constants.vectorTest)
     public void testInsertWithBulkCopyPerformance() throws SQLException {
         String tableName = AbstractSQLGenerator.escapeIdentifier("BulkCopyVectorPerformanceTest");
         // For testing, we can use a smaller set of records to avoid long execution time

--- a/src/test/java/com/microsoft/sqlserver/testframework/AzureDB.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/AzureDB.java
@@ -1,3 +1,8 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+
 package com.microsoft.sqlserver.testframework;
 
 import java.lang.annotation.ElementType;
@@ -7,6 +12,9 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Tag;
 
+/*
+ * Custom annotation to run tests only on Azure DBs
+ */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Tag(Constants.xSQLv11)
@@ -16,4 +24,4 @@ import org.junit.jupiter.api.Tag;
 @Tag(Constants.xSQLv16)
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLMI)
-public @interface VectorTag {}
+public @interface AzureDB {}

--- a/src/test/java/com/microsoft/sqlserver/testframework/VectorTag.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/VectorTag.java
@@ -1,0 +1,19 @@
+package com.microsoft.sqlserver.testframework;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(Constants.xSQLv11)
+@Tag(Constants.xSQLv12)
+@Tag(Constants.xSQLv14)
+@Tag(Constants.xSQLv15)
+@Tag(Constants.xSQLv16)
+@Tag(Constants.xAzureSQLDW)
+@Tag(Constants.xAzureSQLMI)
+public @interface VectorTag {}


### PR DESCRIPTION
Backported PR: https://github.com/microsoft/mssql-jdbc/pull/2749
## Description
This PR introduces support for running vector tests exclusively on AzureDB, where vector functionality is available. Key changes include:

- Vector Support in AzureDB: Tests for vector features are enabled only when running against AzureDB, ensuring compatibility and reducing noise on unsupported platforms.
- Custom JUnit Annotation: Added a custom JUnit annotation to selectively run relevant tests in AzureDB environments.
These changes help streamline the test suite and maintain focus on supported scenarios.