### PR TITLE
Harden ActiveDirectoryInteractive callback with form_post

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -505,7 +505,9 @@ class SQLServerMSAL4JUtils {
                 InteractiveRequestParameters parameters = InteractiveRequestParameters.builder(new URI(REDIRECTURI))
                         .systemBrowserOptions(SystemBrowserOptions.builder()
                                 .htmlMessageSuccess(SQLServerResource.getResource("R_MSALAuthComplete")).build())
-                        .loginHint(user).scopes(Collections.singleton(fedAuthInfo.spn + SLASH_DEFAULT)).build();
+                    .loginHint(user)
+                    .extraQueryParameters(Collections.singletonMap("response_mode", "form_post"))
+                    .scopes(Collections.singleton(fedAuthInfo.spn + SLASH_DEFAULT)).build();
 
                 future = pca.acquireToken(parameters);
                 authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -502,12 +502,8 @@ class SQLServerMSAL4JUtils {
                 if (logger.isLoggable(Level.FINEST)) {
                     logger.finest(LOGCONTEXT + "Interactive authentication");
                 }
-                InteractiveRequestParameters parameters = InteractiveRequestParameters.builder(new URI(REDIRECTURI))
-                        .systemBrowserOptions(SystemBrowserOptions.builder()
-                                .htmlMessageSuccess(SQLServerResource.getResource("R_MSALAuthComplete")).build())
-                    .loginHint(user)
-                    .extraQueryParameters(Collections.singletonMap("response_mode", "form_post"))
-                    .scopes(Collections.singleton(fedAuthInfo.spn + SLASH_DEFAULT)).build();
+                InteractiveRequestParameters parameters = buildInteractiveRequestParameters(
+                        new URI(REDIRECTURI), user, fedAuthInfo.spn);
 
                 future = pca.acquireToken(parameters);
                 authenticationResult = future.get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
@@ -547,6 +543,23 @@ class SQLServerMSAL4JUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * Builds the MSAL4J InteractiveRequestParameters used by the ActiveDirectoryInteractive
+     * authentication flow. Extracted from {@link #getSqlFedAuthTokenInteractive} so the
+     * configuration (notably {@code response_mode=form_post}, which keeps the AAD
+     * authorization response out of the redirect URL) can be unit-tested without driving
+     * a real interactive sign-in.
+     */
+    static InteractiveRequestParameters buildInteractiveRequestParameters(URI redirectUri, String user, String spn) {
+        return InteractiveRequestParameters.builder(redirectUri)
+                .systemBrowserOptions(SystemBrowserOptions.builder()
+                        .htmlMessageSuccess(SQLServerResource.getResource("R_MSALAuthComplete")).build())
+                .loginHint(user)
+                .extraQueryParameters(Collections.singletonMap("response_mode", "form_post"))
+                .scopes(Collections.singleton(spn + SLASH_DEFAULT))
+                .build();
     }
 
     private static SQLServerException getCorrectedException(Exception e, String user, String authenticationString) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtilsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.aad.msal4j.InteractiveRequestParameters;
+
+
+/**
+ * Unit tests for {@link SQLServerMSAL4JUtils} that do not require a SQL Server
+ * connection or an interactive Azure AD sign-in.
+ */
+public class SQLServerMSAL4JUtilsTest {
+
+    /**
+     * Regression guard for the ActiveDirectoryInteractive hardening: the MSAL4J
+     * interactive token request must include {@code response_mode=form_post}
+     * so the AAD authorization response is delivered as an HTTP POST body to
+     * the loopback redirect URI instead of in the URL. This prevents the auth
+     * code / state from leaking via browser history, referrers, or
+     * redirect-based phishing.
+     */
+    @Test
+    public void testInteractiveRequestUsesFormPostResponseMode() throws Exception {
+        String user = "user@contoso.com";
+        String spn = "https://database.windows.net";
+
+        InteractiveRequestParameters params = SQLServerMSAL4JUtils.buildInteractiveRequestParameters(
+                new URI(SQLServerMSAL4JUtils.REDIRECTURI), user, spn);
+
+        assertNotNull(params.extraQueryParameters(), "extraQueryParameters must not be null");
+        assertEquals("form_post", params.extraQueryParameters().get("response_mode"),
+                "response_mode must be form_post to avoid leaking the auth code via the redirect URL");
+        assertEquals(user, params.loginHint(), "loginHint should be propagated from the connection user");
+        assertTrue(params.scopes().contains(spn + SQLServerMSAL4JUtils.SLASH_DEFAULT),
+                "scopes must contain the resource SPN with the /.default suffix");
+    }
+}


### PR DESCRIPTION
## Problem Description

For ActiveDirectoryInteractive authentication, the authorization-code callback can be returned through different response modes. If the callback uses query parameters, the auth code appears in the redirect URL, which increases exposure risk via browser history, URL logging, referrer propagation, and proxy/access logs.

This PR hardens the driver flow by explicitly requesting form post response mode for the interactive MSAL authorization request.

### Fixes Existing GitHub Issue

N/A (security hardening / defense-in-depth)

## Fix Description

In the ActiveDirectoryInteractive path, the driver now sets an explicit MSAL extra query parameter:

- `response_mode=form_post`

This ensures the authorization code is returned in the HTTP POST body to the loopback redirect listener instead of in the URL query string.

Behavioral intent:

- Keep current successful interactive auth behavior.
- Reduce accidental code leakage through URL-based surfaces.
- Make response-mode handling explicit and stable in driver code.

## Testing

### 1. Unit Test (driver)

Added/updated test coverage validating that interactive request parameters include:

- `response_mode=form_post`

This prevents regressions where the explicit setting could be removed inadvertently.

### 2. Runtime A/B Validation (live auth flow)

Executed a live Azure AD authorization flow using the same app registration and loopback redirect pattern to compare behavior:

- **Case A (default / no explicit response_mode):** callback observed as `GET` with `code` in URL query.
- **Case B (explicit `response_mode=form_post`):** callback observed as `POST` with `code` in request body.

Observed result confirms that explicitly using `form_post` moves the authorization code out of the URL and into POST body payload, which is the security goal of this change.

### 3. Build/compile verification

Compiled successfully in local workspace with project profile used for this branch work.

## Risk Assessment

- **Functional risk:** Low
- **Compatibility risk:** Low (standards-compliant OAuth response mode)
- **Security impact:** Positive (reduces URL-based code exposure)

## New Public APIs

None.
