### PR TITLE
support set_nocount swith from jdbc url property

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -94,7 +94,22 @@ import mssql.googlecode.concurrentlinkedhashmap.EvictionListener;
  * SQLServerConnectionPoolProxy
  * 
  */
+
 public class SQLServerConnection implements ISQLServerConnection, java.io.Serializable {
+    
+ /**
+  * This enum is used to represent On and Off values for connection properties that support that. 
+  * It is used instead of a boolean to allow for a third "uninitialized" state, since some connection
+  *  properties have values that are determined
+  * after the connection is established and cannot be determined at connection initialization time 
+  * when the connection  properties are being parsed and set.    
+  */
+    
+    private OnOffOption setNoCount = OnOffOption.OFF;
+
+    final OnOffOption getSetNoCount() {
+        return setNoCount;
+    }
 
     /**
      * Always refresh SerialVersionUID when prompted
@@ -103,6 +118,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * A random netAddress for this process to send during LOGIN7
+     * 
      */
     private static final byte[] netAddress = getRandomNetAddress();
 
@@ -2680,7 +2696,18 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             if (propsIn != null) {
 
                 activeConnectionProperties = (Properties) propsIn.clone();
+                String sPropValueT = activeConnectionProperties.getProperty(
+                        SQLServerDriverStringProperty.SET_NOCOUNT.toString());
 
+                if (null == sPropValueT) {
+                    sPropValueT = SQLServerDriverStringProperty.SET_NOCOUNT.getDefaultValue();
+                }
+
+                setNoCount = OnOffOption.valueOfString(sPropValueT);
+                activeConnectionProperties.setProperty(
+                        SQLServerDriverStringProperty.SET_NOCOUNT.toString(),
+                        setNoCount.toString());
+                    
                 pooledConnectionParent = pooledConnection;
 
                 String trustStorePassword = activeConnectionProperties
@@ -5242,6 +5269,16 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             executeCommand(new ConnectionCommand(sql, logContext));
         }
     }
+    
+    /**
+     * Applies the SET NOCOUNT setting to the connection.
+     * 
+     */
+    
+    void applySetNoCount() throws SQLServerException {
+        connectionCommand("SET NOCOUNT " + setNoCount.toString(), "applySetNoCount");
+       }
+    
 
     /**
      * Build the syntax to initialize the connection at the database side.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -633,6 +633,7 @@ enum PrepareMethod {
 
 
 enum SQLServerDriverStringProperty {
+    SET_NOCOUNT("set_nocount", OnOffOption.OFF.toString()),
     APPLICATION_INTENT("applicationIntent", ApplicationIntent.READ_WRITE.toString()),
     APPLICATION_NAME("applicationName", SQLServerDriver.DEFAULT_APP_NAME),
     PREPARE_METHOD("prepareMethod", PrepareMethod.PREPEXEC.toString()),
@@ -881,10 +882,18 @@ public final class SQLServerDriver implements java.sql.Driver {
     // }
     
     private static final String[] TRUE_FALSE = {"true", "false"};
+    private static final String[] ON_OFF = {OnOffOption.ON.toString(), OnOffOption.OFF.toString()};
+
 
     private static final SQLServerDriverPropertyInfo[] DRIVER_PROPERTIES = {
             // default required available choices
             // property name value property (if appropriate)
+            new SQLServerDriverPropertyInfo(
+                    SQLServerDriverStringProperty.SET_NOCOUNT.toString(),
+                    SQLServerDriverStringProperty.SET_NOCOUNT.getDefaultValue(),
+                    false,
+                    ON_OFF
+                ),
             new SQLServerDriverPropertyInfo(SQLServerDriverStringProperty.APPLICATION_INTENT.toString(),
                     SQLServerDriverStringProperty.APPLICATION_INTENT.getDefaultValue(), false,
                     new String[] {ApplicationIntent.READ_ONLY.toString(), ApplicationIntent.READ_WRITE.toString()}),

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -60,6 +60,8 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_errorReadingStream", "An error occurred while reading the value from the stream object. Error: \"{0}\""},
         {"R_read", "The stream read operation returned an invalid value for the amount of data read."},
 
+        {"R_set_nocountPropertyDescription", "Invalid set_nocount {0}."},
+
         {"R_streamReadReturnedInvalidValue", "The stream read operation returned an invalid value for the amount of data read."},
         {"R_mismatchedStreamLength", "The stream value is not the specified length. The specified length was {0}, the actual length is {1}."},
         {"R_notSupported", "This operation is not supported."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -279,6 +279,7 @@ public class SQLServerStatement implements ISQLServerStatement {
             
             try {
                 // (Re)execute this Statement with the new command
+                connection.applySetNoCount();
                 executeCommand(newStmtCmd);
             } catch (SQLServerException e) {
                 SQLServerError sqlServerError = e.getSQLServerError();


### PR DESCRIPTION
To support set_nocount propert as part URL jdbc connection string 
jdbc:sqlserver://localhost:1433;databaseName=testdb;encrypt=true;trustServerCertificate=true;set_nocount=on
return -1

and 
jdbc:sqlserver://localhost:1433;databaseName=testdb;encrypt=true;trustServerCertificate=true;set_nocount=off
that will automatically return rows
Connected to SQL Server successfully.
101 | John | sk | IT | 75000.0
102 | Mary | Johnson | HR | 68000.0
103 | David | Brown | Finance | 82000.0
104 | Lisa | Davis | Operations | 71000.0
105 | James | Wilson | Support | 65000.0
106 | John | sk | it | 100000.0
107 | John | sk | it | 100000.0
UPDATE Employee SET LastName ='sk' where FirstName = ?
Rows affected: 3