### PR TITLE
Fix getIndexInfo() returning ORDINAL_POSITION=0 for INCLUDE columns

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -293,7 +293,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "CASE WHEN i.is_unique = 1 THEN 0 ELSE 1 END AS NON_UNIQUE, " +
     "t.name COLLATE DATABASE_DEFAULT AS INDEX_QUALIFIER, " +
     "i.name COLLATE DATABASE_DEFAULT AS INDEX_NAME, " +
-    "i.type AS TYPE, ic.index_column_id AS ORDINAL_POSITION, " +
+    "i.type AS TYPE, CAST(ic.index_column_id AS SMALLINT) AS ORDINAL_POSITION, " +
     "c.name COLLATE DATABASE_DEFAULT AS COLUMN_NAME, " +
     "CASE WHEN ic.is_descending_key = 1 THEN 'D' ELSE 'A' END AS ASC_OR_DESC, " +
     "CASE WHEN i.index_id <= 1 THEN ps.row_count ELSE NULL END AS CARDINALITY, " +
@@ -315,7 +315,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "t.name AS INDEX_QUALIFIER, " +
     "i.name AS INDEX_NAME, " +
     "i.type AS TYPE, " +
-    "ic.index_column_id AS ORDINAL_POSITION, " +
+    "CAST(ic.index_column_id AS SMALLINT) AS ORDINAL_POSITION, " +
     "c.name AS COLUMN_NAME, " +
     "CASE WHEN ic.is_descending_key = 1 THEN 'D' ELSE 'A' END AS ASC_OR_DESC, " +
     "NULL AS CARDINALITY, " +
@@ -1550,7 +1550,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                     "t.name AS INDEX_QUALIFIER, " +
                     "i.name AS INDEX_NAME, " +
                     "i.type AS TYPE, " +
-                    "ic.index_column_id AS ORDINAL_POSITION, " +
+                    "CAST(ic.index_column_id AS SMALLINT) AS ORDINAL_POSITION, " +
                     "c.name AS COLUMN_NAME, " +
                     "CASE WHEN ic.is_descending_key = 1 THEN 'D' ELSE 'A' END AS ASC_OR_DESC, " +
                     "NULL AS CARDINALITY, " +

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -293,7 +293,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "CASE WHEN i.is_unique = 1 THEN 0 ELSE 1 END AS NON_UNIQUE, " +
     "t.name COLLATE DATABASE_DEFAULT AS INDEX_QUALIFIER, " +
     "i.name COLLATE DATABASE_DEFAULT AS INDEX_NAME, " +
-    "i.type AS TYPE, ic.key_ordinal AS ORDINAL_POSITION, " +
+    "i.type AS TYPE, ic.index_column_id AS ORDINAL_POSITION, " +
     "c.name COLLATE DATABASE_DEFAULT AS COLUMN_NAME, " +
     "CASE WHEN ic.is_descending_key = 1 THEN 'D' ELSE 'A' END AS ASC_OR_DESC, " +
     "CASE WHEN i.index_id <= 1 THEN ps.row_count ELSE NULL END AS CARDINALITY, " +
@@ -305,7 +305,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "INNER JOIN sys.tables t ON i.object_id = t.object_id " +
     "INNER JOIN sys.schemas sch ON t.schema_id = sch.schema_id " +
     "LEFT JOIN sys.dm_db_partition_stats ps ON ps.object_id = i.object_id AND ps.index_id = i.index_id AND ps.index_id IN (0,1) " +
-    "WHERE t.name = ? AND sch.name = ? AND ic.key_ordinal = 0 " +
+    "WHERE t.name = ? AND sch.name = ? AND i.type IN (5, 6) " +
     "ORDER BY NON_UNIQUE, TYPE, INDEX_NAME COLLATE DATABASE_DEFAULT, ORDINAL_POSITION";
 
     private static final String INDEX_INFO_QUERY_DW = "SELECT db_name() AS TABLE_CAT, " +
@@ -315,7 +315,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "t.name AS INDEX_QUALIFIER, " +
     "i.name AS INDEX_NAME, " +
     "i.type AS TYPE, " +
-    "ic.key_ordinal AS ORDINAL_POSITION, " +
+    "ic.index_column_id AS ORDINAL_POSITION, " +
     "c.name AS COLUMN_NAME, " +
     "CASE WHEN ic.is_descending_key = 1 THEN 'D' ELSE 'A' END AS ASC_OR_DESC, " +
     "NULL AS CARDINALITY, " +
@@ -328,6 +328,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "INNER JOIN sys.schemas sch ON t.schema_id = sch.schema_id " +
     "WHERE t.name = ? " +
     "AND sch.name = ? " +
+    "AND i.type IN (5, 6) " +
     "ORDER BY NON_UNIQUE, TYPE, INDEX_NAME, ORDINAL_POSITION";
 
     // Use LinkedHashMap to force retrieve elements in order they were inserted
@@ -1549,7 +1550,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                     "t.name AS INDEX_QUALIFIER, " +
                     "i.name AS INDEX_NAME, " +
                     "i.type AS TYPE, " +
-                    "ic.key_ordinal AS ORDINAL_POSITION, " +
+                    "ic.index_column_id AS ORDINAL_POSITION, " +
                     "c.name AS COLUMN_NAME, " +
                     "CASE WHEN ic.is_descending_key = 1 THEN 'D' ELSE 'A' END AS ASC_OR_DESC, " +
                     "NULL AS CARDINALITY, " +
@@ -1560,7 +1561,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                     "INNER JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id " +
                     "INNER JOIN sys.tables t ON i.object_id = t.object_id " +
                     "INNER JOIN sys.schemas sch ON t.schema_id = sch.schema_id " +
-                    "WHERE t.name = '" + table + "' AND sch.name = '" + schema + "' AND ic.key_ordinal = 0"
+                    "WHERE t.name = '" + table + "' AND sch.name = '" + schema + "' AND i.type IN (5, 6)"
                 );
 
                 if (0 == azureDwSelectBuilder.length()) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -1565,7 +1565,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
                     "INNER JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id " +
                     "INNER JOIN sys.tables t ON i.object_id = t.object_id " +
                     "INNER JOIN sys.schemas sch ON t.schema_id = sch.schema_id " +
-                    "WHERE t.name = '" + table + "' AND sch.name = '" + schema + "' AND i.type IN (5, 6)"
+                    "WHERE t.name = ? AND sch.name = ? AND i.type IN (5, 6)"
                 );
 
                 if (0 == azureDwSelectBuilder.length()) {
@@ -1576,6 +1576,8 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 
                 resultPstmt = (SQLServerPreparedStatement) this.connection
                         .prepareStatement(azureDwSelectBuilder.toString());
+                resultPstmt.setString(1, table);
+                resultPstmt.setString(2, schema);
                 userRs = (SQLServerResultSet) resultPstmt.executeQuery();
                 resultPstmt.closeOnCompletion();
             } catch (SQLException e) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -315,7 +315,8 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "t.name AS INDEX_QUALIFIER, " +
     "i.name AS INDEX_NAME, " +
     "i.type AS TYPE, " +
-    "CAST(ic.index_column_id AS SMALLINT) AS ORDINAL_POSITION, " +
+    // Use index_column_id for columnstore (type 5, 6) where key_ordinal is always 0, and key_ordinal for rowstore B-tree indexes (matches sp_statistics behavior).
+    "CAST(CASE WHEN i.type IN (5, 6) THEN ic.index_column_id ELSE ic.key_ordinal END AS SMALLINT) AS ORDINAL_POSITION, " +
     "c.name AS COLUMN_NAME, " +
     "CASE WHEN ic.is_descending_key = 1 THEN 'D' ELSE 'A' END AS ASC_OR_DESC, " +
     "NULL AS CARDINALITY, " +
@@ -328,7 +329,10 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     "INNER JOIN sys.schemas sch ON t.schema_id = sch.schema_id " +
     "WHERE t.name = ? " +
     "AND sch.name = ? " +
-    "AND i.type IN (5, 6) " +
+    // Keep rowstore key columns (key_ordinal <> 0) and all columnstore columns (type 5, 6,
+    // where key_ordinal is always 0). Drops INCLUDE columns to honor the JDBC contract that
+    // ORDINAL_POSITION starts at 1.
+    "AND (ic.key_ordinal <> 0 OR i.type IN (5, 6)) " +
     "ORDER BY NON_UNIQUE, TYPE, INDEX_NAME, ORDINAL_POSITION";
 
     // Use LinkedHashMap to force retrieve elements in order they were inserted

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -2341,6 +2341,107 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 }
             }
         }
+
+        /**
+         * Test for ORDINAL_POSITION = 0 regression with INCLUDE (non-key) columns.
+         * 
+         * Validates that getIndexInfo() does NOT return rows for INCLUDE columns of 
+         * nonclustered indexes, and that no ORDINAL_POSITION value of 0 appears in 
+         * the result set. This was a regression introduced in PR #2598 where the 
+         * supplemental sys.index_columns query used "ic.key_ordinal = 0" as the filter,
+         * which inadvertently matched INCLUDE columns (not just columnstore columns).
+         * 
+         * Reproduces the exact scenario from customer escalation Case #2604210040006680:
+         * CREATE INDEX ... INCLUDE (...) causes ORDINAL_POSITION = 0 which breaks 
+         * downstream consumers that compute (ordinal - 1) for array indexing.
+         */
+        @Test
+        public void testGetIndexInfoDoesNotReturnIncludeColumnsWithOrdinalZero() throws SQLException {
+            String includeTestTable = AbstractSQLGenerator.escapeIdentifier("IndexInfoIncludeColTest");
+            
+            try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
+                // Setup: Create table with an index that has INCLUDE columns
+                TestUtils.dropTableIfExists("IndexInfoIncludeColTest", stmt);
+                
+                stmt.executeUpdate(
+                    "CREATE TABLE " + includeTestTable + " (" +
+                    "ID INT NOT NULL, " +
+                    "KeyCol1 INT NOT NULL, " +
+                    "KeyCol2 INT NOT NULL, " +
+                    "IncludedCol1 NVARCHAR(100), " +
+                    "IncludedCol2 NVARCHAR(200)" +
+                    ")"
+                );
+                
+                // Create a nonclustered index with INCLUDE columns — the exact pattern
+                // that caused ORDINAL_POSITION = 0 in driver 13.x
+                stmt.executeUpdate(
+                    "CREATE NONCLUSTERED INDEX IX_WithInclude ON " + includeTestTable + 
+                    " (KeyCol1, KeyCol2) INCLUDE (IncludedCol1, IncludedCol2)"
+                );
+                
+                // Also create a columnstore index to ensure it still gets returned
+                stmt.executeUpdate(
+                    "CREATE NONCLUSTERED COLUMNSTORE INDEX IX_Columnstore ON " + includeTestTable + 
+                    " (IncludedCol1, IncludedCol2)"
+                );
+                
+                String catalog = connection.getCatalog();
+                DatabaseMetaData dbMetadata = connection.getMetaData();
+                
+                try (ResultSet rs = dbMetadata.getIndexInfo(catalog, "dbo", "IndexInfoIncludeColTest", false, false)) {
+                    boolean foundColumnstoreIndex = false;
+                    boolean foundKeyCol1 = false;
+                    boolean foundKeyCol2 = false;
+                    
+                    while (rs.next()) {
+                        short ordinalPosition = rs.getShort("ORDINAL_POSITION");
+                        String columnName = rs.getString("COLUMN_NAME");
+                        String indexName = rs.getString("INDEX_NAME");
+                        
+                        // CRITICAL ASSERTION: No ORDINAL_POSITION should ever be 0
+                        // This is the exact regression that broke TDV (Case #2604210040006680)
+                        assertTrue(ordinalPosition > 0 || rs.wasNull(),
+                            "ORDINAL_POSITION must be > 0 (JDBC spec requires positions starting at 1). " +
+                            "Found ORDINAL_POSITION = " + ordinalPosition + " for column '" + columnName + 
+                            "' in index '" + indexName + "'. This indicates INCLUDE columns are being " +
+                            "returned with key_ordinal = 0, which is the regression from PR #2598.");
+                        
+                        // Verify INCLUDE columns are NOT returned as separate rows
+                        // (they should not appear at all — sp_statistics never returned them)
+                        if ("IX_WithInclude".equals(indexName)) {
+                            assertFalse("IncludedCol1".equals(columnName),
+                                "INCLUDE column 'IncludedCol1' should NOT appear in getIndexInfo() result set. " +
+                                "Only key columns should be returned for B-tree indexes.");
+                            assertFalse("IncludedCol2".equals(columnName),
+                                "INCLUDE column 'IncludedCol2' should NOT appear in getIndexInfo() result set. " +
+                                "Only key columns should be returned for B-tree indexes.");
+                            
+                            if ("KeyCol1".equals(columnName)) foundKeyCol1 = true;
+                            if ("KeyCol2".equals(columnName)) foundKeyCol2 = true;
+                        }
+                        
+                        // Verify columnstore indexes ARE still returned (the original fix goal)
+                        if (indexName != null && indexName.equals("IX_Columnstore")) {
+                            foundColumnstoreIndex = true;
+                        }
+                    }
+                    
+                    // Key columns of the nonclustered index should still be returned
+                    assertTrue(foundKeyCol1, "Key column 'KeyCol1' should be present in getIndexInfo() results");
+                    assertTrue(foundKeyCol2, "Key column 'KeyCol2' should be present in getIndexInfo() results");
+                    
+                    // Columnstore index should still be returned (PR #2598's original goal)
+                    assertTrue(foundColumnstoreIndex, 
+                        "Columnstore index 'IX_Columnstore' should still be returned by getIndexInfo(). " +
+                        "The fix for INCLUDE columns must not remove columnstore index support.");
+                }
+            } finally {
+                try (Connection connection = getConnection(); Statement stmt = connection.createStatement()) {
+                    TestUtils.dropTableIfExists("IndexInfoIncludeColTest", stmt);
+                }
+            }
+        }
     }
 
     private void setupProcedures(String schemaName, String proc1, String proc1Body,


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #2598 where `DatabaseMetaData.getIndexInfo()` returns rows for `INCLUDE` (non-key) columns with `ORDINAL_POSITION = 0`, violating the JDBC specification (which requires `ORDINAL_POSITION >= 1`) and breaking downstream consumers.

## Problem

PR #2598 added a supplemental query to surface columnstore indexes (which `sp_statistics` does not return) by joining `sys.indexes` with `sys.index_columns` and filtering with: `WHERE ic.key_ordinal = 0`

The intent was to match columnstore index columns, since columnstore indexes have no key ordering and all their columns have key_ordinal = 0. However, this filter also matches INCLUDE columns of regular B-tree indexes, which also have key_ordinal = 0 (the actual position is in index_column_id).

As a result, INCLUDE columns started appearing in getIndexInfo() results with ORDINAL_POSITION = 0, which: Breaks downstream consumers that compute ordinal - 1 for zero-based array indexing → java.lang.IndexOutOfBoundsException: argument num cannot be set to -1

### Fix
Replace the ic.key_ordinal = 0 filter with a check on the index type to restrict to columnstore indexes only:
`WHERE i.type IN (5, 6) `  -- 5 = clustered columnstore, 6 = nonclustered columnstore
Also changed` ic.key_ordinal` AS ORDINAL_POSITION to `ic.index_column_id `AS ORDINAL_POSITION. 

Since all columnstore columns have key_ordinal = 0, using index_column_id provides the proper 1-based sequential position required by JDBC.

### Tests

- Added testGetIndexInfoDoesNotReturnIncludeColumnsWithOrdinalZero() inside the existing DatabaseMetadataGetIndexInfoTest nested class.
- Manually validated the fix against Azure Synapse (Azure DW).