### PR TITLE
Add Enhanced Routing support for Hyperscale reader endpoints (TDS FEATUREEXT 0x0F / ENVCHANGE  type 21)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -170,6 +170,9 @@ final class TDS {
     static final byte TDS_FEATURE_EXT_AZURESQLDNSCACHING = 0x0B;
     static final byte TDS_FEATURE_EXT_SESSIONRECOVERY = 0x01;
 
+    // Enhanced Routing support
+    static final byte TDS_FEATURE_EXT_ENHANCEDROUTING = 0x10;
+
     // Vector support
     static final byte TDS_FEATURE_EXT_VECTORSUPPORT = 0x0E;
     static final byte VECTORSUPPORT_NOT_SUPPORTED = 0x00; // vector not supported; will return json formatted string

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -171,7 +171,7 @@ final class TDS {
     static final byte TDS_FEATURE_EXT_SESSIONRECOVERY = 0x01;
 
     // Enhanced Routing support
-    static final byte TDS_FEATURE_EXT_ENHANCEDROUTING = 0x10;
+    static final byte TDS_FEATURE_EXT_ENHANCEDROUTING = 0x0F;
 
     // Vector support
     static final byte TDS_FEATURE_EXT_VECTORSUPPORT = 0x0E;
@@ -261,6 +261,8 @@ final class TDS {
                 return "TDS_FEATURE_EXT_JSONSUPPORT (0x0D)";
             case TDS_FEATURE_EXT_USERAGENT:
                 return "TDS_FEATURE_EXT_USERAGENT (0x10)";
+            case TDS_FEATURE_EXT_ENHANCEDROUTING:
+                return "TDS_FEATURE_EXT_ENHANCEDROUTING (0x0F)";
 
             default:
                 return "unknown token (0x" + Integer.toHexString(tdsTokenType).toUpperCase() + ")";

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -261,7 +261,7 @@ final class TDS {
                 return "TDS_FEATURE_EXT_JSONSUPPORT (0x0D)";
             case TDS_FEATURE_EXT_USERAGENT:
                 return "TDS_FEATURE_EXT_USERAGENT (0x10)";
-                
+
             default:
                 return "unknown token (0x" + Integer.toHexString(tdsTokenType).toUpperCase() + ")";
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3937,6 +3937,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 while (true) {
                     clientConnectionId = null;
                     state = State.INITIALIZED;
+                    // Reset enhanced routing state for each connection attempt so a stale
+                    // ack from a prior failed attempt does not carry over to a different server.
+                    serverSupportsEnhancedRouting = false;
 
                     try {
                         if (isDBMirroring && useFailoverHost) {
@@ -4060,8 +4063,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             } else {
                                 // set isRoutedInCurrentAttempt to false for the next attempt
                                 isRoutedInCurrentAttempt = false;
-                                // Reset so the routed server must re-negotiate enhanced routing
-                                serverSupportsEnhancedRouting = false;
 
                                 continue;
                             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -1343,6 +1343,13 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return serverSupportsJSON;
     }
 
+    /** whether server supports Enhanced Routing */
+    private boolean serverSupportsEnhancedRouting = false;
+
+    boolean getServerSupportsEnhancedRouting() {
+        return serverSupportsEnhancedRouting;
+    }
+
     /** Boolean that indicates whether LOB objects created by this connection should be loaded into memory */
     private boolean delayLoadingLobs = SQLServerDriverBooleanProperty.DELAY_LOADING_LOBS.getDefaultValue();
 
@@ -6025,6 +6032,24 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return len;
     }
 
+    /**
+     * Writes the Enhanced Routing feature request.
+     * 
+     * @param write true to write the request, false to just calculate the length
+     * @param tdsWriter the TDS writer
+     * @return The length of the feature request in bytes
+     * @throws SQLServerException
+     */
+    int writeEnhancedRoutingFeatureRequest(boolean write, /* if false just calculates the length */
+            TDSWriter tdsWriter) throws SQLServerException {
+        int len = 5; // 1byte = featureID, 4bytes = featureData length (0 bytes, no payload)
+        if (write) {
+            tdsWriter.writeByte(TDS.TDS_FEATURE_EXT_ENHANCEDROUTING);
+            tdsWriter.writeInt(0); // No payload for enhanced routing
+        }
+        return len;
+    }
+
     int writeIdleConnectionResiliencyRequest(boolean write, TDSWriter tdsWriter) throws SQLServerException {
         SessionStateTable ssTable = sessionRecovery.getSessionStateTable();
         int len = 1;
@@ -6255,6 +6280,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     private static final int ENVCHANGE_RESET_COMPLETE = 18;
     private static final int ENVCHANGE_USER_INFO = 19;
     private static final int ENVCHANGE_ROUTING = 20;
+    private static final int ENVCHANGE_ENHANCED_ROUTING = 21;
 
     final void processEnvChange(TDSReader tdsReader) throws SQLServerException {
         tdsReader.readUnsignedByte(); // token type
@@ -6369,18 +6395,25 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     connectionlogger.finer(toString() + " Ignored env change: " + envchange);
                 break;
             case ENVCHANGE_ROUTING:
-
-                // initialize to invalid values
-                int routingDataValueLength, routingProtocol, routingPortNumber, routingServerNameLength;
+            case ENVCHANGE_ENHANCED_ROUTING:
+                // Enhanced routing should only be processed if the feature was successfully negotiated
+                boolean isEnhancedRouting = (envchange == ENVCHANGE_ENHANCED_ROUTING);
+                if (isEnhancedRouting && !serverSupportsEnhancedRouting) {
+                    if (connectionlogger.isLoggable(Level.WARNING)) {
+                        connectionlogger.warning(toString() + " Received enhanced routing ENVCHANGE but feature was not negotiated");
+                    }
+                    throwInvalidTDS();
+                }
+                int routingDataValueLength, routingProtocol, routingPortNumber, routingServerNameLength, routingDatabaseNameLength = -1;
                 routingDataValueLength = routingProtocol = routingPortNumber = routingServerNameLength = -1;
 
                 String routingServerName = null;
+                String routingDatabaseName = null;
 
                 try {
                     routingDataValueLength = tdsReader.readUnsignedShort();
-                    if (routingDataValueLength <= 5)// (5 is the no of bytes in protocol + port number+ length field of
-                                                    // server name)
-                    {
+                    int minDataLength = isEnhancedRouting ? 7 : 5; // Enhanced routing requires additional database name field
+                    if (routingDataValueLength <= minDataLength) {
                         throwInvalidTDS();
                     }
 
@@ -6402,12 +6435,24 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     routingServerName = tdsReader.readUnicodeString(routingServerNameLength);
                     assert routingServerName != null;
 
+                    // Enhanced routing includes database name
+                    if (isEnhancedRouting) {
+                        routingDatabaseNameLength = tdsReader.readUnsignedShort();
+                        if (routingDatabaseNameLength <= 0 || routingDatabaseNameLength > 128) {
+                            throwInvalidTDS();
+                        }
+
+                        routingDatabaseName = tdsReader.readUnicodeString(routingDatabaseNameLength);
+                        assert routingDatabaseName != null;
+                    }
+
                 } finally {
                     if (connectionlogger.isLoggable(Level.FINER)) {
                         connectionlogger.finer(toString() + " Received routing ENVCHANGE with the following values."
                                 + " routingDataValueLength:" + routingDataValueLength + " protocol:" + routingProtocol
                                 + " portNumber:" + routingPortNumber + " serverNameLength:" + routingServerNameLength
-                                + " serverName:" + ((routingServerName != null) ? routingServerName : "null"));
+                                + " serverName:" + ((routingServerName != null) ? routingServerName : "null") 
+                                + " routingDatabaseName:" + ((routingDatabaseName != null) ? routingDatabaseName : "null"));
                     }
                 }
 
@@ -6439,13 +6484,15 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                         activeConnectionProperties.setProperty("hostNameInCertificate", newHostName);
 
                         if (connectionlogger.isLoggable(Level.FINER)) {
-                            connectionlogger.finer(toString() + "Using new host to validate the SSL certificate");
+                            connectionlogger.finer(toString() + "Using new host to validate the SSL certificate" 
+                                    + (isEnhancedRouting ? " for enhanced routing" : ""));
                         }
                     }
                 }
 
                 isRoutedInCurrentAttempt = true;
-                routingInfo = new ServerPortPlaceHolder(routingServerName, routingPortNumber, null, integratedSecurity);
+                // For enhanced routing, include the database name in the routing info
+                routingInfo = new ServerPortPlaceHolder(routingServerName, routingPortNumber, null, routingDatabaseName, integratedSecurity);
                 break;
 
             // Error on unrecognized, unused ENVCHANGES
@@ -7480,8 +7527,17 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 .getProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString());
         String interfaceLibName = "Microsoft JDBC Driver " + SQLJdbcVersion.MAJOR + "." + SQLJdbcVersion.MINOR;
         // String interfaceLibName = SQLServerDriver.constructedAppName;
-        String databaseName = activeConnectionProperties
-                .getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
+        String databaseName;
+        // For enhanced routing, use the database name from the routing information if available
+        if (null != currentConnectPlaceHolder && null != currentConnectPlaceHolder.getDatabaseName()) {
+            databaseName = currentConnectPlaceHolder.getDatabaseName();
+            if (connectionlogger.isLoggable(Level.FINER)) {
+                connectionlogger.finer(toString() + " Using database name from enhanced routing: " + databaseName);
+            }
+        } else {
+            databaseName = activeConnectionProperties
+                    .getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
+        }
 
         String serverName;
         if (null != currentConnectPlaceHolder) {
@@ -7568,6 +7624,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         
         // request JSON support
         len += writeJSONSupportFeatureRequest(false, tdsWriter);
+        // request Enhanced Routing support (always sent)
+        len += writeEnhancedRoutingFeatureRequest(false, tdsWriter);
 
         len = len + 1; // add 1 to length because of FeatureEx terminator
 
@@ -7770,6 +7828,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         writeDNSCacheFeatureRequest(true, tdsWriter);
         writeVectorSupportFeatureRequest(true, tdsWriter);
         writeJSONSupportFeatureRequest(true, tdsWriter);
+        writeEnhancedRoutingFeatureRequest(true, tdsWriter);
 
         // Idle Connection Resiliency is requested
         if (connectRetryCount > 0) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3948,6 +3948,18 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             currentConnectPlaceHolder = currentFOPlaceHolder;
                         } else {
                             if (routingInfo != null) {
+                                // If we received enhanced routing info (with database name) but the server
+                                // did not acknowledge the enhanced routing feature, discard the routing info
+                                // and connect to the current server instead.
+                                if (routingInfo.getDatabaseName() != null && !serverSupportsEnhancedRouting) {
+                                    if (connectionlogger.isLoggable(Level.WARNING)) {
+                                        connectionlogger.warning(toString()
+                                                + " Ignoring enhanced routing info because the server did not acknowledge the feature.");
+                                    }
+                                    routingInfo = null;
+                                    break;
+                                }
+                                
                                 if (loggerRedirection.isLoggable(Level.FINE)) {
                                     loggerRedirection
                                             .fine(toString() + " Connection open - redirecting to server and instance: "
@@ -7085,8 +7097,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     }
 
     private void onFeatureExtAck(byte featureId, byte[] data) throws SQLServerException {
-        // To be able to cache both control and tenant ring IPs, need to parse AZURESQLDNSCACHING.
-        if (null != routingInfo && TDS.TDS_FEATURE_EXT_AZURESQLDNSCACHING != featureId)
+        // During routing, only process DNS caching and enhanced routing acks;
+        // enhanced routing must be ack'd before routing info is consumed.
+        if (null != routingInfo && TDS.TDS_FEATURE_EXT_AZURESQLDNSCACHING != featureId
+                && TDS.TDS_FEATURE_EXT_ENHANCEDROUTING != featureId)
             return;
 
         switch (featureId) {
@@ -7288,10 +7302,21 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 break;
             }
 
-            case TDS.TDS_FEATURE_EXT_USERAGENT: {
+            case TDS.TDS_FEATURE_EXT_ENHANCEDROUTING: {
                 if (connectionlogger.isLoggable(Level.FINER)) {
-                    connectionlogger.fine(
-                            toString() + " Received feature extension acknowledgement for User agent feature extension. Received byte: " + data[0]);
+                    connectionlogger.fine(toString() + " Received feature extension acknowledgement for Enhanced Routing.");
+                }
+
+                // Enhanced Routing feature extension ack should contain exactly 1 byte:
+                // data[0] == 1 means the server supports enhanced routing
+                // data[0] == 0 means the server does not support enhanced routing
+                if (1 != data.length) {
+                    throw new SQLServerException(SQLServerException.getErrString("R_enhancedRoutingFeatureAckContainsExtraData"), null);
+                }
+                serverSupportsEnhancedRouting = (data[0] == 1);
+
+                if (connectionlogger.isLoggable(Level.FINER)) {
+                    connectionlogger.fine(toString() + " Enhanced Routing support enabled: " + serverSupportsEnhancedRouting);
                 }
                 break;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3937,6 +3937,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 while (true) {
                     clientConnectionId = null;
                     state = State.INITIALIZED;
+                    // Reset enhanced routing state for each connection attempt so a stale
+                    // ack from a prior failed attempt does not carry over to a different server.
+                    serverSupportsEnhancedRouting = false;
 
                     try {
                         if (isDBMirroring && useFailoverHost) {
@@ -6414,7 +6417,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     if (connectionlogger.isLoggable(Level.WARNING)) {
                         connectionlogger.warning(toString() + " Received enhanced routing ENVCHANGE but feature was not negotiated");
                     }
-                    throwInvalidTDS();
+                    throw new SQLServerException(
+                            SQLServerException.getErrString("R_invalidEnhancedRoutingInfo"), null);
                 }
                 int routingDataValueLength, routingProtocol, routingPortNumber, routingServerNameLength, routingDatabaseNameLength = -1;
                 routingDataValueLength = routingProtocol = routingPortNumber = routingServerNameLength = -1;
@@ -6424,7 +6428,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
                 try {
                     routingDataValueLength = tdsReader.readUnsignedShort();
-                    int minDataLength = isEnhancedRouting ? 7 : 5; // Enhanced routing requires additional database name field
+                    int minDataLength = isEnhancedRouting ? 7 : 5; // Enhanced routing adds a database name field
                     if (routingDataValueLength <= minDataLength) {
                         throwInvalidTDS();
                     }
@@ -6451,7 +6455,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     if (isEnhancedRouting) {
                         routingDatabaseNameLength = tdsReader.readUnsignedShort();
                         if (routingDatabaseNameLength <= 0 || routingDatabaseNameLength > 128) {
-                            throwInvalidTDS();
+                            throw new SQLServerException(
+                                    SQLServerException.getErrString("R_invalidEnhancedRoutingInfo"), null);
                         }
 
                         routingDatabaseName = tdsReader.readUnicodeString(routingDatabaseNameLength);
@@ -7097,6 +7102,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     }
 
     private void onFeatureExtAck(byte featureId, byte[] data) throws SQLServerException {
+        // To be able to cache both control and tenant ring IPs, need to parse AZURESQLDNSCACHING.
         // During routing, only process DNS caching and enhanced routing acks;
         // enhanced routing must be ack'd before routing info is consumed.
         if (null != routingInfo && TDS.TDS_FEATURE_EXT_AZURESQLDNSCACHING != featureId
@@ -7299,6 +7305,14 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     throw new SQLServerException(SQLServerException.getErrString("R_InvalidJSONVersionNumber"), null);
                 }
                 serverSupportsJSON = true;
+                break;
+            }
+
+            case TDS.TDS_FEATURE_EXT_USERAGENT: {
+                if (connectionlogger.isLoggable(Level.FINER)) {
+                    connectionlogger.fine(
+                            toString() + " Received feature extension acknowledgement for User agent feature extension. Received byte: " + data[0]);
+                }
                 break;
             }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3937,9 +3937,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 while (true) {
                     clientConnectionId = null;
                     state = State.INITIALIZED;
-                    // Reset enhanced routing state for each connection attempt so a stale
-                    // ack from a prior failed attempt does not carry over to a different server.
-                    serverSupportsEnhancedRouting = false;
 
                     try {
                         if (isDBMirroring && useFailoverHost) {
@@ -4063,6 +4060,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             } else {
                                 // set isRoutedInCurrentAttempt to false for the next attempt
                                 isRoutedInCurrentAttempt = false;
+                                // Reset so the routed server must re-negotiate enhanced routing
+                                serverSupportsEnhancedRouting = false;
 
                                 continue;
                             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6407,7 +6407,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 break;
             case ENVCHANGE_ROUTING:
             case ENVCHANGE_ENHANCED_ROUTING:
-                boolean isEnhancedRouting = (envchange == ENVCHANGE_ENHANCED_ROUTING);
+                boolean isEnhancedRouting = (envchange == ENVCHANGE_ENHANCED_ROUTING); // Enhanced Routing includes database name in addition to server/port
                 if (isEnhancedRouting && !serverSupportsEnhancedRouting) {
                     if (connectionlogger.isLoggable(Level.WARNING)) {
                         connectionlogger.warning(toString() + " Received enhanced routing ENVCHANGE (type 21) but feature was not negotiated. "
@@ -7312,7 +7312,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
             case TDS.TDS_FEATURE_EXT_ENHANCEDROUTING: {
                 if (connectionlogger.isLoggable(Level.FINER)) {
-                    connectionlogger.fine(toString() + " Received feature extension acknowledgement for Enhanced Routing.");
+                    connectionlogger.finer(toString() + " Received feature extension acknowledgement for Enhanced Routing.");
                 }
 
                 // Enhanced Routing feature extension ack should contain exactly 1 byte:
@@ -7324,7 +7324,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 serverSupportsEnhancedRouting = (data[0] == 1);
 
                 if (connectionlogger.isLoggable(Level.FINER)) {
-                    connectionlogger.fine(toString() + " Enhanced Routing support enabled: " + serverSupportsEnhancedRouting);
+                    connectionlogger.finer(toString() + " Enhanced Routing support enabled: " + serverSupportsEnhancedRouting);
                 }
                 break;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3937,9 +3937,6 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 while (true) {
                     clientConnectionId = null;
                     state = State.INITIALIZED;
-                    // Reset enhanced routing state for each connection attempt so a stale
-                    // ack from a prior failed attempt does not carry over to a different server.
-                    serverSupportsEnhancedRouting = false;
 
                     try {
                         if (isDBMirroring && useFailoverHost) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6408,14 +6408,12 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 break;
             case ENVCHANGE_ROUTING:
             case ENVCHANGE_ENHANCED_ROUTING:
-                // Enhanced routing should only be processed if the feature was successfully negotiated
                 boolean isEnhancedRouting = (envchange == ENVCHANGE_ENHANCED_ROUTING);
                 if (isEnhancedRouting && !serverSupportsEnhancedRouting) {
                     if (connectionlogger.isLoggable(Level.WARNING)) {
-                        connectionlogger.warning(toString() + " Received enhanced routing ENVCHANGE but feature was not negotiated");
+                        connectionlogger.warning(toString() + " Received enhanced routing ENVCHANGE (type 21) but feature was not negotiated. "
+                                + "Database name from routing info will be ignored.");
                     }
-                    throw new SQLServerException(
-                            SQLServerException.getErrString("R_invalidEnhancedRoutingInfo"), null);
                 }
                 int routingDataValueLength, routingProtocol, routingPortNumber, routingServerNameLength, routingDatabaseNameLength = -1;
                 routingDataValueLength = routingProtocol = routingPortNumber = routingServerNameLength = -1;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3950,23 +3950,22 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             if (routingInfo != null) {
                                 // If we received enhanced routing info (with database name) but the server
                                 // did not acknowledge the enhanced routing feature, discard the routing info
-                                // and connect to the current server instead.
+                                // and fall through to connect to the current server instead.
                                 if (routingInfo.getDatabaseName() != null && !serverSupportsEnhancedRouting) {
                                     if (connectionlogger.isLoggable(Level.WARNING)) {
                                         connectionlogger.warning(toString()
                                                 + " Ignoring enhanced routing info because the server did not acknowledge the feature.");
                                     }
                                     routingInfo = null;
-                                    break;
+                                } else {
+                                    if (loggerRedirection.isLoggable(Level.FINE)) {
+                                        loggerRedirection
+                                                .fine(toString() + " Connection open - redirecting to server and instance: "
+                                                        + routingInfo.getFullServerName());
+                                    }
+                                    currentPrimaryPlaceHolder = routingInfo;
+                                    routingInfo = null;
                                 }
-                                
-                                if (loggerRedirection.isLoggable(Level.FINE)) {
-                                    loggerRedirection
-                                            .fine(toString() + " Connection open - redirecting to server and instance: "
-                                                    + routingInfo.getFullServerName());
-                                }
-                                currentPrimaryPlaceHolder = routingInfo;
-                                routingInfo = null;
                             } else if (null == currentPrimaryPlaceHolder) {
                                 currentPrimaryPlaceHolder = primaryPermissionCheck(primary, primaryInstanceName,
                                         primaryPortNumber);
@@ -6412,7 +6411,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (isEnhancedRouting && !serverSupportsEnhancedRouting) {
                     if (connectionlogger.isLoggable(Level.WARNING)) {
                         connectionlogger.warning(toString() + " Received enhanced routing ENVCHANGE (type 21) but feature was not negotiated. "
-                                + "Database name from routing info will be ignored.");
+                                + "Routing info will be parsed but discarded by the login guard.");
                     }
                 }
                 int routingDataValueLength, routingProtocol, routingPortNumber, routingServerNameLength, routingDatabaseNameLength = -1;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -4060,6 +4060,8 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                             } else {
                                 // set isRoutedInCurrentAttempt to false for the next attempt
                                 isRoutedInCurrentAttempt = false;
+                                // Reset so the routed server must re-negotiate enhanced routing
+                                serverSupportsEnhancedRouting = false;
 
                                 continue;
                             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -361,7 +361,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_UnrequestedFeatureAckReceived", "Unrequested feature acknowledge is received. Feature ID: {0}."},
         {"R_FedAuthFeatureAckContainsExtraData", "Federated authentication feature extension ack for ADAL and Security Token includes extra data."},
         {"R_FedAuthFeatureAckUnknownLibraryType", "Attempting to use unknown federated authentication library. Library ID: {0}."},
-        {"R_enhancedRoutingFeatureAckContainsExtraData", "Enhanced routing feature extension ack should not contain any data."},
+        {"R_enhancedRoutingFeatureAckContainsExtraData", "Enhanced routing feature extension ack should contain exactly 1 byte of data."},
         {"R_UnknownFeatureAck", "Unknown feature acknowledge is received."},
         {"R_SetAuthenticationWhenIntegratedSecurityTrue", "Cannot set \"Authentication\" with \"IntegratedSecurity\" set to \"true\"."},
         {"R_NtlmNoUserPasswordDomain", "\"User\" (or \"UserName\") and \"Password\" connection properties must be specified for NTLM authentication."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -362,6 +362,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_FedAuthFeatureAckContainsExtraData", "Federated authentication feature extension ack for ADAL and Security Token includes extra data."},
         {"R_FedAuthFeatureAckUnknownLibraryType", "Attempting to use unknown federated authentication library. Library ID: {0}."},
         {"R_enhancedRoutingFeatureAckContainsExtraData", "Enhanced routing feature extension ack should contain exactly 1 byte of data."},
+        {"R_invalidEnhancedRoutingInfo", "Invalid enhanced routing information received."},
         {"R_UnknownFeatureAck", "Unknown feature acknowledge is received."},
         {"R_SetAuthenticationWhenIntegratedSecurityTrue", "Cannot set \"Authentication\" with \"IntegratedSecurity\" set to \"true\"."},
         {"R_NtlmNoUserPasswordDomain", "\"User\" (or \"UserName\") and \"Password\" connection properties must be specified for NTLM authentication."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -361,6 +361,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_UnrequestedFeatureAckReceived", "Unrequested feature acknowledge is received. Feature ID: {0}."},
         {"R_FedAuthFeatureAckContainsExtraData", "Federated authentication feature extension ack for ADAL and Security Token includes extra data."},
         {"R_FedAuthFeatureAckUnknownLibraryType", "Attempting to use unknown federated authentication library. Library ID: {0}."},
+        {"R_enhancedRoutingFeatureAckContainsExtraData", "Enhanced routing feature extension ack should not contain any data."},
         {"R_UnknownFeatureAck", "Unknown feature acknowledge is received."},
         {"R_SetAuthenticationWhenIntegratedSecurityTrue", "Cannot set \"Authentication\" with \"IntegratedSecurity\" set to \"true\"."},
         {"R_NtlmNoUserPasswordDomain", "\"User\" (or \"UserName\") and \"Password\" connection properties must be specified for NTLM authentication."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ServerPortPlaceHolder.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ServerPortPlaceHolder.java
@@ -24,10 +24,15 @@ final class ServerPortPlaceHolder implements Serializable {
     private final String fullServerName;
     private final int port;
     private final String instanceName;
+    private final String databaseName; // For enhanced routing
     private final boolean checkLink;
     private final transient SQLServerConnectionSecurityManager securityManager;
 
     ServerPortPlaceHolder(String name, int conPort, String instance, boolean fLink) {
+        this(name, conPort, instance, null, fLink);
+    }
+
+    ServerPortPlaceHolder(String name, int conPort, String instance, String database, boolean fLink) {
         serverName = name;
 
         // serverName without named instance
@@ -39,6 +44,7 @@ final class ServerPortPlaceHolder implements Serializable {
 
         port = conPort;
         instanceName = instance;
+        databaseName = database; // For enhanced routing scenarios
         checkLink = fLink;
         securityManager = new SQLServerConnectionSecurityManager(serverName, port);
         doSecurityCheck();
@@ -55,6 +61,10 @@ final class ServerPortPlaceHolder implements Serializable {
 
     String getInstanceName() {
         return instanceName;
+    }
+
+    String getDatabaseName() {
+        return databaseName;
     }
 
     String getParsedServerName() {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
@@ -20,7 +20,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -54,16 +53,12 @@ public class EnhancedRoutingIntegrationTest {
     @DisplayName("Live Server Integration Tests")
     class LiveServerTests extends AbstractTest {
 
-        private static final String DBNAME_QUERY = "SELECT DB_NAME() AS [db]";
+        private final String DBNAME_QUERY = "SELECT DB_NAME() AS [db]";
         private String hyperscaleDatabase;
 
-        @BeforeAll
-        static void setupHyperscale() throws Exception {
-            setConnection();
-        }
-
         @BeforeEach
-        void checkPreconditions() {
+        void setUp() throws Exception {
+            setConnection();
             hyperscaleDatabase = getConfiguredProperty("hyperscaleDatabase", null);
             assumeTrue(hyperscaleDatabase != null && !hyperscaleDatabase.isEmpty(),
                     "Skipping: 'hyperscaleDatabase' not configured.");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
@@ -89,6 +89,13 @@ public class EnhancedRoutingIntegrationTest {
             invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_FEDAUTH, new byte[]{});
         }
 
+        @Test
+        @DisplayName("getTokenName returns correct string for TDS_FEATURE_EXT_ENHANCEDROUTING")
+        void testGetTokenName() {
+            assertEquals("TDS_FEATURE_EXT_ENHANCEDROUTING (0x0F)",
+                    TDS.getTokenName(TDS.TDS_FEATURE_EXT_ENHANCEDROUTING));
+        }
+
         /**
          * Ack enhanced routing, inject ENVCHANGE 21, call login() via reflection.
          * Verifies login() guard accepts routing and sets currentConnectPlaceHolder.

--- a/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
@@ -12,42 +12,32 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
 
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
 /**
- * Enhanced Routing tests (TDS Feature 0x0F / ENVCHANGE 0x21).
- * <p>
- * Contains two nested test classes:
- * <ul>
- *   <li>{@link LiveServerTests} — integration tests against an Azure Hyperscale database
- *       with HA read replicas</li>
- *   <li>{@link MockedProtocolTests} — unit tests using Mockito to verify feature negotiation,
- *       ack parsing, ENVCHANGE handling, and routing guard logic without a live server</li>
- * </ul>
+ * Tests for Enhanced Routing (TDS Feature 0x0F / ENVCHANGE 0x21).
  */
 @Tag(Constants.enhancedRouting)
 public class EnhancedRoutingIntegrationTest {
-
-    // ──────────────────────────────────────────────────────────────────────────
-    //  Nested class 1: Live-server integration tests
-    // ──────────────────────────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("Live Server Integration Tests")
@@ -88,19 +78,16 @@ public class EnhancedRoutingIntegrationTest {
         }
 
         @Test
-        @DisplayName("Server supports enhanced routing (ENVCHANGE 0x21)")
+        @DisplayName("Server acks enhanced routing and ENVCHANGE 0x21 carries database name")
         void testServerSupportsEnhancedRouting() throws Exception {
             try (SQLServerConnection conn = (SQLServerConnection) DriverManager
                     .getConnection(buildConnectionString("ReadOnly"))) {
-
-                assertTrue(conn.getServerSupportsEnhancedRouting(),
-                        "Server must acknowledge enhanced routing feature (TDS_FEATURE_EXT 0x0F)");
+                assertTrue(conn.getServerSupportsEnhancedRouting());
 
                 ServerPortPlaceHolder placeholder = getPlaceHolder(conn);
                 assertNotNull(placeholder, "Connection must have been routed");
                 assertNotNull(placeholder.getDatabaseName(),
-                        "ENVCHANGE 0x21 must carry a database name — confirms enhanced routing (type 21), "
-                                + "not legacy routing (type 20)");
+                        "ENVCHANGE 0x21 must carry a database name");
             }
         }
 
@@ -133,9 +120,6 @@ public class EnhancedRoutingIntegrationTest {
         }
     }
 
-    // ──────────────────────────────────────────────────────────────────────────
-    //  Nested class 2: Mocked protocol unit tests (no live server needed)
-    // ──────────────────────────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("Mocked Protocol Tests")
@@ -145,55 +129,26 @@ public class EnhancedRoutingIntegrationTest {
 
         @BeforeEach
         void setUp() throws Exception {
-            MockitoAnnotations.openMocks(this);
-            conn = new SQLServerConnection("MockedTest");
-        }
-
-        // ── Feature request write tests ──────────────────────────────────────
-
-        @Test
-        @DisplayName("writeEnhancedRoutingFeatureRequest returns correct length (5 bytes)")
-        void testFeatureRequestLength() throws Exception {
-            // write=false → just calculates length, no writer needed
-            int len = conn.writeEnhancedRoutingFeatureRequest(false, null);
-            assertEquals(5, len, "Feature request must be 5 bytes: 1 (featureId) + 4 (int32 length=0)");
-        }
-
-        // ── Feature ack tests (onFeatureExtAck) ─────────────────────────────
-
-        @Test
-        @DisplayName("onFeatureExtAck with data=[1] enables serverSupportsEnhancedRouting")
-        void testFeatureAckEnabled() throws Exception {
-            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
-            assertTrue(conn.getServerSupportsEnhancedRouting(),
-                    "data[0]==1 must enable enhanced routing");
+            conn = new SQLServerConnection("UnitTest");
         }
 
         @Test
-        @DisplayName("onFeatureExtAck with data=[0] keeps serverSupportsEnhancedRouting false")
-        void testFeatureAckDisabled() throws Exception {
-            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{0});
-            assertFalse(conn.getServerSupportsEnhancedRouting(),
-                    "data[0]==0 must not enable enhanced routing");
-        }
+        @DisplayName("onFeatureExtAck throws with exact error message for invalid ack data")
+        void testFeatureAckInvalidDataThrowsWithMessage() {
+            String expectedMessage = "Enhanced routing feature extension ack should contain exactly 1 byte of data.";
 
-        @Test
-        @DisplayName("onFeatureExtAck with empty data throws SQLServerException")
-        void testFeatureAckEmptyDataThrows() {
-            assertThrows(SQLServerException.class,
-                    () -> invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{}),
-                    "Empty ack data must throw — expected exactly 1 byte");
-        }
+            // Empty data — 0 bytes instead of 1
+            SQLServerException emptyEx = assertThrows(SQLServerException.class,
+                    () -> invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{}));
+            assertEquals(expectedMessage, emptyEx.getMessage(),
+                    "Empty ack data must throw with exact error message");
 
-        @Test
-        @DisplayName("onFeatureExtAck with extra data throws SQLServerException")
-        void testFeatureAckExtraDataThrows() {
-            assertThrows(SQLServerException.class,
-                    () -> invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1, 0}),
-                    "More than 1 byte in ack data must throw");
+            // Extra data — 2 bytes instead of 1
+            SQLServerException extraEx = assertThrows(SQLServerException.class,
+                    () -> invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1, 0}));
+            assertEquals(expectedMessage, extraEx.getMessage(),
+                    "Extra ack data must throw with exact error message");
         }
-
-        // ── Feature ack routing filter tests ────────────────────────────────
 
         @Test
         @DisplayName("onFeatureExtAck filters non-DNS/non-enhancedRouting features when routingInfo is set")
@@ -206,99 +161,169 @@ public class EnhancedRoutingIntegrationTest {
         }
 
         @Test
-        @DisplayName("onFeatureExtAck allows enhanced routing ack even when routingInfo is set")
-        void testFeatureAckAllowsEnhancedRoutingDuringRouting() throws Exception {
-            setRoutingInfo(conn, new ServerPortPlaceHolder("routed-server", 1433, null, "mydb", false));
+        @DisplayName("Server under load routes to different database — driver uses routed DB name in Login7")
+        void testFullFlowEnhancedRoutingDatabaseName() throws Exception {
+            String originalDatabase = "OriginalDB";
+            String routedDatabase = "RoutedReplicaDB";
+            String routedServer = "routed-replica.database.windows.net";
+            int routedPort = 1433;
 
+            // Client initially connected to OriginalDB
+            setupActiveConnectionProperties(conn);
+            Field propsField = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
+            propsField.setAccessible(true);
+            Properties props = (Properties) propsField.get(conn);
+            props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), originalDatabase);
+
+            // Before routing: sendLogon() would use the original database
+            String preRouteDatabase = props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
+            assertEquals(originalDatabase, preRouteDatabase,
+                    "Before routing, Login7 must use the original database");
+
+            // Server acks enhanced routing during feature negotiation
             invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
-            assertTrue(conn.getServerSupportsEnhancedRouting());
-        }
+            assertTrue(conn.getServerSupportsEnhancedRouting(), "Feature must be acked");
 
-        // ── Routing guard tests ─────────────────────────────────────────────
+            // Server is under load — sends ENVCHANGE 21 routing client to a different database
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, routedServer, routedPort, routedDatabase);
+            conn.processEnvChange(tdsReader);
 
-        @Test
-        @DisplayName("Enhanced routing info is discarded when server did not ack the feature")
-        void testRoutingGuardDiscardsEnhancedRoutingWhenNotAcked() throws Exception {
-            ServerPortPlaceHolder enhancedRouting = new ServerPortPlaceHolder(
-                    "routed-host", 1433, null, "someDatabase", false);
-            setRoutingInfo(conn, enhancedRouting);
-            setServerSupportsEnhancedRouting(conn, false);
-
-            assertNotNull(getRoutingInfo(conn));
-            assertNotNull(getRoutingInfo(conn).getDatabaseName());
-
-            boolean discarded = simulateRoutingGuard(conn);
-            assertTrue(discarded, "Guard must discard enhanced routing info when feature not acked");
-            assertNull(getRoutingInfo(conn), "routingInfo must be null after guard discards it");
+            // Verify the real TDS parser extracted the routing info correctly
+            ServerPortPlaceHolder routing = getRoutingInfo(conn);
+            assertNotNull(routing, "processEnvChange must populate routingInfo from ENVCHANGE 21");
+            // Verify the routing info carries the routed database, server, and port
+            assertEquals(routedDatabase, routing.getDatabaseName(),
+                    "Login7 must use routed database, not original");
+            assertEquals(routedServer, routing.getServerName(),
+                    "Driver must reconnect to the routed server");
+            assertEquals(routedPort, routing.getPortNumber(),
+                    "Driver must reconnect to the routed port");
         }
 
         @Test
-        @DisplayName("Legacy routing info (no databaseName) is NOT discarded by guard")
-        void testRoutingGuardKeepsLegacyRouting() throws Exception {
-            ServerPortPlaceHolder legacyRouting = new ServerPortPlaceHolder(
-                    "routed-host", 1433, null, false);
-            setRoutingInfo(conn, legacyRouting);
-            setServerSupportsEnhancedRouting(conn, false);
+        @DisplayName("No ack + ENVCHANGE 21 → processEnvChange rejects unrecognized enhanced routing")
+        void testFullFlowNoAckEnvChange21Throws() throws Exception {
+            String originalDatabase = "OriginalDB";
 
-            boolean discarded = simulateRoutingGuard(conn);
-            assertFalse(discarded, "Guard must NOT discard legacy routing info (no databaseName)");
-            assertNotNull(getRoutingInfo(conn));
+            // Client initially connected to OriginalDB
+            setupActiveConnectionProperties(conn);
+            Field propsField = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
+            propsField.setAccessible(true);
+            Properties props = (Properties) propsField.get(conn);
+            props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), originalDatabase);
+
+            // Before routing: Login7 uses original database
+            assertEquals(originalDatabase,
+                    props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString()),
+                    "Before routing, Login7 must use the original database");
+
+            // Server did NOT ack enhanced routing
+            assertFalse(conn.getServerSupportsEnhancedRouting(), "Feature must not be acked");
+
+            // Server sends ENVCHANGE 21 anyway — processEnvChange must reject it
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, "routed-server", 1433, "SomeDB");
+            assertThrows(SQLServerException.class, () -> conn.processEnvChange(tdsReader),
+                    "ENVCHANGE 21 without feature ack must throw");
+
+            // After rejection: routingInfo must remain null, original database unchanged
+            assertNull(getRoutingInfo(conn), "routingInfo must remain null after rejected ENVCHANGE 21");
+            assertEquals(originalDatabase,
+                    props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString()),
+                    "After rejected routing, Login7 must still use original database");
         }
 
         @Test
-        @DisplayName("Enhanced routing info is kept when server DID ack the feature")
-        void testRoutingGuardKeepsWhenAcked() throws Exception {
-            ServerPortPlaceHolder enhancedRouting = new ServerPortPlaceHolder(
-                    "routed-host", 1433, null, "someDatabase", false);
-            setRoutingInfo(conn, enhancedRouting);
-            setServerSupportsEnhancedRouting(conn, true);
+        @DisplayName("Legacy ENVCHANGE 20 → driver routes to new server but keeps original database name")
+        void testFullFlowLegacyRoutingUsesOriginalDatabase() throws Exception {
+            String originalDatabase = "OriginalDB";
+            String routedServer = "routed-server.database.windows.net";
+            int routedPort = 1433;
 
-            boolean discarded = simulateRoutingGuard(conn);
-            assertFalse(discarded, "Guard must NOT discard routing info when feature was acked");
-            assertNotNull(getRoutingInfo(conn));
+            // Client initially connected to OriginalDB
+            setupActiveConnectionProperties(conn);
+            Field propsField = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
+            propsField.setAccessible(true);
+            Properties props = (Properties) propsField.get(conn);
+            props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), originalDatabase);
+
+            // Before routing: Login7 uses original database
+            assertEquals(originalDatabase,
+                    props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString()),
+                    "Before routing, Login7 must use the original database");
+
+            // Server sends legacy ENVCHANGE 20 (no database name in routing info)
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 20, routedServer, routedPort, null);
+            conn.processEnvChange(tdsReader);
+
+            // Verify parser populated routingInfo without database name
+            ServerPortPlaceHolder routing = getRoutingInfo(conn);
+            assertNotNull(routing, "processEnvChange must set routingInfo for legacy routing");
+            assertEquals(routedServer, routing.getServerName(), "Driver must route to the new server");
+            assertEquals(routedPort, routing.getPortNumber(), "Driver must route to the new port");
+            assertNull(routing.getDatabaseName(), "Legacy ENVCHANGE 20 must not carry a database name");
         }
 
-        // ── ServerPortPlaceHolder tests ─────────────────────────────────────
-
         @Test
-        @DisplayName("ServerPortPlaceHolder 5-arg constructor stores databaseName")
-        void testPlaceHolderWithDatabaseName() {
-            ServerPortPlaceHolder ph = new ServerPortPlaceHolder("server1", 1433, "inst", "mydb", false);
-            assertEquals("server1", ph.getServerName());
-            assertEquals(1433, ph.getPortNumber());
-            assertEquals("inst", ph.getInstanceName());
-            assertEquals("mydb", ph.getDatabaseName());
-        }
-
-        @Test
-        @DisplayName("ServerPortPlaceHolder 4-arg constructor has null databaseName")
-        void testPlaceHolderWithoutDatabaseName() {
-            ServerPortPlaceHolder ph = new ServerPortPlaceHolder("server1", 1433, "inst", false);
-            assertEquals("server1", ph.getServerName());
-            assertEquals(1433, ph.getPortNumber());
-            assertNull(ph.getDatabaseName(), "Legacy constructor must leave databaseName null");
-        }
-
-        // ── Diagnostic field tests ───────────────────────────────────────────
-
-        @Test
-        @DisplayName("serverSupportsEnhancedRouting is false by default")
-        void testEnhancedRoutingDefaultFalse() {
+        @DisplayName("Server acks enhanced routing with data[0]=0 (explicitly disabled)")
+        void testFeatureAckExplicitlyDisabled() throws Exception {
+            // Server sends ack with data[0]=0 — explicitly says "I don't support enhanced routing"
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{0});
             assertFalse(conn.getServerSupportsEnhancedRouting(),
-                    "serverSupportsEnhancedRouting must default to false");
-        }
+                    "data[0]=0 must leave serverSupportsEnhancedRouting as false");
 
-        // ── TDS constant tests ──────────────────────────────────────────────
+            // Now if server sends ENVCHANGE 21, it must be rejected
+            setupActiveConnectionProperties(conn);
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, "routed-server", 1433, "SomeDB");
+            assertThrows(SQLServerException.class, () -> conn.processEnvChange(tdsReader),
+                    "ENVCHANGE 21 must be rejected when server explicitly disabled the feature");
+            assertNull(getRoutingInfo(conn), "routingInfo must remain null");
+        }
 
         @Test
-        @DisplayName("TDS_FEATURE_EXT_ENHANCEDROUTING is 0x0F")
-        void testFeatureIdValue() {
-            assertEquals((byte) 0x0F, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING,
-                    "Enhanced routing feature ID must be 0x0F");
+        @DisplayName("ENVCHANGE 21 with port 0 throws invalid TDS")
+        void testEnvChange21InvalidPort() throws Exception {
+            setupActiveConnectionProperties(conn);
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
+
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, "routed-server", 0, "SomeDB");
+            assertThrows(SQLServerException.class, () -> conn.processEnvChange(tdsReader),
+                    "Port 0 in ENVCHANGE 21 must throw");
         }
 
-        // ── Helper methods ──────────────────────────────────────────────────
+        @Test
+        @DisplayName("ENVCHANGE 21 with database name length 0 throws invalid enhanced routing info")
+        void testEnvChange21EmptyDatabaseName() throws Exception {
+            setupActiveConnectionProperties(conn);
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
 
+            // Craft bytes with dbNameLength=0 (invalid for enhanced routing)
+            TDSReader tdsReader = createTdsReaderWithEnvChange21EmptyDb(conn, "routed-server", 1433);
+            assertThrows(SQLServerException.class, () -> conn.processEnvChange(tdsReader),
+                    "Empty database name in ENVCHANGE 21 must throw");
+        }
+
+        @Test
+        @DisplayName("Enhanced routing updates hostNameInCertificate for same-domain routed server")
+        void testHostNameInCertificateUpdatedOnRouting() throws Exception {
+            setupActiveConnectionProperties(conn);
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
+
+            // Route to a server in the same *.database.windows.net domain
+            String routedServer = "replica-xyz.database.windows.net";
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, routedServer, 1433, "RoutedDB");
+            conn.processEnvChange(tdsReader);
+
+            Field propsField = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
+            propsField.setAccessible(true);
+            Properties props = (Properties) propsField.get(conn);
+            String updatedHostName = props.getProperty("hostNameInCertificate");
+
+            // The wildcard should match the routed server's domain
+            assertEquals("*.database.windows.net", updatedHostName,
+                    "hostNameInCertificate must be updated to match routed server domain");
+        }
+
+        // Helper methods
         private void invokeOnFeatureExtAck(SQLServerConnection conn, byte featureId, byte[] data) throws Exception {
             Method m = SQLServerConnection.class.getDeclaredMethod("onFeatureExtAck", byte.class, byte[].class);
             m.setAccessible(true);
@@ -324,31 +349,117 @@ public class EnhancedRoutingIntegrationTest {
             return (ServerPortPlaceHolder) f.get(conn);
         }
 
-        private void setServerSupportsEnhancedRouting(SQLServerConnection conn, boolean value) throws Exception {
-            Field f = SQLServerConnection.class.getDeclaredField("serverSupportsEnhancedRouting");
+        /** Sets fields on conn so processEnvChange and TDSReader don't NPE. */
+        private void setupActiveConnectionProperties(SQLServerConnection conn) throws Exception {
+            Properties props = new Properties();
+            props.setProperty("hostNameInCertificate", "*.database.windows.net");
+            Field f = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
             f.setAccessible(true);
-            f.set(conn, value);
+            f.set(conn, props);
+
+            // TDSReader constructor calls isColumnEncryptionSettingEnabled() which needs this non-null
+            Field ces = SQLServerConnection.class.getDeclaredField("columnEncryptionSetting");
+            ces.setAccessible(true);
+            ces.set(conn, "Disabled");
         }
 
         /**
-         * Simulates the routing guard logic from login()'s else branch:
-         * if routingInfo has a databaseName but the server didn't ack enhanced routing,
-         * discard the routing info.
+         * Crafts a TDS ENVCHANGE routing token and returns a TDSReader positioned at the start.
          *
-         * @return true if routing info was discarded
+         * Wire format: [0xE3] [envValueLength: LE ushort] [envchange: byte]
+         *   [routingDataLen: LE ushort] [protocol=0] [port: LE ushort]
+         *   [serverNameLen: LE ushort] [serverName: UTF-16LE]
+         *   [dbNameLen: LE ushort] [dbName: UTF-16LE]  ← only for envchange=21
+         *   [oldValueLen=0: byte]
          */
-        private boolean simulateRoutingGuard(SQLServerConnection conn) throws Exception {
-            ServerPortPlaceHolder routing = getRoutingInfo(conn);
-            if (routing != null && routing.getDatabaseName() != null) {
-                Field f = SQLServerConnection.class.getDeclaredField("serverSupportsEnhancedRouting");
-                f.setAccessible(true);
-                boolean supported = f.getBoolean(conn);
-                if (!supported) {
-                    setRoutingInfo(conn, null);
-                    return true;
-                }
+        private TDSReader createTdsReaderWithEnvChange(SQLServerConnection conn,
+                int envchange, String serverName, int port, String databaseName) throws Exception {
+
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            byte[] serverBytes = serverName.getBytes(StandardCharsets.UTF_16LE);
+
+            int routingDataLen = 1 + 2 + 2 + serverBytes.length;
+            if (envchange == 21 && databaseName != null) {
+                routingDataLen += 2 + databaseName.getBytes(StandardCharsets.UTF_16LE).length;
             }
-            return false;
+            int envValueLength = 1 + 2 + routingDataLen + 1;
+
+            buf.write(0xE3);                          // token type
+            writeUShortLE(buf, envValueLength);        // envValueLength
+            buf.write(envchange);                      // envchange type (20 or 21)
+            writeUShortLE(buf, routingDataLen);         // routing data length
+            buf.write(0);                              // protocol
+            writeUShortLE(buf, port);                   // port
+            writeUShortLE(buf, serverName.length());    // server name length (chars)
+            buf.write(serverBytes);                    // server name (UTF-16LE)
+
+            if (envchange == 21 && databaseName != null) {
+                byte[] dbBytes = databaseName.getBytes(StandardCharsets.UTF_16LE);
+                writeUShortLE(buf, databaseName.length());
+                buf.write(dbBytes);
+            }
+
+            buf.write(0);  // old value length = 0
+
+            byte[] payload = buf.toByteArray();
+
+            // Inject crafted bytes into a TDSPacket → TDSReader
+            TDSPacket packet = new TDSPacket(payload.length);
+            System.arraycopy(payload, 0, packet.payload, 0, payload.length);
+            packet.payloadLength = payload.length;
+
+            return createTdsReader(conn, packet);
+        }
+
+        private TDSReader createTdsReader(SQLServerConnection conn, TDSPacket packet) throws Exception {
+            java.lang.reflect.Constructor<TDSReader> ctor = TDSReader.class.getDeclaredConstructor(
+                    TDSChannel.class, SQLServerConnection.class, TDSCommand.class);
+            ctor.setAccessible(true);
+            TDSReader reader = ctor.newInstance(null, conn, null);
+
+            Field currentPacketField = TDSReader.class.getDeclaredField("currentPacket");
+            currentPacketField.setAccessible(true);
+            currentPacketField.set(reader, packet);
+
+            Field offsetField = TDSReader.class.getDeclaredField("payloadOffset");
+            offsetField.setAccessible(true);
+            offsetField.set(reader, 0);
+
+            return reader;
+        }
+
+        private void writeUShortLE(ByteArrayOutputStream buf, int value) {
+            buf.write(value & 0xFF);
+            buf.write((value >> 8) & 0xFF);
+        }
+
+        /** Crafts ENVCHANGE 21 with dbNameLength=0 to test empty database name rejection. */
+        private TDSReader createTdsReaderWithEnvChange21EmptyDb(SQLServerConnection conn,
+                String serverName, int port) throws Exception {
+
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            byte[] serverBytes = serverName.getBytes(StandardCharsets.UTF_16LE);
+
+            // routingDataLen includes: protocol(1) + port(2) + serverNameLen(2) + serverBytes + dbNameLen(2)
+            int routingDataLen = 1 + 2 + 2 + serverBytes.length + 2;
+            int envValueLength = 1 + 2 + routingDataLen + 1;
+
+            buf.write(0xE3);
+            writeUShortLE(buf, envValueLength);
+            buf.write(21);                             // enhanced routing
+            writeUShortLE(buf, routingDataLen);
+            buf.write(0);                              // protocol
+            writeUShortLE(buf, port);
+            writeUShortLE(buf, serverName.length());
+            buf.write(serverBytes);
+            writeUShortLE(buf, 0);                     // dbNameLength = 0 (invalid)
+            buf.write(0);                              // old value length = 0
+
+            byte[] payload = buf.toByteArray();
+            TDSPacket packet = new TDSPacket(payload.length);
+            System.arraycopy(payload, 0, packet.payload, 0, payload.length);
+            packet.payloadLength = payload.length;
+            return createTdsReader(conn, packet);
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
@@ -10,17 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +22,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
@@ -38,88 +30,6 @@ import com.microsoft.sqlserver.testframework.Constants;
  */
 @Tag(Constants.enhancedRouting)
 public class EnhancedRoutingIntegrationTest {
-
-    @Nested
-    @DisplayName("Live Server Integration Tests")
-    class LiveServerTests extends AbstractTest {
-
-        private final String DBNAME_QUERY = "SELECT DB_NAME() AS [db]";
-        private String hyperscaleDatabase;
-
-        @BeforeEach
-        void setUp() throws Exception {
-            setConnection();
-            hyperscaleDatabase = getConfiguredProperty("hyperscaleDatabase", null);
-            assumeTrue(hyperscaleDatabase != null && !hyperscaleDatabase.isEmpty(),
-                    "Skipping: 'hyperscaleDatabase' not configured.");
-        }
-
-        private String buildConnectionString(String applicationIntent) {
-            String connStr = connectionString;
-            connStr = TestUtils.addOrOverrideProperty(connStr, "database", hyperscaleDatabase);
-            connStr = TestUtils.addOrOverrideProperty(connStr, "encrypt", "true");
-            connStr = TestUtils.addOrOverrideProperty(connStr, "trustServerCertificate", "false");
-            connStr = TestUtils.addOrOverrideProperty(connStr, "loginTimeout", "30");
-            if (applicationIntent != null) {
-                connStr = TestUtils.addOrOverrideProperty(connStr, "applicationIntent", applicationIntent);
-            }
-            return connStr;
-        }
-
-        @Test
-        @DisplayName("Connect to Hyperscale database")
-        void testConnectivity() throws SQLException {
-            try (Connection conn = DriverManager.getConnection(buildConnectionString("ReadOnly"));
-                    Statement stmt = conn.createStatement();
-                    ResultSet rs = stmt.executeQuery("SELECT 1 AS [ok]")) {
-                assertTrue(rs.next());
-                assertEquals(1, rs.getInt("ok"));
-            }
-        }
-
-        @Test
-        @DisplayName("Server acks enhanced routing and ENVCHANGE 0x21 carries database name")
-        void testServerSupportsEnhancedRouting() throws Exception {
-            try (SQLServerConnection conn = (SQLServerConnection) DriverManager
-                    .getConnection(buildConnectionString("ReadOnly"))) {
-                assertTrue(conn.getServerSupportsEnhancedRouting());
-
-                ServerPortPlaceHolder placeholder = getPlaceHolder(conn);
-                assertNotNull(placeholder, "Connection must have been routed");
-                assertNotNull(placeholder.getDatabaseName(),
-                        "ENVCHANGE 0x21 must carry a database name");
-            }
-        }
-
-        @Test
-        @DisplayName("Routed database name matches DB_NAME() on replica")
-        void testRoutedDatabaseNameMatchesActual() throws Exception {
-            try (SQLServerConnection conn = (SQLServerConnection) DriverManager
-                    .getConnection(buildConnectionString("ReadOnly"))) {
-
-                ServerPortPlaceHolder placeholder = getPlaceHolder(conn);
-                String routedDbName = placeholder.getDatabaseName();
-                assertNotNull(routedDbName, "Enhanced routing must carry a database name");
-
-                try (Statement stmt = conn.createStatement();
-                        ResultSet rs = stmt.executeQuery(DBNAME_QUERY)) {
-                    assertTrue(rs.next());
-                    assertEquals(routedDbName, rs.getString("db"),
-                            "DB_NAME() on replica must match the database name from ENVCHANGE 0x21");
-                }
-
-                assertEquals(hyperscaleDatabase, routedDbName,
-                        "Routed database name must match the requested Hyperscale database");
-            }
-        }
-
-        private ServerPortPlaceHolder getPlaceHolder(SQLServerConnection conn) throws Exception {
-            Field f = SQLServerConnection.class.getDeclaredField("currentConnectPlaceHolder");
-            f.setAccessible(true);
-            return (ServerPortPlaceHolder) f.get(conn);
-        }
-    }
-
 
     @Nested
     @DisplayName("Mocked Protocol Tests")
@@ -150,6 +60,25 @@ public class EnhancedRoutingIntegrationTest {
                     "Extra ack data must throw with exact error message");
         }
 
+        
+        @Test
+        @DisplayName("Feature negotiation: ack disabled [0] sets flag false, ack enabled [1] sets flag true")
+        void testFeatureNegotiationEnabledVsDisabled() throws Exception {
+            // Fresh connection — default is false
+            assertFalse(conn.getServerSupportsEnhancedRouting(),
+                    "Default flag value must be false before any ack");
+
+            // Ack disabled
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{0});
+            assertFalse(conn.getServerSupportsEnhancedRouting(),
+                    "Ack with data[0]=0 must leave flag false");
+
+            // Ack enabled
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
+            assertTrue(conn.getServerSupportsEnhancedRouting(),
+                    "Ack with data[0]=1 must set flag true");
+        }
+
         @Test
         @DisplayName("onFeatureExtAck filters non-DNS/non-enhancedRouting features when routingInfo is set")
         void testFeatureAckFilterDuringRouting() throws Exception {
@@ -160,9 +89,13 @@ public class EnhancedRoutingIntegrationTest {
             invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_FEDAUTH, new byte[]{});
         }
 
+        /**
+         * Ack enhanced routing, inject ENVCHANGE 21, call login() via reflection.
+         * Verifies login() guard accepts routing and sets currentConnectPlaceHolder.
+         */
         @Test
-        @DisplayName("Server under load routes to different database — driver uses routed DB name in Login7")
-        void testFullFlowEnhancedRoutingDatabaseName() throws Exception {
+        @DisplayName("Enhanced routing acked — login() accepts routing to different server and database")
+        void testRoutedConnectionViaLogin() throws Exception {
             String originalDatabase = "OriginalDB";
             String routedDatabase = "RoutedReplicaDB";
             String routedServer = "routed-replica.database.windows.net";
@@ -170,113 +103,49 @@ public class EnhancedRoutingIntegrationTest {
 
             // Client initially connected to OriginalDB
             setupActiveConnectionProperties(conn);
-            Field propsField = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
-            propsField.setAccessible(true);
-            Properties props = (Properties) propsField.get(conn);
+            Properties props = getActiveConnectionProperties(conn);
             props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), originalDatabase);
-
-            // Before routing: sendLogon() would use the original database
-            String preRouteDatabase = props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString());
-            assertEquals(originalDatabase, preRouteDatabase,
-                    "Before routing, Login7 must use the original database");
 
             // Server acks enhanced routing during feature negotiation
             invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
             assertTrue(conn.getServerSupportsEnhancedRouting(), "Feature must be acked");
 
-            // Server is under load — sends ENVCHANGE 21 routing client to a different database
+            // Server sends ENVCHANGE 21 routing client to a different database
             TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, routedServer, routedPort, routedDatabase);
             conn.processEnvChange(tdsReader);
 
-            // Verify the real TDS parser extracted the routing info correctly
-            ServerPortPlaceHolder routing = getRoutingInfo(conn);
-            assertNotNull(routing, "processEnvChange must populate routingInfo from ENVCHANGE 21");
-            // Verify the routing info carries the routed database, server, and port
-            assertEquals(routedDatabase, routing.getDatabaseName(),
-                    "Login7 must use routed database, not original");
-            assertEquals(routedServer, routing.getServerName(),
+            // Invoke actual login() — the routing guard runs in production code
+            ServerPortPlaceHolder routingTarget = invokeLoginAndGetRoutingTarget(conn);
+
+            // login() accepted the routing — currentConnectPlaceHolder has the routed target
+            assertNotNull(routingTarget,
+                    "login() guard must accept routingInfo when server acked enhanced routing");
+            assertEquals(routedServer, routingTarget.getServerName(),
                     "Driver must reconnect to the routed server");
-            assertEquals(routedPort, routing.getPortNumber(),
+            assertEquals(routedPort, routingTarget.getPortNumber(),
                     "Driver must reconnect to the routed port");
+            assertEquals(routedDatabase, routingTarget.getDatabaseName(),
+                    "Login7 must use routed database, not original");
+
+            // routingInfo consumed by login()
+            assertNull(getRoutingInfo(conn),
+                    "routingInfo must be consumed after login() guard accepts it");
         }
 
         @Test
-        @DisplayName("No ack + ENVCHANGE 21 → processEnvChange rejects unrecognized enhanced routing")
-        void testFullFlowNoAckEnvChange21Throws() throws Exception {
-            String originalDatabase = "OriginalDB";
-
-            // Client initially connected to OriginalDB
+        @DisplayName("Legacy ENVCHANGE 20 → routing info carries server and port but no database name")
+        void testFullFlowLegacyRoutingNoDatabaseName() throws Exception {
             setupActiveConnectionProperties(conn);
-            Field propsField = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
-            propsField.setAccessible(true);
-            Properties props = (Properties) propsField.get(conn);
-            props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), originalDatabase);
 
-            // Before routing: Login7 uses original database
-            assertEquals(originalDatabase,
-                    props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString()),
-                    "Before routing, Login7 must use the original database");
-
-            // Server did NOT ack enhanced routing
-            assertFalse(conn.getServerSupportsEnhancedRouting(), "Feature must not be acked");
-
-            // Server sends ENVCHANGE 21 anyway — processEnvChange must reject it
-            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, "routed-server", 1433, "SomeDB");
-            assertThrows(SQLServerException.class, () -> conn.processEnvChange(tdsReader),
-                    "ENVCHANGE 21 without feature ack must throw");
-
-            // After rejection: routingInfo must remain null, original database unchanged
-            assertNull(getRoutingInfo(conn), "routingInfo must remain null after rejected ENVCHANGE 21");
-            assertEquals(originalDatabase,
-                    props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString()),
-                    "After rejected routing, Login7 must still use original database");
-        }
-
-        @Test
-        @DisplayName("Legacy ENVCHANGE 20 → driver routes to new server but keeps original database name")
-        void testFullFlowLegacyRoutingUsesOriginalDatabase() throws Exception {
-            String originalDatabase = "OriginalDB";
-            String routedServer = "routed-server.database.windows.net";
-            int routedPort = 1433;
-
-            // Client initially connected to OriginalDB
-            setupActiveConnectionProperties(conn);
-            Field propsField = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
-            propsField.setAccessible(true);
-            Properties props = (Properties) propsField.get(conn);
-            props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), originalDatabase);
-
-            // Before routing: Login7 uses original database
-            assertEquals(originalDatabase,
-                    props.getProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString()),
-                    "Before routing, Login7 must use the original database");
-
-            // Server sends legacy ENVCHANGE 20 (no database name in routing info)
-            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 20, routedServer, routedPort, null);
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 20,
+                    "routed-server.database.windows.net", 1433, null);
             conn.processEnvChange(tdsReader);
 
-            // Verify parser populated routingInfo without database name
             ServerPortPlaceHolder routing = getRoutingInfo(conn);
             assertNotNull(routing, "processEnvChange must set routingInfo for legacy routing");
-            assertEquals(routedServer, routing.getServerName(), "Driver must route to the new server");
-            assertEquals(routedPort, routing.getPortNumber(), "Driver must route to the new port");
+            assertEquals("routed-server.database.windows.net", routing.getServerName());
+            assertEquals(1433, routing.getPortNumber());
             assertNull(routing.getDatabaseName(), "Legacy ENVCHANGE 20 must not carry a database name");
-        }
-
-        @Test
-        @DisplayName("Server acks enhanced routing with data[0]=0 (explicitly disabled)")
-        void testFeatureAckExplicitlyDisabled() throws Exception {
-            // Server sends ack with data[0]=0 — explicitly says "I don't support enhanced routing"
-            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{0});
-            assertFalse(conn.getServerSupportsEnhancedRouting(),
-                    "data[0]=0 must leave serverSupportsEnhancedRouting as false");
-
-            // Now if server sends ENVCHANGE 21, it must be rejected
-            setupActiveConnectionProperties(conn);
-            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21, "routed-server", 1433, "SomeDB");
-            assertThrows(SQLServerException.class, () -> conn.processEnvChange(tdsReader),
-                    "ENVCHANGE 21 must be rejected when server explicitly disabled the feature");
-            assertNull(getRoutingInfo(conn), "routingInfo must remain null");
         }
 
         @Test
@@ -323,7 +192,91 @@ public class EnhancedRoutingIntegrationTest {
                     "hostNameInCertificate must be updated to match routed server domain");
         }
 
+        /** No feature ack — login() guard discards routingInfo. */
+        @Test
+        @DisplayName("No feature ack — login guard discards routing, original DB preserved")
+        void testServerDoesNotRouteNoAck() throws Exception {
+            setupActiveConnectionProperties(conn);
+            Properties props = getActiveConnectionProperties(conn);
+            props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), "master");
+
+            // No feature ack — flag stays false (default)
+            assertFalse(conn.getServerSupportsEnhancedRouting());
+
+            // Server sends ENVCHANGE 21 with routed DB
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21,
+                    "routed.database.windows.net", 1433, "RoutedDB");
+            conn.processEnvChange(tdsReader);
+
+            // Invoke actual login() via reflection — the routing guard runs in production code
+            ServerPortPlaceHolder routingTarget = invokeLoginAndGetRoutingTarget(conn);
+
+            // Guard discarded the routing — connection stays on original server
+            assertNull(routingTarget,
+                    "login() guard must discard routingInfo when server did not ack enhanced routing");
+            assertNull(getRoutingInfo(conn),
+                    "routingInfo field must be null after login() guard discards it");
+        }
+
+        /** Feature ack data[0]=0 (disabled) — login() guard discards routingInfo. */
+        @Test
+        @DisplayName("Feature ack disabled — login guard discards routing, original DB preserved")
+        void testServerDoesNotRouteDisabled() throws Exception {
+            setupActiveConnectionProperties(conn);
+            Properties props = getActiveConnectionProperties(conn);
+            props.setProperty(SQLServerDriverStringProperty.DATABASE_NAME.toString(), "master");
+
+            // Server acks with data[0]=0 — explicitly disabled
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{0});
+            assertFalse(conn.getServerSupportsEnhancedRouting());
+
+            // Server sends ENVCHANGE 21
+            TDSReader tdsReader = createTdsReaderWithEnvChange(conn, 21,
+                    "routed.database.windows.net", 1433, "RoutedDB");
+            conn.processEnvChange(tdsReader);
+
+            // Invoke actual login() via reflection — the routing guard runs in production code
+            ServerPortPlaceHolder routingTarget = invokeLoginAndGetRoutingTarget(conn);
+
+            assertNull(routingTarget,
+                    "login() guard must discard routingInfo when server disabled enhanced routing");
+            assertNull(getRoutingInfo(conn),
+                    "routingInfo field must be null after login() guard discards it");
+        }
+
         // Helper methods
+
+        /**
+         * Calls login() via reflection. Reads {@code currentConnectPlaceHolder} afterward:
+         * non-null means routing accepted, null means discarded.
+         */
+        private ServerPortPlaceHolder invokeLoginAndGetRoutingTarget(SQLServerConnection conn) throws Exception {
+            // Reset the field so we can detect whether login() set it
+            Field connectField = SQLServerConnection.class.getDeclaredField("currentConnectPlaceHolder");
+            connectField.setAccessible(true);
+            connectField.set(conn, null);
+
+            Method loginMethod = SQLServerConnection.class.getDeclaredMethod("login",
+                    String.class, String.class, int.class, String.class,
+                    FailoverInfo.class, int.class, long.class);
+            loginMethod.setAccessible(true);
+
+            try {
+                loginMethod.invoke(conn, "localhost", null, 1433, null, null, 30, System.currentTimeMillis());
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                // Both paths crash eventually — that's expected
+            }
+
+            // Read the field: non-null means routing was accepted, null means discarded
+            return (ServerPortPlaceHolder) connectField.get(conn);
+        }
+
+        private Properties getActiveConnectionProperties(SQLServerConnection conn) throws Exception {
+            Field f = SQLServerConnection.class.getDeclaredField("activeConnectionProperties");
+            f.setAccessible(true);
+            return (Properties) f.get(conn);
+        }
+
         private void invokeOnFeatureExtAck(SQLServerConnection conn, byte featureId, byte[] data) throws Exception {
             Method m = SQLServerConnection.class.getDeclaredMethod("onFeatureExtAck", byte.class, byte[].class);
             m.setAccessible(true);
@@ -349,7 +302,7 @@ public class EnhancedRoutingIntegrationTest {
             return (ServerPortPlaceHolder) f.get(conn);
         }
 
-        /** Sets fields on conn so processEnvChange and TDSReader don't NPE. */
+        /** Initializes required fields on conn to avoid NPEs in processEnvChange/TDSReader. */
         private void setupActiveConnectionProperties(SQLServerConnection conn) throws Exception {
             Properties props = new Properties();
             props.setProperty("hostNameInCertificate", "*.database.windows.net");
@@ -363,15 +316,7 @@ public class EnhancedRoutingIntegrationTest {
             ces.set(conn, "Disabled");
         }
 
-        /**
-         * Crafts a TDS ENVCHANGE routing token and returns a TDSReader positioned at the start.
-         *
-         * Wire format: [0xE3] [envValueLength: LE ushort] [envchange: byte]
-         *   [routingDataLen: LE ushort] [protocol=0] [port: LE ushort]
-         *   [serverNameLen: LE ushort] [serverName: UTF-16LE]
-         *   [dbNameLen: LE ushort] [dbName: UTF-16LE]  ← only for envchange=21
-         *   [oldValueLen=0: byte]
-         */
+        /** Crafts a TDS ENVCHANGE routing token (type 20 or 21) and returns a positioned TDSReader. */
         private TDSReader createTdsReaderWithEnvChange(SQLServerConnection conn,
                 int envchange, String serverName, int port, String databaseName) throws Exception {
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
@@ -1,0 +1,116 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.Constants;
+
+
+/**
+ * Enhanced Routing integration tests (TDS Feature 0x0F / ENVCHANGE 0x21).
+ * Validates connectivity, feature negotiation, and database name routing
+ * against an Azure Hyperscale database with HA read replicas.
+ */
+@Tag(Constants.enhancedRouting)
+public class EnhancedRoutingIntegrationTest extends AbstractTest {
+
+    private static final String DBNAME_QUERY = "SELECT DB_NAME() AS [db]";
+
+    private static String hyperscaleDatabase;
+
+    @BeforeAll
+    static void setupHyperscale() throws Exception {
+        setConnection();
+        hyperscaleDatabase = getConfiguredProperty("hyperscaleDatabase", null);
+        assumeTrue(hyperscaleDatabase != null && !hyperscaleDatabase.isEmpty(),
+                "Skipping: 'hyperscaleDatabase' not configured.");
+    }
+
+    private String buildConnectionString(String applicationIntent) {
+        String connStr = connectionString;
+        connStr = TestUtils.addOrOverrideProperty(connStr, "database", hyperscaleDatabase);
+        connStr = TestUtils.addOrOverrideProperty(connStr, "encrypt", "true");
+        connStr = TestUtils.addOrOverrideProperty(connStr, "trustServerCertificate", "false");
+        connStr = TestUtils.addOrOverrideProperty(connStr, "loginTimeout", "30");
+        if (applicationIntent != null) {
+            connStr = TestUtils.addOrOverrideProperty(connStr, "applicationIntent", applicationIntent);
+        }
+        return connStr;
+    }
+
+    @Test
+    @DisplayName("Connect to Hyperscale database")
+    void testConnectivity() throws SQLException {
+        try (Connection conn = DriverManager.getConnection(buildConnectionString("ReadOnly"));
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT 1 AS [ok]")) {
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt("ok"));
+        }
+    }
+
+    @Test
+    @DisplayName("Server supports enhanced routing (ENVCHANGE 0x21)")
+    void testServerSupportsEnhancedRouting() throws Exception {
+        try (SQLServerConnection conn = (SQLServerConnection) DriverManager
+                .getConnection(buildConnectionString("ReadOnly"))) {
+
+            assertTrue(conn.getServerSupportsEnhancedRouting(),
+                    "Server must acknowledge enhanced routing feature (TDS_FEATURE_EXT 0x0F)");
+
+            Field f = SQLServerConnection.class.getDeclaredField("currentConnectPlaceHolder");
+            f.setAccessible(true);
+            ServerPortPlaceHolder placeholder = (ServerPortPlaceHolder) f.get(conn);
+            assertNotNull(placeholder, "Connection must have been routed");
+            assertNotNull(placeholder.getDatabaseName(),
+                    "ENVCHANGE 0x21 must carry a database name — confirms enhanced routing (type 21), "
+                            + "not legacy routing (type 20)");
+        }
+    }
+
+    @Test
+    @DisplayName("Routed database name matches DB_NAME() on replica")
+    void testRoutedDatabaseNameMatchesActual() throws Exception {
+        try (SQLServerConnection conn = (SQLServerConnection) DriverManager
+                .getConnection(buildConnectionString("ReadOnly"))) {
+
+            Field f = SQLServerConnection.class.getDeclaredField("currentConnectPlaceHolder");
+            f.setAccessible(true);
+            ServerPortPlaceHolder placeholder = (ServerPortPlaceHolder) f.get(conn);
+            String routedDbName = placeholder.getDatabaseName();
+            assertNotNull(routedDbName, "Enhanced routing must carry a database name");
+
+            // The database name the server sent via ENVCHANGE 0x21 must match
+            // what the replica actually reports as DB_NAME()
+            try (Statement stmt = conn.createStatement();
+                    ResultSet rs = stmt.executeQuery(DBNAME_QUERY)) {
+                assertTrue(rs.next());
+                assertEquals(routedDbName, rs.getString("db"),
+                        "DB_NAME() on replica must match the database name from ENVCHANGE 0x21");
+            }
+
+            // And both must match the originally requested database
+            assertEquals(hyperscaleDatabase, routedDbName,
+                    "Routed database name must match the requested Hyperscale database");
+        }
+    }
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/EnhancedRoutingIntegrationTest.java
@@ -5,11 +5,15 @@
 package com.microsoft.sqlserver.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -17,100 +21,339 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 
 
 /**
- * Enhanced Routing integration tests (TDS Feature 0x0F / ENVCHANGE 0x21).
- * Validates connectivity, feature negotiation, and database name routing
- * against an Azure Hyperscale database with HA read replicas.
+ * Enhanced Routing tests (TDS Feature 0x0F / ENVCHANGE 0x21).
+ * <p>
+ * Contains two nested test classes:
+ * <ul>
+ *   <li>{@link LiveServerTests} — integration tests against an Azure Hyperscale database
+ *       with HA read replicas</li>
+ *   <li>{@link MockedProtocolTests} — unit tests using Mockito to verify feature negotiation,
+ *       ack parsing, ENVCHANGE handling, and routing guard logic without a live server</li>
+ * </ul>
  */
 @Tag(Constants.enhancedRouting)
-public class EnhancedRoutingIntegrationTest extends AbstractTest {
+public class EnhancedRoutingIntegrationTest {
 
-    private static final String DBNAME_QUERY = "SELECT DB_NAME() AS [db]";
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Nested class 1: Live-server integration tests
+    // ──────────────────────────────────────────────────────────────────────────
 
-    private static String hyperscaleDatabase;
+    @Nested
+    @DisplayName("Live Server Integration Tests")
+    class LiveServerTests extends AbstractTest {
 
-    @BeforeAll
-    static void setupHyperscale() throws Exception {
-        setConnection();
-        hyperscaleDatabase = getConfiguredProperty("hyperscaleDatabase", null);
-        assumeTrue(hyperscaleDatabase != null && !hyperscaleDatabase.isEmpty(),
-                "Skipping: 'hyperscaleDatabase' not configured.");
-    }
+        private static final String DBNAME_QUERY = "SELECT DB_NAME() AS [db]";
+        private String hyperscaleDatabase;
 
-    private String buildConnectionString(String applicationIntent) {
-        String connStr = connectionString;
-        connStr = TestUtils.addOrOverrideProperty(connStr, "database", hyperscaleDatabase);
-        connStr = TestUtils.addOrOverrideProperty(connStr, "encrypt", "true");
-        connStr = TestUtils.addOrOverrideProperty(connStr, "trustServerCertificate", "false");
-        connStr = TestUtils.addOrOverrideProperty(connStr, "loginTimeout", "30");
-        if (applicationIntent != null) {
-            connStr = TestUtils.addOrOverrideProperty(connStr, "applicationIntent", applicationIntent);
+        @BeforeAll
+        static void setupHyperscale() throws Exception {
+            setConnection();
         }
-        return connStr;
-    }
 
-    @Test
-    @DisplayName("Connect to Hyperscale database")
-    void testConnectivity() throws SQLException {
-        try (Connection conn = DriverManager.getConnection(buildConnectionString("ReadOnly"));
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT 1 AS [ok]")) {
-            assertTrue(rs.next());
-            assertEquals(1, rs.getInt("ok"));
+        @BeforeEach
+        void checkPreconditions() {
+            hyperscaleDatabase = getConfiguredProperty("hyperscaleDatabase", null);
+            assumeTrue(hyperscaleDatabase != null && !hyperscaleDatabase.isEmpty(),
+                    "Skipping: 'hyperscaleDatabase' not configured.");
         }
-    }
 
-    @Test
-    @DisplayName("Server supports enhanced routing (ENVCHANGE 0x21)")
-    void testServerSupportsEnhancedRouting() throws Exception {
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager
-                .getConnection(buildConnectionString("ReadOnly"))) {
-
-            assertTrue(conn.getServerSupportsEnhancedRouting(),
-                    "Server must acknowledge enhanced routing feature (TDS_FEATURE_EXT 0x0F)");
-
-            Field f = SQLServerConnection.class.getDeclaredField("currentConnectPlaceHolder");
-            f.setAccessible(true);
-            ServerPortPlaceHolder placeholder = (ServerPortPlaceHolder) f.get(conn);
-            assertNotNull(placeholder, "Connection must have been routed");
-            assertNotNull(placeholder.getDatabaseName(),
-                    "ENVCHANGE 0x21 must carry a database name — confirms enhanced routing (type 21), "
-                            + "not legacy routing (type 20)");
-        }
-    }
-
-    @Test
-    @DisplayName("Routed database name matches DB_NAME() on replica")
-    void testRoutedDatabaseNameMatchesActual() throws Exception {
-        try (SQLServerConnection conn = (SQLServerConnection) DriverManager
-                .getConnection(buildConnectionString("ReadOnly"))) {
-
-            Field f = SQLServerConnection.class.getDeclaredField("currentConnectPlaceHolder");
-            f.setAccessible(true);
-            ServerPortPlaceHolder placeholder = (ServerPortPlaceHolder) f.get(conn);
-            String routedDbName = placeholder.getDatabaseName();
-            assertNotNull(routedDbName, "Enhanced routing must carry a database name");
-
-            // The database name the server sent via ENVCHANGE 0x21 must match
-            // what the replica actually reports as DB_NAME()
-            try (Statement stmt = conn.createStatement();
-                    ResultSet rs = stmt.executeQuery(DBNAME_QUERY)) {
-                assertTrue(rs.next());
-                assertEquals(routedDbName, rs.getString("db"),
-                        "DB_NAME() on replica must match the database name from ENVCHANGE 0x21");
+        private String buildConnectionString(String applicationIntent) {
+            String connStr = connectionString;
+            connStr = TestUtils.addOrOverrideProperty(connStr, "database", hyperscaleDatabase);
+            connStr = TestUtils.addOrOverrideProperty(connStr, "encrypt", "true");
+            connStr = TestUtils.addOrOverrideProperty(connStr, "trustServerCertificate", "false");
+            connStr = TestUtils.addOrOverrideProperty(connStr, "loginTimeout", "30");
+            if (applicationIntent != null) {
+                connStr = TestUtils.addOrOverrideProperty(connStr, "applicationIntent", applicationIntent);
             }
+            return connStr;
+        }
 
-            // And both must match the originally requested database
-            assertEquals(hyperscaleDatabase, routedDbName,
-                    "Routed database name must match the requested Hyperscale database");
+        @Test
+        @DisplayName("Connect to Hyperscale database")
+        void testConnectivity() throws SQLException {
+            try (Connection conn = DriverManager.getConnection(buildConnectionString("ReadOnly"));
+                    Statement stmt = conn.createStatement();
+                    ResultSet rs = stmt.executeQuery("SELECT 1 AS [ok]")) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt("ok"));
+            }
+        }
+
+        @Test
+        @DisplayName("Server supports enhanced routing (ENVCHANGE 0x21)")
+        void testServerSupportsEnhancedRouting() throws Exception {
+            try (SQLServerConnection conn = (SQLServerConnection) DriverManager
+                    .getConnection(buildConnectionString("ReadOnly"))) {
+
+                assertTrue(conn.getServerSupportsEnhancedRouting(),
+                        "Server must acknowledge enhanced routing feature (TDS_FEATURE_EXT 0x0F)");
+
+                ServerPortPlaceHolder placeholder = getPlaceHolder(conn);
+                assertNotNull(placeholder, "Connection must have been routed");
+                assertNotNull(placeholder.getDatabaseName(),
+                        "ENVCHANGE 0x21 must carry a database name — confirms enhanced routing (type 21), "
+                                + "not legacy routing (type 20)");
+            }
+        }
+
+        @Test
+        @DisplayName("Routed database name matches DB_NAME() on replica")
+        void testRoutedDatabaseNameMatchesActual() throws Exception {
+            try (SQLServerConnection conn = (SQLServerConnection) DriverManager
+                    .getConnection(buildConnectionString("ReadOnly"))) {
+
+                ServerPortPlaceHolder placeholder = getPlaceHolder(conn);
+                String routedDbName = placeholder.getDatabaseName();
+                assertNotNull(routedDbName, "Enhanced routing must carry a database name");
+
+                try (Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(DBNAME_QUERY)) {
+                    assertTrue(rs.next());
+                    assertEquals(routedDbName, rs.getString("db"),
+                            "DB_NAME() on replica must match the database name from ENVCHANGE 0x21");
+                }
+
+                assertEquals(hyperscaleDatabase, routedDbName,
+                        "Routed database name must match the requested Hyperscale database");
+            }
+        }
+
+        private ServerPortPlaceHolder getPlaceHolder(SQLServerConnection conn) throws Exception {
+            Field f = SQLServerConnection.class.getDeclaredField("currentConnectPlaceHolder");
+            f.setAccessible(true);
+            return (ServerPortPlaceHolder) f.get(conn);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Nested class 2: Mocked protocol unit tests (no live server needed)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Mocked Protocol Tests")
+    class MockedProtocolTests {
+
+        private SQLServerConnection conn;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            MockitoAnnotations.openMocks(this);
+            conn = new SQLServerConnection("MockedTest");
+        }
+
+        // ── Feature request write tests ──────────────────────────────────────
+
+        @Test
+        @DisplayName("writeEnhancedRoutingFeatureRequest returns correct length (5 bytes)")
+        void testFeatureRequestLength() throws Exception {
+            // write=false → just calculates length, no writer needed
+            int len = conn.writeEnhancedRoutingFeatureRequest(false, null);
+            assertEquals(5, len, "Feature request must be 5 bytes: 1 (featureId) + 4 (int32 length=0)");
+        }
+
+        // ── Feature ack tests (onFeatureExtAck) ─────────────────────────────
+
+        @Test
+        @DisplayName("onFeatureExtAck with data=[1] enables serverSupportsEnhancedRouting")
+        void testFeatureAckEnabled() throws Exception {
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
+            assertTrue(conn.getServerSupportsEnhancedRouting(),
+                    "data[0]==1 must enable enhanced routing");
+        }
+
+        @Test
+        @DisplayName("onFeatureExtAck with data=[0] keeps serverSupportsEnhancedRouting false")
+        void testFeatureAckDisabled() throws Exception {
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{0});
+            assertFalse(conn.getServerSupportsEnhancedRouting(),
+                    "data[0]==0 must not enable enhanced routing");
+        }
+
+        @Test
+        @DisplayName("onFeatureExtAck with empty data throws SQLServerException")
+        void testFeatureAckEmptyDataThrows() {
+            assertThrows(SQLServerException.class,
+                    () -> invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{}),
+                    "Empty ack data must throw — expected exactly 1 byte");
+        }
+
+        @Test
+        @DisplayName("onFeatureExtAck with extra data throws SQLServerException")
+        void testFeatureAckExtraDataThrows() {
+            assertThrows(SQLServerException.class,
+                    () -> invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1, 0}),
+                    "More than 1 byte in ack data must throw");
+        }
+
+        // ── Feature ack routing filter tests ────────────────────────────────
+
+        @Test
+        @DisplayName("onFeatureExtAck filters non-DNS/non-enhancedRouting features when routingInfo is set")
+        void testFeatureAckFilterDuringRouting() throws Exception {
+            setRoutingInfo(conn, new ServerPortPlaceHolder("routed-server", 1433, null, "mydb", false));
+
+            // FEDAUTH ack should be silently skipped (no exception) because routingInfo != null
+            // and featureId is neither DNS_CACHING nor ENHANCED_ROUTING
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_FEDAUTH, new byte[]{});
+        }
+
+        @Test
+        @DisplayName("onFeatureExtAck allows enhanced routing ack even when routingInfo is set")
+        void testFeatureAckAllowsEnhancedRoutingDuringRouting() throws Exception {
+            setRoutingInfo(conn, new ServerPortPlaceHolder("routed-server", 1433, null, "mydb", false));
+
+            invokeOnFeatureExtAck(conn, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING, new byte[]{1});
+            assertTrue(conn.getServerSupportsEnhancedRouting());
+        }
+
+        // ── Routing guard tests ─────────────────────────────────────────────
+
+        @Test
+        @DisplayName("Enhanced routing info is discarded when server did not ack the feature")
+        void testRoutingGuardDiscardsEnhancedRoutingWhenNotAcked() throws Exception {
+            ServerPortPlaceHolder enhancedRouting = new ServerPortPlaceHolder(
+                    "routed-host", 1433, null, "someDatabase", false);
+            setRoutingInfo(conn, enhancedRouting);
+            setServerSupportsEnhancedRouting(conn, false);
+
+            assertNotNull(getRoutingInfo(conn));
+            assertNotNull(getRoutingInfo(conn).getDatabaseName());
+
+            boolean discarded = simulateRoutingGuard(conn);
+            assertTrue(discarded, "Guard must discard enhanced routing info when feature not acked");
+            assertNull(getRoutingInfo(conn), "routingInfo must be null after guard discards it");
+        }
+
+        @Test
+        @DisplayName("Legacy routing info (no databaseName) is NOT discarded by guard")
+        void testRoutingGuardKeepsLegacyRouting() throws Exception {
+            ServerPortPlaceHolder legacyRouting = new ServerPortPlaceHolder(
+                    "routed-host", 1433, null, false);
+            setRoutingInfo(conn, legacyRouting);
+            setServerSupportsEnhancedRouting(conn, false);
+
+            boolean discarded = simulateRoutingGuard(conn);
+            assertFalse(discarded, "Guard must NOT discard legacy routing info (no databaseName)");
+            assertNotNull(getRoutingInfo(conn));
+        }
+
+        @Test
+        @DisplayName("Enhanced routing info is kept when server DID ack the feature")
+        void testRoutingGuardKeepsWhenAcked() throws Exception {
+            ServerPortPlaceHolder enhancedRouting = new ServerPortPlaceHolder(
+                    "routed-host", 1433, null, "someDatabase", false);
+            setRoutingInfo(conn, enhancedRouting);
+            setServerSupportsEnhancedRouting(conn, true);
+
+            boolean discarded = simulateRoutingGuard(conn);
+            assertFalse(discarded, "Guard must NOT discard routing info when feature was acked");
+            assertNotNull(getRoutingInfo(conn));
+        }
+
+        // ── ServerPortPlaceHolder tests ─────────────────────────────────────
+
+        @Test
+        @DisplayName("ServerPortPlaceHolder 5-arg constructor stores databaseName")
+        void testPlaceHolderWithDatabaseName() {
+            ServerPortPlaceHolder ph = new ServerPortPlaceHolder("server1", 1433, "inst", "mydb", false);
+            assertEquals("server1", ph.getServerName());
+            assertEquals(1433, ph.getPortNumber());
+            assertEquals("inst", ph.getInstanceName());
+            assertEquals("mydb", ph.getDatabaseName());
+        }
+
+        @Test
+        @DisplayName("ServerPortPlaceHolder 4-arg constructor has null databaseName")
+        void testPlaceHolderWithoutDatabaseName() {
+            ServerPortPlaceHolder ph = new ServerPortPlaceHolder("server1", 1433, "inst", false);
+            assertEquals("server1", ph.getServerName());
+            assertEquals(1433, ph.getPortNumber());
+            assertNull(ph.getDatabaseName(), "Legacy constructor must leave databaseName null");
+        }
+
+        // ── Diagnostic field tests ───────────────────────────────────────────
+
+        @Test
+        @DisplayName("serverSupportsEnhancedRouting is false by default")
+        void testEnhancedRoutingDefaultFalse() {
+            assertFalse(conn.getServerSupportsEnhancedRouting(),
+                    "serverSupportsEnhancedRouting must default to false");
+        }
+
+        // ── TDS constant tests ──────────────────────────────────────────────
+
+        @Test
+        @DisplayName("TDS_FEATURE_EXT_ENHANCEDROUTING is 0x0F")
+        void testFeatureIdValue() {
+            assertEquals((byte) 0x0F, TDS.TDS_FEATURE_EXT_ENHANCEDROUTING,
+                    "Enhanced routing feature ID must be 0x0F");
+        }
+
+        // ── Helper methods ──────────────────────────────────────────────────
+
+        private void invokeOnFeatureExtAck(SQLServerConnection conn, byte featureId, byte[] data) throws Exception {
+            Method m = SQLServerConnection.class.getDeclaredMethod("onFeatureExtAck", byte.class, byte[].class);
+            m.setAccessible(true);
+            try {
+                m.invoke(conn, featureId, data);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                if (e.getCause() instanceof SQLServerException) {
+                    throw (SQLServerException) e.getCause();
+                }
+                throw e;
+            }
+        }
+
+        private void setRoutingInfo(SQLServerConnection conn, ServerPortPlaceHolder routing) throws Exception {
+            Field f = SQLServerConnection.class.getDeclaredField("routingInfo");
+            f.setAccessible(true);
+            f.set(conn, routing);
+        }
+
+        private ServerPortPlaceHolder getRoutingInfo(SQLServerConnection conn) throws Exception {
+            Field f = SQLServerConnection.class.getDeclaredField("routingInfo");
+            f.setAccessible(true);
+            return (ServerPortPlaceHolder) f.get(conn);
+        }
+
+        private void setServerSupportsEnhancedRouting(SQLServerConnection conn, boolean value) throws Exception {
+            Field f = SQLServerConnection.class.getDeclaredField("serverSupportsEnhancedRouting");
+            f.setAccessible(true);
+            f.set(conn, value);
+        }
+
+        /**
+         * Simulates the routing guard logic from login()'s else branch:
+         * if routingInfo has a databaseName but the server didn't ack enhanced routing,
+         * discard the routing info.
+         *
+         * @return true if routing info was discarded
+         */
+        private boolean simulateRoutingGuard(SQLServerConnection conn) throws Exception {
+            ServerPortPlaceHolder routing = getRoutingInfo(conn);
+            if (routing != null && routing.getDatabaseName() != null) {
+                Field f = SQLServerConnection.class.getDeclaredField("serverSupportsEnhancedRouting");
+                f.setAccessible(true);
+                boolean supported = f.getBoolean(conn);
+                if (!supported) {
+                    setRoutingInfo(conn, null);
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
@@ -37,6 +37,7 @@ public final class Constants {
      * vectorFloat16Test - For tests requiring vector(float16) setup
      * alwaysEncrypted  - - For tests in the AlwaysEncrypted package
      * bulkCopy - - - - - - For tests in the bulkCopy package
+     * enhancedRouting  - For tests requiring Hyperscale database with HA read replicas
      * </pre>
      */
     public static final String xJDBC42 = "xJDBC42";
@@ -66,6 +67,7 @@ public final class Constants {
     public static final String legacyFxXa = "legacyFx_Xa";
     public static final String PrepareMethodUseTempTableScopeTest = "PrepareMethodUseTempTableScopeTest";
     public static final String vectorFloat16Test = "vectorFloat16Test";
+    public static final String enhancedRouting = "enhancedRouting";
 
     public static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
     public static final Logger LOGGER = Logger.getLogger("AbstractTest");


### PR DESCRIPTION
## Overview

Hyperscale is introducing reader endpoints that load balance connections across named replicas. Unlike standard gateway routing (ENVCHANGE type 20 0x14) which only carries server and port, reader endpoints need to route connections to both a target network location **and a specific database** — since the client doesn't know the database ahead of time.

This PR implements the full TDS protocol changes required for the JDBC driver to support this scenario.

## Changes

**Feature negotiation:**
The driver now always sends `FEATUREEXT 0x0F` (EnhancedRouting) in the Login7 feature extension block, regardless of the target server. When the server acknowledges with a 1-byte payload (`data[0]=1`), the driver enables enhanced routing support for the session. This ensures backward compatibility — older servers that don't recognize the token simply ignore it.

**ENVCHANGE 0x21 parsing:**
A new ENVCHANGE type 21 (EnhancedRouting) is now parsed alongside the existing type 20 (Routing). The enhanced payload includes all standard routing fields plus a required `AlternateDatabase` field (≤128 characters). The driver validates port number and database name, and updates `hostNameInCertificate` for the routed server domain.

**Routing guard in login():**
When the server sends ENVCHANGE type 21 0X15 with a database name but did **not** acknowledge the enhanced routing feature, the driver discards the routing info and stays on the original server. This is the critical safety mechanism that prevents an unverified server from redirecting the client to an arbitrary database.

**Login7 database name override:**
On the reconnection to the routed target, the driver uses the database name from the routing info (not the connection string) in the Login7 packet. This ensures the routed replica receives the correct database context.

**ServerPortPlaceHolder extension:**
The routing placeholder now carries a `databaseName` field, enabling the routing info to flow through the existing connection lifecycle without structural changes.

## Test coverage
13 tests organized into 3 groups, using crafted TDS packets injected via mocked `TDSReader`/`TDSPacket`:

**Routing behavior**:
- Enhanced routing enabled — server acks feature + sends ENVCHANGE 21 → routing info carries routed server, port, and database
- No feature ack — login() guard discards routing, original database preserved
- Feature ack disabled — login() guard discards routing, original database preserved
- Legacy ENVCHANGE 20 — backward-compatible routing with server/port only

**Feature negotiation**:
- Enabled — ack `[1]` sets flag true
- Disabled — ack `[0]` leaves flag false
- DoNotAcknowledge — no ack, flag stays false
- Invalid ack data — empty/extra bytes throw with exact error message
- Feature ack filter — non-DNS/non-ER acks silently skipped during routing

**ENVCHANGE 21 validation**:
- Port 0 → throws
- Empty database name → throws
- `hostNameInCertificate` updated for routed server domain

### Manual testing

Validated end-to-end against an Azure Hyperscale database on a OneBox server with 3 named replicas behind a reader endpoint:
- 15 consecutive connections successfully load balanced across all 3 replica servers
- Verified FEATUREEXT 0x0F negotiation and ENVCHANGE type 21 0x15 parsing in TDS traffic
- Confirmed routed database name matches `DB_NAME()` on each target replica