### PR TITLE
Overflow when reading PLP chunk sizes from TDS stream

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
@@ -307,12 +307,23 @@ class PLPInputStream extends BaseInputStream {
              * chunk or determine that we have reached the end of the stream.
              */
             if (0 == currentChunkRemain) {
-                currentChunkRemain = (int) tdsReader.readUnsignedInt();
-                assert currentChunkRemain >= 0;
-                if (0 == currentChunkRemain) {
+                long chunkSize = tdsReader.readUnsignedInt();
+                
+                // Check for end of stream
+                if (0 == chunkSize) {
                     currentChunkRemain = PLP_EOS;
                     break;
                 }
+                
+                // Validate chunk size to prevent integer overflow (CWE-190)
+                // A malicious server could send a chunk size > Integer.MAX_VALUE
+                // which would cause silent data truncation or crash when cast to int
+                if (chunkSize > Integer.MAX_VALUE) {
+                    throw new SQLServerException(SQLServerException.getErrString("R_invalidTDS"), null);
+                }
+                
+                currentChunkRemain = (int) chunkSize;
+                assert currentChunkRemain >= 0;
             }
 
             if (bytesRead == maxBytes)


### PR DESCRIPTION
Prevent CWE-190 Integer Overflow when reading PLP chunk sizes from TDS stream.
Previously, readBytesInternal() unsafely cast unsigned 32-bit chunk size (long) to signed int without validation.