### PR TITLE
Account for defaults when normalizing properties

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -1212,7 +1212,7 @@ public final class SQLServerDriver implements java.sql.Driver {
     static Properties fixupProperties(Properties props) throws SQLServerException {
         // assert props !=null
         Properties fixedup = new Properties();
-        Enumeration<?> e = props.keys();
+        Enumeration<?> e = props.propertyNames();
         while (e.hasMoreElements()) {
             String name = (String) e.nextElement();
             String newname = getNormalizedPropertyName(name, drLogger);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerDriverTest.java
@@ -192,6 +192,37 @@ public class SQLServerDriverTest extends AbstractTest {
             }
         }
     }
+
+    /**
+     * test connection properties
+     * 
+     * @throws SQLException
+     */
+    @Test
+    public void testDefaultProperties() throws SQLException {
+        SQLServerDriver d = new SQLServerDriver();
+        Properties defaults = new Properties();
+        defaults.setProperty(SQLServerDriverIntProperty.PORT_NUMBER.toString(), "101");
+        defaults.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), "test");
+
+        Properties info = new Properties(defaults);
+        StringBuffer url = new StringBuffer();
+        url.append(Constants.JDBC_PREFIX).append(randomServer).append(";packetSize=512;");
+
+        // test defaults
+        DriverPropertyInfo[] infoArray = d.getPropertyInfo(url.toString(), info);
+
+        for (DriverPropertyInfo anInfoArray : infoArray) {
+            if (anInfoArray.name.equalsIgnoreCase(Constants.PORT_NUMBER)) {
+                assertTrue(anInfoArray.value.equalsIgnoreCase("101"),
+                        TestResource.getResource("R_valuesAreDifferent"));
+            }
+            if (anInfoArray.name.equalsIgnoreCase(Constants.DATABASE_NAME)) {
+                assertTrue(anInfoArray.value.equalsIgnoreCase("test"),
+                        TestResource.getResource("R_valuesAreDifferent"));
+            }
+        }
+    }
     
     /**
      * test application name


### PR DESCRIPTION
## Problem description
When passing in a Properties object to the SQLServerDriver the supplied properties go through a normalization process. The current normalization (fixupProperties(Properties props)) ignores any default values and only enumerates the explicitly set properties.

### Fixes existing GitHub issue
N/A

## Fix Description
This fix changes the enumeration when normalizing the properties to also account for any default values.

## New Public APIs
N/A
