### PR TITLE
Remove outdated comment about escaping delimiter

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -82,7 +82,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
      * @param encoding
      *        Charset encoding to use for reading the file, or NULL for the default encoding.
      * @param delimiter
-     *        Delimiter to used to separate each column. Regex characters must be escaped with double backslashes.
+     *        Delimiter to used to separate each column.
      * @param firstLineIsColumnNames
      *        True if the first line of the file should be parsed as column names; false otherwise
      * @throws SQLServerException
@@ -131,7 +131,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
      * @param encoding
      *        Charset encoding to use for reading the file, or NULL for the default encoding.
      * @param delimiter
-     *        Delimiter to used to separate each column. Regex characters must be escaped with double backslashes.
+     *        Delimiter to used to separate each column.
      * @param firstLineIsColumnNames
      *        True if the first line of the file should be parsed as column names; false otherwise
      * @throws SQLServerException


### PR DESCRIPTION
Pull request #2795 removed all remaining support for regex delimiters in `SQLServerBulkCSVFileRecord`.

After digging through old versions of the code, it appears that the original support for a regex delimiter was an accidental feature. Even then it might not have worked properly—or it was broken at some point—when `escapeDelimiters` is true and a line contains a double quote. Also, a note about needing to escape regex characters in the delimiter was added to javadoc in #1711 in response to #1691, but this only documented existing (at the time) behavior.

In any case, a delimiter cannot be a regex pattern in the latest version. The delimiter is currently used as literal text.