### PR TITLE
Handling proper fallback for SQL functions in bulk copy batch insert operations

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2855,12 +2855,16 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                 continue;
             }
             if (localUserSQL.charAt(0) == ',' || localUserSQL.charAt(0) == ')') {
+
+                if (!"?".equals(sb.toString())) {
+                    // throw IllegalArgumentException and fallback to original logic for batch insert
+                    // Wildcards (?) are the only supported parameters for this functionality
+                    // Does not support functions or literals (e.g. len(), 'string', 1, etc.)
+                    throw new IllegalArgumentException(SQLServerException.getErrString("R_onlyFullParamAllowed"));
+                }
+
                 if (localUserSQL.charAt(0) == ',') {
                     localUserSQL = localUserSQL.substring(1);
-                    if (!"?".equals(sb.toString())) {
-                        // throw IllegalArgumentException and fallback to original logic for batch insert
-                        throw new IllegalArgumentException(SQLServerException.getErrString("R_onlyFullParamAllowed"));
-                    }
                     listOfValues.add(sb.toString());
                     sb.setLength(0);
                 } else {
@@ -2868,6 +2872,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                     listOfValues.add(sb.toString());
                     return listOfValues; // reached exit condition.
                 }
+                
             } else {
                 sb.append(localUserSQL.charAt(0));
                 localUserSQL = localUserSQL.substring(1);


### PR DESCRIPTION
## Description
GitHub issue : [PreparedStatement.executeBatch() fails for VARBINARY function parameters with bulk copy enabled #2825](https://github.com/microsoft/mssql-jdbc/issues/2825)

This PR addresses a critical bug where PreparedStatement.executeBatch() fails when SQL functions are used as parameters in INSERT statements with bulk copy enabled (useBulkCopyForBatchInsert=true). The driver now properly detects incompatible SQL constructs and automatically falls back to standard batch execution.

## Problem
When bulk copy for batch insert is enabled, the driver attempts to process all batch operations through the Bulk Copy API, including those containing SQL functions like len(?), encryptbykey(), or other expressions wrapping parameters. However, as documented in the [Bulk Copy API limitations](https://learn.microsoft.com/en-us/sql/connect/jdbc/use-bulk-copy-api-batch-insert-operation?view=sql-server-ver17#:~:text=Wildcards%20(%3F)%20are%20the%20only%20supported%20parameters%20for%20this%20function.), wildcards (?) are the only supported parameters for this functionality.

This incompatibility resulted in various failures:

- "Parsing user's Batch Insert SQL Query failed: Number of provided columns X does not match the table definition Y"
- Invalid data type conversion errors
- "Unable to retrieve data from the source"
- Complete batch operation failures without proper fallback mechanism

## Fix
Enhanced the fallback detection logic to identify when SQL functions or unsupported expressions are present in parameterized INSERT statements during bulk copy batch operations. When such cases are detected:

- Bulk copy processing is bypassed
- The driver automatically switches to standard PreparedStatement batch execution
- Operations complete successfully without data loss or user intervention

## Testing
- Added comprehensive test in `BatchExecutionWithBulkCopyTest` to validat fallback behavior for SQL function scenarios
- Confirmed no regression for standard bulk copy operations
- Verified proper logging and error messaging during fallback detection

This fix ensures reliable batch operations for all SQL statement types while maintaining optimal performance for compatible bulk copy scenarios.
