### PR TITLE
Fix | Avoid extra whitespace around prepared statement parameter markers (#2946)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -3946,21 +3946,26 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             if (sqlSrc.length() == srcEnd)
                 break;
 
-            // Issue #2946: only insert whitespace around @P<n> when the surrounding source SQL
-            // does not already provide a separator. Preserves PR #2192's fix for cases like
-            // "=?" while avoiding extra spaces that break exact-text matching (plan guides).
-            if (dstBegin > 0 && !Character.isWhitespace(sqlDst[dstBegin - 1])) {
-                sqlDst[dstBegin++] = ' ';
-            }
+            // Issue #2946: avoid injecting extra whitespace around the substituted @P<n>
+            // marker, which broke exact-text matching used by SQL Server plan guides,
+            // Query Store forced plans, sql_text-based auditing, etc.  PR #2192 added
+            // unconditional padding to fix queries like "c1=?and c2=?" where the lack of
+            // a separator caused "@P<n>and" to be parsed as a single identifier.  We
+            // preserve that safety property by inserting a single space only when the
+            // *next* source character would extend the @P<n> (or @P<n> OUT) token into a
+            // longer identifier -- i.e. when it is a letter, digit, or underscore.  A
+            // leading separator is never required because '@' cannot continue a
+            // preceding token.
             dstBegin += SQLServerConnection.makeParamName(nParam++, sqlDst, dstBegin, false);
             srcBegin = srcEnd + 1;
-            if (srcBegin < sqlSrc.length() && !Character.isWhitespace(sqlSrc.charAt(srcBegin))) {
-                sqlDst[dstBegin++] = ' ';
-            }
 
             if (params[paramIndex++].isOutput() && (!isReturnValueSyntax || paramIndex > 1)) {
                 System.arraycopy(OUT, 0, sqlDst, dstBegin, OUT.length);
                 dstBegin += OUT.length;
+            }
+
+            if (srcBegin < sqlSrc.length() && Character.isJavaIdentifierPart(sqlSrc.charAt(srcBegin))) {
+                sqlDst[dstBegin++] = ' ';
             }
         }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -3946,8 +3946,17 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             if (sqlSrc.length() == srcEnd)
                 break;
 
-            dstBegin += SQLServerConnection.makeParamName(nParam++, sqlDst, dstBegin, true);
-            srcBegin = srcEnd + 1 <= sqlSrc.length() - 1 && sqlSrc.charAt(srcEnd + 1) == ' ' ? srcEnd + 2 : srcEnd + 1;
+            // Issue #2946: only insert whitespace around @P<n> when the surrounding source SQL
+            // does not already provide a separator. Preserves PR #2192's fix for cases like
+            // "=?" while avoiding extra spaces that break exact-text matching (plan guides).
+            if (dstBegin > 0 && !Character.isWhitespace(sqlDst[dstBegin - 1])) {
+                sqlDst[dstBegin++] = ' ';
+            }
+            dstBegin += SQLServerConnection.makeParamName(nParam++, sqlDst, dstBegin, false);
+            srcBegin = srcEnd + 1;
+            if (srcBegin < sqlSrc.length() && !Character.isWhitespace(sqlSrc.charAt(srcBegin))) {
+                sqlDst[dstBegin++] = ' ';
+            }
 
             if (params[paramIndex++].isOutput() && (!isReturnValueSyntax || paramIndex > 1)) {
                 System.arraycopy(OUT, 0, sqlDst, dstBegin, OUT.length);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -370,7 +370,7 @@ public class PreparedStatementTest extends AbstractTest {
      * whitespace around the substituted @P&lt;n&gt; marker when the source SQL already
      * provides a separator. This was breaking exact-text matching used by SQL Server
      * plan guides, query-text auditing, etc. The fix preserves PR #2192's behavior of
-     * inserting a separator only when one is missing (e.g. "=?" -> "= @P1").
+     * inserting a separator only when one is missing (e.g. "=?" -> "= @P0").
      */
     @Test
     public void testPreparedStatementParamNameSpacingNoExtraWhitespace() throws SQLException {
@@ -378,31 +378,31 @@ public class PreparedStatementTest extends AbstractTest {
             // Case 1: already-spaced operator, trailing '?'. No double space, no trailing space.
             assertRewrittenSQL(con,
                     "SELECT 1 WHERE 1 = ?",
-                    "SELECT 1 WHERE 1 = @P1",
+                    "SELECT 1 WHERE 1 = @P0",
                     new String[] {"1"});
 
             // Case 2: already-spaced operator, '?' not at end. No double space.
             assertRewrittenSQL(con,
                     "SELECT 1 WHERE 1 = ? AND 2 = 2",
-                    "SELECT 1 WHERE 1 = @P1 AND 2 = 2",
+                    "SELECT 1 WHERE 1 = @P0 AND 2 = 2",
                     new String[] {"1"});
 
             // Case 3: no spaces around '?' (PR #2192 case) -- separator must still be inserted.
             assertRewrittenSQL(con,
                     "SELECT 1 WHERE 1=?AND 2=2",
-                    "SELECT 1 WHERE 1= @P1 AND 2=2",
+                    "SELECT 1 WHERE 1= @P0 AND 2=2",
                     new String[] {"1"});
 
             // Case 4: multiple parameters with various spacing.
             assertRewrittenSQL(con,
                     "SELECT 1 WHERE 1 = ? AND 2=? AND 3 =?",
-                    "SELECT 1 WHERE 1 = @P1 AND 2= @P2 AND 3 = @P3",
+                    "SELECT 1 WHERE 1 = @P0 AND 2= @P1 AND 3 = @P2",
                     new String[] {"1", "2", "3"});
 
             // Case 5: '?' at end of statement -- no trailing space.
             assertRewrittenSQL(con,
                     "SELECT ?",
-                    "SELECT @P1",
+                    "SELECT @P0",
                     new String[] {"1"});
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -411,8 +411,8 @@ public class PreparedStatementTest extends AbstractTest {
             // Case 6: parenthesised list of markers -- punctuation surrounds the '?',
             // so no separators should be inserted at all.
             assertRewrittenSQL(con,
-                    "SELECT 1 WHERE c IN (?,?,?)",
-                    "SELECT 1 WHERE c IN (@P0,@P1,@P2)",
+                    "SELECT 1 WHERE 1 IN (?,?,?)",
+                    "SELECT 1 WHERE 1 IN (@P0,@P1,@P2)",
                     new String[] {"1", "2", "3"});
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -365,6 +365,72 @@ public class PreparedStatementTest extends AbstractTest {
         }
     }
 
+    /**
+     * Regression test for issue #2946: replaceParameterMarkers must not inject extra
+     * whitespace around the substituted @P&lt;n&gt; marker when the source SQL already
+     * provides a separator. This was breaking exact-text matching used by SQL Server
+     * plan guides, query-text auditing, etc. The fix preserves PR #2192's behavior of
+     * inserting a separator only when one is missing (e.g. "=?" -> "= @P1").
+     */
+    @Test
+    public void testPreparedStatementParamNameSpacingNoExtraWhitespace() throws SQLException {
+        try (SQLServerConnection con = (SQLServerConnection) getConnection()) {
+            // Case 1: already-spaced operator, trailing '?'. No double space, no trailing space.
+            assertRewrittenSQL(con,
+                    "SELECT 1 WHERE 1 = ?",
+                    "SELECT 1 WHERE 1 = @P1",
+                    new String[] {"1"});
+
+            // Case 2: already-spaced operator, '?' not at end. No double space.
+            assertRewrittenSQL(con,
+                    "SELECT 1 WHERE 1 = ? AND 2 = 2",
+                    "SELECT 1 WHERE 1 = @P1 AND 2 = 2",
+                    new String[] {"1"});
+
+            // Case 3: no spaces around '?' (PR #2192 case) -- separator must still be inserted.
+            assertRewrittenSQL(con,
+                    "SELECT 1 WHERE 1=?AND 2=2",
+                    "SELECT 1 WHERE 1= @P1 AND 2=2",
+                    new String[] {"1"});
+
+            // Case 4: multiple parameters with various spacing.
+            assertRewrittenSQL(con,
+                    "SELECT 1 WHERE 1 = ? AND 2=? AND 3 =?",
+                    "SELECT 1 WHERE 1 = @P1 AND 2= @P2 AND 3 = @P3",
+                    new String[] {"1", "2", "3"});
+
+            // Case 5: '?' at end of statement -- no trailing space.
+            assertRewrittenSQL(con,
+                    "SELECT ?",
+                    "SELECT @P1",
+                    new String[] {"1"});
+        }
+    }
+
+    /**
+     * Helper for {@link #testPreparedStatementParamNameSpacingNoExtraWhitespace()}.
+     * Prepares and executes a statement, then reflects out the rewritten preparedSQL
+     * field and asserts it matches expectedSQL exactly.
+     */
+    private static void assertRewrittenSQL(SQLServerConnection con, String userSQL, String expectedSQL,
+            String[] stringParams) throws SQLException {
+        try (SQLServerPreparedStatement ps = (SQLServerPreparedStatement) con.prepareStatement(userSQL)) {
+            for (int i = 0; i < stringParams.length; i++) {
+                ps.setString(i + 1, stringParams[i]);
+            }
+            ps.executeQuery();
+            try {
+                Field f = SQLServerPreparedStatement.class.getDeclaredField("preparedSQL");
+                f.setAccessible(true);
+                String actual = (String) f.get(ps);
+                assertEquals(expectedSQL, actual,
+                        "Rewritten preparedSQL must not contain extra whitespace around @P<n> (issue #2946)");
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                fail("Could not read preparedSQL field via reflection: " + e.getMessage());
+            }
+        }
+    }
+
     @Test
     public void testPreparedStatementPoolEvictionWithSpPrepare() throws SQLException {
         int cacheSize = 3;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/PreparedStatementTest.java
@@ -367,10 +367,11 @@ public class PreparedStatementTest extends AbstractTest {
 
     /**
      * Regression test for issue #2946: replaceParameterMarkers must not inject extra
-     * whitespace around the substituted @P&lt;n&gt; marker when the source SQL already
-     * provides a separator. This was breaking exact-text matching used by SQL Server
-     * plan guides, query-text auditing, etc. The fix preserves PR #2192's behavior of
-     * inserting a separator only when one is missing (e.g. "=?" -> "= @P0").
+     * whitespace around the substituted @P&lt;n&gt; marker. This was breaking exact-text
+     * matching used by SQL Server plan guides, Query Store, sql_text-based auditing, etc.
+     * The fix preserves PR #2192's safety property (a separator is still inserted when
+     * the next source character would extend @P&lt;n&gt; into a longer identifier, e.g.
+     * "?and" -&gt; "@P0 and") while leaving all other whitespace untouched.
      */
     @Test
     public void testPreparedStatementParamNameSpacingNoExtraWhitespace() throws SQLException {
@@ -387,16 +388,18 @@ public class PreparedStatementTest extends AbstractTest {
                     "SELECT 1 WHERE 1 = @P0 AND 2 = 2",
                     new String[] {"1"});
 
-            // Case 3: no spaces around '?' (PR #2192 case) -- separator must still be inserted.
+            // Case 3: PR #2192 safety case -- "?and" would otherwise be parsed as a
+            // single identifier "@P0and"; a separator must still be inserted.
             assertRewrittenSQL(con,
-                    "SELECT 1 WHERE 1=?AND 2=2",
-                    "SELECT 1 WHERE 1= @P0 AND 2=2",
+                    "SELECT 1 WHERE 1=?and 2=2",
+                    "SELECT 1 WHERE 1=@P0 and 2=2",
                     new String[] {"1"});
 
-            // Case 4: multiple parameters with various spacing.
+            // Case 4: multiple parameters, mixed spacing. Operators '=' and ',' do not
+            // need separators; the identifier 'and' after '?' does.
             assertRewrittenSQL(con,
-                    "SELECT 1 WHERE 1 = ? AND 2=? AND 3 =?",
-                    "SELECT 1 WHERE 1 = @P0 AND 2= @P1 AND 3 = @P2",
+                    "SELECT 1 WHERE 1 = ? AND 2=? AND 3 =?and 4=4",
+                    "SELECT 1 WHERE 1 = @P0 AND 2=@P1 AND 3 =@P2 and 4=4",
                     new String[] {"1", "2", "3"});
 
             // Case 5: '?' at end of statement -- no trailing space.
@@ -404,6 +407,13 @@ public class PreparedStatementTest extends AbstractTest {
                     "SELECT ?",
                     "SELECT @P0",
                     new String[] {"1"});
+
+            // Case 6: parenthesised list of markers -- punctuation surrounds the '?',
+            // so no separators should be inserted at all.
+            assertRewrittenSQL(con,
+                    "SELECT 1 WHERE c IN (?,?,?)",
+                    "SELECT 1 WHERE c IN (@P0,@P1,@P2)",
+                    new String[] {"1", "2", "3"});
         }
     }
 


### PR DESCRIPTION
## Problem description

The driver unconditionally pads every substituted `@P<n>` parameter marker with a leading and trailing space when rewriting user SQL for a prepared statement. As a result, source SQL such as

```sql
WHERE t0.ID = ?
```

is sent to SQL Server as

```sql
WHERE t0.ID =  @P0 
```

This breaks any feature that matches on the exact normalized statement text:

- **SQL Server plan guides** (`sp_create_plan_guide`) silently stop matching, so DBA-applied hints are no longer injected at compile time.
- **Query Store forced plans** keyed on `query_hash` similarly fail to match.
- **Audit / Extended Events / Resource Governor classifier** filters that inspect `sys.dm_exec_sql_text` no longer match.
- **APM tools** that fingerprint SQL produce duplicate entries for the same logical query.

The regression appeared between mssql-jdbc 11.2.4 and 12.4.1 and was introduced in PR #2192, which solved a real bug (queries like `c1=?and c2=?` lacked a separator after parameter substitution) but did so by padding *every* marker rather than only those that needed a separator.

### Fixes existing GitHub issue

Fixes #2946.

## Fix Description

`SQLServerPreparedStatement.replaceParameterMarkers` now invokes `SQLServerConnection.makeParamName` with `isPreparedSQL = false` (which emits a bare `@P<n>` with no padding) and **conditionally** writes a single space *after* the marker (or after `@P<n> OUT` for output parameters) only when the next source character would otherwise extend the substituted text into a longer SQL identifier (i.e. when it is a letter, digit, or underscore -- `Character.isJavaIdentifierPart`). A leading separator is never needed because `@` always starts a fresh SQL token.

This preserves PR #2192's safety property -- the driver still inserts a separator when one is required for correctness (e.g. `?and` -> `@P0 and`) -- while leaving all other whitespace in the user SQL untouched.

Behavior summary:

| User SQL                | Rewritten SQL (without fix)        | Rewritten SQL (with fix)   | Behavior  |
|-------------------------|------------------------------------|----------------------------|-----------|
| `... ID = ?`            | `... ID =  @P0 `                   | `... ID = @P0`             | Changed   |
| `... ID = ? ORDER BY x` | `... ID =  @P0  ORDER BY x`        | `... ID = @P0 ORDER BY x`  | Changed   |
| `... ID=?`              | `... ID= @P0 `                     | `... ID=@P0`               | Changed   |
| `... ID=?and y=2`       | `... ID= @P0 and y=2`              | `... ID=@P0 and y=2`       | Changed (separator preserved) |
| `(?,?,?)`               | `( @P0 , @P1 , @P2 )`              | `(@P0,@P1,@P2)`            | Changed   |
| `SELECT ?`              | `SELECT  @P0 `                     | `SELECT @P0`               | Changed   |

The `?and` row keeps a single space between `@P0` and `and` because they would otherwise merge into the identifier `@P0and` -- that is the case PR #2192 was solving and the fix continues to handle it. All other rows show the spurious whitespace that broke exact-text matching.

Tests added in `PreparedStatementTest.testPreparedStatementParamNameSpacingNoExtraWhitespace` prepare each scenario, execute it, then reflect the private `preparedSQL` field on `SQLServerPreparedStatement` and assert on the exact rewritten string. The pre-existing PR #2192 test (`testPreparedStatementParamNameSpacingWithMultipleParams`) is kept and continues to cover the no-separator cases.

## New Public APIs

None.
