### PR TITLE
Deprecate microsoft.sql.DateTimeOffset in favor of java.time.OffsetDateTime

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement.java
@@ -149,7 +149,10 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      * @throws SQLServerException
      *         if parameterIndex is out of range; if a database access error occurs or this method is called on a closed
      *         <code>CallableStatement</code>
+     * @deprecated Use {@link #getOffsetDateTime(int)} instead. This method is being deprecated in favor of using the
+     *             standard Java time API (JSR-310) for handling SQL Server datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     microsoft.sql.DateTimeOffset getDateTimeOffset(int parameterIndex) throws SQLServerException;
 
     /**
@@ -161,8 +164,37 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      * @throws SQLServerException
      *         if parameterName does not correspond to a named parameter; if a database access error occurs or this
      *         method is called on a closed <code>CallableStatement</code>
+     * @deprecated Use {@link #getOffsetDateTime(String)} instead. This method is being deprecated in favor of using the
+     *             standard Java time API (JSR-310) for handling SQL Server datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     microsoft.sql.DateTimeOffset getDateTimeOffset(String parameterName) throws SQLServerException;
+
+    /**
+     * Returns the OffsetDateTime value of parameter with index parameterIndex. This is the preferred method for
+     * retrieving SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterIndex
+     *        the first parameter is 1, the second is 2, and so on
+     * @return OffsetDateTime value if the value is SQL NULL, the value returned is null
+     * @throws SQLServerException
+     *         if parameterIndex is out of range; if a database access error occurs or this method is called on a closed
+     *         <code>CallableStatement</code>
+     */
+    java.time.OffsetDateTime getOffsetDateTime(int parameterIndex) throws SQLServerException;
+
+    /**
+     * Returns the OffsetDateTime value of parameter with name parameterName. This is the preferred method for
+     * retrieving SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterName
+     *        the name of the parameter
+     * @return OffsetDateTime value if the value is SQL NULL, the value returned is null
+     * @throws SQLServerException
+     *         if parameterName does not correspond to a named parameter; if a database access error occurs or this
+     *         method is called on a closed <code>CallableStatement</code>
+     */
+    java.time.OffsetDateTime getOffsetDateTime(String parameterName) throws SQLServerException;
 
     /**
      * Returns the value of the designated column in the current row of this <code>ResultSet</code> object as a stream
@@ -500,7 +532,11 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      *        DateTimeOffset value
      * @throws SQLServerException
      *         if an error occurs
+     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime)} instead. This method is being
+     *             deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value) throws SQLServerException;
 
     /**
@@ -514,7 +550,11 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      *        the scale of the parameter
      * @throws SQLServerException
      *         if an error occurs
+     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime, int)} instead. This method is being
+     *             deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value,
             int scale) throws SQLServerException;
 
@@ -533,8 +573,60 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         if an error occurs
+     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime, int, boolean)} instead. This method
+     *             is being deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value, int scale,
+            boolean forceEncrypt) throws SQLServerException;
+
+    /**
+     * Sets parameter parameterName to OffsetDateTime value. This is the preferred method for setting SQL Server
+     * datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterName
+     *        the name of the parameter
+     * @param value
+     *        OffsetDateTime value
+     * @throws SQLServerException
+     *         if an error occurs
+     */
+    void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value) throws SQLServerException;
+
+    /**
+     * Sets parameter parameterName to OffsetDateTime value. This is the preferred method for setting SQL Server
+     * datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterName
+     *        the name of the parameter
+     * @param value
+     *        OffsetDateTime value
+     * @param scale
+     *        the scale of the parameter
+     * @throws SQLServerException
+     *         if an error occurs
+     */
+    void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value, int scale) throws SQLServerException;
+
+    /**
+     * Sets parameter parameterName to OffsetDateTime value. This is the preferred method for setting SQL Server
+     * datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterName
+     *        the name of the parameter
+     * @param value
+     *        OffsetDateTime value
+     * @param scale
+     *        the scale of the parameter
+     * @param forceEncrypt
+     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
+     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
+     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
+     * @throws SQLServerException
+     *         if an error occurs
+     */
+    void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value, int scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement.java
@@ -25,7 +25,11 @@ public interface ISQLServerPreparedStatement extends java.sql.PreparedStatement,
      * @throws SQLServerException
      *         if parameterIndex does not correspond to a parameter marker in the SQL statement; if a database access
      *         error occurs or this method is called on a closed <code>PreparedStatement</code>
+     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime)} instead. This method is being
+     *             deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x) throws SQLServerException;
 
     /**
@@ -563,7 +567,11 @@ public interface ISQLServerPreparedStatement extends java.sql.PreparedStatement,
      *        the scale of the column
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime, int)} instead. This method is being
+     *             deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x, int scale) throws SQLServerException;
 
     /**
@@ -581,8 +589,61 @@ public interface ISQLServerPreparedStatement extends java.sql.PreparedStatement,
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime, int, boolean)} instead. This method is
+     *             being deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x, int scale,
+            boolean forceEncrypt) throws SQLServerException;
+
+    /**
+     * Sets the designated parameter to the given <code>java.time.OffsetDateTime</code> value. This is the preferred
+     * method for setting SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterIndex
+     *        the first parameter is 1, the second is 2, ...
+     * @param x
+     *        the parameter value
+     * @throws SQLServerException
+     *         if parameterIndex does not correspond to a parameter marker in the SQL statement; if a database access
+     *         error occurs or this method is called on a closed <code>PreparedStatement</code>
+     */
+    void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x) throws SQLServerException;
+
+    /**
+     * Sets the designated parameter to the given <code>java.time.OffsetDateTime</code> value. This is the preferred
+     * method for setting SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterIndex
+     *        the first parameter is 1, the second is 2, ...
+     * @param x
+     *        the parameter value
+     * @param scale
+     *        the scale of the column
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x, int scale) throws SQLServerException;
+
+    /**
+     * Sets the designated parameter to the given <code>java.time.OffsetDateTime</code> value. This is the preferred
+     * method for setting SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param parameterIndex
+     *        the first parameter is 1, the second is 2, ...
+     * @param x
+     *        the parameter value
+     * @param scale
+     *        the scale of the column
+     * @param forceEncrypt
+     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
+     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
+     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x, int scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet.java
@@ -247,7 +247,10 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      * @return A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #getOffsetDateTime(int)} instead. This method is being deprecated in favor of using the
+     *             standard Java time API (JSR-310) for handling SQL Server datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     microsoft.sql.DateTimeOffset getDateTimeOffset(int columnIndex) throws SQLServerException;
 
     /**
@@ -258,8 +261,36 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      * @return A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #getOffsetDateTime(String)} instead. This method is being deprecated in favor of using the
+     *             standard Java time API (JSR-310) for handling SQL Server datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     microsoft.sql.DateTimeOffset getDateTimeOffset(String columnName) throws SQLServerException;
+
+    /**
+     * Returns the value of the designated column as a java.time.OffsetDateTime object, given a zero-based column
+     * ordinal. This is the preferred method for retrieving SQL Server datetimeoffset values, using the standard Java
+     * time API (JSR-310).
+     * 
+     * @param columnIndex
+     *        The zero-based ordinal of a column.
+     * @return An OffsetDateTime object.
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    java.time.OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLServerException;
+
+    /**
+     * Returns the value of the column specified as a java.time.OffsetDateTime object, given a column name. This is the
+     * preferred method for retrieving SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param columnName
+     *        The name of a column.
+     * @return An OffsetDateTime object.
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    java.time.OffsetDateTime getOffsetDateTime(String columnName) throws SQLServerException;
 
     /**
      * Returns the value of the column specified as a java.math.BigDecimal object.
@@ -314,7 +345,11 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime)} instead. This method is being
+     *             deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x) throws SQLServerException;
 
     /**
@@ -326,8 +361,39 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime)} instead. This method is being
+     *             deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x) throws SQLServerException;
+
+    /**
+     * Updates the value of the column specified to the OffsetDateTime value, given a zero-based column ordinal. This
+     * is the preferred method for updating SQL Server datetimeoffset values, using the standard Java time API
+     * (JSR-310).
+     * 
+     * @param index
+     *        The zero-based ordinal of a column.
+     * @param x
+     *        An OffsetDateTime object.
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    void updateOffsetDateTime(int index, java.time.OffsetDateTime x) throws SQLServerException;
+
+    /**
+     * Updates the value of the column specified to the OffsetDateTime value, given a column name. This is the
+     * preferred method for updating SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param columnName
+     *        The name of a column.
+     * @param x
+     *        An OffsetDateTime object.
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x) throws SQLServerException;
 
     /**
      * Updates the designated column with an {@code Object} value.
@@ -981,7 +1047,11 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        scale of the column
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime, Integer)} instead. This method is
+     *             being deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x, Integer scale) throws SQLServerException;
 
     /**
@@ -999,8 +1069,49 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         when an error occurs
+     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime, Integer, boolean)} instead. This
+     *             method is being deprecated in favor of using the standard Java time API (JSR-310) for handling SQL
+     *             Server datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x, Integer scale,
+            boolean forceEncrypt) throws SQLServerException;
+
+    /**
+     * Updates the value of the column specified to the OffsetDateTime value, given a zero-based column ordinal. This
+     * is the preferred method for updating SQL Server datetimeoffset values, using the standard Java time API
+     * (JSR-310).
+     * 
+     * @param index
+     *        The zero-based ordinal of a column.
+     * @param x
+     *        An OffsetDateTime object.
+     * @param scale
+     *        scale of the column
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale) throws SQLServerException;
+
+    /**
+     * Updates the value of the column specified to the OffsetDateTime value, given a zero-based column ordinal. This
+     * is the preferred method for updating SQL Server datetimeoffset values, using the standard Java time API
+     * (JSR-310).
+     * 
+     * @param index
+     *        The zero-based ordinal of a column.
+     * @param x
+     *        An OffsetDateTime object.
+     * @param scale
+     *        scale of the column
+     * @param forceEncrypt
+     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
+     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
+     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
+     * @throws SQLServerException
+     *         when an error occurs
+     */
+    void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**
@@ -1489,7 +1600,11 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        the scale of the column
      * @throws SQLServerException
      *         If any errors occur.
+     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime, int)} instead. This method is
+     *             being deprecated in favor of using the standard Java time API (JSR-310) for handling SQL Server
+     *             datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x, int scale) throws SQLServerException;
 
     /**
@@ -1507,8 +1622,47 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         If any errors occur.
+     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime, int, boolean)} instead. This
+     *             method is being deprecated in favor of using the standard Java time API (JSR-310) for handling SQL
+     *             Server datetimeoffset values.
      */
+    @Deprecated(since = "13.5.1")
     void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x, int scale,
+            boolean forceEncrypt) throws SQLServerException;
+
+    /**
+     * Updates the value of the column specified to the OffsetDateTime value, given a column name. This is the
+     * preferred method for updating SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param columnName
+     *        The name of a column.
+     * @param x
+     *        An OffsetDateTime object.
+     * @param scale
+     *        the scale of the column
+     * @throws SQLServerException
+     *         If any errors occur.
+     */
+    void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x, int scale) throws SQLServerException;
+
+    /**
+     * Updates the value of the column specified to the OffsetDateTime value, given a column name. This is the
+     * preferred method for updating SQL Server datetimeoffset values, using the standard Java time API (JSR-310).
+     * 
+     * @param columnName
+     *        The name of a column.
+     * @param x
+     *        An OffsetDateTime object.
+     * @param scale
+     *        the scale of the column
+     * @param forceEncrypt
+     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
+     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
+     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
+     * @throws SQLServerException
+     *         If any errors occur.
+     */
+    void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x, int scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1089,6 +1089,40 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     }
 
     @Override
+    public java.time.OffsetDateTime getOffsetDateTime(int parameterIndex) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", parameterIndex);
+        checkClosed();
+
+        if (!connection.isKatmaiOrLater())
+            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
+                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
+
+        microsoft.sql.DateTimeOffset dto = (microsoft.sql.DateTimeOffset) getValue(parameterIndex,
+                JDBCType.DATETIMEOFFSET);
+        java.time.OffsetDateTime value = (dto != null) ? dto.getOffsetDateTime() : null;
+        loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", value);
+        return value;
+    }
+
+    @Override
+    public java.time.OffsetDateTime getOffsetDateTime(String parameterName) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", parameterName);
+        checkClosed();
+
+        if (!connection.isKatmaiOrLater())
+            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
+                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
+
+        microsoft.sql.DateTimeOffset dto = (microsoft.sql.DateTimeOffset) getValue(findColumn(parameterName),
+                JDBCType.DATETIMEOFFSET);
+        java.time.OffsetDateTime value = (dto != null) ? dto.getOffsetDateTime() : null;
+        loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", value);
+        return value;
+    }
+
+    @Override
     public boolean wasNull() throws SQLServerException {
         loggerExternal.entering(getClassNameLogging(), "wasNull");
         checkClosed();
@@ -1862,6 +1896,41 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         setValue(findColumn(parameterName), JDBCType.DATETIMEOFFSET, value, JavaType.DATETIMEOFFSET, null, scale,
                 forceEncrypt);
         loggerExternal.exiting(getClassNameLogging(), "setDateTimeOffset");
+    }
+
+    @Override
+    public void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime", new Object[] {parameterName, value});
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (value != null) ? microsoft.sql.DateTimeOffset.valueOf(value) : null;
+        setValue(findColumn(parameterName), JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, false);
+        loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
+    }
+
+    @Override
+    public void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value,
+            int scale) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime",
+                    new Object[] {parameterName, value, scale});
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (value != null) ? microsoft.sql.DateTimeOffset.valueOf(value) : null;
+        setValue(findColumn(parameterName), JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale, false);
+        loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
+    }
+
+    @Override
+    public void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value, int scale,
+            boolean forceEncrypt) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime",
+                    new Object[] {parameterName, value, scale, forceEncrypt});
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (value != null) ? microsoft.sql.DateTimeOffset.valueOf(value) : null;
+        setValue(findColumn(parameterName), JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale,
+                forceEncrypt);
+        loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
     }
 
     @Override

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2168,6 +2168,40 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     }
 
     @Override
+    public final void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime", new Object[] {parameterIndex, x});
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        setValue(parameterIndex, JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, false);
+        loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
+    }
+
+    @Override
+    public final void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x,
+            int scale) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime",
+                    new Object[] {parameterIndex, x, scale});
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        setValue(parameterIndex, JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale, false);
+        loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
+    }
+
+    @Override
+    public final void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x, int scale,
+            boolean forceEncrypt) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime",
+                    new Object[] {parameterIndex, x, scale, forceEncrypt});
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        setValue(parameterIndex, JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale, forceEncrypt);
+        loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
+    }
+
+    @Override
     public final void setDate(int n, java.sql.Date x) throws SQLServerException {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "setDate", new Object[] {n, x});

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2831,6 +2831,40 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         return value;
     }
 
+    @Override
+    public java.time.OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", columnIndex);
+        checkClosed();
+
+        if (!stmt.connection.isKatmaiOrLater())
+            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
+                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
+
+        microsoft.sql.DateTimeOffset dto = (microsoft.sql.DateTimeOffset) getValue(columnIndex,
+                JDBCType.DATETIMEOFFSET);
+        java.time.OffsetDateTime value = (dto != null) ? dto.getOffsetDateTime() : null;
+        loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", value);
+        return value;
+    }
+
+    @Override
+    public java.time.OffsetDateTime getOffsetDateTime(String columnName) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", columnName);
+        checkClosed();
+
+        if (!stmt.connection.isKatmaiOrLater())
+            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
+                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
+
+        microsoft.sql.DateTimeOffset dto = (microsoft.sql.DateTimeOffset) getValue(findColumn(columnName),
+                JDBCType.DATETIMEOFFSET);
+        java.time.OffsetDateTime value = (dto != null) ? dto.getOffsetDateTime() : null;
+        loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", value);
+        return value;
+    }
+
     /**
      * @deprecated
      */
@@ -3781,6 +3815,44 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
     }
 
     @Override
+    public void updateOffsetDateTime(int index, java.time.OffsetDateTime x) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime", new Object[] {index, x});
+
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        updateValue(index, JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, false);
+
+        loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
+    }
+
+    @Override
+    public void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime", new Object[] {index, x, scale});
+
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        updateValue(index, JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale, false);
+
+        loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
+    }
+
+    @Override
+    public void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale,
+            boolean forceEncrypt) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime",
+                    new Object[] {index, x, scale, forceEncrypt});
+
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        updateValue(index, JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale, forceEncrypt);
+
+        loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
+    }
+
+    @Override
     public void updateUniqueIdentifier(int index, String x) throws SQLServerException {
         if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
             loggerExternal.entering(getClassNameLogging(), "updateUniqueIdentifier", new Object[] {index, x});
@@ -4612,6 +4684,47 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                 forceEncrypt);
 
         loggerExternal.exiting(getClassNameLogging(), "updateDateTimeOffset");
+    }
+
+    @Override
+    public void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime", new Object[] {columnName, x});
+
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        updateValue(findColumn(columnName), JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, false);
+
+        loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
+    }
+
+    @Override
+    public void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x,
+            int scale) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime",
+                    new Object[] {columnName, x, scale});
+
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        updateValue(findColumn(columnName), JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale, false);
+
+        loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
+    }
+
+    @Override
+    public void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x, int scale,
+            boolean forceEncrypt) throws SQLServerException {
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime",
+                    new Object[] {columnName, x, scale, forceEncrypt});
+
+        checkClosed();
+        microsoft.sql.DateTimeOffset dto = (x != null) ? microsoft.sql.DateTimeOffset.valueOf(x) : null;
+        updateValue(findColumn(columnName), JDBCType.DATETIMEOFFSET, dto, JavaType.DATETIMEOFFSET, null, scale,
+                forceEncrypt);
+
+        loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
     }
 
     @Override

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -558,12 +558,12 @@ public class PrecisionScaleTest extends AESetup {
 
         // datetimeoffset scale
         for (int i = 7; i <= 9; i++) {
-            pstmt.setDateTimeOffset(i, null, scale);
+            pstmt.setDateTimeOffset(i, (microsoft.sql.DateTimeOffset) null, scale);
         }
 
         // datetimeoffset default
         for (int i = 10; i <= 12; i++) {
-            pstmt.setDateTimeOffset(i, null);
+            pstmt.setDateTimeOffset(i, (microsoft.sql.DateTimeOffset) null);
         }
 
         // time scale

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -1087,7 +1087,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.setObject(3, null); // DATETIME2
             pstmt.setDate(4, null); // DATE
             pstmt.setObject(5, null); // TIME
-            pstmt.setDateTimeOffset(6, null); // DATETIMEOFFSET
+            pstmt.setDateTimeOffset(6, (microsoft.sql.DateTimeOffset) null); // DATETIMEOFFSET
             pstmt.setMoney(7, null); // MONEY
             pstmt.setSmallMoney(8, null); // SMALLMONEY
 
@@ -1240,7 +1240,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.setObject(3, null); // DATETIME2
             pstmt.setDate(4, null); // DATE
             pstmt.setObject(5, null); // TIME
-            pstmt.setDateTimeOffset(6, null); // DATETIMEOFFSET
+            pstmt.setDateTimeOffset(6, (microsoft.sql.DateTimeOffset) null); // DATETIMEOFFSET
             pstmt.setMoney(7, null); // MONEY
             pstmt.setSmallMoney(8, null); // SMALLMONEY
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/WrapperTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/WrapperTest.java
@@ -88,7 +88,7 @@ public class WrapperTest extends AbstractTest {
                         stmt3.setResponseBuffering("adaptive");
 
                         if (isKatmaiServer())
-                            stmt3.setDateTimeOffset(1, null);
+                            stmt3.setDateTimeOffset(1, (microsoft.sql.DateTimeOffset) null);
 
                         // Try Unwrapping CallableStatement to a callableStatement
                         isWrapper = ((SQLServerCallableStatement) cs)


### PR DESCRIPTION
This change modernizes the JDBC driver API by deprecating the proprietary microsoft.sql.DateTimeOffset type and promoting java.time.OffsetDateTime (JSR-310) as the canonical Java mapping for SQL Server datetimeoffset columns.

**Key Changes:**
- Added new getOffsetDateTime(), setOffsetDateTime(), and updateOffsetDateTime() methods to ISQLServerCallableStatement, ISQLServerPreparedStatement, and ISQLServerResultSet interfaces
- Deprecated all existing getDateTimeOffset(), setDateTimeOffset(), and updateDateTimeOffset() methods with @Deprecated(since = 13.5.1)
- Implemented new OffsetDateTime-based methods in SQLServerCallableStatement, SQLServerPreparedStatement, and SQLServerResultSet with proper conversion
- Fixed method overload ambiguity in test files (PrecisionScaleTest, BatchExecutionWithBulkCopyTest, WrapperTest)

**Benefits:**
- Aligns with modern Java (JSR-310) best practices
- Removes vendor-specific types from application code
- Improves portability and interoperability with ORMs and middleware
- Simplifies conversion logic for database-agnostic frameworks

Based on external contribution by @rrobetti
External PR: https://github.com/microsoft/mssql-jdbc/pull/2906