### PR TITLE
Addressed CVE-2025-59250 and version updates for 10.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [10.2.4] Hotfix & Stable Release
+### Fixed issues
+- **Address a hostname validation vulnerability by securely parsing certificate common names.**
+  **What was fixed**: Secure hostname validation is enforced by replacing the vulnerable CN parsing logic in SQLServerCertificateUtils.java, preventing spoofing attacks.
+  **Who benefits**:  All users of the SQL Server JDBC driver, especially those relying on TLS for secure connections, benefit from improved certificate validation.
+
 ## [10.2.3] HotFix & Stable Release
 ### Fixed issues
 - Fixed incorrect update counts when timeout occurs in batch queries [2024](https://github.com/microsoft/mssql-jdbc/pull/2024)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We're now on the Maven Central Repository. Add the following to your POM file to
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>10.2.2.jre17</version>
+	<version>10.2.4.jre17</version>
 </dependency>
 ```
 The driver can be downloaded from the [Microsoft Download Center](https://go.microsoft.com/fwlink/?linkid=2168495).
@@ -91,7 +91,7 @@ To get the latest preview version of the driver, add the following to your POM f
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>10.2.2.jre17</version>
+	<version>10.2.4.jre17</version>
 </dependency>
 ```
 
@@ -126,7 +126,7 @@ Projects that require either of the two features need to explicitly declare the 
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>10.2.2.jre17</version>
+	<version>10.2.4.jre17</version>
 	<scope>compile</scope>
 </dependency>
 
@@ -144,7 +144,7 @@ Projects that require either of the two features need to explicitly declare the 
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>10.2.2.jre17</version>
+	<version>10.2.4.jre17</version>
 	<scope>compile</scope>
 </dependency>
 
@@ -171,7 +171,7 @@ When setting 'useFmtOnly' property to 'true' for establishing a connection or cr
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>10.2.2.jre17</version>
+	<version>10.2.4.jre17</version>
 </dependency>
 
 <dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@
 
 apply plugin: 'java'
 
-version = '10.2.3'
+version = '10.2.4'
 def jreVersion = ""
 def testOutputDir = file("build/classes/java/test")
 def archivesBaseName = 'mssql-jdbc'

--- a/mssql-jdbc_auth_LICENSE
+++ b/mssql-jdbc_auth_LICENSE
@@ -1,5 +1,5 @@
 MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT JDBC DRIVER 10.2.3 FOR SQL SERVER
+MICROSOFT JDBC DRIVER 10.2.4 FOR SQL SERVER
 
 These license terms are an agreement between you and Microsoft Corporation (or one of its affiliates). They apply to the software named above and any Microsoft services or software updates (except to the extent such services or updates are accompanied by new or additional terms, in which case those different terms apply prospectively and do not alter your or Microsoft’s rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.  BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>10.2.3</version>
+	<version>10.2.4</version>
 	<packaging>jar</packaging>
 
 	<name>Microsoft JDBC Driver for SQL Server</name>

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLJdbcVersion.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLJdbcVersion.java
@@ -8,7 +8,7 @@ package com.microsoft.sqlserver.jdbc;
 final class SQLJdbcVersion {
     static final int major = 10;
     static final int minor = 2;
-    static final int patch = 3;
+    static final int patch = 4;
     static final int build = 0;
     /*
      * Used to load mssql-jdbc_auth DLL.

--- a/src/samples/adaptive/pom.xml
+++ b/src/samples/adaptive/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/alwaysencrypted/pom.xml
+++ b/src/samples/alwaysencrypted/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/azureactivedirectoryauthentication/pom.xml
+++ b/src/samples/azureactivedirectoryauthentication/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/connections/pom.xml
+++ b/src/samples/connections/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/constrained/pom.xml
+++ b/src/samples/constrained/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>10.2.0.jre17</version>
+            <version>10.2.4.jre17</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/src/samples/dataclassification/pom.xml
+++ b/src/samples/dataclassification/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/datatypes/pom.xml
+++ b/src/samples/datatypes/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/resultsets/pom.xml
+++ b/src/samples/resultsets/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/sparse/pom.xml
+++ b/src/samples/sparse/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>10.2.0.jre17</version>
+			<version>10.2.4.jre17</version>
 		</dependency>
 	</dependencies>
 	<profiles>


### PR DESCRIPTION
This PR includes:
- Addressing CVE-2025-59250: JDBC Driver for SQL Server Spoofing Vulnerability: Improper input validation in JDBC Driver for SQL Server allows an unauthorized attacker to perform spoofing over a network.
- Version updates to 10.2.4

## Problem Statement
The MSSQL JDBC driver's SSL certificate validation contains a critical security vulnerability that allows hostname spoofing attacks. The current parseCommonName() method uses unsafe string parsing on the "canonical" format of X.509 Distinguished Names, which can be exploited by malicious certificates.

## Security Impact
An attacker can craft malicious X.509 certificates that bypass hostname validation by embedding fake hostnames within other certificate attributes. This allows man-in-the-middle attacks where:

Attacker presents a certificate with DN like: OU=CN=legitimate-server.com, [CN=attacker.com](http://cn=attacker.com/)
The vulnerable parser incorrectly extracts [legitimate-server.com](http://legitimate-server.com/) instead of the actual CN [attacker.com](http://attacker.com/)
Application accepts the certificate as valid for [legitimate-server.com](http://legitimate-server.com/) when it's actually issued for [attacker.com](http://attacker.com/)
SSL/TLS connection proceeds with compromised security

## Root Cause Analysis
Unsafe String Parsing: Original code used indexOf("cn=") and substring operations on the "canonical" DN format
Format Ambiguities: The "canonical" format lowercases and reverses RDN order, creating parsing ambiguities
Insufficient Validation: No proper escaping/unescaping of DN components
Regex Vulnerabilities: Simple pattern matching vulnerable to DN injection attacks

## Solution
Complete rewrite of CN parsing logic using secure, industry-standard approaches:

## Secure DN Parsing:
Replaced custom string parsing with javax.naming.ldap.LdapName and Rdn classes
Uses RFC2253 format instead of vulnerable "canonical" format
Proper handling of escaped characters and DN structure

## Security Testing:
Added testSecureCNParsing_preventsHostnameSpoofing() test case
Validates fix prevents known attack vectors
Mock certificate testing framework for edge cases