### PR TITLE
Add link for CVE-2025-59250 (spoofing vulnerability) in 12.8.2 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [12.8.2] Hotfix & Stable Release
 ### Fixed issues
-- **Address a hostname validation vulnerability by securely parsing certificate common names.**
+- **Address a hostname validation vulnerability by securely parsing certificate common names. [#2804](https://github.com/microsoft/mssql-jdbc/pull/2804)**
   **What was fixed**: Secure hostname validation is enforced by replacing the vulnerable CN parsing logic in SQLServerCertificateUtils.java, preventing spoofing attacks.
   **Who benefits**:  All users of the SQL Server JDBC driver, especially those relying on TLS for secure connections, benefit from improved certificate validation.
 


### PR DESCRIPTION
Add link for CVE-2025-59250 (spoofing vulnerability) in 12.8.2 notes