### PR TITLE
[Retire FX] Port functional test scenarios for TVP

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPDataRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPDataRecordTest.java
@@ -53,6 +53,7 @@ import com.microsoft.sqlserver.testframework.Constants;
  */
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.legacyFx)
 public class TVPDataRecordTest extends AbstractTest {
 
     private static String tvpName;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPDataTableBehaviorTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPDataTableBehaviorTest.java
@@ -49,6 +49,7 @@ import com.microsoft.sqlserver.testframework.Constants;
  */
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.legacyFx)
 public class TVPDataTableBehaviorTest extends AbstractTest {
 
     private static String tvpName;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPFuzzTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPFuzzTest.java
@@ -45,6 +45,7 @@ import com.microsoft.sqlserver.testframework.Constants;
  */
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.legacyFx)
 public class TVPFuzzTest extends AbstractTest {
 
     private static String tvpName;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPPrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPPrecisionScaleTest.java
@@ -43,6 +43,7 @@ import microsoft.sql.DateTimeOffset;
  */
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.legacyFx)
 public class TVPPrecisionScaleTest extends AbstractTest {
 
     private static String tvpName;
@@ -168,8 +169,8 @@ public class TVPPrecisionScaleTest extends AbstractTest {
         tvp.addColumnMetadata("decimal4", java.sql.Types.DECIMAL);
         tvp.addColumnMetadata("float1", java.sql.Types.DOUBLE);
         tvp.addColumnMetadata("float2", java.sql.Types.DOUBLE);
-        tvp.addColumnMetadata("real1", java.sql.Types.FLOAT);
-        tvp.addColumnMetadata("real2", java.sql.Types.FLOAT);
+        tvp.addColumnMetadata("real1", java.sql.Types.REAL);
+        tvp.addColumnMetadata("real2", java.sql.Types.REAL);
         tvp.addColumnMetadata("TIME1", java.sql.Types.TIME);
         tvp.addColumnMetadata("TIME2", java.sql.Types.TIME);
         tvp.addColumnMetadata("TIME3", java.sql.Types.TIME);
@@ -571,7 +572,7 @@ public class TVPPrecisionScaleTest extends AbstractTest {
         tvp.addColumnMetadata("n1", java.sql.Types.NUMERIC);
         tvp.addColumnMetadata("d1", java.sql.Types.DECIMAL);
         tvp.addColumnMetadata("f1", java.sql.Types.DOUBLE);
-        tvp.addColumnMetadata("r1", java.sql.Types.FLOAT);
+        tvp.addColumnMetadata("r1", java.sql.Types.REAL);
         tvp.addColumnMetadata("t1", java.sql.Types.TIME);
         tvp.addColumnMetadata("dt1", java.sql.Types.TIMESTAMP);
         tvp.addColumnMetadata("dto1", microsoft.sql.Types.DATETIMEOFFSET);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPSchemaTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPSchemaTest.java
@@ -58,13 +58,13 @@ public class TVPSchemaTest extends AbstractTest {
         final String sql = "{call " + procedureName + "(?)}";
 
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement();
-                SQLServerPreparedStatement P_C_statement = (SQLServerPreparedStatement) conn.prepareStatement(sql);
-                ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                SQLServerPreparedStatement P_C_statement = (SQLServerPreparedStatement) conn.prepareStatement(sql)) {
             P_C_statement.setStructured(1, tvpNameWithSchema, tvp);
             P_C_statement.execute();
 
-            verify(rs);
-
+            try (ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                verify(rs);
+            }
         }
     }
 
@@ -80,12 +80,13 @@ public class TVPSchemaTest extends AbstractTest {
         final String sql = "{call " + procedureName + "(?)}";
 
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement();
-                SQLServerCallableStatement P_C_statement = (SQLServerCallableStatement) conn.prepareCall(sql);
-                ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                SQLServerCallableStatement P_C_statement = (SQLServerCallableStatement) conn.prepareCall(sql)) {
             P_C_statement.setStructured(1, tvpNameWithSchema, tvp);
             P_C_statement.execute();
 
-            verify(rs);
+            try (ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                verify(rs);
+            }
         }
     }
 
@@ -101,12 +102,13 @@ public class TVPSchemaTest extends AbstractTest {
 
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement();
                 SQLServerPreparedStatement P_C_stmt = (SQLServerPreparedStatement) conn
-                        .prepareStatement("INSERT INTO " + charTable + " select * from ? ;");
-                ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                        .prepareStatement("INSERT INTO " + charTable + " select * from ? ;")) {
             P_C_stmt.setStructured(1, tvpNameWithSchema, tvp);
             P_C_stmt.executeUpdate();
 
-            verify(rs);
+            try (ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                verify(rs);
+            }
         }
     }
 
@@ -122,12 +124,13 @@ public class TVPSchemaTest extends AbstractTest {
 
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement();
                 SQLServerCallableStatement P_C_stmt = (SQLServerCallableStatement) conn
-                        .prepareCall("INSERT INTO " + charTable + " select * from ? ;");
-                ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                        .prepareCall("INSERT INTO " + charTable + " select * from ? ;")) {
             P_C_stmt.setStructured(1, tvpNameWithSchema, tvp);
             P_C_stmt.executeUpdate();
 
-            verify(rs);
+            try (ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                verify(rs);
+            }
         }
     }
 
@@ -138,6 +141,7 @@ public class TVPSchemaTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @Tag(Constants.legacyFx)
     @DisplayName("TVPSchemaPreparedStatementSetObject()")
     public void testTVPSchemaPreparedStatementSetObject() throws SQLException {
 
@@ -146,12 +150,13 @@ public class TVPSchemaTest extends AbstractTest {
         tvp.setTvpName(tvpNameWithSchema);
 
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement();
-                SQLServerPreparedStatement P_C_statement = (SQLServerPreparedStatement) conn.prepareStatement(sql);
-                ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                SQLServerPreparedStatement P_C_statement = (SQLServerPreparedStatement) conn.prepareStatement(sql)) {
             P_C_statement.setObject(1, tvp);
             P_C_statement.execute();
 
-            verify(rs);
+            try (ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                verify(rs);
+            }
         }
     }
 
@@ -162,6 +167,7 @@ public class TVPSchemaTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @Tag(Constants.legacyFx)
     @DisplayName("TVPSchemaCallableStatementSetObject()")
     public void testTVPSchemaCallableStatementSetObject() throws SQLException {
 
@@ -170,12 +176,13 @@ public class TVPSchemaTest extends AbstractTest {
         tvp.setTvpName(tvpNameWithSchema);
 
         try (Connection conn = getConnection(); Statement stmt = conn.createStatement();
-                SQLServerCallableStatement P_C_statement = (SQLServerCallableStatement) conn.prepareCall(sql);
-                ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                SQLServerCallableStatement P_C_statement = (SQLServerCallableStatement) conn.prepareCall(sql)) {
             P_C_statement.setObject(1, tvp);
             P_C_statement.execute();
 
-            verify(rs);
+            try (ResultSet rs = stmt.executeQuery("select * from " + charTable)) {
+                verify(rs);
+            }
         }
     }
 
@@ -186,6 +193,7 @@ public class TVPSchemaTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @Tag(Constants.legacyFx)
     @DisplayName("TVPSchemaStoredProcedureWithReturnSetStructured()")
     public void testTVPSchemaStoredProcedureWithReturnSetStructured() throws SQLException {
 
@@ -218,6 +226,7 @@ public class TVPSchemaTest extends AbstractTest {
      * @throws SQLException
      */
     @Test
+    @Tag(Constants.legacyFx)
     @DisplayName("TVPSchemaStoredProcedureWithReturnSetObject()")
     public void testTVPSchemaStoredProcedureWithReturnSetObject() throws SQLException {
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypeBoundaryTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/tvp/TVPTypeBoundaryTest.java
@@ -50,6 +50,7 @@ import com.microsoft.sqlserver.testframework.Constants;
  */
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.legacyFx)
 public class TVPTypeBoundaryTest extends AbstractTest {
 
     private static String tvpName;
@@ -338,11 +339,11 @@ public class TVPTypeBoundaryTest extends AbstractTest {
                     "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(tableName) + " select * from ? ;")) {
                 pstmt.setStructured(1, tvpName, tvp);
                 pstmt.execute();
+                fail("Expected SQLException for out-of-range " + sqlType + " value, but insert succeeded");
             }
         } catch (SQLException e) {
             // Client-side addRow() validation or server-side execute() rejection — both are valid
             assertNotNull(e.getMessage(), "Exception should have a descriptive message");
-            return;
         }
     }
 
@@ -434,12 +435,7 @@ public class TVPTypeBoundaryTest extends AbstractTest {
                 pstmt.execute();
 
                 if (expectFailure) {
-                    // Data present means server handled it (possible rounding/truncation)
-                    try (Statement verifyStmt = connection.createStatement();
-                            ResultSet verifyRs = verifyStmt.executeQuery(
-                                    "select c1 from " + AbstractSQLGenerator.escapeIdentifier(tableName))) {
-                        // No assertion needed; reaching here means no overflow exception was thrown
-                    }
+                    fail("Expected overflow SQLException was not thrown for: " + displayName);
                 }
             }
         } catch (SQLException e) {
@@ -660,33 +656,6 @@ public class TVPTypeBoundaryTest extends AbstractTest {
     }
 
     /**
-     * Tests conversion from VARBINARY to INT via DataTable TVP.
-     * Expects the server to reject the implicit binary-to-integer conversion.
-     *
-     * @throws SQLException if an unexpected database error occurs
-     */
-    @Test
-    @DisplayName("Conversion DataTable: VARBINARY to INT (expect error)")
-    public void testVarbinaryToIntDataTable() throws SQLException {
-        String destType = "int";
-        byte[] testBytes = new byte[] {0x00, 0x00, 0x30, 0x39};
-
-        createTableAndTVP(destType);
-
-        SQLServerDataTable tvp = new SQLServerDataTable();
-        tvp.addColumnMetadata("c1", Types.VARBINARY);
-        tvp.addRow(testBytes);
-
-        try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement(
-                "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(tableName) + " select * from ? ;")) {
-            pstmt.setStructured(1, tvpName, tvp);
-            pstmt.execute();
-        } catch (SQLException e) {
-            assertNotNull(e.getMessage(), "Exception should have a descriptive message");
-        }
-    }
-
-    /**
      * Tests that inserting a string longer than the NVARCHAR(10) destination column
      * via DataTable TVP produces a truncation error.
      *
@@ -708,6 +677,7 @@ public class TVPTypeBoundaryTest extends AbstractTest {
                 "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(tableName) + " select * from ? ;")) {
             pstmt.setStructured(1, tvpName, tvp);
             pstmt.execute();
+            fail("Expected SQLException for NVARCHAR(MAX) truncation into NVARCHAR(10)");
         } catch (SQLException e) {
             assertNotNull(e.getMessage(), "Truncation should produce an error message");
         }


### PR DESCRIPTION
Ports set of legacy FX functional test scenarios into the current JUnit-based test suite for Table-Valued Parameters (TVPs), expanding coverage around boundary conditions, precision/scale handling, fuzzing, and schema/procedure invocation variants.

Changes:

- Added new TVP test classes covering type boundary/out-of-range, precision & scale round-trips, API fuzzing, DataTable behaviors, and ISQLServerDataRecord scenarios.
- Extended TVPSchemaTest with setObject(...) variants and stored procedures that return a value.
Consolidated multiple FX test suites into parameterized and grouped JUnit test structures.