### PR TITLE
Add support for JDK 26

### DIFF
--- a/.github/instructions/glossary.instructions.md
+++ b/.github/instructions/glossary.instructions.md
@@ -480,7 +480,7 @@ All SQL Server types supported by the driver, mapped from the `SSType` enum in `
 | Term | Description |
 |------|-------------|
 | **JDBC 4.2** | Java 8 compatible API. Build profile: `jre8`. |
-| **JDBC 4.3** | Java 9+ compatible API. Build profiles: `jre11`, `jre17`, `jre21`, `jre25`. |
+| **JDBC 4.3** | Java 9+ compatible API. Build profiles: `jre11`, `jre17`, `jre21`, `jre25`, `jre26`. |
 | **TDS 7.2 (YUKON)** | Protocol version for SQL Server 2005+. Constant: `VER_YUKON` (`0x72090002`). |
 | **TDS 7.3B (KATMAI)** | Protocol version for SQL Server 2008+ (adds null-bit compression). Constant: `VER_KATMAI` (`0x730B0003`). |
 | **TDS 7.4 (DENALI)** | Protocol version for SQL Server 2012+. Constant: `VER_DENALI` (`0x74000004`). |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To build the jar files, you must use minimum version of Java 11 with Maven. You 
 * Maven:
 	1. If you have not already done so, add the environment variable `mssql_jdbc_test_connection_properties` in your system with the connection properties for your SQL Server or SQL DB instance.
 	2. Run one of the commands below to build a JRE 11 and newer versions compatible jar or JRE 8 compatible jar in the `\target` directory. 
+        * Run `mvn install -Pjre26`. This creates JRE 26 compatible jar in `\target` directory which is JDBC 4.3 compliant (Build with JDK 26).
         * Run `mvn install -Pjre25`. This creates JRE 25 compatible jar in `\target` directory which is JDBC 4.3 compliant (Build with JDK 25).
         * Run `mvn install -Pjre21`. This creates JRE 21 compatible jar in `\target` directory which is JDBC 4.3 compliant (Build with JDK 21+).
         * Run `mvn install -Pjre17`. This creates JRE 17 compatible jar in `\target` directory which is JDBC 4.3 compliant (Build with JDK 17+).
@@ -55,6 +56,7 @@ To build the jar files, you must use minimum version of Java 11 with Maven. You 
 * Gradle:
 	1. If you have not already done so, add the environment variable `mssql_jdbc_test_connection_properties` in your system with the connection properties for your SQL Server or SQL DB instance.
 	2. Run one of the commands below to build a JRE 11 and newer versions compatible jar or JRE 8 compatible jar in the `\build\libs` directory. 
+        * Run `gradle build -PbuildProfile=jre26`. This creates JRE 26 compatible jar in `\build\libs` directory which is JDBC 4.3 compliant (Build with JDK 26).
         * Run `gradle build -PbuildProfile=jre25`. This creates JRE 25 compatible jar in `\build\libs` directory which is JDBC 4.3 compliant (Build with JDK 25).
         * Run `gradle build -PbuildProfile=jre21`. This creates JRE 21 compatible jar in `\build\libs` directory which is JDBC 4.3 compliant (Build with JDK 21+).
         * Run `gradle build -PbuildProfile=jre17`. This creates JRE 17 compatible jar in `\build\libs` directory which is JDBC 4.3 compliant (Build with JDK 17+).

--- a/build.gradle
+++ b/build.gradle
@@ -35,104 +35,40 @@ test {
     }
 }
 
-if (!hasProperty('buildProfile') || (hasProperty('buildProfile') && buildProfile == "jre25")) {
+// Common configuration for all JDBC 4.3 profiles (JRE 11+)
+def jdbc43Profiles = ['jre11', 'jre17', 'jre21', 'jre25', 'jre26']
+def currentProfile = hasProperty('buildProfile') ? buildProfile : 'jre26' // Default to latest JRE profile if not specified
 
-	jreVersion = "jre25"
-	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
-	jar {
-		manifest {
-			attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
-		}
-	}
-	java {
-		sourceCompatibility = JavaVersion.VERSION_25
-		targetCompatibility = JavaVersion.VERSION_25
-	}
-	test {
-    useJUnitPlatform {
-        excludeTags(hasProperty('excludedGroups') ? excludedGroups : 'vectorTest','JSONTest','vectorFloat16Test','legacyFx','legacyFx_Xa')
+// Apply common configuration for JDBC 4.3 profiles
+if (jdbc43Profiles.contains(currentProfile)) {
+    jreVersion = currentProfile
+    excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
+
+    jar {
+        manifest {
+            attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
+        }
     }
-}
-}
 
-if (hasProperty('buildProfile') && buildProfile == "jre26") {
+    // Set Java version based on profile
+    def versionMap = [
+        'jre11': JavaVersion.VERSION_11,
+        'jre17': JavaVersion.VERSION_17,
+        'jre21': JavaVersion.VERSION_21,
+        'jre25': JavaVersion.VERSION_25,
+        'jre26': JavaVersion.VERSION_26
+    ]
 
-	jreVersion = "jre26"
-	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
-	jar {
-		manifest {
-			attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
-		}
-	}
-	java {
-		sourceCompatibility = JavaVersion.VERSION_26
-		targetCompatibility = JavaVersion.VERSION_26
-	}
-	test {
-    useJUnitPlatform {
-        excludeTags(hasProperty('excludedGroups') ? excludedGroups : 'vectorTest','JSONTest','vectorFloat16Test','legacyFx','legacyFxXa')
+    java {
+        sourceCompatibility = versionMap[currentProfile]
+        targetCompatibility = versionMap[currentProfile]
     }
-}
-}
 
-if (hasProperty('buildProfile') && buildProfile == "jre21") {
-
-	jreVersion = "jre21"
-	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
-	jar {
-		manifest {
-			attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
-		}
-	}
-	java {
-		sourceCompatibility = JavaVersion.VERSION_21
-		targetCompatibility = JavaVersion.VERSION_21
-	}
-	test {
-    useJUnitPlatform {
-        excludeTags(hasProperty('excludedGroups') ? excludedGroups : 'vectorTest','JSONTest','vectorFloat16Test','legacyFx','legacyFx_Xa')
+    test {
+        useJUnitPlatform {
+            excludeTags(hasProperty('excludedGroups') ? excludedGroups : 'vectorTest','JSONTest','vectorFloat16Test', 'legacyFx','legacyFx_Xa')
+        }
     }
-}
-}
-
-if (hasProperty('buildProfile') && buildProfile == "jre17") {
-	
-	jreVersion = "jre17"
-	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
-	jar {
-		manifest {
-			attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
-		}
-	}
-	java {
-		sourceCompatibility = JavaVersion.VERSION_17
-		targetCompatibility = JavaVersion.VERSION_17
-	}
-	test {
-    useJUnitPlatform {
-        excludeTags(hasProperty('excludedGroups') ? excludedGroups : 'vectorTest','JSONTest','vectorFloat16Test','legacyFx','legacyFx_Xa')
-    }
-}
-}
-
-if (hasProperty('buildProfile') && buildProfile == "jre11") {
-	
-	jreVersion = "jre11"
-	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
-	jar {
-		manifest {
-			attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
-		}
-	}
-	java {
-		sourceCompatibility = JavaVersion.VERSION_11
-		targetCompatibility = JavaVersion.VERSION_11
-	}
-	test {
-    useJUnitPlatform {
-        excludeTags(hasProperty('excludedGroups') ? excludedGroups : 'vectorTest','JSONTest','vectorFloat16Test','legacyFx','legacyFx_Xa')
-    }
-}
 }
 
 if(hasProperty('buildProfile') && buildProfile == "jre8") {
@@ -229,14 +165,8 @@ dependencies {
 				'org.mockito:mockito-inline:4.11.0',
 				'net.bytebuddy:byte-buddy:1.15.11',
 				'net.bytebuddy:byte-buddy-agent:1.15.11'
-	} else if (hasProperty('buildProfile') && buildProfile == "jre25") {
-		// JRE 25 profile
-		testImplementation 'org.mockito:mockito-core:5.20.0',
-				'org.mockito:mockito-inline:5.20.0',
-				'net.bytebuddy:byte-buddy:1.18.2',
-				'net.bytebuddy:byte-buddy-agent:1.18.2'
-	} else if (hasProperty('buildProfile') && buildProfile == "jre26") {
-		// JRE 26 profile
+	} else if (hasProperty('buildProfile') && (buildProfile == "jre25" || buildProfile == "jre26")) {
+		// JRE 25, 26 profile
 		testImplementation 'org.mockito:mockito-core:5.20.0',
 				'org.mockito:mockito-inline:5.20.0',
 				'net.bytebuddy:byte-buddy:1.18.2',

--- a/build.gradle
+++ b/build.gradle
@@ -237,10 +237,10 @@ dependencies {
 				'net.bytebuddy:byte-buddy-agent:1.18.2'
 	} else if (hasProperty('buildProfile') && buildProfile == "jre26") {
 		// JRE 26 profile
-		testImplementation 'org.mockito:mockito-core:5.23.0',
-				'org.mockito:mockito-inline:5.23.0',
-				'net.bytebuddy:byte-buddy:1.18.8',
-				'net.bytebuddy:byte-buddy-agent:1.18.8'
+		testImplementation 'org.mockito:mockito-core:5.20.0',
+				'org.mockito:mockito-inline:5.20.0',
+				'net.bytebuddy:byte-buddy:1.18.2',
+				'net.bytebuddy:byte-buddy-agent:1.18.2'
 	} else {
 		// JRE 11, 17, 21 profiles (all use same versions)
 		testImplementation 'org.mockito:mockito-core:5.14.2',

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,26 @@ if (!hasProperty('buildProfile') || (hasProperty('buildProfile') && buildProfile
 }
 }
 
+if (hasProperty('buildProfile') && buildProfile == "jre26") {
+
+	jreVersion = "jre26"
+	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java'
+	jar {
+		manifest {
+			attributes 'Automatic-Module-Name': 'com.microsoft.sqlserver.jdbc'
+		}
+	}
+	java {
+		sourceCompatibility = JavaVersion.VERSION_26
+		targetCompatibility = JavaVersion.VERSION_26
+	}
+	test {
+    useJUnitPlatform {
+        excludeTags(hasProperty('excludedGroups') ? excludedGroups : 'vectorTest','JSONTest','vectorFloat16Test','legacyFx','legacyFxXa')
+    }
+}
+}
+
 if (hasProperty('buildProfile') && buildProfile == "jre21") {
 
 	jreVersion = "jre21"
@@ -215,8 +235,14 @@ dependencies {
 				'org.mockito:mockito-inline:5.20.0',
 				'net.bytebuddy:byte-buddy:1.18.2',
 				'net.bytebuddy:byte-buddy-agent:1.18.2'
+	} else if (hasProperty('buildProfile') && buildProfile == "jre26") {
+		// JRE 26 profile
+		testImplementation 'org.mockito:mockito-core:5.23.0',
+				'org.mockito:mockito-inline:5.23.0',
+				'net.bytebuddy:byte-buddy:1.18.8',
+				'net.bytebuddy:byte-buddy-agent:1.18.8'
 	} else {
-		// JRE 11, 17, 21, 25 profiles (all use same versions)
+		// JRE 11, 17, 21 profiles (all use same versions)
 		testImplementation 'org.mockito:mockito-core:5.14.2',
 				'net.bytebuddy:byte-buddy:1.17.5',
 				'net.bytebuddy:byte-buddy-agent:1.17.5'

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ dependencies {
 				'net.bytebuddy:byte-buddy:1.15.11',
 				'net.bytebuddy:byte-buddy-agent:1.15.11'
 	} else if (hasProperty('buildProfile') && (buildProfile == "jre25" || buildProfile == "jre26")) {
-		// JRE 25, 26 profile
+		// JRE 25 and 26 profile (uses same versions)
 		testImplementation 'org.mockito:mockito-core:5.20.0',
 				'org.mockito:mockito-inline:5.20.0',
 				'net.bytebuddy:byte-buddy:1.18.2',

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@
  * For building particular version of the driver, use commands:
  * jreXX - - PS> gradle build -PbuildProfile=jreXX
  *
+ * Default profile (no -PbuildProfile specified): jre26
+ * Requires JDK 26+ installed to build without specifying a profile.
+ *
  * For Excluding Groups in command line:
  * PS> gradle build -PbuildProfile=jre11 "-PexcludedGroups=['xSQLv15','xGradle']"
  ****************************************************************/
@@ -71,7 +74,7 @@ if (jdbc43Profiles.contains(currentProfile)) {
     }
 }
 
-if(hasProperty('buildProfile') && buildProfile == "jre8") {
+if (currentProfile == "jre8") {
 	
 	jreVersion = "jre8"
 	excludedFile = 'com/microsoft/sqlserver/jdbc/SQLServerJdbc43.java'
@@ -168,7 +171,6 @@ dependencies {
 	} else if (hasProperty('buildProfile') && (buildProfile == "jre25" || buildProfile == "jre26")) {
 		// JRE 25 and 26 profile (uses same versions)
 		testImplementation 'org.mockito:mockito-core:5.20.0',
-				'org.mockito:mockito-inline:5.20.0',
 				'net.bytebuddy:byte-buddy:1.18.2',
 				'net.bytebuddy:byte-buddy-agent:1.18.2'
 	} else {

--- a/pom.xml
+++ b/pom.xml
@@ -506,9 +506,6 @@
 			<properties>
 				<bundle.version.suffix>${version}.jre25${releaseExt}</bundle.version.suffix>
 			</properties>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
 			<dependencies>
 				<!-- JDK 25 compatible Mockito -->
 				<dependency>
@@ -566,6 +563,9 @@
 			<properties>
 				<bundle.version.suffix>${version}.jre26${releaseExt}</bundle.version.suffix>
 			</properties>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
 			<dependencies>
 				<!-- JDK 26 compatible Mockito -->
 				<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -561,6 +561,63 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jre26</id>
+			<properties>
+				<bundle.version.suffix>${version}.jre26${releaseExt}</bundle.version.suffix>
+			</properties>
+			<dependencies>
+				<!-- JDK 26 compatible Mockito -->
+				<dependency>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+					<version>5.23.0</version>
+					<scope>test</scope>
+				</dependency>
+				<dependency>
+					<groupId>net.bytebuddy</groupId>
+					<artifactId>byte-buddy</artifactId>
+					<version>1.18.8</version>
+					<scope>test</scope>
+				</dependency>
+				<dependency>
+					<groupId>net.bytebuddy</groupId>
+					<artifactId>byte-buddy-agent</artifactId>
+					<version>1.18.8</version>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+			<build>
+				<finalName>${project.artifactId}-${project.version}.jre26${releaseExt}</finalName>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.8.0</version>
+						<configuration>
+							<excludes>
+								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
+							</excludes>
+							<source>26</source>
+							<target>26</target>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>3.1.1</version>
+						<configuration>
+							<archive>
+								<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+								<manifestEntries>
+									<Automatic-Module-Name>com.microsoft.sqlserver.jdbc</Automatic-Module-Name>
+								</manifestEntries>
+							</archive>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<build>
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -571,19 +571,19 @@
 				<dependency>
 					<groupId>org.mockito</groupId>
 					<artifactId>mockito-core</artifactId>
-					<version>5.23.0</version>
+					<version>5.20.0</version>
 					<scope>test</scope>
 				</dependency>
 				<dependency>
 					<groupId>net.bytebuddy</groupId>
 					<artifactId>byte-buddy</artifactId>
-					<version>1.18.8</version>
+					<version>1.18.2</version>
 					<scope>test</scope>
 				</dependency>
 				<dependency>
 					<groupId>net.bytebuddy</groupId>
 					<artifactId>byte-buddy-agent</artifactId>
-					<version>1.18.8</version>
+					<version>1.18.2</version>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.8.0</version>
+						<version>3.13.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/ISQLServerConnection43.java</exclude>
@@ -362,13 +362,12 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.8.0</version>
+						<version>3.13.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<source>11</source>
-							<target>11</target>
+							<release>11</release>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -419,13 +418,12 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.8.0</version>
+						<version>3.13.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<source>17</source>
-							<target>17</target>
+							<release>17</release>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -476,13 +474,12 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.8.0</version>
+						<version>3.13.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<source>21</source>
-							<target>21</target>
+							<release>21</release>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -533,13 +530,12 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.8.0</version>
+						<version>3.13.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<source>25</source>
-							<target>25</target>
+							<release>25</release>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -593,13 +589,12 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.8.0</version>
+						<version>3.13.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<source>26</source>
-							<target>26</target>
+							<release>26</release>
 						</configuration>
 					</plugin>
 					<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.13.0</version>
+						<version>3.8.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/ISQLServerConnection43.java</exclude>
@@ -362,12 +362,13 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.13.0</version>
+						<version>3.8.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<release>11</release>
+							<source>11</source>
+							<target>11</target>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -418,12 +419,13 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.13.0</version>
+						<version>3.8.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<release>17</release>
+							<source>17</source>
+							<target>17</target>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -474,12 +476,13 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.13.0</version>
+						<version>3.8.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<release>21</release>
+							<source>21</source>
+							<target>21</target>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -530,12 +533,13 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.13.0</version>
+						<version>3.8.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<release>25</release>
+							<source>25</source>
+							<target>25</target>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -589,12 +593,13 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.13.0</version>
+						<version>3.8.0</version>
 						<configuration>
 							<excludes>
 								<exclude>**/com/microsoft/sqlserver/jdbc/SQLServerJdbc42.java</exclude>
 							</excludes>
-							<release>26</release>
+							<source>26</source>
+							<target>26</target>
 						</configuration>
 					</plugin>
 					<plugin>


### PR DESCRIPTION
This PR adds JDK 26 build support to the Microsoft JDBC Driver for SQL Server by introducing a new jre26 build profile for both Maven and Gradle, along with corresponding documentation updates.

## Summary of changes

**- Maven (pom.xml)**

Adds a new jre26 profile.
Builds a JRE 26–compatible artifact (suffix .jre26).
Sets compiler source/target to 26.

**- Gradle (build.gradle)**

Adds support for -PbuildProfile=jre26.
Sets sourceCompatibility and targetCompatibility to Java 26.
Ensures the jar manifest includes Automatic-Module-Name.
Aligns test dependencies for the JDK 26 profile.

**- Documentation**

Updates README.md to include build instructions for jre26:
Maven: mvn install -Pjre26
Gradle: gradle build -PbuildProfile=jre26
Updates glossary instructions to list jre26 among supported JDBC 4.3 build profiles.

**- How to build**

Maven: mvn install -Pjre26
Gradle: gradle build -PbuildProfile=jre26

**- Notes**

This PR focuses on build/profile enablement and dependency alignment to support compiling/testing on JDK 26, without changing driver runtime behavior.