### PR TITLE
Expose register/unregister APIs for PerformanceLogger  at the SQLServerDriver level

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -1188,6 +1188,24 @@ public final class SQLServerDriver implements java.sql.Driver {
     }
 
     /**
+     * Registers a global performance log callback.
+     *
+     * @param cb The callback to register.
+     * @throws IllegalStateException if a callback is already registered.
+     */
+    public static synchronized void registerPerformanceLogCallback(PerformanceLogCallback cb) {
+        PerformanceLog.registerCallback(cb);
+    }
+
+    /**
+     * Unregisters the global performance log callback.
+     */
+    public static synchronized void unregisterPerformanceLogCallback() {
+        PerformanceLog.unregisterCallback();
+    }
+
+
+    /**
      * Provides Helper function used to fix the case sensitivity, synonyms and remove unknown tokens from the
      * properties.
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
@@ -74,7 +74,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
             }
         };
 
-        PerformanceLog.registerCallback(callbackInstance);
+        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
 
         try (Connection con = getConnection()) {
             DatabaseMetaData metaData = con.getMetaData();
@@ -87,7 +87,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
         assertTrue(Files.exists(logPath), "performance.log file should exist");
         System.out.println("Log file absolute path: " + logPath.toAbsolutePath());
 
-        PerformanceLog.unregisterCallback();
+        SQLServerDriver.unregisterPerformanceLogCallback();
 
     }
 }


### PR DESCRIPTION
### Overview

This PR exposes new APIs to **register** and **unregister** PerformanceLogger instances at the `SQLServerDriver` level. This change provides more flexible and centralized management of performance logging within the Microsoft JDBC Driver for SQL Server.

### Details

- **Added**: Public `registerPerformanceLogger()` and `unregisterPerformanceLogger()` APIs directly on `SQLServerDriver`.
- **Purpose**: Enables users and integrators to globally register or unregister custom `PerformanceLogger` implementations, streamlining performance logging setup and teardown—especially for driver-wide or application-level scenarios.
- **How it works**:  
  - Developers can now call these APIs on `SQLServerDriver` to register a `PerformanceLogger` once, affecting all relevant connections and operations.

### Example Usage

```java
SQLServerDriver.registerPerformanceLogger(customPerformanceLogger);
// ... driver usage ...
SQLServerDriver.unregisterPerformanceLogger();
```

### Motivation

- Improves API ergonomics by allowing global configuration.
- Eases performance monitoring for enterprise integrations and diagnostics.
