### PR TITLE
Fix flaky randomized Statement test: align getGeneratedKeys() with FX framework pattern

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/statement/StatementExecutionStateTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/statement/StatementExecutionStateTest.java
@@ -226,7 +226,8 @@ public class StatementExecutionStateTest extends AbstractTest {
             setState(HAS_RESULT_SET, hasResultSet);
             setState(LAST_EXECUTE_WAS_BATCH, false);
             setState(LAST_EXECUTE_WAS_UPDATE, false);
-            setState(LAST_EXECUTE_GENERATED_KEYS, true);
+            setState(LAST_EXECUTE_GENERATED_KEYS,
+                    autoKeyFlag == Statement.RETURN_GENERATED_KEYS);
             setState(QUERY_INDEX, 0);
             if (isInsert && autoKeyFlag == Statement.RETURN_GENERATED_KEYS) {
                 try (ResultSet keys = stmt.getGeneratedKeys()) {
@@ -259,7 +260,8 @@ public class StatementExecutionStateTest extends AbstractTest {
             setState(HAS_RESULT_SET, false);
             setState(LAST_EXECUTE_WAS_BATCH, false);
             setState(LAST_EXECUTE_WAS_UPDATE, true);
-            setState(LAST_EXECUTE_GENERATED_KEYS, true);
+            setState(LAST_EXECUTE_GENERATED_KEYS,
+                    autoKeyFlag == Statement.RETURN_GENERATED_KEYS);
             setState(QUERY_INDEX, 0);
             if (isInsert && autoKeyFlag == Statement.RETURN_GENERATED_KEYS) {
                 try (ResultSet keys = stmt.getGeneratedKeys()) {
@@ -282,11 +284,11 @@ public class StatementExecutionStateTest extends AbstractTest {
                 int newId = getStateInt(NEXT_INSERT_ID);
                 setState(NEXT_INSERT_ID, newId + 1);
                 hasResultSet = stmt.execute("INSERT INTO " + tableName + " (id, value, name) VALUES ("
-                        + newId + ", " + getRandom().nextInt(10000) + ", 'GenKey')", new int[]{1});
+                        + newId + ", " + getRandom().nextInt(10000) + ", 'GenKey')", new int[]{4});
             } else {
                 int rowId = getRandom().nextInt(getStateInt(ROW_COUNT)) + 1;
                 hasResultSet = stmt.execute("UPDATE " + tableName + " SET value = "
-                        + getRandom().nextInt(10000) + " WHERE id = " + rowId, new int[]{1});
+                        + getRandom().nextInt(10000) + " WHERE id = " + rowId, new int[]{4});
             }
             setState(EXECUTED, true); setState(HAS_RESULT_SET, hasResultSet);
             setState(LAST_EXECUTE_WAS_BATCH, false); setState(LAST_EXECUTE_WAS_UPDATE, false);
@@ -341,11 +343,11 @@ public class StatementExecutionStateTest extends AbstractTest {
                 int newId = getStateInt(NEXT_INSERT_ID);
                 setState(NEXT_INSERT_ID, newId + 1);
                 stmt.executeUpdate("INSERT INTO " + tableName + " (id, value, name) VALUES ("
-                        + newId + ", " + getRandom().nextInt(10000) + ", 'GenKey')", new int[]{1});
+                        + newId + ", " + getRandom().nextInt(10000) + ", 'GenKey')", new int[]{4});
             } else {
                 int rowId = getRandom().nextInt(getStateInt(ROW_COUNT)) + 1;
                 stmt.executeUpdate("UPDATE " + tableName + " SET value = "
-                        + getRandom().nextInt(10000) + " WHERE id = " + rowId, new int[]{1});
+                        + getRandom().nextInt(10000) + " WHERE id = " + rowId, new int[]{4});
             }
             setState(EXECUTED, true); setState(HAS_RESULT_SET, false);
             setState(LAST_EXECUTE_WAS_BATCH, false); setState(LAST_EXECUTE_WAS_UPDATE, true);
@@ -1118,8 +1120,8 @@ public class StatementExecutionStateTest extends AbstractTest {
             try (Connection conn = PrepUtil.getConnection(connectionString)) {
                 createTestTable(conn);
                 try (Statement stmt = conn.createStatement()) {
-                    stmt.addBatch("INSERT INTO " + TABLE_NAME + " VALUES (100, 1000, 'NewRow100')");
-                    stmt.addBatch("INSERT INTO " + TABLE_NAME + " VALUES (1, 9999, 'DuplicatePK')");
+                    stmt.addBatch("INSERT INTO " + TABLE_NAME + " (id, value, name) VALUES (100, 1000, 'NewRow100')");
+                    stmt.addBatch("INSERT INTO " + TABLE_NAME + " (id, value, name) VALUES (1, 9999, 'DuplicatePK')");
                     BatchUpdateException bue = assertThrows(BatchUpdateException.class,
                             () -> stmt.executeBatch(),
                             "executeBatch should throw BatchUpdateException when batch contains a PK violation");
@@ -2545,7 +2547,7 @@ public class StatementExecutionStateTest extends AbstractTest {
                 try (Statement stmt = conn.createStatement()) {
                     assertThrows(SQLException.class,
                             () -> stmt.executeUpdate(
-                                    "INSERT INTO " + TABLE_NAME + " VALUES (1, 9999, 'Dup')"),
+                                    "INSERT INTO " + TABLE_NAME + " (id, value, name) VALUES (1, 9999, 'Dup')"),
                             "Duplicate PK insert should throw");
                 }
             }


### PR DESCRIPTION
## Problem

`testRandomizedStatementExecution` in StatementExecutionStateTest was flaky, intermittently failing with:
`SQLServerException: The statement must be executed before any results can be obtained.`


The failure was non-deterministic because the state machine engine randomly picks actions each run. When `GetGeneratedKeysAction` was selected after an `execute(UPDATE, RETURN_GENERATED_KEYS)` call, the driver threw an exception because it had no identity result to return.

## Root Cause

The JDBC driver only appends `SELECT SCOPE_IDENTITY() AS GENERATED_KEYS` when the SQL is an **INSERT** statement . For UPDATE/DELETE, even with `RETURN_GENERATED_KEYS`, the driver does not produce a generated-keys result, so `getGeneratedKeys()` fails.

The JUnit test had `GetGeneratedKeysAction` as a **standalone randomized action**, allowing invalid call sequences depending on the seed.

## Fix (aligned with FX framework)

The FX framework handles this: specifically `fxStatement.execute(query, autokeys)` and `fxTable.insert()`:

1. **FX has no `_modelgetGeneratedKeys`**: `getGeneratedKeys()` is never a standalone randomized action. It is only called inline within execute validation, and only when `query.isInsert() && query.hasIdentity()`.

2. **FX uses `randomquery()`** for execute-with-keys calls: the query can be INSERT, UPDATE, SELECT, or DELETE. Generated keys are only validated for INSERT on tables with an IDENTITY column.

Applied the same pattern:

- **Added `id_col INT IDENTITY(1,1)`** to the test table, required for `SCOPE_IDENTITY()` to return a value.
- **Execute-with-keys actions now randomly choose INSERT or UPDATE** : matching FX's `randomquery()`.
- **`getGeneratedKeys()` is validated inline** within each execute-with-keys action, only when the query is an INSERT: matching FX's `query.isInsert() && query.hasIdentity()` guard.
- **`GetGeneratedKeysAction` removed from the randomized action pool** : no FX equivalent exists. 
- **`NEXT_INSERT_ID` counter** ensures collision-free primary keys across any random seed.

## What this covers

| API variant | INSERT path | UPDATE path | getGeneratedKeys() |
|---|---|---|---|
| `execute(sql, int autokeys)` | Yes | Yes | Inline, INSERT only |
| `executeUpdate(sql, int autokeys)` | Yes | Yes | Inline, INSERT only |
| `execute(sql, int[] columnIndexes)` | Yes | Yes | Inline, INSERT only |
| `execute(sql, String[] columnNames)` | Yes | Yes | Inline, INSERT only |
| `executeUpdate(sql, int[] columnIndexes)` | Yes | Yes | Inline, INSERT only |
| `executeUpdate(sql, String[] columnNames)` | Yes | Yes | Inline, INSERT only |

Dedicated deterministic generated-keys tests remain in the `GeneratedKeysTests` nested class.