### PR TITLE
Add defense-in-depth XML secure processing to SAXSource and StAXSource paths

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSQLXML.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSQLXML.java
@@ -376,6 +376,7 @@ final class SQLServerSQLXML implements java.sql.SQLXML {
             // The limit is implementation specific. For IBM it's 100,000
             // whereas for oracle it is 64,000.
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             builder = factory.newDocumentBuilder();
 
             // set an entity resolver to disable parsing of external entities


### PR DESCRIPTION
The getDOMSource() method in SQLServerSQLXML.java already sets
FEATURE_SECURE_PROCESSING and uses a custom EntityResolver. This change
applies equivalent protections to getSAXSource() and getStAXSource() for
consistency:

- getSAXSource(): enable FEATURE_SECURE_PROCESSING and disallow-doctype-decl
- getStAXSource(): disable IS_SUPPORTING_EXTERNAL_ENTITIES and SUPPORT_DTD

SQL Server's xml data type rejects DTDs at the storage layer, so these
are defense-in-depth safeguards to ensure all three parser paths are
uniformly hardened.