### PR TITLE
Allow minus sign in point wkt

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSpatialDatatype.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSpatialDatatype.java
@@ -1484,7 +1484,8 @@ abstract class SQLServerSpatialDatatype {
 
             while (currentWktPos < wkt.length()
                     && (Character.isDigit(wkt.charAt(currentWktPos)) || wkt.charAt(currentWktPos) == '.'
-                            || wkt.charAt(currentWktPos) == 'E' || wkt.charAt(currentWktPos) == 'e')) {
+                            || wkt.charAt(currentWktPos) == 'E' || wkt.charAt(currentWktPos) == 'e'
+                            || wkt.charAt(currentWktPos) == '-')) {
                 currentWktPos++;
             }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/SQLServerSpatialDatatypeTest.java
@@ -2122,6 +2122,18 @@ public class SQLServerSpatialDatatypeTest extends AbstractTest {
         }
     }
 
+    /**
+     * Tests Geography almost zero coordinates like 0.0001234. The string representation is "1.234E-4", which
+     * caused a bug when creating a Geography object.
+     */
+    @Test
+    public void testGeographySmallCoordinates() throws SQLException {
+        Geography g = Geography.point(0.0001234, 1.234, 4326);
+
+        assertEquals(0.0001234, g.getLatitude());
+        assertEquals(1.234, g.getLongitude());
+    }
+
     private void beforeEachSetup() throws SQLException {
         try (Statement stmt = connection.createStatement()) {
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(geomTableName), stmt);


### PR DESCRIPTION
Very small double values that contain three or more zeros after the dot (like 0.000123) have a string representation of 1.23E-4. The readPointWkt did not account for this and set the end pos to the E, thus the BigDecimal tried to parse "1.23E". This resulted in a NumberFormatException.

This fixes the issue by also allowing the minus sign when determining the end of the number.

Please backport this fix to version 12, thanks!

Fixes #2820