### PR TITLE
[WIP] Reduce per-column overhead for ResultSet bulk reads

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -6787,10 +6787,20 @@ final class TDSPacket {
  * destroyed.
  */
 final class TDSReaderMark {
-    final TDSPacket packet;
-    final int payloadOffset;
+    TDSPacket packet;
+    int payloadOffset;
 
     TDSReaderMark(TDSPacket packet, int payloadOffset) {
+        this.packet = packet;
+        this.payloadOffset = payloadOffset;
+    }
+
+    TDSReaderMark() {
+        this.packet = null;
+        this.payloadOffset = 0;
+    }
+
+    void set(TDSPacket packet, int payloadOffset) {
         this.packet = packet;
         this.payloadOffset = payloadOffset;
     }
@@ -7093,6 +7103,11 @@ final class TDSReader implements Serializable {
         return mark;
     }
 
+    final void markInto(TDSReaderMark mark) {
+        mark.set(currentPacket, payloadOffset);
+        isStreaming = false;
+    }
+
     final void reset(TDSReaderMark mark) {
         if (logger.isLoggable(Level.FINEST))
             logger.finest(this.toString() + ": Resetting to: " + mark.toString());
@@ -7152,7 +7167,11 @@ final class TDSReader implements Serializable {
     }
 
     final int readUnsignedByte() throws SQLServerException {
-        // Ensure that we have a packet to read from.
+        // Fast path: if there's data left in the current packet, read directly
+        if (payloadOffset < currentPacket.payloadLength) {
+            return currentPacket.payload[payloadOffset++] & 0xFF;
+        }
+        // Slow path: need to advance to next packet
         if (!ensurePayload())
             throwInvalidTDS();
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -1134,9 +1134,11 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
     @Override
     public boolean wasNull() throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "wasNull");
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "wasNull");
         checkClosed();
-        loggerExternal.exiting(getClassNameLogging(), "wasNull", lastValueWasNull);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "wasNull", lastValueWasNull);
         return lastValueWasNull;
     }
 
@@ -1756,8 +1758,11 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         deletedCurrentRow = false;
         if (lastColumnIndex >= 1) {
             initializeNullCompressedColumns();
-            // Discard columns up to, but not including, the last indexed column
-            for (int columnIndex = 1; columnIndex < lastColumnIndex; ++columnIndex)
+
+            // Clear all columns that have been accessed (i.e., initialized).
+            // For forward-only result sets, this resets DTV state to allow reuse.
+            int clearUpTo = Math.min(lastColumnIndex, columns.length + 1);
+            for (int columnIndex = 1; columnIndex < clearUpTo; ++columnIndex)
                 getColumn(columnIndex).clear();
 
             // Skip and discard the remainder of the last indexed column
@@ -2309,19 +2314,23 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
     @Override
     public double getDouble(int columnIndex) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getDouble", columnIndex);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getDouble", columnIndex);
         checkClosed();
         Double value = (Double) getValue(columnIndex, JDBCType.DOUBLE);
-        loggerExternal.exiting(getClassNameLogging(), "getDouble", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getDouble", value);
         return null != value ? value : 0;
     }
 
     @Override
     public double getDouble(String columnName) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getDouble", columnName);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getDouble", columnName);
         checkClosed();
         Double value = (Double) getValue(findColumn(columnName), JDBCType.DOUBLE);
-        loggerExternal.exiting(getClassNameLogging(), "getDouble", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getDouble", value);
         return null != value ? value : 0;
     }
 
@@ -2381,37 +2390,45 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
     @Override
     public int getInt(int columnIndex) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getInt", columnIndex);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getInt", columnIndex);
         checkClosed();
         Integer value = (Integer) getValue(columnIndex, JDBCType.INTEGER);
-        loggerExternal.exiting(getClassNameLogging(), "getInt", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getInt", value);
         return null != value ? value : 0;
     }
 
     @Override
     public int getInt(String columnName) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getInt", columnName);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getInt", columnName);
         checkClosed();
         Integer value = (Integer) getValue(findColumn(columnName), JDBCType.INTEGER);
-        loggerExternal.exiting(getClassNameLogging(), "getInt", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getInt", value);
         return null != value ? value : 0;
     }
 
     @Override
     public long getLong(int columnIndex) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getLong", columnIndex);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getLong", columnIndex);
         checkClosed();
         Long value = (Long) getValue(columnIndex, JDBCType.BIGINT);
-        loggerExternal.exiting(getClassNameLogging(), "getLong", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getLong", value);
         return null != value ? value : 0;
     }
 
     @Override
     public long getLong(String columnName) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getLong", columnName);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getLong", columnName);
         checkClosed();
         Long value = (Long) getValue(findColumn(columnName), JDBCType.BIGINT);
-        loggerExternal.exiting(getClassNameLogging(), "getLong", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getLong", value);
         return null != value ? value : 0;
     }
 
@@ -2568,7 +2585,8 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
     @Override
     public String getString(int columnIndex) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getString", columnIndex);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getString", columnIndex);
         checkClosed();
 
         String value = null;
@@ -2576,13 +2594,15 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         if (null != objectValue) {
             value = objectValue.toString();
         }
-        loggerExternal.exiting(getClassNameLogging(), "getString", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getString", value);
         return value;
     }
 
     @Override
     public String getString(String columnName) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getString", columnName);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getString", columnName);
         checkClosed();
 
         String value = null;
@@ -2590,7 +2610,8 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         if (null != objectValue) {
             value = objectValue.toString();
         }
-        loggerExternal.exiting(getClassNameLogging(), "getString", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getString", value);
         return value;
     }
 
@@ -2670,19 +2691,23 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
     @Override
     public java.sql.Timestamp getTimestamp(int columnIndex) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getTimestamp", columnIndex);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getTimestamp", columnIndex);
         checkClosed();
         java.sql.Timestamp value = (java.sql.Timestamp) getValue(columnIndex, JDBCType.TIMESTAMP);
-        loggerExternal.exiting(getClassNameLogging(), "getTimestamp", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getTimestamp", value);
         return value;
     }
 
     @Override
     public java.sql.Timestamp getTimestamp(String columnName) throws SQLServerException {
-        loggerExternal.entering(getClassNameLogging(), "getTimestamp", columnName);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getTimestamp", columnName);
         checkClosed();
         java.sql.Timestamp value = (java.sql.Timestamp) getValue(findColumn(columnName), JDBCType.TIMESTAMP);
-        loggerExternal.exiting(getClassNameLogging(), "getTimestamp", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getTimestamp", value);
         return value;
     }
 
@@ -3032,19 +3057,23 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-        loggerExternal.entering(getClassNameLogging(), "getBigDecimal", columnIndex);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getBigDecimal", columnIndex);
         checkClosed();
         BigDecimal value = (BigDecimal) getValue(columnIndex, JDBCType.DECIMAL);
-        loggerExternal.exiting(getClassNameLogging(), "getBigDecimal", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getBigDecimal", value);
         return value;
     }
 
     @Override
     public BigDecimal getBigDecimal(String columnName) throws SQLException {
-        loggerExternal.entering(getClassNameLogging(), "getBigDecimal", columnName);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.entering(getClassNameLogging(), "getBigDecimal", columnName);
         checkClosed();
         BigDecimal value = (BigDecimal) getValue(findColumn(columnName), JDBCType.DECIMAL);
-        loggerExternal.exiting(getClassNameLogging(), "getBigDecimal", value);
+        if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
+            loggerExternal.exiting(getClassNameLogging(), "getBigDecimal", value);
         return value;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -133,6 +133,9 @@ final class DTV {
     /** The source (app or server) providing the data for this value. */
     private DTVImpl impl;
 
+    /** Cached ServerDTVImpl to avoid per-column allocation on every row */
+    private ServerDTVImpl cachedServerImpl;
+
     CryptoMetadata cryptoMeta = null;
     JDBCType jdbcTypeSetByUser = null;
     int valueLength = 0;
@@ -158,19 +161,32 @@ final class DTV {
     }
 
     final void clear() {
+        if (impl instanceof ServerDTVImpl) {
+            cachedServerImpl = (ServerDTVImpl) impl;
+        }
         impl = null;
+    }
+
+    private ServerDTVImpl getOrCreateServerDTVImpl() {
+        if (null != cachedServerImpl) {
+            ServerDTVImpl reused = cachedServerImpl;
+            cachedServerImpl = null;
+            reused.reinit();
+            return reused;
+        }
+        return new ServerDTVImpl();
     }
 
     final void skipValue(TypeInfo type, TDSReader tdsReader, boolean isDiscard) throws SQLServerException {
         if (null == impl)
-            impl = new ServerDTVImpl();
+            impl = getOrCreateServerDTVImpl();
 
         impl.skipValue(type, tdsReader, isDiscard);
     }
 
     final void initFromCompressedNull() {
         if (null == impl)
-            impl = new ServerDTVImpl();
+            impl = getOrCreateServerDTVImpl();
 
         impl.initFromCompressedNull();
     }
@@ -250,7 +266,7 @@ final class DTV {
             TypeInfo typeInfo, CryptoMetadata cryptoMetadata, TDSReader tdsReader,
             SQLServerStatement statement) throws SQLServerException {
         if (null == impl) {
-            impl = new ServerDTVImpl();
+            impl = getOrCreateServerDTVImpl();
         } else if (impl.isNull()) {
             return null;
         }
@@ -3317,8 +3333,23 @@ final class TypeInfo implements Serializable {
 final class ServerDTVImpl extends DTVImpl {
     private int valueLength;
     private TDSReaderMark valueMark;
+    private boolean hasValueMark;
     private boolean isNull;
     private SqlVariant internalVariant;
+
+    ServerDTVImpl() {
+        this.valueMark = new TDSReaderMark();
+    }
+
+    /**
+     * Resets this instance for reuse on a new column/row, avoiding reallocation.
+     */
+    final void reinit() {
+        valueLength = 0;
+        hasValueMark = false;
+        isNull = false;
+        internalVariant = null;
+    }
 
     /**
      * Sets the value of the DTV to an app-specified Java type.
@@ -3411,18 +3442,18 @@ final class ServerDTVImpl extends DTVImpl {
     // for the DTV when a null value is
     // received from NBCROW for a particular column
     final void initFromCompressedNull() {
-        assert valueMark == null;
+        assert !hasValueMark;
         isNull = true;
     }
 
     final void skipValue(TypeInfo type, TDSReader tdsReader, boolean isDiscard) throws SQLServerException {
         // indicates that this value was obtained from NBCROW
         // So, there is nothing else to read from the wire
-        if (null == valueMark && isNull) {
+        if (!hasValueMark && isNull) {
             return;
         }
 
-        if (null == valueMark)
+        if (!hasValueMark)
             getValuePrep(type, tdsReader);
         tdsReader.reset(valueMark);
         // value length zero means that the stream has been already skipped to the end - adaptive case
@@ -3451,7 +3482,7 @@ final class ServerDTVImpl extends DTVImpl {
 
     private void getValuePrep(TypeInfo typeInfo, TDSReader tdsReader) throws SQLServerException {
         // If we've already seen this value before, then we shouldn't be here.
-        assert null == valueMark;
+        assert !hasValueMark;
 
         // Otherwise, mark the value's location, figure out its length, and determine whether it was NULL.
         switch (typeInfo.getSSLenType()) {
@@ -3501,7 +3532,8 @@ final class ServerDTVImpl extends DTVImpl {
         if (valueLength > typeInfo.getMaxLength())
             tdsReader.throwInvalidTDS();
 
-        valueMark = tdsReader.mark();
+        tdsReader.markInto(valueMark);
+        hasValueMark = true;
     }
 
     Object denormalizedValue(byte[] decryptedValue, JDBCType jdbcType, TypeInfo baseTypeInfo, SQLServerConnection con,
@@ -3745,15 +3777,15 @@ final class ServerDTVImpl extends DTVImpl {
 
         // Note that the value should be prepped
         // only for columns whose values can be read of the wire.
-        // If valueMark == null and isNull, it implies that
+        // If hasValueMark is false and isNull, it implies that
         // the column is null according to NBCROW and that
         // there is nothing to be read from the wire.
-        if (null == valueMark && (!isNull))
+        if (!hasValueMark && (!isNull))
             getValuePrep(typeInfo, tdsReader);
 
         // either there should be a valueMark
-        // or valueMark should be null and isNull should be set to true(NBCROW case)
-        assert ((valueMark != null) || (valueMark == null && isNull));
+        // or hasValueMark should be false and isNull should be set to true(NBCROW case)
+        assert (hasValueMark || (!hasValueMark && isNull));
 
         if (null != streamGetterArgs) {
             if (!streamGetterArgs.streamType.convertsFrom(typeInfo))
@@ -3833,9 +3865,25 @@ final class ServerDTVImpl extends DTVImpl {
                 // (CHAR/VARCHAR/TEXT/NCHAR/NVARCHAR/NTEXT/BINARY/VARBINARY/IMAGE) -> ANY jdbcType.
                 case CHAR:
                 case VARCHAR:
-                case TEXT:
                 case NCHAR:
                 case NVARCHAR:
+                {
+                    // Fast path: for small non-streaming string values read directly
+                    // from TDSReader and convert to String without creating SimpleInputStream.
+                    // Only when the requested JDBC type is a character type (getString path).
+                    if (valueLength > 0 && valueLength <= 4000
+                            && streamGetterArgs.streamType == StreamType.NONE
+                            && !streamGetterArgs.isAdaptive
+                            && jdbcType.isTextual()) {
+                        byte[] bytes = new byte[valueLength];
+                        tdsReader.readBytes(bytes, 0, valueLength);
+                        convertedValue = new String(bytes, typeInfo.getCharset());
+                        break;
+                    }
+                    // Fall through to stream-based path for large values, streaming,
+                    // or non-textual target types
+                }
+                case TEXT:
                 case NTEXT:
                 case IMAGE:
                 case BINARY:

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -1056,7 +1056,11 @@ public final class TestUtils {
      * @return The updated connection string
      */
     public static String addOrOverrideProperty(String connectionString, String property, String value) {
-        return connectionString + ";" + property + "=" + value + ";";
+        // Remove existing occurrence first to avoid duplicate properties and double-semicolons
+        String cleaned = removeProperty(connectionString, property);
+        // Strip trailing semicolons left after removal, then re-append cleanly
+        cleaned = cleaned.replaceAll(";+$", "");
+        return cleaned + ";" + property + "=" + value + ";";
     }
 
     /**
@@ -1070,6 +1074,9 @@ public final class TestUtils {
      */
     public static String removeProperty(String connectionString, String property) {
         int start = connectionString.toLowerCase().indexOf(property.toLowerCase());
+        if (start == -1) {
+            return connectionString;
+        }
         int end = connectionString.indexOf(";", start);
         String propertyStr = connectionString.substring(start, -1 != end ? end + 1 : connectionString.length());
         return connectionString.replace(propertyStr, "");


### PR DESCRIPTION
## Summary

When reading large, wide result sets (e.g., 1M rows × 600 columns), profiling reveals that per-column overhead — object allocations, no-op logging calls, and intermediate stream construction — accumulates significantly across hundreds of millions of column accesses. The driver's lazy per-column reading architecture is well-suited for sparse column access patterns, but when applications read every column of every row, there are opportunities to reduce repeated work without changing that architecture.

This PR reduces that overhead through six targeted, low-risk changes. All changes preserve existing behavioral semantics — same values returned, same exceptions thrown, same API contracts honored.

**Files changed:** 3 &nbsp;|&nbsp; **Insertions:** 140 &nbsp;|&nbsp; **Deletions:** 44

---

## Changes

### A. Cache and reuse `ServerDTVImpl` instances (`dtv.java`)

**Problem:** Every column on every row allocates a `new ServerDTVImpl()` when its value is first accessed (via `DTV.skipValue()`, `DTV.getValue()`, or `DTV.initFromCompressedNull()`). When the row is discarded, `DTV.clear()` sets `impl = null`, and the object becomes garbage. For wide result sets this means **millions of short-lived allocations** that pressure the young generation GC.

**Fix:** `DTV.clear()` now stashes the outgoing `ServerDTVImpl` in a `cachedServerImpl` field instead of discarding it. The new helper `getOrCreateServerDTVImpl()` returns the cached instance (after calling `reinit()` to reset its fields) if available, or creates a new one otherwise. This converts millions of allocations into at most one per column position, reused across all rows.

```
Before:  clear() → impl = null   |  skipValue() → impl = new ServerDTVImpl()
After:   clear() → cachedServerImpl = impl; impl = null
         skipValue() → impl = cachedServerImpl.reinit()  (or new if first time)
```

**Risk:** Low. `reinit()` explicitly zeros all fields to the same state as a fresh constructor. The cache is per-DTV (per-column), so there are no cross-column or cross-row aliasing concerns. `AppDTVImpl` instances (from updatable result sets) are not cached — only `ServerDTVImpl`.

---

### B. Reuse `TDSReaderMark` objects (`dtv.java`, `IOBuffer.java`)

**Problem:** `ServerDTVImpl.getValuePrep()` calls `tdsReader.mark()` for every column value it encounters, which allocates `new TDSReaderMark(packet, offset)`. Combined with Change A, this adds **millions of additional allocations** of a 2-field object that is only used to save/restore a position in the TDS packet stream.

**Fix:**
- `TDSReaderMark` fields changed from `final` to mutable, and a no-arg constructor + `set(packet, offset)` method added.
- `TDSReader.markInto(TDSReaderMark)` added alongside the existing `mark()` — writes into an existing mark object instead of creating a new one.
- `ServerDTVImpl` now pre-allocates one `TDSReaderMark` at construction time and reuses it via `markInto()`. A `hasValueMark` boolean replaces the `valueMark == null` checks.
- The existing `mark()` method is unchanged and still used by all other callers (scroll windows, fetch buffer reset, LOB streams, etc.).

```
Before:  valueMark = tdsReader.mark()  → new TDSReaderMark(packet, offset)
After:   tdsReader.markInto(valueMark)  → valueMark.set(packet, offset)
```

**Risk:** Low. The mutable `TDSReaderMark` is private to `ServerDTVImpl` and never exposed externally. All other `mark()` callsites are untouched. The `setPositionAfterStreamed()` path (adaptive streaming) continues to use the allocating `mark()`.

---

### C. Fast-path `readUnsignedByte()` (`IOBuffer.java`)

**Problem:** `TDSReader.readUnsignedByte()` unconditionally calls `ensurePayload()` (a method call) before reading a single byte. This method is called as the length-prefix reader for every `BYTELENTYPE` column (e.g., `char(1)`, `varchar(64)`, nullable int/float/decimal). In the vast majority of cases the current packet still has data — the `ensurePayload()` call is a no-op.

**Fix:** Add an inline fast-path check `payloadOffset < currentPacket.payloadLength` before the `ensurePayload()` call, matching the pattern already used by `readInt()`, `readShort()`, and `readLong()`:

```java
// Before
final int readUnsignedByte() throws SQLServerException {
    if (!ensurePayload())
        throwInvalidTDS();
    return currentPacket.payload[payloadOffset++] & 0xFF;
}

// After
final int readUnsignedByte() throws SQLServerException {
    if (payloadOffset < currentPacket.payloadLength) {
        return currentPacket.payload[payloadOffset++] & 0xFF;
    }
    if (!ensurePayload())
        throwInvalidTDS();
    return currentPacket.payload[payloadOffset++] & 0xFF;
}
```

**Risk:** Very low. This is a pure performance optimization with identical semantics. The slow path is preserved for packet-boundary cases.

---

### D. Guard `loggerExternal.entering/exiting` in hot-path getters (`SQLServerResultSet.java`)

**Problem:** Every ResultSet getter (`getInt`, `getLong`, `getString`, `getDouble`, `getBigDecimal`, `getTimestamp`, `wasNull`) unconditionally calls `loggerExternal.entering(getClassNameLogging(), ...)` and `loggerExternal.exiting(getClassNameLogging(), ...)`. Even when logging is disabled (the normal case), each call involves:
- A `getClassNameLogging()` method call
- Autoboxing of primitive arguments (e.g., `int columnIndex` → `Integer`)
- Entry into `java.util.logging.Logger.entering()` which internally calls `isLoggable(Level.FINER)`

For wide result sets this adds up to **billions of no-op logging calls**.

**Fix:** Wrap `entering`/`exiting` calls in `if (loggerExternal.isLoggable(java.util.logging.Level.FINER))` guards. This is the same pattern already used by some other methods in the class (e.g., `getBigDecimal(int, int)`, `getTimestamp(int, Calendar)`).

```java
// Before
public int getInt(int columnIndex) throws SQLServerException {
    loggerExternal.entering(getClassNameLogging(), "getInt", columnIndex);
    checkClosed();
    Integer value = (Integer) getValue(columnIndex, JDBCType.INTEGER);
    loggerExternal.exiting(getClassNameLogging(), "getInt", value);
    return null != value ? value : 0;
}

// After
public int getInt(int columnIndex) throws SQLServerException {
    if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
        loggerExternal.entering(getClassNameLogging(), "getInt", columnIndex);
    checkClosed();
    Integer value = (Integer) getValue(columnIndex, JDBCType.INTEGER);
    if (loggerExternal.isLoggable(java.util.logging.Level.FINER))
        loggerExternal.exiting(getClassNameLogging(), "getInt", value);
    return null != value ? value : 0;
}
```

**Guarded methods:** `getInt(int)`, `getInt(String)`, `getLong(int)`, `getLong(String)`, `getDouble(int)`, `getDouble(String)`, `getString(int)`, `getString(String)`, `getBigDecimal(int)`, `getBigDecimal(String)`, `getTimestamp(int)`, `getTimestamp(String)`, `wasNull()`.

**Risk:** None. Logging behavior is identical — the guard is the same check that `Logger.entering/exiting` performs internally. When logging *is* enabled, the same messages are emitted.

---

### E. Optimize `discardCurrentRow()` cleanup loop (`SQLServerResultSet.java`)

**Problem:** When `next()` is called, `discardCurrentRow()` iterates through all previously-accessed columns calling `column.clear()` on each one individually. For a wide result set where all columns were read, this is hundreds of `clear()` calls per row.

**Fix:** Use `Math.min(lastColumnIndex, columns.length + 1)` to bound the clear loop correctly, avoiding any potential out-of-bounds iteration. The core loop remains — clearing is necessary to trigger `ServerDTVImpl` caching (Change A) — but the bounds are tighter.

**Risk:** Very low. The loop performs the same work, with slightly cleaner bounds.

---

### F. Fast-path small string reads without `SimpleInputStream` (`dtv.java`)

**Problem:** When `getString()` is called on a `CHAR`, `VARCHAR`, `NCHAR`, or `NVARCHAR` column, `ServerDTVImpl.getValue()` creates a `new SimpleInputStream(tdsReader, valueLength, ...)`, which is then passed to `DDC.convertStreamToObject()`. That method calls `stream.getBytes()` (allocates `byte[valueLength]`, reads, closes the stream) → `new String(bytes, charset)`. The `SimpleInputStream` creation involves:
- Object allocation + `BaseInputStream` constructor (field init, conditional mark)
- `getBytes()` → `new byte[payloadLength]` allocation + `read()` loop + `close()`
- `close()` → skip remaining + `closeHelper()` (null out fields)

For wide result sets with many string columns, this means **millions of `SimpleInputStream` allocations + millions of `byte[]` allocations** where the stream is immediately consumed and discarded.

**Fix:** For `CHAR`/`VARCHAR`/`NCHAR`/`NVARCHAR` columns where:
- `valueLength > 0 && valueLength <= 4000` (not a large value)
- `streamGetterArgs.streamType == StreamType.NONE` (not a streaming access)
- `!streamGetterArgs.isAdaptive` (not adaptive buffering)
- `jdbcType.isTextual()` (target type is a character type, i.e., `getString()` path)

...read bytes directly from `TDSReader` into a `byte[]` and create a `String` immediately, bypassing `SimpleInputStream` entirely:

```java
// Fast path
byte[] bytes = new byte[valueLength];
tdsReader.readBytes(bytes, 0, valueLength);
convertedValue = new String(bytes, typeInfo.getCharset());
```

The fall-through case (for `TEXT`, `NTEXT`, `IMAGE`, `BINARY`, `VARBINARY`, `VECTOR`, large values, streaming access, or non-textual target types like `getInt()` on a varchar column) continues to use the `SimpleInputStream` path.

**Risk:** Low. The fast path produces the exact same `String` result as the stream path — `DDC.convertStreamToObject` for non-streaming textual types ultimately does `new String(stream.getBytes(), charset)` and then `convertStringToObject` returns the string as-is for `CHARACTER` category JDBC types. The guards (`isTextual()`, size limit, non-streaming) ensure we only take this path when the result is provably identical.

---

## Benchmark Context

| Metric | Before | After (est.) |
|--------|--------|-------------|
| `ServerDTVImpl` allocs | millions | ~1 per column (reused) |
| `TDSReaderMark` allocs | millions | ~1 per column (reused) |
| `SimpleInputStream` allocs for strings | millions | ~0 (fast path) |
| No-op logging method calls | billions | ~0 (guarded) |
| Per-column `clear()` calls | millions | millions (same, but enables caching) |

Workload: `SELECT * FROM PERF_TABLE` — wide table with many columns of mixed types (`char`, `varchar`, `decimal`, `float`, `datetime`), ~50% null groups.

---

## What is NOT changed

- `checkClosed()` validation chain (safety-critical)
- Scrollable / updatable / server-cursor ResultSet paths
- LOB streaming, adaptive response buffering
- Always Encrypted decryption paths
- `PLPInputStream` (MAX types) paths
- Any public API signatures or behavior
