### PR TITLE
Backport: Enable JSON tests to run on Azure SQL Database (#2756)

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -464,6 +464,7 @@ public class BulkCopyCSVTest extends AbstractTest {
      * It verifies that the data is copied correctly by comparing the values in the table with the expected values.
      */
     @Test
+    @AzureDB
     @DisplayName("Test Bulk Copy with JSON Data")
     @Tag(Constants.JSONTest)
     public void testBulkCopyWithJson() throws Exception {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
@@ -201,6 +201,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with a single JSON row.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyJSON() throws SQLException {
         String dstTable = TestUtils
@@ -235,6 +236,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with empty JSON document
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyWithEmptyJsonDocument() throws SQLException {
         String dstTable = TestUtils
@@ -274,6 +276,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * and compared using getString(columnIndex)
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyMultipleJsonRowsWithDifferentStructures() throws SQLException {
         String dstTable = TestUtils
@@ -316,6 +319,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with multiple JSON rows.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyMultipleJsonRows() throws SQLException {
         String dstTable = TestUtils
@@ -358,6 +362,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with multiple JSON rows and columns.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyMultipleJsonRowsAndColumns() throws SQLException {
         String dstTable = TestUtils
@@ -400,6 +405,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with sendStringParametersAsUnicode set to true and false for JSON column.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyWithSendStringParametersAsUnicode() throws SQLException {
         // Unicode scenario
@@ -459,6 +465,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with nested JSON documents.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyNestedJsonRows() throws SQLException {
         String dstTable = TestUtils
@@ -501,6 +508,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with various data types in JSON.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyWithVariousDataTypes() throws SQLException {
         String dstTable = TestUtils
@@ -539,6 +547,7 @@ public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
      * Test bulk copy with count verification.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testBulkCopyWithCountVerification() throws SQLException {
         String dstTable = TestUtils

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -38,6 +38,7 @@ import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
@@ -610,6 +611,7 @@ public class CallableStatementTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
 	public void testJSONColumnInTableWithSetObject() throws SQLException {
 
@@ -631,6 +633,7 @@ public class CallableStatementTest extends AbstractTest {
 	}
 
 	@Test
+    @AzureDB
     @Tag(Constants.JSONTest)
 	public void testJSONProcedureWithSetObject() throws SQLException {
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -1160,6 +1160,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testJSONMetaData() throws SQLException {
         String jsonTableName = RandomUtil.getIdentifier("try_SQLJSON_Table");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/JSONFunctionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/JSONFunctionTest.java
@@ -41,10 +41,12 @@ import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test Json Functions")
+@AzureDB
 @Tag(Constants.JSONTest)
 public class JSONFunctionTest extends AbstractTest {
 
@@ -61,7 +63,6 @@ public class JSONFunctionTest extends AbstractTest {
      * ISJSON -> Tests whether a string contains valid JSON.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testISJSON() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -98,7 +99,6 @@ public class JSONFunctionTest extends AbstractTest {
      * ISJSON -> Tests whether a string contains valid JSON.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testISJSONWithVariousInputs() throws SQLException {
         String dstTable = TestUtils
             .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -149,7 +149,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["value1",123]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayWithoutNulls() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -182,7 +181,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["value1",123,null,"value2"]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayWithNulls() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -216,7 +214,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["a",{"name":"value","type":1},[1,null,2]]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayWithMixedElements() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -249,7 +246,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: [1,"<GUID>","<SPID>"]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayWithVariablesAndExpressions() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -288,7 +284,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["<host_name>","<program_name>","<client_interface_name>"]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayPerRow() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -329,7 +324,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["<value1>","<value2>"]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayAgg() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -365,7 +359,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["c","b","a"]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayAggWithThreeElements() throws SQLException {
         String select = "SELECT JSON_ARRAYAGG(c1) AS jsonArrayAgg FROM (VALUES ('c'), ('b'), ('a')) AS t(c1)";
         try (Connection conn = DriverManager.getConnection(connectionString);
@@ -384,7 +377,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["a","b","c"]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayAggWithOrderedElements() throws SQLException {
         String select = "SELECT JSON_ARRAYAGG(c1 ORDER BY c1) AS jsonArrayAgg FROM (VALUES ('c'), ('b'), ('a')) AS t(c1)";
         try (Connection conn = DriverManager.getConnection(connectionString);
@@ -403,7 +395,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: ["column1","column2"]
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONArrayAggWithTwoColumns() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -455,7 +446,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"key":"value2"}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONModify() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -534,7 +524,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"name":"Mike","skills":["C#","SQL","Azure"],"surname":"Smith"}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONModifyMultipleUpdates() throws SQLException {
         String json = "{\"name\":\"John\",\"skills\":[\"C#\",\"SQL\"]}";
         String expectedJson = "{\"name\":\"Mike\",\"skills\":[\"C#\",\"SQL\",\"Azure\"],\"surname\":\"Smith\"}";
@@ -560,7 +549,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"Price":49.99}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONModifyRenameKey() throws SQLException {
         String json = "{\"price\":49.99}";
         String expectedJson = "{\"Price\":49.99}";
@@ -586,7 +574,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"click_count":174}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONModifyIncrementValue() throws SQLException {
         String json = "{\"click_count\":173}";
         String expectedJson = "{\"click_count\":174}";
@@ -611,7 +598,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"info":{"address":{"town":"London"}}}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONModifyUpdateJsonColumn() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -650,7 +636,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONObjectEmpty() throws SQLException {
         String select = "SELECT JSON_OBJECT() AS jsonObject";
         try (Connection conn = DriverManager.getConnection(connectionString);
@@ -669,7 +654,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"name":"value"}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONObjectWithMultipleKeys() throws SQLException {
         String select = "SELECT JSON_OBJECT('name':'value', 'type':NULL ABSENT ON NULL) AS jsonObject";
         try (Connection conn = DriverManager.getConnection(connectionString);
@@ -688,7 +672,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"name":"value","type":[1,2]}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONObjectWithJsonArray() throws SQLException {
         String select = "SELECT JSON_OBJECT('name':'value', 'type':JSON_ARRAY(1, 2)) AS jsonObject";
         try (Connection conn = DriverManager.getConnection(connectionString);
@@ -708,7 +691,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"name":"value","type":{"type_id":1,"name":"a"}}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONObjectWithNestedJsonObject() throws SQLException {
         String select = "SELECT JSON_OBJECT('name':'value', 'type':JSON_OBJECT('type_id':1, 'name':'a')) AS jsonObject";
         try (Connection conn = DriverManager.getConnection(connectionString);
@@ -728,7 +710,6 @@ public class JSONFunctionTest extends AbstractTest {
      * {"security_id":"<security_id>","login":"<login_name>","status":"<status>"}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONObjectPerRow() throws SQLException {
         String select = "SELECT s.session_id, JSON_OBJECT('security_id':s.security_id, 'login':s.login_name, 'status':s.status) AS info "
                 +
@@ -755,7 +736,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"key1":"c","key2":"b","key3":"a"}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONObjectAggWithThreeProperties() throws SQLException {
         String select = "SELECT JSON_OBJECTAGG(c1:c2) AS jsonObjectAgg FROM (VALUES('key1', 'c'), ('key2', 'b'), ('key3','a')) AS t(c1, c2)";
         try (Connection conn = DriverManager.getConnection(connectionString);
@@ -777,7 +757,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: {"column1":1,"column2":2}
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONObjectAggWithColumnNamesAndIDs() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -829,7 +808,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: 1
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONPathExistsTrue() throws SQLException {
         String jsonInfo = "{\"info\":{\"address\":[{\"town\":\"Paris\"},{\"town\":\"London\"}]}}";
         String select = "DECLARE @jsonInfo AS JSON = N'" + jsonInfo + "'; " +
@@ -851,7 +829,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: 0
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONPathExistsFalse() throws SQLException {
         String jsonInfo = "{\"info\":{\"address\":[{\"town\":\"Paris\"},{\"town\":\"London\"}]}}";
         String select = "DECLARE @jsonInfo AS JSON = N'" + jsonInfo + "'; " +
@@ -872,7 +849,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: JSON fragment of OtherLanguages
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONQueryFragment() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -919,7 +895,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: JSON fragments in the output of the FOR JSON clause
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONQueryForJSONClause() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -969,7 +944,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: JSON property value of town
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONValueInQueryResults() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1018,7 +992,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: JSON property value of longitude
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONValueComputedColumns() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1069,7 +1042,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: Parsed JSON data
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testOpenJsonParseJson() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1109,7 +1081,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: Parsed nested JSON data
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testOpenJsonParseNestedJson() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1149,7 +1120,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: Parsed JSON array data
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testOpenJsonParseArray() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1190,7 +1160,6 @@ public class JSONFunctionTest extends AbstractTest {
      * until all sessions using them close.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJsonInsertionInGlobalTempTable() throws SQLException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("##TempJson")));
@@ -1233,7 +1202,6 @@ public class JSONFunctionTest extends AbstractTest {
      * automatically when the session ends.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJsonInsertionInLocalTempTable() throws SQLException {
         try (Connection conn = getConnection()) {
             String dstTable = TestUtils
@@ -1271,7 +1239,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: A new table `TargetJsonTable` with copied JSON data.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testSelectIntoWithJsonType() throws SQLException {
         String sourceTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("SourceJsonTable")));
@@ -1330,7 +1297,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: Joined data with extracted JSON fields.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJoinQueryWithJsonType() throws SQLException {
         String usersTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("UsersTable")));
@@ -1409,7 +1375,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: Extracted JSON age field in various queries.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJsonInputOutputWithUdf() throws SQLException {
         String personsTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("Persons")));
@@ -1488,7 +1453,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: JSON object with id and name fields.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testUdfReturningJson() throws SQLException {
         String personsTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("Persons")));
@@ -1548,7 +1512,6 @@ public class JSONFunctionTest extends AbstractTest {
      * And verify there is no data loss.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testInsert1GBJson() throws SQLException, IOException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1635,7 +1598,6 @@ public class JSONFunctionTest extends AbstractTest {
      * Note: This test took around 4 mins to run
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testInsertHugeJsonData() throws SQLException, IOException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1691,7 +1653,6 @@ public class JSONFunctionTest extends AbstractTest {
      * Expected error -> org.opentest4j.AssertionFailedError: Test failed due to: Attempting to grow LOB beyond maximum allowed size of 216895848447 bytes.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testInsert2GBData() throws SQLException, FileNotFoundException, IOException {
         String dstTable = TestUtils
                 .escapeSingleQuotes(AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable")));
@@ -1742,7 +1703,6 @@ public class JSONFunctionTest extends AbstractTest {
      * output: JSON data returned from the procedure.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJsonStoredProcedureInputOutput() throws SQLException {
         createProcedure();
         String call = "{call " + AbstractSQLGenerator.escapeIdentifier(procedureName) + "(?, ?)}";
@@ -1767,7 +1727,6 @@ public class JSONFunctionTest extends AbstractTest {
      * when the `sendStringParametersAsUnicode` property is set to false or true.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONWithSendStringParameterAsUnicodeFalse() throws SQLException {
         String dstTable = TestUtils.escapeSingleQuotes(
             AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"))
@@ -1804,7 +1763,6 @@ public class JSONFunctionTest extends AbstractTest {
      * when the `sendStringParametersAsUnicode` property is set to true.
      */
     @Test
-    @Tag(Constants.JSONTest)
     public void testJSONWithSendStringParameterAsUnicodeTrue() throws SQLException {
         String dstTable = TestUtils.escapeSingleQuotes(
             AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dstTable"))

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -819,6 +819,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      * Test inserting complex JSON data using prepared statement with bulk copy enabled.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testInsertJsonWithBulkCopy() throws Exception {
         String tableName = RandomUtil.getIdentifier("BulkCopyComplexJsonTest");
@@ -869,6 +870,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
      * Test select, update, create, and delete operations on JSON data and verify at each step.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testCRUDOperationsWithJson() throws Exception {
         String tableName = RandomUtil.getIdentifier("CRUDJsonTest");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -49,6 +49,7 @@ import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 
 @RunWith(JUnitPlatform.class)
@@ -714,6 +715,7 @@ public class ResultSetTest extends AbstractTest {
      * Test casting JSON data and retrieving it as various data types.
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testCastOnJSON() throws SQLException {
         String dstTable = TestUtils
@@ -765,6 +767,7 @@ public class ResultSetTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @AzureDB
     @Tag(Constants.xAzureSQLDW)
     @Tag(Constants.JSONTest)
     public void testJdbc41ResultSetJsonColumn() throws SQLException {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypesTest.java
@@ -34,6 +34,7 @@ import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
@@ -155,6 +156,7 @@ public class TVPTypesTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testJSON() throws SQLException {
         createTables("json");
@@ -386,6 +388,7 @@ public class TVPTypesTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testTVPJSONStoredProcedure() throws SQLException {
         createTables("json");
@@ -759,6 +762,7 @@ public class TVPTypesTest extends AbstractTest {
     }
     
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testJSONTVPCallableAPI() throws SQLException {
         createTables("json");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/RegressionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/RegressionTest.java
@@ -27,6 +27,7 @@ import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
@@ -244,6 +245,7 @@ public class RegressionTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @AzureDB
     @Tag(Constants.JSONTest)
     public void testJsonQuery() throws SQLException {
         try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {


### PR DESCRIPTION
**Overview**
This PR backports the fix from #2756 into the release/13.2 branch.

**Key changes include:**

- JSON Support in AzureDB: Tests for JSON features are enabled only when running against AzureDB, ensuring compatibility and reducing noise on unsupported platforms.

These changes help streamline the test suite and maintain focus on supported scenarios.