### PR TITLE
Update bundle-version in manifest file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,9 @@
 		</profile>
 		<profile>
 			<id>jre11</id>
+			<properties>
+				<bundle.version.suffix>${version}.jre11${releaseExt}</bundle.version.suffix>
+			</properties>
 			<dependencies>
 				<!-- JDK 11 compatible Mockito -->
 				<dependency>
@@ -385,6 +388,9 @@
 		</profile>
 		<profile>
 			<id>jre17</id>
+			<properties>
+				<bundle.version.suffix>${version}.jre17${releaseExt}</bundle.version.suffix>
+			</properties>
 			<dependencies>
 				<!-- JDK 17 compatible Mockito -->
 				<dependency>
@@ -439,6 +445,9 @@
 		</profile>
 		<profile>
 			<id>jre21</id>
+			<properties>
+				<bundle.version.suffix>${version}.jre21${releaseExt}</bundle.version.suffix>
+			</properties>
 			<dependencies>
 				<!-- JDK 21 compatible Mockito -->
 				<dependency>
@@ -493,6 +502,9 @@
 		</profile>
 		<profile>
 			<id>jre25</id>
+			<properties>
+				<bundle.version.suffix>${version}.jre25${releaseExt}</bundle.version.suffix>
+			</properties>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>


### PR DESCRIPTION
Description:

This PR addresses the issue described in https://github.com/microsoft/mssql-jdbc/issues/2831 by updating the bundle-version in the manifest file to include the jre11/jre8 suffix to make it look exactly similar to the jar file name.

Testing:
-Manual testing of the driver build.