### PR TITLE
SQL Server integrity enhancement support in supportsIntegrityEnhancementFacility #2745

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -2289,7 +2289,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     @Override
     public boolean supportsIntegrityEnhancementFacility() throws SQLServerException {
         checkClosed();
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
**Problem**:
The DatabaseMetaData.supportsIntegrityEnhancementFacility() method incorrectly returns false for SQL Server databases. This method is part of the JDBC specification and indicates whether the database supports integrity enhancement facilities such as primary key and foreign key constraints. SQL Server has comprehensive support for these integrity features, but the driver was not accurately reporting this capability to applications. This could lead to applications incorrectly assuming that SQL Server lacks integrity constraint support, potentially affecting application logic and database schema decisions.

**Root Cause**:
The supportsIntegrityEnhancementFacility() method in SQLServerDatabaseMetaData.java was hardcoded to return false. This was an incorrect implementation as SQL Server fully supports integrity enhancement facilities including:
Primary key constraints
Foreign key constraints
Check constraints
Unique constraints
NOT NULL constraints

The method implementation did not reflect the actual capabilities of SQL Server, causing a mismatch between the database's features and what the driver reported.

**Solution**:
Updated the supportsIntegrityEnhancementFacility() method in SQLServerDatabaseMetaData.java to return true instead of false. This change aligns the driver's reported capabilities with SQL Server's actual support for integrity enhancement facilities. The fix ensures that applications using this metadata method will receive accurate information about SQL Server's constraint support capabilities.