### PR TITLE
Update pom.xml to use Azure Artifacts feed for mssql-jdbc 12.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,30 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<repositories>
+		<repository>
+			<id>central</id>
+			<url>https://sqlclientdrivers.pkgs.visualstudio.com/public/_packaging/mssql-jdbc/maven/v1</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>central</id>
+			<url>https://sqlclientdrivers.pkgs.visualstudio.com/public/_packaging/mssql-jdbc/maven/v1</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 	<profiles>
 		<profile>
 			<id>jre8</id>


### PR DESCRIPTION
This PR is for being compliant with the company's security policies. Msft requires OSS project to pull from a public Azure Artifacts Feed for dependencies.

For open source contributors, you may encounter a 401 error when attempting to download dependencies. In which case, you can wait for a maintainer to update the public Azure Artifact Feed, or you can point the project's pom.xml to maven central instead to get around it.

For maintainers, any time a dependency version is updated, we also need to update the Azure Artifact Feed. Otherwise, public users won't be able to pull the dependency and our internal pipelines would fail.

Maintainers should refer to the internal doc on how to update the public Azure Artifacts Feed.