### PR TITLE
Preserve original exception cause chain in socket/IO error paths issue #2969

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -1441,7 +1441,7 @@ final class DDC {
         } catch (IOException ioEx) {
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_errorReadingStream"));
             Object[] msgArgs = {ioEx.toString()};
-            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), "", true);
+            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), "", true, ioEx);
         }
 
         // Unreachable code, but needed for compiler.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/FailOverInfo.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/FailOverInfo.java
@@ -75,7 +75,7 @@ final class FailoverInfo {
                     // Should not get here as the server should give a proper port number anyway.
                     MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidPortNumber"));
                     Object[] msgArgs = {instancePort};
-                    SQLServerException.makeFromDriverError(con, null, form.format(msgArgs), null, false);
+                    SQLServerException.makeFromDriverError(con, null, form.format(msgArgs), null, false, e);
                 }
             } else
                 portNumber = SQLServerConnection.DEFAULTPORT;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -915,7 +915,7 @@ final class TDSChannel implements Serializable {
                     sslHandshakeOutputStream.endMessage();
                 } catch (SQLServerException e) {
                     logger.finer(logContext + " Ending TDS message threw exception:" + e.getMessage());
-                    throw new IOException(e.getMessage());
+                    throw new IOException(e.getMessage(), e);
                 }
 
                 if (logger.isLoggable(Level.FINEST))
@@ -925,7 +925,7 @@ final class TDSChannel implements Serializable {
                     tdsReader.readPacket();
                 } catch (SQLServerException e) {
                     logger.finer(logContext + " Reading response packet threw exception:" + e.getMessage());
-                    throw new IOException(e.getMessage());
+                    throw new IOException(e.getMessage(), e);
                 }
             }
         }
@@ -947,7 +947,7 @@ final class TDSChannel implements Serializable {
                 tdsReader.skip((int) n);
             } catch (SQLServerException e) {
                 logger.finer(logContext + " Skipping bytes threw exception:" + e.getMessage());
-                throw new IOException(e.getMessage());
+                throw new IOException(e.getMessage(), e);
             }
 
             return n;
@@ -985,7 +985,7 @@ final class TDSChannel implements Serializable {
                 tdsReader.readBytes(b, offset, maxBytes);
             } catch (SQLServerException e) {
                 logger.finer(logContext + " Reading bytes threw exception:" + e.getMessage());
-                throw new IOException(e.getMessage());
+                throw new IOException(e.getMessage(), e);
             }
 
             return maxBytes;
@@ -1075,7 +1075,7 @@ final class TDSChannel implements Serializable {
                 tdsWriter.writeBytes(b, off, len);
             } catch (SQLServerException e) {
                 logger.finer(logContext + " Writing bytes threw exception:" + e.getMessage());
-                throw new IOException(e.getMessage());
+                throw new IOException(e.getMessage(), e);
             }
         }
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerEnclaveProvider.java
@@ -85,7 +85,7 @@ interface ISQLServerEnclaveProvider {
                 enclavePackage.write(algo.encryptData(keys.toByteArray()));
                 return enclavePackage.toByteArray();
             } catch (GeneralSecurityException | SQLServerException | IOException e) {
-                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
         return null;
@@ -383,7 +383,7 @@ abstract class BaseAttestationRequest {
             x = adjustBigInt(w.getAffineX().toByteArray());
             y = adjustBigInt(w.getAffineY().toByteArray());
         } catch (GeneralSecurityException | IOException e) {
-            SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);
+            SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false, e);
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
@@ -191,7 +191,7 @@ class PLPInputStream extends BaseInputStream {
 
             return available;
         } catch (SQLServerException e) {
-            throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage(), e);
         }
 
     }
@@ -285,7 +285,7 @@ class PLPInputStream extends BaseInputStream {
         try {
             return readBytesInternal(b, offset, maxBytes);
         } catch (SQLServerException e) {
-            throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PLPInputStream.java
@@ -130,7 +130,7 @@ class PLPInputStream extends BaseInputStream {
         try {
             close();
         } catch (IOException e) {
-            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
         }
 
         return value;
@@ -514,7 +514,7 @@ final class PLPXMLInputStream extends PLPInputStream {
             } else
                 bytesToReturn = valueWithoutBOM;
         } catch (IOException e) {
-            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
         }
 
         return bytesToReturn;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -1139,7 +1139,7 @@ final class Parameter {
                     } catch (IOException e) {
                         MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_errorReadingStream"));
                         Object[] msgArgs = {e.toString()};
-                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), "", true);
+                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), "", true, e);
                     }
 
                     dtv.setValue(bufferedStream, JavaType.INPUTSTREAM);
@@ -1189,7 +1189,7 @@ final class Parameter {
                     } catch (IOException e) {
                         MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_errorReadingStream"));
                         Object[] msgArgs = {e.toString()};
-                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), "", true);
+                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), "", true, e);
                     }
 
                     dtv.setValue(bufferedReader, JavaType.READER);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerAASEnclaveProvider.java
@@ -63,7 +63,7 @@ public class SQLServerAASEnclaveProvider implements ISQLServerEnclaveProvider {
             try {
                 aasParams = new AASAttestationParameters(attestationUrl);
             } catch (IOException e) {
-                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
     }
@@ -91,7 +91,7 @@ public class SQLServerAASEnclaveProvider implements ISQLServerEnclaveProvider {
                 enclaveCache.addEntry(connection.getServerName(), connection.getCatalog(),
                         connection.enclaveAttestationUrl, aasParams, enclaveSession);
             } catch (GeneralSecurityException e) {
-                SQLServerException.makeFromDriverError(connection, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(connection, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
         return b;
@@ -118,7 +118,7 @@ public class SQLServerAASEnclaveProvider implements ISQLServerEnclaveProvider {
                 hgsResponse.validateToken(attestationUrl, aasParams.getNonce());
                 hgsResponse.validateDHPublicKey(aasParams.getNonce());
             } catch (GeneralSecurityException e) {
-                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
     }
@@ -374,7 +374,7 @@ class AASAttestationResponse extends BaseAttestationResponse {
             SQLServerException.makeFromDriverError(null, this, SQLServerResource.getResource("R_AasJWTError"), "0",
                     false);
         } catch (IOException | GeneralSecurityException e) {
-            SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "", false);
+            SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "", false, e);
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBlob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBlob.java
@@ -443,7 +443,7 @@ final class SQLServerBlobOutputStream extends java.io.OutputStream {
             int bytesWritten = parentBlob.setBytes(currentPos, b, off, len);
             currentPos += bytesWritten;
         } catch (SQLException ex) {
-            throw new IOException(ex.getMessage());
+            throw new IOException(ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1755,7 +1755,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                     sourceResultSet.setFetchSize(1);
                 } catch (SQLException e) {
                     SQLServerException.makeFromDriverError(connection, sourceResultSet, e.getMessage(), e.getSQLState(),
-                            true);
+                            true, e);
                 }
             }
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1516,7 +1516,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             try {
                 activeStream.close();
             } catch (IOException e) {
-                SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+                SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
             } finally {
                 activeStream = null;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
@@ -689,7 +689,7 @@ final class SQLServerClobWriter extends java.io.Writer {
             int charsWritten = parentClob.setString(streamPos, str, off, len);
             streamPos += charsWritten;
         } catch (SQLException ex) {
-            throw new IOException(ex.getMessage());
+            throw new IOException(ex.getMessage(), ex);
         }
     }
 
@@ -751,7 +751,7 @@ final class SQLServerClobAsciiOutputStream extends java.io.OutputStream {
             int charsWritten = parentClob.setString(streamPos, s);
             streamPos += charsWritten;
         } catch (SQLException ex) {
-            throw new IOException(ex.getMessage());
+            throw new IOException(ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerClob.java
@@ -223,7 +223,7 @@ abstract class SQLServerClobBase extends SQLServerLob {
             try {
                 inputStream.reset();
             } catch (IOException e) {
-                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false);
+                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false, e);
             }
             getterStream = new BufferedInputStream(inputStream);
         } else {
@@ -255,7 +255,7 @@ abstract class SQLServerClobBase extends SQLServerLob {
             try {
                 inputStream.reset();
             } catch (IOException e) {
-                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false);
+                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false, e);
             }
             Charset cs = (defaultCharset == null) ? typeInfo.getCharset() : defaultCharset;
             getterStream = new BufferedReader(new InputStreamReader(inputStream, cs));
@@ -374,7 +374,7 @@ abstract class SQLServerClobBase extends SQLServerLob {
             try {
                 stream.reset();
             } catch (IOException e) {
-                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false);
+                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false, e);
             }
             Charset cs = (defaultCharset == null) ? typeInfo.getCharset() : defaultCharset;
             value = new String(stream.getBytes(), cs);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5086,7 +5086,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
                                 // Keep compiler happy, something's probably seriously wrong if this line is run
                                 SQLServerException.makeFromDriverError(this, sessionRecovery, e.getMessage(), null,
-                                        false);
+                                        false, e);
                             }
 
                             if (sessionRecovery.getReconnectException() != null) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -395,7 +395,7 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             }
             handleMap.put(request, hassoc);
         } catch (SQLException e) {
-            SQLServerException.makeFromDriverError(connection, cs, e.toString(), null, false);
+            SQLServerException.makeFromDriverError(connection, cs, e.toString(), null, false, e);
         }
         return cs;
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -292,6 +292,27 @@ public final class SQLServerException extends java.sql.SQLException {
      */
     static void makeFromDriverError(SQLServerConnection con, Object obj, String errText, String state,
             boolean bStack) throws SQLServerException {
+        makeFromDriverError(con, obj, errText, state, bStack, null);
+    }
+
+    /**
+     * Constructs a SQLServerException from an error detected by the driver.
+     * 
+     * @param con
+     *        the connection
+     * @param obj
+     * @param errText
+     *        the exception message
+     * @param state
+     *        the exception state
+     * @param bStack
+     *        true to generate the stack trace
+     * @param cause
+     *        the underlying cause
+     * @throws SQLServerException
+     */
+    static void makeFromDriverError(SQLServerConnection con, Object obj, String errText, String state,
+            boolean bStack, Throwable cause) throws SQLServerException {
         // The sql error code is 0 since the error was not returned from the database
         // The state code is supplied by the calling code as XOPEN compliant.
         // XOPEN is used as the primary code here since they are published free
@@ -306,6 +327,10 @@ public final class SQLServerException extends java.sql.SQLException {
 
         SQLServerException theException = new SQLServerException(obj,
                 SQLServerException.checkAndAppendClientConnId(errText, con), stateCode, 0, bStack);
+        if (null != cause) {
+            theException.initCause(cause);
+        }
+
         if ((null != state && state.equals(EXCEPTION_XOPEN_CONNECTION_FAILURE)) && (null != con)) {
             con.notifyPooledConnection(theException);
             // note this close wont close the connection if there is an associated pooled connection.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerException.java
@@ -240,6 +240,31 @@ public final class SQLServerException extends java.sql.SQLException {
     }
 
     /**
+     * Constructs a new SQLServerException with cause.
+     * 
+     * @param obj
+     *        the object
+     * @param errText
+     *        the exception message
+     * @param errState
+     *        the exception state
+     * @param errNum
+     *        the error number
+     * @param bStack
+     *        true to generate the stack trace
+     * @param cause
+     *        the underlying cause (set before logging)
+     */
+    SQLServerException(Object obj, String errText, String errState, int errNum, boolean bStack, Throwable cause) {
+        super(errText, errState, errNum);
+        // Set the cause BEFORE logging so that logException can include it in the log
+        if (null != cause) {
+            initCause(cause);
+        }
+        logException(obj, errText, bStack);
+    }
+
+    /**
      * Constructs a new SQLServerException from SQL Server error
      * 
      * @param sqlServerError
@@ -325,11 +350,9 @@ public final class SQLServerException extends java.sql.SQLException {
         if (con == null || !con.xopenStates)
             stateCode = mapFromXopen(state);
 
+        // Use the new constructor that sets cause BEFORE logging (so logs include the cause chain)
         SQLServerException theException = new SQLServerException(obj,
-                SQLServerException.checkAndAppendClientConnId(errText, con), stateCode, 0, bStack);
-        if (null != cause) {
-            theException.initCause(cause);
-        }
+                SQLServerException.checkAndAppendClientConnId(errText, con), stateCode, 0, bStack, cause);
 
         if ((null != state && state.equals(EXCEPTION_XOPEN_CONNECTION_FAILURE)) && (null != con)) {
             con.notifyPooledConnection(theException);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerFMTQuery.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerFMTQuery.java
@@ -99,7 +99,7 @@ class SQLServerFMTQuery {
             try {
                 lexer = new SQLServerLexer(CharStreams.fromStream(stream));
             } catch (IOException e) {
-                SQLServerException.makeFromDriverError(null, userSql, e.getLocalizedMessage(), null, false);
+                SQLServerException.makeFromDriverError(null, userSql, e.getLocalizedMessage(), null, false, e);
             }
             if (null != lexer) {
                 lexer.removeErrorListeners();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerNoneEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerNoneEnclaveProvider.java
@@ -74,7 +74,7 @@ public class SQLServerNoneEnclaveProvider implements ISQLServerEnclaveProvider {
                 enclaveCache.addEntry(connection.getServerName(), connection.getCatalog(),
                         connection.enclaveAttestationUrl, noneParams, enclaveSession);
             } catch (GeneralSecurityException e) {
-                SQLServerException.makeFromDriverError(connection, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(connection, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
         return b;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -385,7 +385,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         catch (SQLServerException e) {
             throw e;
         } catch (SQLException | StringIndexOutOfBoundsException e) {
-            SQLServerException.makeFromDriverError(con, stmtParent, e.getMessage(), null, false);
+            SQLServerException.makeFromDriverError(con, stmtParent, e.getMessage(), null, false, e);
         }
     }
 
@@ -457,7 +457,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                 return JDBCType.of((short) getParameterInfo(param).get(DATA_TYPE)).className();
             }
         } catch (SQLServerException e) {
-            SQLServerException.makeFromDriverError(con, stmtParent, e.getMessage(), null, false);
+            SQLServerException.makeFromDriverError(con, stmtParent, e.getMessage(), null, false, e);
             return null;
         }
     }
@@ -585,7 +585,7 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
                 return JDBCType.of((short) getParameterInfo(param).get(DATA_TYPE)).isSigned();
             }
         } catch (SQLException e) {
-            SQLServerException.makeFromDriverError(con, stmtParent, e.getMessage(), null, false);
+            SQLServerException.makeFromDriverError(con, stmtParent, e.getMessage(), null, false, e);
             return false;
         }
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParser.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParser.java
@@ -429,7 +429,7 @@ final class SQLServerParser {
             }
         } catch (java.util.NoSuchElementException e) {
             SQLServerException.makeFromDriverError(null, null, SQLServerResource.getResource("R_invalidCTEFormat"),
-                    null, false);
+                    null, false, e);
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -791,7 +791,7 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                 fillLOBs();
                 activeStream.close();
             } catch (IOException e) {
-                SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+                SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
             } finally {
                 activeStream = null;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSQLXML.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerSQLXML.java
@@ -168,7 +168,7 @@ final class SQLServerSQLXML implements java.sql.SQLXML {
                 try {
                     contents.close();
                 } catch (IOException e) {
-                    SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+                    SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
                 }
             }
         }
@@ -262,7 +262,7 @@ final class SQLServerSQLXML implements java.sql.SQLXML {
             contents.read();
             contents.read();
         } catch (IOException e) {
-            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
         }
 
         return (Reader) DDC.convertStreamToObject(contents, typeInfo, type.getJDBCType(), newArgs);
@@ -279,7 +279,7 @@ final class SQLServerSQLXML implements java.sql.SQLXML {
             contents.read();
             contents.read();
         } catch (IOException e) {
-            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
         }
 
         byte[] byteContents = contents.getBytes();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerVSMEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerVSMEnclaveProvider.java
@@ -85,7 +85,7 @@ public class SQLServerVSMEnclaveProvider implements ISQLServerEnclaveProvider {
                 enclaveCache.addEntry(connection.getServerName(), connection.getCatalog(),
                         connection.enclaveAttestationUrl, vsmParams, enclaveSession);
             } catch (GeneralSecurityException e) {
-                SQLServerException.makeFromDriverError(connection, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(connection, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
         return b;
@@ -114,7 +114,7 @@ public class SQLServerVSMEnclaveProvider implements ISQLServerEnclaveProvider {
                 hgsResponse.validateStatementSignature();
                 hgsResponse.validateDHPublicKey();
             } catch (IOException | GeneralSecurityException e) {
-                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
     }
@@ -286,7 +286,7 @@ class VSMAttestationResponse extends BaseAttestationResponse {
         } catch (CertificateException ce) {
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_HealthCertError"));
             Object[] msgArgs = {ce.getLocalizedMessage()};
-            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true, ce);
         }
     }
 
@@ -307,7 +307,7 @@ class VSMAttestationResponse extends BaseAttestationResponse {
                     }
                 }
             } catch (GeneralSecurityException e) {
-                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false);
+                SQLServerException.makeFromDriverError(null, this, e.getLocalizedMessage(), "0", false, e);
             }
         }
         SQLServerException.makeFromDriverError(null, this, SQLServerResource.getResource("R_InvalidHealthCert"), "0",

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerXAResource.java
@@ -468,7 +468,7 @@ public final class SQLServerXAResource implements javax.transaction.xa.XAResourc
                         Object[] msgArgs = {e1.getMessage()};
                         if (xaLogger.isLoggable(Level.FINER))
                             xaLogger.finer(toString() + " exception:" + form.format(msgArgs));
-                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true, e1);
                     }
                     xaInitDone = true;
                 }
@@ -720,7 +720,7 @@ public final class SQLServerXAResource implements javax.transaction.xa.XAResourc
                         } catch (SQLServerException e1) {
                             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_failedToEnlist"));
                             Object[] msgArgs = {e1.getMessage()};
-                            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+                            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true, e1);
                         }
                     }
                 }
@@ -735,7 +735,7 @@ public final class SQLServerXAResource implements javax.transaction.xa.XAResourc
                     } catch (SQLServerException e1) {
                         MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_failedToUnEnlist"));
                         Object[] msgArgs = {e1.getMessage()};
-                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true, e1);
                     }
                 }
                 if (nType == XA_RECOVER)
@@ -747,7 +747,7 @@ public final class SQLServerXAResource implements javax.transaction.xa.XAResourc
                         MessageFormat form = new MessageFormat(
                                 SQLServerException.getErrString("R_failedToReadRecoveryXIDs"));
                         Object[] msgArgs = {e1.getMessage()};
-                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+                        SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true, e1);
                     }
                 }
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SimpleInputStream.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SimpleInputStream.java
@@ -205,7 +205,7 @@ final class SimpleInputStream extends BaseInputStream {
         try {
             tdsReader.skip(skipAmount);
         } catch (SQLServerException e) {
-            throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage(), e);
         }
         streamPos += skipAmount;
         if (isReadLimitSet && ((streamPos - markedStreamPos) > readLimit))
@@ -306,7 +306,7 @@ final class SimpleInputStream extends BaseInputStream {
         try {
             tdsReader.readBytes(b, offset, readAmount);
         } catch (SQLServerException e) {
-            throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage(), e);
         }
         streamPos += readAmount;
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SimpleInputStream.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SimpleInputStream.java
@@ -356,7 +356,7 @@ final class SimpleInputStream extends BaseInputStream {
             read(value);
             close();
         } catch (IOException e) {
-            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true);
+            SQLServerException.makeFromDriverError(null, null, e.getMessage(), null, true, e);
         }
 
         return value;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -318,7 +318,7 @@ final class DTV {
                 clobLength = DataTypes.getCheckedLength(conn, dtv.getJdbcType(), clobValue.length(), false);
                 clobReader = clobValue.getCharacterStream();
             } catch (SQLException e) {
-                SQLServerException.makeFromDriverError(conn, null, e.getMessage(), null, false);
+                SQLServerException.makeFromDriverError(conn, null, e.getMessage(), null, false, e);
             }
 
             // If the Clob value is to be sent as MBCS, then convert the value to an MBCS InputStream
@@ -1396,7 +1396,7 @@ final class DTV {
                 blobLength = DataTypes.getCheckedLength(conn, dtv.getJdbcType(), blobValue.length(), false);
                 blobStream = blobValue.getBinaryStream();
             } catch (SQLException e) {
-                SQLServerException.makeFromDriverError(conn, null, e.getMessage(), null, false);
+                SQLServerException.makeFromDriverError(conn, null, e.getMessage(), null, false, e);
             }
 
             if (null == blobStream) {
@@ -2088,7 +2088,7 @@ final class AppDTVImpl extends DTVImpl {
             try {
                 DataTypes.getCheckedLength(con, dtv.getJdbcType(), clobValue.length(), false);
             } catch (SQLException e) {
-                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false);
+                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false, e);
             }
         }
 
@@ -2228,7 +2228,7 @@ final class AppDTVImpl extends DTVImpl {
             try {
                 DataTypes.getCheckedLength(con, dtv.getJdbcType(), blobValue.length(), false);
             } catch (SQLException e) {
-                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false);
+                SQLServerException.makeFromDriverError(con, null, e.getMessage(), null, false, e);
             }
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerExceptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerExceptionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+
+@RunWith(JUnitPlatform.class)
+public class SQLServerExceptionTest {
+
+    @Test
+    public void testMakeFromDriverErrorPreservesCause() {
+        IOException ioException = new IOException("Connection reset");
+
+        SQLServerException exception = assertThrows(SQLServerException.class, () -> SQLServerException
+                .makeFromDriverError(null, null, ioException.getMessage(), null, true, ioException));
+
+        assertSame(ioException, exception.getCause());
+    }
+
+    @Test
+    public void testMakeFromDriverErrorWithoutCauseHasNoCause() {
+        SQLServerException exception = assertThrows(SQLServerException.class,
+                () -> SQLServerException.makeFromDriverError(null, null, "no cause", null, true));
+
+        assertNull(exception.getCause());
+    }
+}


### PR DESCRIPTION
## Problem description

Socket and IO errors in the JDBC driver are caught and converted to `SQLServerException` via the `makeFromDriverError()` helper. However, the original exception cause was being discarded—callers invoking `getCause()` on the wrapped exception would receive `null`, blocking diagnosis of the root cause (connection reset, timeout, TLS handshake failure, etc.).

This is particularly problematic in production troubleshooting, where the underlying `IOException` often contains critical details needed to distinguish between transient network glitches, infrastructure misconfigurations, and security issues.

### Fixes existing GitHub issue

Fixes #2969

## Fix Description

A new 6-parameter overload of `SQLServerException.makeFromDriverError()` now accepts an optional `Throwable cause` parameter. The existing 5-parameter signature is preserved for backward compatibility and delegates to the new overload with `null` cause.

Effects:

- When an IO operation fails, the original `IOException` or `SocketException` is now preserved as the cause chain
- Callers can inspect `exception.getCause()` to diagnose network issues, timeouts, and TLS failures
- Backward compatible: existing code that doesn't pass a cause continues to work unchanged
