### PR TITLE
Address CVE-2025-59250: Fix spoofing vulnerability in JDBC Driver for SQL Server due to improper input validation and update version to 12.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [12.6.5] Hotfix & Stable Release
+### Fixed issues
+- **Address a hostname validation vulnerability by securely parsing certificate common names.**
+  **What was fixed**: Secure hostname validation is enforced by replacing the vulnerable CN parsing logic in SQLServerCertificateUtils.java, preventing spoofing attacks.
+  **Who benefits**:  All users of the SQL Server JDBC driver, especially those relying on TLS for secure connections, benefit from improved certificate validation.
+
 ## [12.6.4] Hotfix & Stable Release
 ### Fixed issues
 - Reverted "Execute Stored Procedures Directly" feature, as well as subsequent changes related to the feature. [#2500](https://github.com/microsoft/mssql-jdbc/pull/2500)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We're now on the Maven Central Repository. Add the following to your POM file to
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>12.6.4.jre11</version>
+	<version>12.6.5.jre11</version>
 </dependency>
 ```
 The driver can be downloaded from [Microsoft](https://aka.ms/downloadmssqljdbc). For driver version 12.1.0 and greater, please use the jre11 version when using Java 11 or greater, and the jre8 version when using Java 8.
@@ -92,7 +92,7 @@ To get the latest version of the driver, add the following to your POM file:
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>12.6.4.jre11</version>
+	<version>12.6.5.jre11</version>
 </dependency>
 ```
 
@@ -127,7 +127,7 @@ Projects that require either of the two features need to explicitly declare the 
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>12.6.4.jre11</version>
+	<version>12.6.5.jre11</version>
 	<scope>compile</scope>
 </dependency>
 
@@ -145,7 +145,7 @@ Projects that require either of the two features need to explicitly declare the 
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>12.6.4.jre11</version>
+	<version>12.6.5.jre11</version>
 	<scope>compile</scope>
 </dependency>
 
@@ -172,7 +172,7 @@ When setting 'useFmtOnly' property to 'true' for establishing a connection or cr
 <dependency>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>12.6.4.jre11</version>
+	<version>12.6.5.jre11</version>
 </dependency>
 
 <dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@
 
 apply plugin: 'java'
 
-version = '12.6.4'
+version = '12.6.5'
 def releaseExt = ''
 def jreVersion = ""
 def testOutputDir = file("build/classes/java/test")

--- a/mssql-jdbc_auth_LICENSE
+++ b/mssql-jdbc_auth_LICENSE
@@ -1,5 +1,5 @@
 MICROSOFT SOFTWARE LICENSE TERMS
-MICROSOFT JDBC DRIVER 12.6.4 FOR SQL SERVER
+MICROSOFT JDBC DRIVER 12.6.5 FOR SQL SERVER
 
 These license terms are an agreement between you and Microsoft Corporation (or one of its affiliates). They apply to the software named above and any Microsoft services or software updates (except to the extent such services or updates are accompanied by new or additional terms, in which case those different terms apply prospectively and do not alter your or Microsoft’s rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.  BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.sqlserver</groupId>
 	<artifactId>mssql-jdbc</artifactId>
-	<version>12.6.4</version>
+	<version>12.6.5</version>
 	<packaging>jar</packaging>
 	<name>Microsoft JDBC Driver for SQL Server</name>
 	<description>

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLJdbcVersion.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLJdbcVersion.java
@@ -8,7 +8,7 @@ package com.microsoft.sqlserver.jdbc;
 final class SQLJdbcVersion {
     static final int MAJOR = 12;
     static final int MINOR = 6;
-    static final int PATCH = 4;
+    static final int PATCH = 5;
     static final int BUILD = 0;
     /*
      * Used to load mssql-jdbc_auth DLL.

--- a/src/samples/adaptive/pom.xml
+++ b/src/samples/adaptive/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/alwaysencrypted/pom.xml
+++ b/src/samples/alwaysencrypted/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/azureactivedirectoryauthentication/pom.xml
+++ b/src/samples/azureactivedirectoryauthentication/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/connections/pom.xml
+++ b/src/samples/connections/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/constrained/pom.xml
+++ b/src/samples/constrained/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>12.6.3.jre11</version>
+            <version>12.6.5.jre11</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/src/samples/dataclassification/pom.xml
+++ b/src/samples/dataclassification/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/datatypes/pom.xml
+++ b/src/samples/datatypes/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/resultsets/pom.xml
+++ b/src/samples/resultsets/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/samples/sparse/pom.xml
+++ b/src/samples/sparse/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>12.6.3.jre11</version>
+			<version>12.6.5.jre11</version>
 		</dependency>
 	</dependencies>
 	<profiles>


### PR DESCRIPTION
This PR includes:
- Addressing CVE-2025-59250: JDBC Driver for SQL Server Spoofing Vulnerability: Improper input validation in JDBC Driver for SQL Server allows an unauthorized attacker to perform spoofing over a network.
- Version updates to 12.6.5

## Problem Statement
The MSSQL JDBC driver's SSL certificate validation contains a critical security vulnerability that allows hostname spoofing attacks. The current parseCommonName() method uses unsafe string parsing on the "canonical" format of X.509 Distinguished Names, which can be exploited by malicious certificates.

## Security Impact
An attacker can craft malicious X.509 certificates that bypass hostname validation by embedding fake hostnames within other certificate attributes. This allows man-in-the-middle attacks where:

Attacker presents a certificate with DN like: OU=CN=legitimate-server.com, [CN=attacker.com](http://cn=attacker.com/)
The vulnerable parser incorrectly extracts [legitimate-server.com](http://legitimate-server.com/) instead of the actual CN [attacker.com](http://attacker.com/)
Application accepts the certificate as valid for [legitimate-server.com](http://legitimate-server.com/) when it's actually issued for [attacker.com](http://attacker.com/)
SSL/TLS connection proceeds with compromised security

## Root Cause Analysis
Unsafe String Parsing: Original code used indexOf("cn=") and substring operations on the "canonical" DN format
Format Ambiguities: The "canonical" format lowercases and reverses RDN order, creating parsing ambiguities
Insufficient Validation: No proper escaping/unescaping of DN components
Regex Vulnerabilities: Simple pattern matching vulnerable to DN injection attacks

## Solution
Complete rewrite of CN parsing logic using secure, industry-standard approaches:

## Secure DN Parsing:
Replaced custom string parsing with javax.naming.ldap.LdapName and Rdn classes
Uses RFC2253 format instead of vulnerable "canonical" format
Proper handling of escaped characters and DN structure

## Security Testing:
Added testSecureCNParsing_preventsHostnameSpoofing() test case
Validates fix prevents known attack vectors
Mock certificate testing framework for edge cases