### PR TITLE
Suppress CodeQL SM05136 for protocol-mandated crypto algorithms

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
@@ -456,7 +456,7 @@ abstract class BaseAttestationResponse {
         RSAPublicKeySpec spec = new RSAPublicKeySpec(new BigInteger(1, modulus), new BigInteger(1, exponent));
         KeyFactory factory = KeyFactory.getInstance("RSA");
         PublicKey pub = factory.generatePublic(spec);
-        Signature sig = Signature.getInstance("SHA256withRSA");
+        Signature sig = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Always Encrypted with secure enclaves attestation protocol signs the enclave Diffie-Hellman public key with SHA256withRSA (https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-enclaves)
         sig.initVerify(pub);
         sig.update(dhPublicKey);
         if (!sig.verify(publicKeySig)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KeyStoreProviderCommon.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KeyStoreProviderCommon.java
@@ -146,7 +146,7 @@ class KeyStoreProviderCommon {
         Signature signVerify;
         boolean verificationSuccess = false;
         try {
-            signVerify = Signature.getInstance("SHA256withRSA");
+            signVerify = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Always Encrypted column master key metadata signatures must use SHA256withRSA (RSA PKCS#1 v1.5 with SHA-256) (https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-cryptography)
             signVerify.initVerify(certificate.getPublicKey());
             signVerify.update(hash);
             verificationSuccess = signVerify.verify(signature);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
@@ -347,7 +347,7 @@ class AASAttestationResponse extends BaseAttestationResponse {
                         CertificateFactory cf = CertificateFactory.getInstance("X.509");
                         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                                 new ByteArrayInputStream(java.util.Base64.getDecoder().decode(jsonCert.getAsString())));
-                        Signature sig = Signature.getInstance("SHA256withRSA");
+                        Signature sig = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Azure Attestation Service signs JWT attestation tokens using RS256 (SHA256withRSA) per RFC 7515 JWS; the driver must verify with the algorithm declared by the issuer (https://learn.microsoft.com/azure/attestation/overview)
                         sig.initVerify(cert.getPublicKey());
                         sig.update(signatureBytes);
                         if (sig.verify(stmtSig)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
@@ -347,7 +347,7 @@ class AASAttestationResponse extends BaseAttestationResponse {
                         CertificateFactory cf = CertificateFactory.getInstance("X.509");
                         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                                 new ByteArrayInputStream(java.util.Base64.getDecoder().decode(jsonCert.getAsString())));
-                        Signature sig = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Azure Attestation Service signs JWT attestation tokens using RS256 (SHA256withRSA) per RFC 7515 JWS; the driver must verify with the algorithm declared by the issuer (https://learn.microsoft.com/azure/attestation/overview)
+                        Signature sig = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Azure Attestation Service JWT attestation tokens are expected to use RS256, which maps to SHA256withRSA in Java; the driver intentionally verifies using this fixed algorithm for AAS tokens (https://learn.microsoft.com/azure/attestation/overview)
                         sig.initVerify(cert.getPublicKey());
                         sig.update(signatureBytes);
                         if (sig.verify(stmtSig)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerColumnEncryptionJavaKeyStoreProvider.java
@@ -135,7 +135,7 @@ public class SQLServerColumnEncryptionJavaKeyStoreProvider extends SQLServerColu
             md.update("true".getBytes(java.nio.charset.StandardCharsets.UTF_16LE));
 
             byte[] dataToVerify = md.digest();
-            Signature sig = Signature.getInstance("SHA256withRSA");
+            Signature sig = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Always Encrypted column master key metadata signatures must use SHA256withRSA (RSA PKCS#1 v1.5 with SHA-256) (https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-cryptography)
 
             sig.initSign((PrivateKey) certificateDetails.privateKey);
             sig.update(dataToVerify);
@@ -195,7 +195,7 @@ public class SQLServerColumnEncryptionJavaKeyStoreProvider extends SQLServerColu
             // value of allowEnclaveComputations is always true here
             md.update("true".getBytes(java.nio.charset.StandardCharsets.UTF_16LE));
 
-            Signature sig = Signature.getInstance("SHA256withRSA");
+            Signature sig = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Always Encrypted column master key metadata signatures must use SHA256withRSA (RSA PKCS#1 v1.5 with SHA-256) (https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-cryptography)
             sig.initSign((PrivateKey) certificateDetails.privateKey);
             sig.update(md.digest());
 
@@ -389,7 +389,7 @@ public class SQLServerColumnEncryptionJavaKeyStoreProvider extends SQLServerColu
         byte[] signedHash = null;
 
         try {
-            signature = Signature.getInstance("SHA256withRSA");
+            signature = Signature.getInstance("SHA256withRSA"); // CodeQL [SM05136] Required for an external standard: Always Encrypted column master key metadata signatures must use SHA256withRSA (RSA PKCS#1 v1.5 with SHA-256) (https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-cryptography)
             signature.initSign((PrivateKey) certificateDetails.privateKey);
             signature.update(dataToSign);
             signedHash = signature.sign();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerVSMEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerVSMEnclaveProvider.java
@@ -352,14 +352,14 @@ class VSMAttestationResponse extends BaseAttestationResponse {
 
         Signature sig = null;
         try {
-            sig = Signature.getInstance("RSASSA-PSS");
+            sig = Signature.getInstance("RSASSA-PSS"); // CodeQL [SM05136] Required for an external standard: Always Encrypted with VBS secure enclaves attestation reports are signed with RSASSA-PSS using SHA-256/MGF1-SHA256 per the Windows VBS health attestation format (https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-enclaves)
         } catch (NoSuchAlgorithmException e) {
             /*
              * RSASSA-PSS was added in JDK 11, the user might be using an older version of Java. Use BC as backup.
              * Remove this logic if JDK 8 stops being supported or backports RSASSA-PSS
              */
             SQLServerBouncyCastleLoader.loadBouncyCastle();
-            sig = Signature.getInstance("RSASSA-PSS");
+            sig = Signature.getInstance("RSASSA-PSS"); // CodeQL [SM05136] Required for an external standard: Always Encrypted with VBS secure enclaves attestation reports are signed with RSASSA-PSS using SHA-256/MGF1-SHA256 per the Windows VBS health attestation format (https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-enclaves)
         }
         PSSParameterSpec pss = new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
         sig.setParameter(pss);


### PR DESCRIPTION
## Problem Description

A CodeQL scan flagged several `Signature.getInstance(...)` call sites as using "weak / unapproved" cryptographic algorithms. The algorithms in question are mandated by external protocols the driver must interoperate with (Always Encrypted column master key signatures, AE secure-enclave attestation, Azure Attestation Service JWTs, and Windows VBS enclave health attestation) and cannot be substituted.

### Fixes Existing GitHub Issue

N/A.

## Fix Description

Added inline CodeQL suppression comments with protocol-interop justifications at each affected site. No behavior change; follows the existing repo convention (e.g. the `RSA/ECB/OAEPWithSHA-1AndMGF1Padding` and `HmacMD5` suppressions already in the codebase).

Files touched:

- `KeyStoreProviderCommon.java` — `SHA256withRSA` (AE CMK signature verification)
- `SQLServerColumnEncryptionJavaKeyStoreProvider.java` — `SHA256withRSA` (AE CMK sign/verify, 3 sites)
- `ISQLServerEnclaveProvider.java` — `SHA256withRSA` (AE enclave DH key attestation)
- `SQLServerAASEnclaveProvider.java` — `SHA256withRSA` (AAS JWT / RS256 verification)
- `SQLServerVSMEnclaveProvider.java` — `RSASSA-PSS` (VBS attestation report, 2 sites)

## Testing

Comment-only change; existing Always Encrypted, enclave, and attestation test coverage applies unchanged. Local compile verified.

## Risk Assessment

- **Functional risk:** None
- **Compatibility risk:** None
- **Security impact:** Neutral (algorithms unchanged; only static-analysis annotations added)

## New Public APIs

None.
