### PR TITLE
Add updated Gradle configuration for JDK 25 support and deprecation fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ if(hasProperty('buildProfile') && buildProfile == "jre8") {
 		sourceCompatibility = JavaVersion.VERSION_1_8
 		targetCompatibility = JavaVersion.VERSION_1_8
 	}
+	
 	test {
 		useJUnitPlatform {
 			excludeTags (hasProperty('excludedGroups') ? excludedGroups : 'xSQLv15','xGradle','NTLM','reqExternalSetup','MSI','clientCertAuth','fedAuth','xJDBC42','vectorTest','JSONTest')


### PR DESCRIPTION
## Overview
The build started failing when running under JDK 25, which automatically triggered an updated Gradle version.
This failure stems from deprecated Gradle APIs and incompatible Java compatibility configuration in the build script.
The error message observed was:
```
FAILURE: Build failed with an exception.
* Where: Build file 'D:\a\_work\1\github\build.gradle' line: 99
* What went wrong:
A problem occurred evaluating root project 'github'.
> Could not set unknown property 'sourceCompatibility' for root project 'github' of type org.gradle.api.Project.
```
Additionally, deprecation warnings were appearing when building with Java 17:
`The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0.`

## Problem Statement
- Deprecated Plugin Syntax: The build script was using the legacy apply plugin: 'java' syntax instead of the modern plugins block
- Incompatible Java Compatibility Settings: Direct assignment of sourceCompatibility and targetCompatibility properties was failing with newer Gradle versions when using JDK 25
- Missing JDK 25 Support: The JavaVersion.VERSION_25 constant may not be available in current Gradle versions
Build Failures: These issues were preventing successful builds in CI/CD environments with newer JDK versions

## Resolution and Fixes
- Modernized Plugin Declaration
```
plugins {
    id 'java'
}
```
- Updated Java Compatibility Configuration for all the jdk version used
```
java {
    sourceCompatibility = JavaVersion.VERSION_11
    targetCompatibility = JavaVersion.VERSION_11
}
```