### PR TITLE
Update Mockito dependencies for different JDK profiles(8,11,17,21,25) compatibility 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,9 +200,20 @@ dependencies {
 			'org.bouncycastle:bcprov-jdk18on:1.79',
 			'com.azure:azure-security-keyvault-keys:4.9.2',
 			'com.azure:azure-identity:1.15.3',
-			'com.h2database:h2:2.2.220',
-			'org.mockito:mockito-core:4.11.0',
-			'org.mockito:mockito-inline:4.11.0',
-			'net.bytebuddy:byte-buddy:1.15.11',
-			'net.bytebuddy:byte-buddy-agent:1.15.11'
+			'com.h2database:h2:2.2.220'
+
+	// Mockito and Byte Buddy dependencies based on JRE version
+	if (hasProperty('buildProfile') && buildProfile == "jre8") {
+		// JRE 8 profile
+		testImplementation 'org.mockito:mockito-core:4.11.0',
+				'org.mockito:mockito-inline:4.11.0',
+				'net.bytebuddy:byte-buddy:1.15.11',
+				'net.bytebuddy:byte-buddy-agent:1.15.11'
+	} else {
+		// JRE 11, 17, 21, 25 profiles (all use same versions)
+		testImplementation 'org.mockito:mockito-core:5.14.2',
+				'net.bytebuddy:byte-buddy:1.17.5',
+				'net.bytebuddy:byte-buddy-agent:1.17.5'
+	}
+
 }


### PR DESCRIPTION
## Overview
Gradle Test job was failing with MockitoException errors when running builds with newer JDK versions (JDK 25). The Gradle build was using a single Mockito version for all JDK profiles, unlike the Maven build which already had profile-specific dependency management.

Below are some Error Examples:
```
SQLServerConnectionTest > testConnectionRecoveryCheckDoesNotThrowWhenRoutingDetailsNotNull() FAILED
    org.mockito.exceptions.base.MockitoException at SQLServerConnectionTest.java:1564
        Caused by: java.lang.IllegalStateException at SQLServerConnectionTest.java:1564
            Caused by: java.lang.IllegalArgumentException at SQLServerConnectionTest.java:1564

TDSTokenHandlerTest > testSeverity20FatalErrorSimulation() FAILED
    org.mockito.exceptions.base.MockitoException at TDSTokenHandlerTest.java:31
        Caused by: java.lang.IllegalStateException at TDSTokenHandlerTest.java:31
```
## Problem Description
- **Single Mockito version for all JDK profiles:** Gradle build used Mockito 4.11.0 for all JDK versions (8, 11, 17, 21, 25)  
- **JDK compatibility issues:** Mockito 4.11.0 is incompatible with Java 25, causing test failures  
- **Inconsistent with pom.xml:** Maven already had profile-specific Mockito versions, but `build.gradle` didn’t follow the same pattern  
- **Pipeline test failures:** Modern JDK builds were failing due to Mockito compatibility issues  

## Resolution Steps
Use below combination of dependency versions with respective JRE profiles:
<html>
<body>

<!--StartFragment-->
<table>
  <tr>
    <th>JDK Profile</th>
    <th>Mockito Core</th>
    <th>Mockito Inline</th>
    <th>Byte Buddy</th>
  </tr>
  <tr>
    <td>JRE 8</td>
    <td>4.11.0</td>
    <td>4.11.0</td>
    <td>1.15.11</td>
  </tr>
  <tr>
    <td>JRE 11</td>
    <td>5.14.2</td>
    <td>❌ (not needed)</td>
    <td>1.17.5</td>
  </tr>
  <tr>
    <td>JRE 17</td>
    <td>5.14.2</td>
    <td>❌ (not needed)</td>
    <td>1.17.5</td>
  </tr>
  <tr>
    <td>JRE 21</td>
    <td>5.14.2</td>
    <td>❌ (not needed)</td>
    <td>1.17.5</td>
  </tr>
  <tr>
    <td>JRE 25</td>
    <td>5.14.2</td>
    <td>❌ (not needed)</td>
    <td>1.17.5</td>
  </tr>
</table>
<!--EndFragment-->

</body>
</html>