### PR TITLE
Remove outdated comment about escaping delimiter

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCSVFileRecord.java
@@ -82,7 +82,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
      * @param encoding
      *        Charset encoding to use for reading the file, or NULL for the default encoding.
      * @param delimiter
-     *        Delimiter to used to separate each column. Regex characters must be escaped with double backslashes.
+     *        Delimiter to used to separate each column.
      * @param firstLineIsColumnNames
      *        True if the first line of the file should be parsed as column names; false otherwise
      * @throws SQLServerException
@@ -131,7 +131,7 @@ public class SQLServerBulkCSVFileRecord extends SQLServerBulkRecord implements j
      * @param encoding
      *        Charset encoding to use for reading the file, or NULL for the default encoding.
      * @param delimiter
-     *        Delimiter to used to separate each column. Regex characters must be escaped with double backslashes.
+     *        Delimiter to used to separate each column.
      * @param firstLineIsColumnNames
      *        True if the first line of the file should be parsed as column names; false otherwise
      * @throws SQLServerException


### PR DESCRIPTION
### Description
Pull request https://github.com/microsoft/mssql-jdbc/pull/2795 removed all remaining support for regex delimiters in SQLServerBulkCSVFileRecord.

A review of older versions of the code suggests that regex delimiter support was never an intentional feature. Even when present, it likely did not work correctly—or was broken at some point—particularly when escapeDelimiters is true and the input line contains a double quote.

A note was added to the Javadoc in https://github.com/microsoft/mssql-jdbc/pull/1711 (in response to https://github.com/microsoft/mssql-jdbc/issues/1691) indicating that regex characters in delimiters must be escaped. However, this only documented the behavior at the time and did not establish regex delimiters as a supported feature.

### Fix
Update the description to reflect the current and correct behavior: delimiters in SQLServerBulkCSVFileRecord are treated strictly as literal text. Regex patterns are not supported.