### PR TITLE
Add nanosecond granularity option to PerformanceLogCallback

### DIFF
--- a/.github/instructions/performance-metrics.instructions.md
+++ b/.github/instructions/performance-metrics.instructions.md
@@ -34,6 +34,39 @@ SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
 });
 ```
 
+#### Nanosecond Granularity
+
+By default, the `duration` parameter is reported in **milliseconds**. To receive
+**nanosecond** granularity instead, override `useNanoseconds()` to return `true`:
+
+```java
+SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
+    @Override
+    public boolean useNanoseconds() {
+        return true; // duration values will be in nanoseconds
+    }
+
+    @Override
+    public void publish(PerformanceActivity activity, int connectionId, long durationNs, 
+            Exception exception) {
+        System.out.printf("Activity: %s, Connection: %d, Duration: %d ns%n",
+                activity, connectionId, durationNs);
+    }
+
+    @Override
+    public void publish(PerformanceActivity activity, int connectionId, int statementId, 
+            long durationNs, Exception exception) {
+        System.out.printf("Activity: %s, Connection: %d, Statement: %d, Duration: %d ns%n",
+                activity, connectionId, statementId, durationNs);
+    }
+});
+```
+
+When `useNanoseconds()` returns `true`:
+- Timing uses `System.nanoTime()` instead of `System.currentTimeMillis()`
+- Log output uses `ns` as the unit suffix instead of `ms`
+- All publish calls (connection-level and statement-level) use nanosecond values
+
 ### 2. Java Logging Configuration
 
 Configure `java.util.logging` for the performance metrics loggers at `FINE` level:
@@ -242,3 +275,4 @@ try {
 - `SQLServerPreparedStatement.java` - Prepared statement activities
 - `PerformanceActivity.java` - Activity enum definitions
 - `PerformanceLog.java` - Logging infrastructure
+- `PerformanceLogCallback.java` - Callback interface (includes `useNanoseconds()` for nanosecond granularity)

--- a/.github/instructions/performance-metrics.instructions.md
+++ b/.github/instructions/performance-metrics.instructions.md
@@ -37,12 +37,12 @@ SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
 #### Nanosecond Granularity
 
 By default, the `duration` parameter is reported in **milliseconds**. To receive
-**nanosecond** granularity instead, override `useNanoseconds()` to return `true`:
+**nanosecond** granularity instead, override `useNanoSeconds()` to return `true`:
 
 ```java
 SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
     @Override
-    public boolean useNanoseconds() {
+    public boolean useNanoSeconds() {
         return true; // duration values will be in nanoseconds
     }
 
@@ -62,7 +62,11 @@ SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
 });
 ```
 
-When `useNanoseconds()` returns `true`:
+The value of `useNanoSeconds()` is captured once at registration time and remains fixed
+for the lifetime of the callback. To change the duration unit, unregister and re-register
+with the new setting.
+
+When `useNanoSeconds()` returns `true`:
 - Timing uses `System.nanoTime()` instead of `System.currentTimeMillis()`
 - Log output uses `ns` as the unit suffix instead of `ms`
 - All publish calls (connection-level and statement-level) use nanosecond values
@@ -275,4 +279,4 @@ try {
 - `SQLServerPreparedStatement.java` - Prepared statement activities
 - `PerformanceActivity.java` - Activity enum definitions
 - `PerformanceLog.java` - Logging infrastructure
-- `PerformanceLogCallback.java` - Callback interface (includes `useNanoseconds()` for nanosecond granularity)
+- `PerformanceLogCallback.java` - Callback interface (includes `useNanoSeconds()` for nanosecond granularity)

--- a/.github/instructions/performance-metrics.instructions.md
+++ b/.github/instructions/performance-metrics.instructions.md
@@ -37,12 +37,12 @@ SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
 #### Nanosecond Granularity
 
 By default, the `duration` parameter is reported in **milliseconds**. To receive
-**nanosecond** granularity instead, override `useNanoSeconds()` to return `true`:
+**nanosecond** granularity instead, override `useNanoseconds()` to return `true`:
 
 ```java
 SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
     @Override
-    public boolean useNanoSeconds() {
+    public boolean useNanoseconds() {
         return true; // duration values will be in nanoseconds
     }
 
@@ -62,11 +62,11 @@ SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
 });
 ```
 
-The value of `useNanoSeconds()` is captured once at registration time and remains fixed
+The value of `useNanoseconds()` is captured once at registration time and remains fixed
 for the lifetime of the callback. To change the duration unit, unregister and re-register
 with the new setting.
 
-When `useNanoSeconds()` returns `true`:
+When `useNanoseconds()` returns `true`:
 - Timing uses `System.nanoTime()` instead of `System.currentTimeMillis()`
 - Log output uses `ns` as the unit suffix instead of `ms`
 - All publish calls (connection-level and statement-level) use nanosecond values
@@ -279,4 +279,4 @@ try {
 - `SQLServerPreparedStatement.java` - Prepared statement activities
 - `PerformanceActivity.java` - Activity enum definitions
 - `PerformanceLog.java` - Logging infrastructure
-- `PerformanceLogCallback.java` - Callback interface (includes `useNanoSeconds()` for nanosecond granularity)
+- `PerformanceLogCallback.java` - Callback interface (includes `useNanoseconds()` for nanosecond granularity)

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
@@ -50,6 +50,7 @@ class PerformanceLog {
         private PerformanceActivity activity;
         private long startTime;
         private final boolean enabled;
+        private final boolean nanos;
 
         private Exception exception;
 
@@ -60,16 +61,15 @@ class PerformanceLog {
 
         // Constructor for statement-level activities
         public Scope(Logger logger, int connectionId, int statementId, PerformanceActivity activity) {
-
-            // Check if logging is enabled
             this.enabled = logger.isLoggable(Level.FINE) || (callback != null);
+            this.nanos = (callback != null && callback.useNanoseconds());
 
             if (enabled) {
                 this.logger = logger;
                 this.connectionId = connectionId;
                 this.statementId = statementId;
                 this.activity = activity;
-                this.startTime = System.currentTimeMillis();
+                this.startTime = nanos ? System.nanoTime() : System.currentTimeMillis();
             }
         }
 
@@ -91,33 +91,28 @@ class PerformanceLog {
                 return;
             }
 
-            long endTime = System.currentTimeMillis();
-            long duration = endTime - startTime;
+            long duration = nanos ? (System.nanoTime() - startTime) : (System.currentTimeMillis() - startTime);
 
             if (callback != null) {
                 try {
-                    
                     if (statementId == 0) {
-                        // Connection-level activity
                         callback.publish(activity, connectionId, duration, exception);
                     } else {
-                        // Statement-level activity
                         callback.publish(activity, connectionId, statementId, duration, exception);
                     }
-
                 } catch (Exception e) {
                     logger.fine(String.format("Failed to publish performance log: %s", e.getMessage()));
                 }
             }
 
             if (logger != null && logger.isLoggable(Level.FINE)) {
+                String unit = nanos ? "ns" : "ms";
                 if (exception != null) {
-                    logger.fine(String.format("%s %s, duration: %dms, exception: %s", getTraceId(), activity, duration, exception.getMessage()));
+                    logger.fine(String.format("%s %s, duration: %d%s, exception: %s", getTraceId(), activity, duration, unit, exception.getMessage()));
                 } else {
-                    logger.fine(String.format("%s %s, duration: %dms", getTraceId(), activity, duration));
+                    logger.fine(String.format("%s %s, duration: %d%s", getTraceId(), activity, duration, unit));
                 }
             }
-
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
@@ -62,7 +62,15 @@ class PerformanceLog {
         // Constructor for statement-level activities
         public Scope(Logger logger, int connectionId, int statementId, PerformanceActivity activity) {
             this.enabled = logger.isLoggable(Level.FINE) || (callback != null);
-            this.nanos = (callback != null && callback.useNanoseconds());
+            boolean useNanos = false;
+            if (callback != null) {
+                try {
+                    useNanos = callback.useNanoseconds();
+                } catch (Exception e) {
+                    logger.fine(String.format("Failed to call useNanoseconds(), defaulting to milliseconds: %s", e.getMessage()));
+                }
+            }
+            this.nanos = useNanos;
 
             if (enabled) {
                 this.logger = logger;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
@@ -22,7 +22,7 @@ class PerformanceLog {
 
     /**
      * Register a callback for performance log events.
-     * The value of {@link PerformanceLogCallback#useNanoSeconds()} is captured at registration
+     * The value of {@link PerformanceLogCallback#useNanoseconds()} is captured at registration
      * time and remains fixed for the lifetime of this callback. To change the duration unit,
      * unregister and re-register with the new setting.
      *
@@ -33,7 +33,7 @@ class PerformanceLog {
             throw new IllegalStateException("Callback has already been set");
         }
         callback = cb;
-        cachedUseNanos = cb.useNanoSeconds();
+        cachedUseNanos = cb.useNanoseconds();
         callbackInitialized = true;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
@@ -18,9 +18,13 @@ class PerformanceLog {
 
     private static PerformanceLogCallback callback;
     private static boolean callbackInitialized = false;
+    private static boolean cachedUseNanos = false;
 
     /**
      * Register a callback for performance log events.
+     * The value of {@link PerformanceLogCallback#useNanoSeconds()} is captured at registration
+     * time and remains fixed for the lifetime of this callback. To change the duration unit,
+     * unregister and re-register with the new setting.
      *
      * @param cb The callback to register.
      */
@@ -29,6 +33,7 @@ class PerformanceLog {
             throw new IllegalStateException("Callback has already been set");
         }
         callback = cb;
+        cachedUseNanos = cb.useNanoSeconds();
         callbackInitialized = true;
     }
 
@@ -37,6 +42,7 @@ class PerformanceLog {
      */
     public static synchronized void unregisterCallback() {
         callback = null;
+        cachedUseNanos = false;
         callbackInitialized = false;
     }
 
@@ -50,7 +56,7 @@ class PerformanceLog {
         private PerformanceActivity activity;
         private long startTime;
         private final boolean enabled;
-        private final boolean nanos;
+        private final boolean useNanos;
 
         private Exception exception;
 
@@ -62,22 +68,14 @@ class PerformanceLog {
         // Constructor for statement-level activities
         public Scope(Logger logger, int connectionId, int statementId, PerformanceActivity activity) {
             this.enabled = logger.isLoggable(Level.FINE) || (callback != null);
-            boolean useNanos = false;
-            if (callback != null) {
-                try {
-                    useNanos = callback.useNanoseconds();
-                } catch (Exception e) {
-                    logger.fine(String.format("Failed to call useNanoseconds(), defaulting to milliseconds: %s", e.getMessage()));
-                }
-            }
-            this.nanos = useNanos;
+            this.useNanos = cachedUseNanos;
 
             if (enabled) {
                 this.logger = logger;
                 this.connectionId = connectionId;
                 this.statementId = statementId;
                 this.activity = activity;
-                this.startTime = nanos ? System.nanoTime() : System.currentTimeMillis();
+                this.startTime = useNanos ? System.nanoTime() : System.currentTimeMillis();
             }
         }
 
@@ -99,7 +97,7 @@ class PerformanceLog {
                 return;
             }
 
-            long duration = nanos ? (System.nanoTime() - startTime) : (System.currentTimeMillis() - startTime);
+            long duration = useNanos ? (System.nanoTime() - startTime) : (System.currentTimeMillis() - startTime);
 
             if (callback != null) {
                 try {
@@ -114,7 +112,7 @@ class PerformanceLog {
             }
 
             if (logger != null && logger.isLoggable(Level.FINE)) {
-                String unit = nanos ? "ns" : "ms";
+                String unit = useNanos ? "ns" : "ms";
                 if (exception != null) {
                     logger.fine(String.format("%s %s, duration: %d%s, exception: %s", getTraceId(), activity, duration, unit, exception.getMessage()));
                 } else {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
@@ -7,6 +7,10 @@ package com.microsoft.sqlserver.jdbc;
 
 /**
  * Callback interface for publishing performance logs.
+ *
+ * <p>The {@code duration} parameter in {@link #publish} contains the operation duration
+ * in milliseconds by default. To receive nanosecond granularity instead, override
+ * {@link #useNanoseconds()} to return {@code true}.</p>
  */
 public interface PerformanceLogCallback {
 
@@ -14,19 +18,33 @@ public interface PerformanceLogCallback {
      * Publish performance log for connection-level activities.
      * @param activity        The type of activity being logged.
      * @param connectionId    The ID of the connection.
-     * @param durationMs      The duration of the operation in milliseconds.
+     * @param duration        The duration of the operation (milliseconds by default, nanoseconds if
+     *                        {@link #useNanoseconds()} returns true).
      * @param exception       An exception, if an error occurred.
      */
-    void publish(PerformanceActivity activity, int connectionId, long durationMs, Exception exception) throws Exception;
+    void publish(PerformanceActivity activity, int connectionId, long duration, Exception exception) throws Exception;
 
     /**
      * Publish performance log for statement-level activities.
      * @param activity        The type of activity being logged.
      * @param connectionId    The ID of the connection.
      * @param statementId     The ID of the statement (if applicable).
-     * @param durationMs      The duration of the operation in milliseconds.
+     * @param duration        The duration of the operation (milliseconds by default, nanoseconds if
+     *                        {@link #useNanoseconds()} returns true).
      * @param exception       An exception, if an error occurred.
      */
-    void publish(PerformanceActivity activity, int connectionId, int statementId, long durationMs, Exception exception) throws Exception;
+    void publish(PerformanceActivity activity, int connectionId, int statementId, long duration, Exception exception) throws Exception;
+
+    /**
+     * Indicates whether the callback wants duration values in nanoseconds.
+     * Override this method to return {@code true} to receive nanosecond granularity
+     * in the {@code duration} parameter of {@link #publish}.
+     * The default is {@code false} (milliseconds).
+     *
+     * @return true if duration should be reported in nanoseconds, false for milliseconds.
+     */
+    default boolean useNanoseconds() {
+        return false;
+    }
 
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
@@ -8,9 +8,10 @@ package com.microsoft.sqlserver.jdbc;
 /**
  * Callback interface for publishing performance logs.
  *
- * <p>The {@code duration} parameter in {@link #publish} contains the operation duration
+ * The {@code duration} parameter in {@link #publish(PerformanceActivity, int, long, Exception)}
+ * and {@link #publish(PerformanceActivity, int, int, long, Exception)} contains the operation duration
  * in milliseconds by default. To receive nanosecond granularity instead, override
- * {@link #useNanoseconds()} to return {@code true}.</p>
+ * {@link #useNanoseconds()} to return {@code true}.
  */
 public interface PerformanceLogCallback {
 
@@ -38,7 +39,8 @@ public interface PerformanceLogCallback {
     /**
      * Indicates whether the callback wants duration values in nanoseconds.
      * Override this method to return {@code true} to receive nanosecond granularity
-     * in the {@code duration} parameter of {@link #publish}.
+     * in the {@code duration} parameter of {@link #publish(PerformanceActivity, int, long, Exception)}
+     * and {@link #publish(PerformanceActivity, int, int, long, Exception)}.
      * The default is {@code false} (milliseconds).
      *
      * @return true if duration should be reported in nanoseconds, false for milliseconds.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
@@ -11,7 +11,7 @@ package com.microsoft.sqlserver.jdbc;
  * The {@code duration} parameter in {@link #publish(PerformanceActivity, int, long, Exception)}
  * and {@link #publish(PerformanceActivity, int, int, long, Exception)} contains the operation duration
  * in milliseconds by default. To receive nanosecond granularity instead, override
- * {@link #useNanoseconds()} to return {@code true}.
+ * {@link #useNanoSeconds()} to return {@code true}.
  */
 public interface PerformanceLogCallback {
 
@@ -20,7 +20,7 @@ public interface PerformanceLogCallback {
      * @param activity        The type of activity being logged.
      * @param connectionId    The ID of the connection.
      * @param duration        The duration of the operation (milliseconds by default, nanoseconds if
-     *                        {@link #useNanoseconds()} returns true).
+     *                        {@link #useNanoSeconds()} returns true).
      * @param exception       An exception, if an error occurred.
      */
     void publish(PerformanceActivity activity, int connectionId, long duration, Exception exception) throws Exception;
@@ -31,7 +31,7 @@ public interface PerformanceLogCallback {
      * @param connectionId    The ID of the connection.
      * @param statementId     The ID of the statement (if applicable).
      * @param duration        The duration of the operation (milliseconds by default, nanoseconds if
-     *                        {@link #useNanoseconds()} returns true).
+     *                        {@link #useNanoSeconds()} returns true).
      * @param exception       An exception, if an error occurred.
      */
     void publish(PerformanceActivity activity, int connectionId, int statementId, long duration, Exception exception) throws Exception;
@@ -45,7 +45,7 @@ public interface PerformanceLogCallback {
      *
      * @return true if duration should be reported in nanoseconds, false for milliseconds.
      */
-    default boolean useNanoseconds() {
+    default boolean useNanoSeconds() {
         return false;
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
@@ -11,7 +11,7 @@ package com.microsoft.sqlserver.jdbc;
  * The {@code duration} parameter in {@link #publish(PerformanceActivity, int, long, Exception)}
  * and {@link #publish(PerformanceActivity, int, int, long, Exception)} contains the operation duration
  * in milliseconds by default. To receive nanosecond granularity instead, override
- * {@link #useNanoSeconds()} to return {@code true}.
+ * {@link #useNanoseconds()} to return {@code true}.
  */
 public interface PerformanceLogCallback {
 
@@ -20,7 +20,7 @@ public interface PerformanceLogCallback {
      * @param activity        The type of activity being logged.
      * @param connectionId    The ID of the connection.
      * @param duration        The duration of the operation (milliseconds by default, nanoseconds if
-     *                        {@link #useNanoSeconds()} returns true).
+     *                        {@link #useNanoseconds()} returns true).
      * @param exception       An exception, if an error occurred.
      */
     void publish(PerformanceActivity activity, int connectionId, long duration, Exception exception) throws Exception;
@@ -31,7 +31,7 @@ public interface PerformanceLogCallback {
      * @param connectionId    The ID of the connection.
      * @param statementId     The ID of the statement (if applicable).
      * @param duration        The duration of the operation (milliseconds by default, nanoseconds if
-     *                        {@link #useNanoSeconds()} returns true).
+     *                        {@link #useNanoseconds()} returns true).
      * @param exception       An exception, if an error occurred.
      */
     void publish(PerformanceActivity activity, int connectionId, int statementId, long duration, Exception exception) throws Exception;
@@ -45,7 +45,7 @@ public interface PerformanceLogCallback {
      *
      * @return true if duration should be reported in nanoseconds, false for milliseconds.
      */
-    default boolean useNanoSeconds() {
+    default boolean useNanoseconds() {
         return false;
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
@@ -152,7 +152,8 @@ class PerformanceLogCallbackTest extends AbstractTest {
 
     /**
      * Performance overhead test for connection and statement operations.
-     * Compares execution time with callback/logging disabled vs enabled.
+     * Compares execution time with callback/logging disabled vs enabled (milliseconds)
+     * vs enabled (nanoseconds).
      * For testing purpose - iterations set to 1
      */
     @Test
@@ -170,7 +171,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
 
             long disabledDuration = executeStatementsWithNewConnectionsPerIteration(count);
 
-            // Test with callback/logging ENABLED
+            // Test with callback/logging ENABLED (milliseconds - default)
             PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
                 @Override
                 public void publish(PerformanceActivity activity, int connectionId, long durationMs, 
@@ -190,8 +191,35 @@ class PerformanceLogCallbackTest extends AbstractTest {
 
             long enabledDuration = executeStatementsWithNewConnectionsPerIteration(count);
 
-            // Uncomment below line to print performance comparison for connection overhead test
-            // printPerformanceComparison(disabledDuration, enabledDuration, count, "new connection per iteration");
+            // Test with callback/logging ENABLED (nanoseconds)
+            SQLServerDriver.unregisterPerformanceLogCallback();
+            PerformanceLogCallback nanosCallbackInstance = new PerformanceLogCallback() {
+                @Override
+                public boolean useNanoseconds() {
+                    return true;
+                }
+
+                @Override
+                public void publish(PerformanceActivity activity, int connectionId, long durationNs, 
+                        Exception exception) {
+                    // No-op callback to measure overhead with nanosecond granularity
+                }
+
+                @Override
+                public void publish(PerformanceActivity activity, int connectionId, int statementId, 
+                        long durationNs, Exception exception) {
+                    // No-op callback to measure overhead with nanosecond granularity
+                }
+            };
+            SQLServerDriver.registerPerformanceLogCallback(nanosCallbackInstance);
+            perfLoggerConnection.setLevel(Level.FINE);
+            perfLoggerStatement.setLevel(Level.FINE);
+
+            long enabledNanosDuration = executeStatementsWithNewConnectionsPerIteration(count);
+
+            // Uncomment below lines to print performance comparison for connection overhead test
+            // printPerformanceComparison(disabledDuration, enabledDuration, count, "new connection per iteration (ms mode)");
+            // printPerformanceComparison(disabledDuration, enabledNanosDuration, count, "new connection per iteration (nanos mode)");
 
             // Cleanup for next iteration
             SQLServerDriver.unregisterPerformanceLogCallback();
@@ -200,52 +228,87 @@ class PerformanceLogCallbackTest extends AbstractTest {
 
     /**
      * High-volume statement execution performance test.
-     * Reuses a single connection to test 10000 statement executions efficiently.
-     * Compares performance with logging disabled vs enabled.
+     * Reuses a single connection to test statement executions efficiently.
+     * Compares performance with logging disabled vs enabled (milliseconds)
+     * vs enabled (nanoseconds).
      */
     @Test
     void testHighVolumeStatementPerformance() throws Exception {
-        int iterations = 10; // Set to 10000 for actual high-volume test
+        int[] iterations = {10};
+        // Uncomment below line to run with higher iterations
+        // int[] iterations = {1000, 10000};
 
-        // Test with callback/logging DISABLED
-        SQLServerDriver.unregisterPerformanceLogCallback();
-        perfLoggerConnection.setLevel(Level.OFF);
-        perfLoggerStatement.setLevel(Level.OFF);
+        for (int count : iterations) {
 
-        long disabledDuration;
-        try (Connection con = getConnection()) {
-            disabledDuration = executeStatementsWithTiming(con, iterations);
-        }
+            // Test with callback/logging DISABLED
+            SQLServerDriver.unregisterPerformanceLogCallback();
+            perfLoggerConnection.setLevel(Level.OFF);
+            perfLoggerStatement.setLevel(Level.OFF);
 
-        // Test with callback/logging ENABLED
-        PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
-            @Override
-            public void publish(PerformanceActivity activity, int connectionId, long durationMs, 
-                    Exception exception) {
-                // No-op callback
+            long disabledDuration;
+            try (Connection con = getConnection()) {
+                disabledDuration = executeStatementsWithTiming(con, count);
             }
 
-            @Override
-            public void publish(PerformanceActivity activity, int connectionId, int statementId, 
-                    long durationMs, Exception exception) {
-                // No-op callback
+            // Test with callback/logging ENABLED (milliseconds - default)
+            PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
+                @Override
+                public void publish(PerformanceActivity activity, int connectionId, long durationMs, 
+                        Exception exception) {
+                    // No-op callback
+                }
+
+                @Override
+                public void publish(PerformanceActivity activity, int connectionId, int statementId, 
+                        long durationMs, Exception exception) {
+                    // No-op callback
+                }
+            };
+            SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
+            perfLoggerConnection.setLevel(Level.FINE);
+            perfLoggerStatement.setLevel(Level.FINE);
+
+            long enabledDuration;
+            try (Connection con = getConnection()) {
+                enabledDuration = executeStatementsWithTiming(con, count);
             }
-        };
-        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
-        perfLoggerConnection.setLevel(Level.FINE);
-        perfLoggerStatement.setLevel(Level.FINE);
 
-        long enabledDuration;
-        try (Connection con = getConnection()) {
-            enabledDuration = executeStatementsWithTiming(con, iterations);
+            // Test with callback/logging ENABLED (nanoseconds)
+            SQLServerDriver.unregisterPerformanceLogCallback();
+            PerformanceLogCallback nanosCallbackInstance = new PerformanceLogCallback() {
+                @Override
+                public boolean useNanoseconds() {
+                    return true;
+                }
+
+                @Override
+                public void publish(PerformanceActivity activity, int connectionId, long durationNs, 
+                        Exception exception) {
+                    // No-op callback to measure overhead with nanosecond granularity
+                }
+
+                @Override
+                public void publish(PerformanceActivity activity, int connectionId, int statementId, 
+                        long durationNs, Exception exception) {
+                    // No-op callback to measure overhead with nanosecond granularity
+                }
+            };
+            SQLServerDriver.registerPerformanceLogCallback(nanosCallbackInstance);
+            perfLoggerConnection.setLevel(Level.FINE);
+            perfLoggerStatement.setLevel(Level.FINE);
+
+            long enabledNanosDuration;
+            try (Connection con = getConnection()) {
+                enabledNanosDuration = executeStatementsWithTiming(con, count);
+            }
+
+            // Uncomment below lines to print performance comparison for high-volume test
+            // printPerformanceComparison(disabledDuration, enabledDuration, count, "single connection (ms mode)");
+            // printPerformanceComparison(disabledDuration, enabledNanosDuration, count, "single connection (nanos mode)");
+
+            // Cleanup for next iteration
+            SQLServerDriver.unregisterPerformanceLogCallback();
         }
-
-        // Uncomment below line to print performance comparison for high-volume test
-        // printPerformanceComparison(disabledDuration, enabledDuration, iterations, "single connection");
-
-        // Cleanup
-        SQLServerDriver.unregisterPerformanceLogCallback();
-
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
@@ -603,6 +603,97 @@ class PerformanceLogCallbackTest extends AbstractTest {
     }
 
     /**
+     * Test to validate that when useNanoseconds() returns true,
+     * the duration field in publish() contains nanosecond values.
+     */
+    @Test
+    void testPublishWithNanosecondGranularity() throws Exception {
+        List<Long> connectionDurations = new ArrayList<>();
+        List<Long> statementDurations = new ArrayList<>();
+
+        PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
+            @Override
+            public boolean useNanoseconds() {
+                return true;
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, long duration,
+                    Exception exception) {
+                connectionDurations.add(duration);
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, int statementId,
+                    long duration, Exception exception) {
+                statementDurations.add(duration);
+            }
+        };
+
+        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
+
+        try (Connection con = getConnection()) {
+            try (Statement stmt = con.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT 1")) {
+            }
+        }
+
+        // Durations should be in nanoseconds (much larger than millisecond values)
+        assertTrue(connectionDurations.size() > 0, "publish should have been called for connection-level activities");
+        for (long duration : connectionDurations) {
+            assertTrue(duration > 1_000, "Duration in nanoseconds should be larger than 1000 (i.e. > 1 microsecond)");
+        }
+
+        assertTrue(statementDurations.size() > 0, "publish should have been called for statement-level activities");
+        for (long duration : statementDurations) {
+            assertTrue(duration >= 0, "Duration should be non-negative");
+        }
+
+        SQLServerDriver.unregisterPerformanceLogCallback();
+    }
+
+    /**
+     * Test to validate backward compatibility: when registered without useNanoseconds
+     * (default), the duration field contains millisecond values.
+     */
+    @Test
+    void testPublishDefaultDelegatesToMsOverload() throws Exception {
+        List<Long> connectionMs = new ArrayList<>();
+        List<Long> statementMs = new ArrayList<>();
+
+        PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, long duration,
+                    Exception exception) {
+                connectionMs.add(duration);
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, int statementId,
+                    long duration, Exception exception) {
+                statementMs.add(duration);
+            }
+        };
+
+        // Register without useNanoseconds (default = milliseconds)
+        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
+
+        try (Connection con = getConnection()) {
+            try (Statement stmt = con.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT 1")) {
+            }
+        }
+
+        // Durations should be in milliseconds
+        assertTrue(connectionMs.size() > 0,
+                "publish should have been called for connection-level activities");
+        assertTrue(statementMs.size() > 0,
+                "publish should have been called for statement-level activities");
+
+        SQLServerDriver.unregisterPerformanceLogCallback();
+    }
+
+    /**
      * Helper method to execute Statement and PreparedStatement queries in a loop.
      * Uses a provided connection. Returns the duration in nanoseconds.
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
@@ -195,7 +195,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
             SQLServerDriver.unregisterPerformanceLogCallback();
             PerformanceLogCallback nanosCallbackInstance = new PerformanceLogCallback() {
                 @Override
-                public boolean useNanoseconds() {
+                public boolean useNanoSeconds() {
                     return true;
                 }
 
@@ -277,7 +277,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
             SQLServerDriver.unregisterPerformanceLogCallback();
             PerformanceLogCallback nanosCallbackInstance = new PerformanceLogCallback() {
                 @Override
-                public boolean useNanoseconds() {
+                public boolean useNanoSeconds() {
                     return true;
                 }
 
@@ -676,7 +676,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
 
         PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
             @Override
-            public boolean useNanoseconds() {
+            public boolean useNanoSeconds() {
                 return true;
             }
 
@@ -752,6 +752,61 @@ class PerformanceLogCallbackTest extends AbstractTest {
                 "publish should have been called for connection-level activities");
         assertTrue(statementMs.size() > 0,
                 "publish should have been called for statement-level activities");
+
+        SQLServerDriver.unregisterPerformanceLogCallback();
+    }
+
+    /**
+     * Test to validate that useNanoseconds() is cached at registration time.
+     * Mutating the callback's return value after registration should have no effect.
+     */
+    @Test
+    void testUseNanosecondsCachedAtRegistration() throws Exception {
+        List<Long> durations = new ArrayList<>();
+
+        // Mutable callback whose useNanoseconds() can be flipped at runtime
+        class MutableCallback implements PerformanceLogCallback {
+            volatile boolean nanos = false;
+
+            @Override
+            public boolean useNanoSeconds() {
+                return nanos;
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, long duration,
+                    Exception exception) {
+                durations.add(duration);
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, int statementId,
+                    long duration, Exception exception) {
+                durations.add(duration);
+            }
+        }
+
+        MutableCallback cb = new MutableCallback();
+        cb.nanos = false; // register with milliseconds
+        SQLServerDriver.registerPerformanceLogCallback(cb);
+
+        // Mutate after registration — should have no effect
+        cb.nanos = true;
+
+        try (Connection con = getConnection()) {
+            try (Statement stmt = con.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT 1")) {
+            }
+        }
+
+        // Durations should still be in milliseconds (small values), not nanoseconds
+        assertTrue(durations.size() > 0, "publish should have been called");
+        for (long duration : durations) {
+            // A millisecond duration for a simple query should be well under 1,000,000
+            // (which would be 1 second). Nanosecond values would typically be > 1,000,000.
+            assertTrue(duration < 1_000_000,
+                    "Duration should be in milliseconds (cached at registration), got: " + duration);
+        }
 
         SQLServerDriver.unregisterPerformanceLogCallback();
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
@@ -195,7 +195,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
             SQLServerDriver.unregisterPerformanceLogCallback();
             PerformanceLogCallback nanosCallbackInstance = new PerformanceLogCallback() {
                 @Override
-                public boolean useNanoSeconds() {
+                public boolean useNanoseconds() {
                     return true;
                 }
 
@@ -277,7 +277,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
             SQLServerDriver.unregisterPerformanceLogCallback();
             PerformanceLogCallback nanosCallbackInstance = new PerformanceLogCallback() {
                 @Override
-                public boolean useNanoSeconds() {
+                public boolean useNanoseconds() {
                     return true;
                 }
 
@@ -676,7 +676,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
 
         PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
             @Override
-            public boolean useNanoSeconds() {
+            public boolean useNanoseconds() {
                 return true;
             }
 
@@ -769,7 +769,7 @@ class PerformanceLogCallbackTest extends AbstractTest {
             volatile boolean nanos = false;
 
             @Override
-            public boolean useNanoSeconds() {
+            public boolean useNanoseconds() {
                 return nanos;
             }
 


### PR DESCRIPTION
# Add nanosecond granularity option to PerformanceLogCallback

## Summary

Adds an opt-in nanosecond duration mode to the `PerformanceLogCallback` interface, allowing applications to receive high-resolution timing data without any breaking changes to the existing API.

## Motivation

Millisecond resolution is insufficient for profiling fast operations (e.g., cached statement execution, connection pool checkout). Applications that need sub-millisecond visibility can now opt into nanosecond granularity by overriding a single default method.

## Design

- **No API signature changes** — the `publish()` methods and `registerPerformanceLogCallback()` remain identical.
- **Opt-in via default method** — `PerformanceLogCallback` gains a `default boolean useNanoseconds()` that returns `false`. Applications override it to return `true` to receive nanosecond values in the existing `duration` parameter.
- **Correct time source** — when `useNanoseconds()` is `true`, the driver uses `System.nanoTime()` for both start and end; otherwise it uses `System.currentTimeMillis()`.
- **Zero impact on existing users** — the default behavior is unchanged (milliseconds).

## Changes

| File | Change |
|------|--------|
| `PerformanceLogCallback.java` | Added `default boolean useNanoseconds()` with Javadoc |
| `PerformanceLog.java` | `Scope` reads `useNanoseconds()` at construction, selects `nanoTime()` or `currentTimeMillis()` accordingly; logger output includes correct unit label ("ms" or "ns") |
| `PerformanceLogCallbackTest.java` | Added `testPublishWithNanosecondGranularity` test |

## Usage

```java
SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
    @Override
    public boolean useNanoseconds() {
        return true; // opt-in to nanosecond durations
    }

    @Override
    public void publish(PerformanceActivity activity, int connectionId, long duration, Exception ex) {
        // duration is now in nanoseconds
        System.out.printf("%s conn=%d duration=%dns%n", activity, connectionId, duration);
    }

    @Override
    public void publish(PerformanceActivity activity, int connectionId, int statementId, long duration, Exception ex) {
        System.out.printf("%s conn=%d stmt=%d duration=%dns%n", activity, connectionId, statementId, duration);
    }
});
```

## Testing

- All 11 existing `PerformanceLogCallbackTest` tests pass.
- New test validates nanosecond values are within expected range (> 1000ns for a 1ms+ operation).

## Backward Compatibility

Fully backward compatible. Existing callbacks that do not override `useNanoseconds()` continue to receive millisecond durations with no code changes required.

## Performance Considerations

When useNanoseconds() returns true, an **additional overhead** is expected compared to millisecond mode. This is because System.nanoTime() have higher invocation cost than System.currentTimeMillis() on some platforms. This overhead only applies when a callback is registered and logging is enabled — there is no impact when both are disabled.

## Sample Output

```
May 13, 2026 3:21:25 PM com.microsoft.sqlserver.jdbc.PerformanceLog$Scope close
FINE: ConnectionID:1 Prelogin, duration: 16078800ns
May 13, 2026 3:21:25 PM com.microsoft.sqlserver.jdbc.PerformanceLog$Scope close
FINE: ConnectionID:1 Login, duration: 736384700ns
May 13, 2026 3:21:25 PM com.microsoft.sqlserver.jdbc.PerformanceLog$Scope close
FINE: ConnectionID:1 Connection, duration: 746256200ns
May 13, 2026 3:21:25 PM com.microsoft.sqlserver.jdbc.PerformanceLog$Scope close
FINE: ConnectionID:1, StatementID:1 Request build time, duration: 1098600ns
May 13, 2026 3:21:25 PM com.microsoft.sqlserver.jdbc.PerformanceLog$Scope close
FINE: ConnectionID:1, StatementID:1 First server response, duration: 1334200ns
May 13, 2026 3:21:25 PM com.microsoft.sqlserver.jdbc.PerformanceLog$Scope close
FINE: ConnectionID:1, StatementID:1 Statement execute, duration: 48569800ns
```
