### PR TITLE
Backport: Fix PreparedStatement getGeneratedKeys() returning "statement must be executed" error when triggers are present

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -792,11 +792,14 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      * Override TDS token processing behavior for PreparedStatement.
      * For regular Statement, the execute API for INSERT requires reading an additional explicit 
      * TDS_DONE token that contains the actual update count returned by the server.
-     * PreparedStatement does not require this additional token processing.
+     * PreparedStatement does not require this additional token processing, unless
+     * generated keys were requested (which requires processing additional TDS tokens).
      */
     @Override
     protected boolean hasUpdateCountTDSTokenForInsertCmd() {
-        return false;
+        // When generated keys are requested, we need to process additional TDS tokens
+        // to properly locate the ResultSet containing the generated keys
+        return bRequestedGeneratedKeys;
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -2798,6 +2798,31 @@ public class StatementTest extends AbstractTest {
         }
 
         /**
+         * Tests execute using PreparedStatement for Insert followed by getGenerateKeys
+         *
+         * @throws Exception
+         */
+        @Test
+        public void testPrepStmtExecuteInsertAndGenKeys() {
+            try (Connection con = getConnection()) {
+                String sql = "INSERT INTO " + tableName + " (NAME) VALUES('test');";
+                try(PreparedStatement stmt = con.prepareStatement(sql,PreparedStatement.RETURN_GENERATED_KEYS)) {
+                    stmt.execute();
+                    int updateCount = stmt.getUpdateCount();
+                    assertEquals(updateCount, 1, "updateCount should have been 1, but received : " + updateCount);
+                    try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                        if (generatedKeys.next()) {
+                            int id = generatedKeys.getInt(1);
+                            assertEquals(id, 4, "id should have been 4, but received : " + id);
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                fail(TestResource.getResource("R_unexpectedException") + e.getMessage());
+            }
+        }
+
+        /**
          * Tests executeUpdate using PreparedStatement for Insert followed by getGenerateKeys
          *
          * @throws Exception
@@ -3321,6 +3346,62 @@ public class StatementTest extends AbstractTest {
                         retval = ps.getMoreResults();
                     } while (true);
                 }
+            }
+        }
+
+        /**
+         * Tests PreparedStatement with triggers and generated keys to validate PR #2742 fix.
+         * This test validates that both update counts work correctly AND getGeneratedKeys() 
+         * works when triggers are involved.
+         *
+         * @throws SQLException
+         */
+        @Test
+        public void testPreparedStatementWithTriggersAndGeneratedKeys() throws SQLException {
+            // Create separate test tables to avoid conflicts with existing setup
+            String testTableA = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("TriggerTestTableA"));
+            String testTableB = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("TriggerTestTableB"));
+            String testTrigger = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("TriggerTestTrigger"));
+
+            try (Connection conn = getConnection();
+                 Statement stmt = conn.createStatement()) {
+
+                // Cleanup any existing objects
+                TestUtils.dropTriggerIfExists(testTrigger, stmt);
+                TestUtils.dropTableIfExists(testTableB, stmt);
+                TestUtils.dropTableIfExists(testTableA, stmt);
+
+                // Create schema
+                stmt.executeUpdate("CREATE TABLE " + testTableA + " (ID int NOT NULL IDENTITY(1,1) PRIMARY KEY, NAME varchar(32))");
+                stmt.executeUpdate("CREATE TABLE " + testTableB + " (ID int NOT NULL IDENTITY(1,1) PRIMARY KEY)");
+                stmt.executeUpdate("CREATE TRIGGER " + testTrigger + " ON " + testTableA + " FOR INSERT AS "
+                        + "INSERT INTO " + testTableB + " DEFAULT VALUES");
+
+                // Insert row into TABLE_A requesting generated keys
+                String sql = "INSERT INTO " + testTableA + " (NAME) VALUES (?)";
+                try (PreparedStatement ps = conn.prepareStatement(sql, new String[]{"ID"})) {
+                    ps.setString(1, "test");
+
+                    // Execute the insert + trigger
+                    ps.execute();
+
+                    // Validate update count is correct (should be 1 for the INSERT)
+                    int updateCount = ps.getUpdateCount();
+                    assertEquals(1, updateCount, "Update count should be 1 for single INSERT");
+
+                    // Validate generated keys can be retrieved (this was broken before the fix)
+                    try (ResultSet rs = ps.getGeneratedKeys()) {
+                        assertTrue(rs.next(), "Generated keys ResultSet should have at least one row");
+                        int generatedKey = rs.getInt(1);
+                        assertTrue(generatedKey > 0, "Generated key should be a positive integer, got: " + generatedKey);
+                    }
+                }
+
+                // Cleanup
+                TestUtils.dropTriggerIfExists(testTrigger, stmt);
+                TestUtils.dropTableIfExists(testTableB, stmt);
+                TestUtils.dropTableIfExists(testTableA, stmt);
+
             }
         }
 


### PR DESCRIPTION
**Overview**
This PR backports the fix from [#2742](https://github.com/microsoft/mssql-jdbc/pull/2742) into the release/13.2 branch.

**Problem:**
- PreparedStatement.getGeneratedKeys() was failing with "The statement must be executed before any results can be obtained" when INSERT statements had triggers

**Root Cause:**
- PR [#2737](https://github.com/microsoft/mssql-jdbc/pull/2737) correctly made SQLServerPreparedStatement.hasUpdateCountTDSTokenForInsertCmd() return false to fix update count issues for multi-statement queries
- However, this change did not account for the generated keys use case where bRequestedGeneratedKeys is true
- When hasUpdateCountTDSTokenForInsertCmd() returns false for PreparedStatement, it affects the TDS token processing in such a way that the generated keys ResultSet is not properly consumed or made available
- When triggers fire and generated keys are requested, additional TDS tokens must be processed to locate the ResultSet containing the generated keys

**Solution:**
- Modified hasUpdateCountTDSTokenForInsertCmd() to return true when generated keys are requested (bRequestedGeneratedKeys = true)
- This maintains the correct update count behavior for multi-statement queries while preserving generated keys functionality
- The conditional approach ensures both scenarios work correctly without breaking existing functionality

**Testing:**
- Validates both update count accuracy and generated keys retrieval work correctly with triggers
- Ensures multi-statement PreparedStatement queries still return correct update counts