### PR TITLE
Fixed issue for PreparedStatement INSERT multiple values update count issue with triggers

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -789,20 +789,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     }
 
     /**
-     * Override TDS token processing behavior for PreparedStatement.
-     * For regular Statement, the execute API for INSERT requires reading an additional explicit 
-     * TDS_DONE token that contains the actual update count returned by the server.
-     * PreparedStatement does not require this additional token processing, unless
-     * generated keys were requested (which requires processing additional TDS tokens).
-     */
-    @Override
-    protected boolean hasUpdateCountTDSTokenForInsertCmd() {
-        // When generated keys are requested, we need to process additional TDS tokens
-        // to properly locate the ResultSet containing the generated keys
-        return bRequestedGeneratedKeys;
-    }
-
-    /**
      * Sends the statement parameters by RPC.
      */
     void sendParamsByRPC(TDSWriter tdsWriter, Parameter[] params) throws SQLServerException {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -1602,7 +1602,7 @@ public class SQLServerStatement implements ISQLServerStatement {
                             return false;
 
                         // For Insert operations, check if additional TDS_DONE token processing is required.
-                        if (hasUpdateCountTDSTokenForInsertCmd() && (StreamDone.CMD_INSERT == doneToken.getCurCmd()) && (-1 != doneToken.getUpdateCount())
+                        if ((StreamDone.CMD_INSERT == doneToken.getCurCmd()) && (-1 != doneToken.getUpdateCount())
                                 && EXECUTE == executeMethod) {
                             return true;
                         }
@@ -1843,19 +1843,6 @@ public class SQLServerStatement implements ISQLServerStatement {
         }
 
         return false;
-    }
-
-    /**
-     * Determines whether to continue processing additional TDS_DONE tokens for INSERT statements.
-     * For INSERT operations, regular Statement requires reading an additional TDS_DONE token that contains
-     * the actual update count. This method can be overridden by subclasses to customize 
-     * TDS token processing behavior.
-     * 
-     * @return true to continue processing more tokens to get the actual update count for INSERT operations
-     */
-    protected boolean hasUpdateCountTDSTokenForInsertCmd() {
-        // For Insert, we must fetch additional TDS_DONE token that comes with the actual update count
-        return true;
     }
 
     // --------------------------JDBC 2.0-----------------------------

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -3405,6 +3405,56 @@ public class StatementTest extends AbstractTest {
             }
         }
 
+        /**
+         * Tests PreparedStatement INSERT with multiple values and trigger to validate update count.
+         * Reproduces the scenario where INSERT INTO TABLE (col) VALUES (?), (?) should return 2 but returns 1.
+         * This test validates the fix for TDS token processing with triggers that affect update counts.
+         *
+         * @throws SQLException
+         */
+        @Test
+        public void testPreparedStatementInsertMultipleValuesWithTrigger() throws SQLException {
+            // Create separate test tables to avoid conflicts with existing setup
+            String testTableA = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("UpdateCountTestTableA"));
+            String testTableB = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("UpdateCountTestTableB"));
+            String testTrigger = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("UpdateCountTestTrigger"));
+
+            try (Connection conn = getConnection();
+                 Statement stmt = conn.createStatement()) {
+
+                TestUtils.dropTriggerIfExists(testTrigger, stmt);
+                TestUtils.dropTableIfExists(testTableB, stmt);
+                TestUtils.dropTableIfExists(testTableA, stmt);
+
+                stmt.executeUpdate("CREATE TABLE " + testTableA + " (ID int NOT NULL IDENTITY(1,1) PRIMARY KEY, NAME varchar(32))");
+                stmt.executeUpdate("CREATE TABLE " + testTableB + " (ID int NOT NULL IDENTITY(1,1) PRIMARY KEY)");
+                
+             
+                stmt.executeUpdate("CREATE TRIGGER " + testTrigger + " ON " + testTableA + " FOR INSERT AS "
+                        + "INSERT INTO " + testTableB + " DEFAULT VALUES");
+
+                // Test case: INSERT with multiple values should return correct update count
+                String sql = "INSERT INTO " + testTableA + " (NAME) VALUES (?), (?)";
+                try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                    ps.setString(1, "value1");
+                    ps.setString(2, "value2");
+
+                    boolean hasResultSet = ps.execute();
+                    
+                    if (!hasResultSet) {
+                        int updateCount = ps.getUpdateCount();
+                        // This should return 2 (for 2 inserted rows), not 1
+                        assertEquals(2, updateCount, "Update count should be 2 for INSERT with 2 values, but got: " + updateCount);
+                    } else {
+                        fail("Expected update count, but got ResultSet instead");
+                    }
+                }
+                TestUtils.dropTriggerIfExists(testTrigger, stmt);
+                TestUtils.dropTableIfExists(testTableB, stmt);
+                TestUtils.dropTableIfExists(testTableA, stmt);
+            }
+        }
+
         @AfterEach
         public void terminate() {
             try (Connection con = getConnection(); Statement stmt = con.createStatement()) {


### PR DESCRIPTION
Fixed issue for PreparedStatement INSERT multiple values update count issue with triggers
This pull request refactors how update counts are determined for INSERT statements in the JDBC driver, ensuring more accurate update counts, especially for `PreparedStatement` executions involving triggers and multiple value inserts. It removes the subclass override mechanism for TDS token processing and centralizes the logic. Additionally, a new unit test is added to validate correct behavior with triggers and multiple inserts.

**Refactoring and logic simplification:**

* Removed the `hasUpdateCountTDSTokenForInsertCmd()` method and its overrides from both `SQLServerStatement` and `SQLServerPreparedStatement`, consolidating the logic for handling update counts for INSERT commands. [[1]](diffhunk://#diff-91b3b4c578a0576d9802120b226827a1042390818544fa7ff9d9ef1a537f225eL1848-L1860) [[2]](diffhunk://#diff-5b42c4353c0002cca09a7a3c309a5b13fd543a9fc27bec5a37523d0b86404ce2L791-L804)
* Updated the condition in the TDS_DONE token processing to directly check for INSERT commands and execution method, rather than relying on the now-removed method.

**Testing improvements:**

* Added a new test, `testPreparedStatementInsertMultipleValuesWithTrigger`, to ensure that `PreparedStatement` correctly returns the number of inserted rows when using multiple values and triggers, addressing a prior bug where the update count could be incorrect.