### PR TITLE
Add @Tag(alwaysEncrypted) and @Tag(bulkCopy) to enable pipeline…

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/BulkCopySendTemporalDataTypesAsStringAETest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/BulkCopySendTemporalDataTypesAsStringAETest.java
@@ -58,6 +58,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class BulkCopySendTemporalDataTypesAsStringAETest extends AESetup {
     static String inputFile = "BulkCopyCSVSendTemporalDataTypesAsStringForBulkCopy.csv";
     static String encoding = "UTF-8";

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -54,6 +54,7 @@ import microsoft.sql.DateTimeOffset;
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class CallableStatementTest extends AESetup {
 
     private static String multiStatementsProcedure = AbstractSQLGenerator

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
@@ -45,6 +45,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
 @Tag(Constants.requireSecret)
+@Tag(Constants.alwaysEncrypted)
 public class EnclaveTest extends AESetup {
     /**
      * Tests basic connection.

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
@@ -62,6 +62,7 @@ import microsoft.sql.DateTimeOffset;
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class JDBCEncryptionDecryptionTest extends AESetup {
     private boolean nullable = false;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/MSITest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/MSITest.java
@@ -44,6 +44,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
  */
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.MSI)
+@Tag(Constants.alwaysEncrypted)
 public class MSITest extends AESetup {
 
     /*

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/MultiUserAKVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/MultiUserAKVTest.java
@@ -61,6 +61,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class MultiUserAKVTest extends AESetup {
 
     private static Map<String, SQLServerColumnEncryptionKeyStoreProvider> requiredKeyStoreProvider = new HashMap<>();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/ParameterMetaDataCacheTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/ParameterMetaDataCacheTest.java
@@ -33,6 +33,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xSQLv12)
 @Tag(Constants.xSQLv14)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class ParameterMetaDataCacheTest extends AESetup {
 
     @BeforeAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -43,6 +43,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class PrecisionScaleTest extends AESetup {
     private static java.util.Date date = null;
     private static int offsetFromGMT = 0;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/RegressionAlwaysEncryptedTest.java
@@ -30,6 +30,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class RegressionAlwaysEncryptedTest extends AESetup {
     static String numericTable[][] = {{"Bit", "bit"}, {"Tinyint", "tinyint"}, {"Smallint", "smallint"},};
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -1056,11 +1056,9 @@ public final class TestUtils {
      * @return The updated connection string
      */
     public static String addOrOverrideProperty(String connectionString, String property, String value) {
-        // Remove the property first if it already exists, then append — prevents duplicate
-        // properties and the double-semicolons they produce when the base connection string
-        // already contains the property being "overridden".
+        // Remove existing occurrence first to avoid duplicate properties, then append.
         String cleaned = removeProperty(connectionString, property);
-        // Strip any trailing semicolons left by removeProperty before re-appending
+        // Ensure there is exactly one trailing semicolon before appending.
         cleaned = cleaned.replaceAll(";+$", "");
         return cleaned + ";" + property + "=" + value + ";";
     }
@@ -1075,13 +1073,23 @@ public final class TestUtils {
      * @return The updated connection string
      */
     public static String removeProperty(String connectionString, String property) {
-        int start = connectionString.toLowerCase().indexOf(property.toLowerCase());
+        // Search for ';property=' (with the leading semicolon) so we only match actual
+        // key=value pairs in the properties section and never accidentally match the same
+        // word appearing as a substring inside the server hostname (e.g. 'database' in
+        // 'msjdbctest.database.windows.net').
+        String searchKey = ";" + property.toLowerCase() + "=";
+        int start = connectionString.toLowerCase().indexOf(searchKey);
         if (start == -1) {
             return connectionString;
         }
-        int end = connectionString.indexOf(";", start);
-        String propertyStr = connectionString.substring(start, -1 != end ? end + 1 : connectionString.length());
-        return connectionString.replace(propertyStr, "");
+        // Find the ';' that ends this property's value.
+        int end = connectionString.indexOf(";", start + 1);
+        if (end == -1) {
+            // Property is the last one — remove from the leading ';' to end of string.
+            return connectionString.substring(0, start);
+        }
+        // Remove ';property=value' keeping the semicolon that follows (owned by next property).
+        return connectionString.substring(0, start) + connectionString.substring(end);
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -1056,7 +1056,13 @@ public final class TestUtils {
      * @return The updated connection string
      */
     public static String addOrOverrideProperty(String connectionString, String property, String value) {
-        return connectionString + ";" + property + "=" + value + ";";
+        // Remove the property first if it already exists, then append — prevents duplicate
+        // properties and the double-semicolons they produce when the base connection string
+        // already contains the property being "overridden".
+        String cleaned = removeProperty(connectionString, property);
+        // Strip any trailing semicolons left by removeProperty before re-appending
+        cleaned = cleaned.replaceAll(";+$", "");
+        return cleaned + ";" + property + "=" + value + ";";
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TestUtils.java
@@ -1076,6 +1076,9 @@ public final class TestUtils {
      */
     public static String removeProperty(String connectionString, String property) {
         int start = connectionString.toLowerCase().indexOf(property.toLowerCase());
+        if (start == -1) {
+            return connectionString;
+        }
         int end = connectionString.indexOf(";", start);
         String propertyStr = connectionString.substring(start, -1 != end ? end + 1 : connectionString.length());
         return connectionString.replace(propertyStr, "");

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyAllTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyAllTypesTest.java
@@ -57,6 +57,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 
 
 @RunWith(JUnitPlatform.class)
+@Tag(Constants.bulkCopy)
 public class BulkCopyAllTypesTest extends AbstractTest {
 
     private static DBTable tableSrc = null;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyCSVTest.java
@@ -67,6 +67,7 @@ import microsoft.sql.Vector;
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test bulkCopy with CSV")
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.bulkCopy)
 public class BulkCopyCSVTest extends AbstractTest {
 
     static String inputFile = "BulkCopyCSVTestInput.csv";

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnMappingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnMappingTest.java
@@ -42,6 +42,7 @@ import com.microsoft.sqlserver.testframework.sqlType.SqlType;
  */
 @RunWith(JUnitPlatform.class)
 @DisplayName("BulkCopy Column Mapping Test")
+@Tag(Constants.bulkCopy)
 public class BulkCopyColumnMappingTest extends BulkCopyTestSetUp {
     private String prcdb = RandomUtil.getIdentifier("BulkCopy_PRC_DB");
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnOrderHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyColumnOrderHintTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @RunWith(JUnitPlatform.class)
 @DisplayName("BulkCopy Column Order Hints Test")
+@Tag(Constants.bulkCopy)
 public class BulkCopyColumnOrderHintTest extends BulkCopyTestSetUp {
     private String prcdb = RandomUtil.getIdentifier("BulkCopy_PRC_DB");
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyConnectionTest.java
@@ -34,6 +34,7 @@ import com.microsoft.sqlserver.testframework.Constants;
  */
 @RunWith(JUnitPlatform.class)
 @DisplayName("BulkCopy Connection Test")
+@Tag(Constants.bulkCopy)
 public class BulkCopyConnectionTest extends BulkCopyTestSetUp {
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyISQLServerBulkRecordTest.java
@@ -58,6 +58,7 @@ import microsoft.sql.Vector.VectorDimensionType;
 @RunWith(JUnitPlatform.class)
 @DisplayName("Test ISQLServerBulkRecord")
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.bulkCopy)
 public class BulkCopyISQLServerBulkRecordTest extends AbstractTest {
 
     @BeforeAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyResultSetCursorTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyResultSetCursorTest.java
@@ -36,6 +36,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
 
 @RunWith(JUnitPlatform.class)
 @Tag(Constants.xAzureSQLDW)
+@Tag(Constants.bulkCopy)
 public class BulkCopyResultSetCursorTest extends AbstractTest {
 
     static BigDecimal[] expectedBigDecimals = {new BigDecimal("12345.12345"), new BigDecimal("125.123"),

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyRowSetTest.java
@@ -31,6 +31,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 
 @RunWith(JUnitPlatform.class)
+@Tag(Constants.bulkCopy)
 public class BulkCopyRowSetTest extends AbstractTest {
 
     private static String tableName = AbstractSQLGenerator

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopySendTemporalDataTypesAsStringTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopySendTemporalDataTypesAsStringTest.java
@@ -54,6 +54,7 @@ import com.microsoft.sqlserver.testframework.PrepUtil;
  * 
  */
 @RunWith(JUnitPlatform.class)
+@Tag(Constants.bulkCopy)
 public class BulkCopySendTemporalDataTypesAsStringTest extends AbstractTest {
     static String inputFile = "BulkCopyCSVSendTemporalDataTypesAsStringForBulkCopy.csv";
     static String inputFile2 = "BulkCopyCSVSendTemporalDataTypesAsStringForBulkCopy2.csv";

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopySendTemporalDataTypesAsStringTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopySendTemporalDataTypesAsStringTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -31,6 +32,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.PrepUtil;
 
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTimeoutTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyTimeoutTest.java
@@ -23,6 +23,7 @@ import com.microsoft.sqlserver.testframework.Constants;
  */
 @RunWith(JUnitPlatform.class)
 @DisplayName("BulkCopy Timeout Test")
+@Tag(Constants.bulkCopy)
 public class BulkCopyTimeoutTest extends BulkCopyTestSetUp {
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/ISQLServerBulkRecordIssuesTest.java
@@ -42,6 +42,7 @@ import com.microsoft.sqlserver.testframework.Constants;
 
 @SuppressWarnings("deprecation")
 @RunWith(JUnitPlatform.class)
+@Tag(Constants.bulkCopy)
 public class ISQLServerBulkRecordIssuesTest extends AbstractTest {
 
     static String query;

--- a/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
+++ b/src/test/java/com/microsoft/sqlserver/testframework/Constants.java
@@ -35,6 +35,8 @@ public final class Constants {
      * CodeCov - - - - - - For tests tracked in coverage-only runs
      * legacyFx  - - - - - For tests validating legacy FX regressions
      * vectorFloat16Test - For tests requiring vector(float16) setup
+     * alwaysEncrypted  - - For tests in the AlwaysEncrypted package
+     * bulkCopy - - - - - - For tests in the bulkCopy package
      * </pre>
      */
     public static final String xJDBC42 = "xJDBC42";
@@ -59,6 +61,8 @@ public final class Constants {
     public static final String JSONTest = "JSONTest";
     public static final String CodeCov = "CodeCov";
     public static final String legacyFx = "legacyFx";
+    public static final String alwaysEncrypted = "alwaysEncrypted";
+    public static final String bulkCopy = "bulkCopy";
     public static final String PrepareMethodUseTempTableScopeTest = "PrepareMethodUseTempTableScopeTest";
     public static final String vectorFloat16Test = "vectorFloat16Test";
 


### PR DESCRIPTION
- Add Constants.alwaysEncrypted and Constants.bulkCopy tag constants
- Tag all 9 runnable test classes in AlwaysEncrypted package
- Tag all 11 runnable test classes in bulkCopy package
- Enables -Dgroups=alwaysEncrypted / -DexcludedGroups=alwaysEncrypted for splitting Core_SQLServer_Latest into parallel jobs