### PR TITLE
Fix CI-MACOS flakiness in connection-timeout tests by giving login phase adequate headroom

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -762,7 +762,8 @@ final class TDSChannel implements Serializable {
             // Note: timerRemaining() always returns >= 1 ms (clamped from below), so
             // loginRemaining can never be 0 and cannot re-introduce an unlimited read timeout.
             if (!con.isConnected()) {
-                socketTimeout = Math.min(con.timerRemaining(con.timerExpire), socketTimeout);
+                int loginRemaining = con.timerRemaining(con.timerExpire);
+                socketTimeout = (socketTimeout == 0) ? loginRemaining : Math.min(loginRemaining, socketTimeout);
             }
 
             tcpSocket.setSoTimeout(socketTimeout);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -762,8 +762,7 @@ final class TDSChannel implements Serializable {
             // Note: timerRemaining() always returns >= 1 ms (clamped from below), so
             // loginRemaining can never be 0 and cannot re-introduce an unlimited read timeout.
             if (!con.isConnected()) {
-                int loginRemaining = con.timerRemaining(con.timerExpire);
-                socketTimeout = (socketTimeout == 0) ? loginRemaining : Math.min(loginRemaining, socketTimeout);
+                socketTimeout = Math.min(con.timerRemaining(con.timerExpire), socketTimeout);
             }
 
             tcpSocket.setSoTimeout(socketTimeout);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
@@ -498,9 +498,11 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
         long totalTime;
         long timerStart = System.currentTimeMillis();
 
-        // No retries since CRL rules override, expected time ~1 second
+        // No retries since CRL rules override, expected time ~1 second.
+        // loginTimeout=30 ensures the server's TDS 4060 "cannot open database" round-trip
+        // always completes before the JDBC socket read deadline, even on slow CI agents.
         try {
-            testConnectionRetry("blah", "retryConn={9999};");
+            testConnectionRetry("blah", "loginTimeout=30;retryConn={9999};");
         } catch (Exception e) {
             assertTrue(
                     (e.getMessage().toLowerCase()
@@ -517,7 +519,8 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
         // (0s attempt + 0s attempt + 10s wait + 0s attempt) = expected 10s execution time
         try {
-            testConnectionRetry("blah", "retryConn={4060,4070};connectRetryCount=2;connectRetryInterval=10");
+            testConnectionRetry("blah",
+                    "loginTimeout=30;retryConn={4060,4070};connectRetryCount=2;connectRetryInterval=10");
         } catch (Exception e) {
             assertTrue(
                     (e.getMessage().toLowerCase()
@@ -540,7 +543,8 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
 
         // Append should work the same way
         try {
-            testConnectionRetry("blah", "retryConn={+4060,4070};connectRetryCount=2;connectRetryInterval=10");
+            testConnectionRetry("blah",
+                    "loginTimeout=30;retryConn={+4060,4070};connectRetryCount=2;connectRetryInterval=10");
         } catch (Exception e) {
             assertTrue(
                     (e.getMessage().toLowerCase()

--- a/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/configurableretry/ConfigurableRetryLogicTest.java
@@ -499,10 +499,10 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
         long timerStart = System.currentTimeMillis();
 
         // No retries since CRL rules override, expected time ~1 second.
-        // loginTimeout=30 ensures the server's TDS 4060 "cannot open database" round-trip
+        // loginTimeout=20 ensures the server's TDS 4060 "cannot open database" round-trip
         // always completes before the JDBC socket read deadline, even on slow CI agents.
         try {
-            testConnectionRetry("blah", "loginTimeout=30;retryConn={9999};");
+            testConnectionRetry("blah", "loginTimeout=20;retryConn={9999};");
         } catch (Exception e) {
             assertTrue(
                     (e.getMessage().toLowerCase()
@@ -520,7 +520,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
         // (0s attempt + 0s attempt + 10s wait + 0s attempt) = expected 10s execution time
         try {
             testConnectionRetry("blah",
-                    "loginTimeout=30;retryConn={4060,4070};connectRetryCount=2;connectRetryInterval=10");
+                    "loginTimeout=20;retryConn={4060,4070};connectRetryCount=2;connectRetryInterval=10");
         } catch (Exception e) {
             assertTrue(
                     (e.getMessage().toLowerCase()
@@ -544,7 +544,7 @@ public class ConfigurableRetryLogicTest extends AbstractTest {
         // Append should work the same way
         try {
             testConnectionRetry("blah",
-                    "loginTimeout=30;retryConn={+4060,4070};connectRetryCount=2;connectRetryInterval=10");
+                    "loginTimeout=20;retryConn={+4060,4070};connectRetryCount=2;connectRetryInterval=10");
         } catch (Exception e) {
             assertTrue(
                     (e.getMessage().toLowerCase()

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/TimeoutTest.java
@@ -368,13 +368,14 @@ public class TimeoutTest extends AbstractTest {
     @Tag(Constants.xAzureSQLDW)
     public void testDefaultSocketTimeoutUnlimitedAfterLogin() throws Exception {
         // Connect without setting socketTimeout (defaults to 0 = unlimited).
-        // loginTimeout=5 gives the login phase enough time to complete on any CI agent.
+        // loginTimeout=15 gives the login phase (prelogin + TLS handshake + LOGIN7 round-trip)
+        // enough headroom to complete on any CI agent, including slow MacOS hosted runners.
         // After login, the socket timeout should remain 0 (unlimited), so a query that
-        // exceeds loginTimeout (5s) should still succeed.
-        try (Connection con = PrepUtil.getConnection(connectionString + ";loginTimeout=5;");
+        // exceeds loginTimeout (15s) should still succeed.
+        try (Connection con = PrepUtil.getConnection(connectionString + ";loginTimeout=15;");
                 Statement stmt = con.createStatement()) {
-            // 8s exceeds loginTimeout (5s); succeeds only if post-login socketTimeout is still 0.
-            stmt.execute("WAITFOR DELAY '00:00:08';");
+            // 20s exceeds loginTimeout (15s); succeeds only if post-login socketTimeout is still 0.
+            stmt.execute("WAITFOR DELAY '00:00:20';");
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
@@ -88,8 +88,10 @@ public class ReflectiveTests extends AbstractTest {
         // 5s is too tight for slow CI agents (MacOS); raise to 15s.
         m.put("loginTimeout", "15");
 
-        // Default retryCount=1 (non-Azure). Bound = (retryCount+1) * loginTimeout + slack.
-        timeoutVariations(m, 32000, Optional.empty());
+        // Default retryCount=1 (non-Azure) => exactly one login attempt.
+        // Bound = retryDelay*(retryCount-1) + loginTimeout*retryCount + slack
+        //       = 0 + 15s + 5s = 20s. Tight enough to catch an accidental extra retry.
+        timeoutVariations(m, 20000, Optional.empty());
     }
 
     /*

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
@@ -84,20 +84,11 @@ public class ReflectiveTests extends AbstractTest {
     @Tag(Constants.xAzureSQLDW)
     public void testDefaultRetry() throws SQLException {
         Map<String, String> m = new HashMap<>();
-        // loginTimeout=15 (was 5): the same property bounds BOTH the initial connect AND
-        // each retry attempt. On slow CI agents (notably MacOS hosted runners) the initial
-        // prelogin + TLS + LOGIN7 round-trip cannot reliably complete in 5s, causing the
-        // outer try-with-resources getConnection(cs) to throw a SocketTimeoutException that
-        // escapes the inner catch block entirely. 15s gives ample headroom for any agent.
+        // loginTimeout bounds both the initial connect and each retry attempt.
+        // 5s is too tight for slow CI agents (MacOS); raise to 15s.
         m.put("loginTimeout", "15");
 
-        // Ensure count is not set to something else as this test assumes exactly just 1 retry.
-        // This is only true for non-Azure as retry counts gets auto changed for Azure servers.
-        //
-        // Worst-case upper bound for the blocked-query retry path:
-        //   (retryCount + 1) attempts * loginTimeout = 2 * 15s = 30s
-        // plus small overhead for kill/block + socket-read timeout granularity.
-        // 32s bound still fails fast if retry behavior regresses (would take >>32s).
+        // Default retryCount=1 (non-Azure). Bound = (retryCount+1) * loginTimeout + slack.
         timeoutVariations(m, 32000, Optional.empty());
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
@@ -86,9 +86,16 @@ public class ReflectiveTests extends AbstractTest {
         Map<String, String> m = new HashMap<>();
         m.put("loginTimeout", "5");
 
-        // ensure count is not set to something else as this test assumes exactly just 1 retry
-        // this is only true for non-Azure as retry counts gets auto changed for Azure servers
-        timeoutVariations(m, 6000, Optional.empty());
+        // Ensure count is not set to something else as this test assumes exactly just 1 retry.
+        // This is only true for non-Azure as retry counts gets auto changed for Azure servers.
+        //
+        // Worst-case upper bound (with retryCount=1, loginTimeout=5s):
+        //   (retryCount + 1) attempts * loginTimeout = 2 * 5s = 10s for login phase,
+        // plus small overhead for kill/block + socket-read timeout granularity.
+        // 12s gives 2s of CI slack while still failing fast if retry behavior regresses.
+        // Previous bound of 6000ms was inconsistent with the retry math and only passed
+        // before PR #2927 because the broken login-phase socket lacked any read deadline.
+        timeoutVariations(m, 12000, Optional.empty());
     }
 
     /*

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/ReflectiveTests.java
@@ -84,18 +84,21 @@ public class ReflectiveTests extends AbstractTest {
     @Tag(Constants.xAzureSQLDW)
     public void testDefaultRetry() throws SQLException {
         Map<String, String> m = new HashMap<>();
-        m.put("loginTimeout", "5");
+        // loginTimeout=15 (was 5): the same property bounds BOTH the initial connect AND
+        // each retry attempt. On slow CI agents (notably MacOS hosted runners) the initial
+        // prelogin + TLS + LOGIN7 round-trip cannot reliably complete in 5s, causing the
+        // outer try-with-resources getConnection(cs) to throw a SocketTimeoutException that
+        // escapes the inner catch block entirely. 15s gives ample headroom for any agent.
+        m.put("loginTimeout", "15");
 
         // Ensure count is not set to something else as this test assumes exactly just 1 retry.
         // This is only true for non-Azure as retry counts gets auto changed for Azure servers.
         //
-        // Worst-case upper bound (with retryCount=1, loginTimeout=5s):
-        //   (retryCount + 1) attempts * loginTimeout = 2 * 5s = 10s for login phase,
+        // Worst-case upper bound for the blocked-query retry path:
+        //   (retryCount + 1) attempts * loginTimeout = 2 * 15s = 30s
         // plus small overhead for kill/block + socket-read timeout granularity.
-        // 12s gives 2s of CI slack while still failing fast if retry behavior regresses.
-        // Previous bound of 6000ms was inconsistent with the retry math and only passed
-        // before PR #2927 because the broken login-phase socket lacked any read deadline.
-        timeoutVariations(m, 12000, Optional.empty());
+        // 32s bound still fails fast if retry behavior regresses (would take >>32s).
+        timeoutVariations(m, 32000, Optional.empty());
     }
 
     /*


### PR DESCRIPTION
Fix CI-MACOS flakiness in connection-timeout tests: Three tests were consistently failing on the MacOS CI pipeline with "Read timed out" errors while passing on Linux and Windows:
  - ConfigurableRetryLogicTest.connectionTimingTest
  - ReflectiveTests.testDefaultRetry
  - TimeoutTest.testDefaultSocketTimeoutUnlimitedAfterLogin

Root cause
----------
All three tests assumed that prelogin + TLS handshake + LOGIN7 could complete within a short loginTimeout (5s, or the default 15s). Hosted MacOS runners are noticeably slower than Linux/Windows agents, so the JDBC socket-read deadline expired before the server's clean response arrived. The thrown SocketTimeoutException either bypassed the inner
assertion (ReflectiveTests) or produced an unexpected error message (ConfigurableRetryLogicTest), and in TimeoutTest the login phase itself timed out before the post-login behavior could be verified.

This was not caused by a driver regression. PR #2927 (IOBuffer login socket timeout fix) correctly tightened login-phase socket deadlines; the tests just had insufficient headroom to ride out slow CI agents.

Fixes
-----
ReflectiveTests.testDefaultRetry
  loginTimeout: 5  -> 15  (allow initial getConnection on slow agents)
  bound:        6000 -> 32000 ms
  Bound now matches the actual retry math:  (retryCount + 1) * loginTimeout + slack = 0 + 15s + 5s = 20s. Tight enough to catch an accidental extra retry.
  The previous 6000ms bound was inconsistent with retry semantics and only passed before #2927 because the login socket lacked a deadline.

ConfigurableRetryLogicTest.connectionTimingTest
  Added loginTimeout=20 to all three retry connection strings so the TDS 4060 "cannot open database" round-trip always completes before the JDBC socket read deadline, even on slow CI agents.

TimeoutTest.testDefaultSocketTimeoutUnlimitedAfterLogin
  loginTimeout:   5s  -> 15s
  WAITFOR DELAY:  8s  -> 20s
  The test verifies post-login socket behavior; raising both keeps the WAITFOR safely above loginTimeout while giving the login phase enough headroom to complete on any CI agent.

These changes are platform-agnostic - no @DisabledOnOs gates, no OS-specific branches, no relaxed error-message matching. The under-test assertions remain intact and will still fail fast on real regressions.