### PR TITLE
Backport: Fix NON_UNIQUE value inconsistency in DatabaseMetaData.getIndexInfo()…

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -271,7 +271,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     private static final String INDEX_INFO_QUERY = "SELECT db_name() AS TABLE_CAT, " +
     "sch.name AS TABLE_SCHEM, " +
     "t.name AS TABLE_NAME, " +
-    "i.is_unique AS NON_UNIQUE, " +
+    "CASE WHEN i.is_unique = 1 THEN 0 ELSE 1 END AS NON_UNIQUE, " +
     "t.name AS INDEX_QUALIFIER, " +
     "i.name AS INDEX_NAME, " +
     "i.type AS TYPE, " +
@@ -295,7 +295,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     private static final String INDEX_INFO_QUERY_DW = "SELECT db_name() AS TABLE_CAT, " +
     "sch.name AS TABLE_SCHEM, " +
     "t.name AS TABLE_NAME, " +
-    "i.is_unique AS NON_UNIQUE, " +
+    "CASE WHEN i.is_unique = 1 THEN 0 ELSE 1 END AS NON_UNIQUE, " +
     "t.name AS INDEX_QUALIFIER, " +
     "i.name AS INDEX_NAME, " +
     "i.type AS TYPE, " +


### PR DESCRIPTION
**Overview**
This PR backports the fix from #2773 into the release/13.2 branch.

## Problem
DatabaseMetaData.getIndexInfo() was returning incorrect NON_UNIQUE values due to inconsistent handling between sp_statistics and sys.indexes result sets.

- **sp_statistics**: NON_UNIQUE with 1 = not unique, 0 = unique
- **sys.indexes**: is_unique with 1 = unique, 0 = not unique

The method was merging results from both sources without properly converting the sys.indexes.is_unique values to the expected JDBC NON_UNIQUE format, causing the same index to appear as both unique and non-unique.

## Solution
- Added proper conversion logic: `CASE WHEN i.is_unique = 1 THEN 0 ELSE 1 END AS NON_UNIQUE`
- Applied consistent NON_UNIQUE value mapping across all index queries
- Ensured compatibility with both regular SQL Server and Azure Synapse Analytics

## Testing
- Verified correct NON_UNIQUE values for unique and non-unique indexes

Closes #2771 