### PR TITLE
Perf: Optimize the ResultSet read path and reduce allocation overhead

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7157,6 +7157,12 @@ final class TDSReader implements Serializable {
     }
 
     final int readUnsignedByte() throws SQLServerException {
+        // Fast path for the common case where the current TDS packet still
+        // has payload available; falls back to ensurePayload() at boundaries.
+        if (payloadOffset < currentPacket.payloadLength) {
+            return currentPacket.payload[payloadOffset++] & 0xFF;
+        }
+
         // Ensure that we have a packet to read from.
         if (!ensurePayload())
             throwInvalidTDS();
@@ -7231,6 +7237,7 @@ final class TDSReader implements Serializable {
     }
 
     final void readBytes(byte[] value, int valueOffset, int valueLength) throws SQLServerException {
+        final boolean isLogging = logger.isLoggable(Level.FINEST);
         for (int bytesRead = 0; bytesRead < valueLength;) {
             // Ensure that we have a packet to read from.
             if (!ensurePayload())
@@ -7243,7 +7250,7 @@ final class TDSReader implements Serializable {
                 bytesToCopy = currentPacket.payloadLength - payloadOffset;
 
             // Copy some bytes from the current packet to the destination value.
-            if (logger.isLoggable(Level.FINEST))
+            if (isLogging)
                 logger.finest(toString() + " Reading " + bytesToCopy + " bytes from offset " + payloadOffset);
 
             System.arraycopy(currentPacket.payload, payloadOffset, value, valueOffset + bytesRead, bytesToCopy);
@@ -7259,6 +7266,7 @@ final class TDSReader implements Serializable {
      * @throws SQLServerException
      */
     final void readSkipBytes(int valueLength) throws SQLServerException {
+        final boolean isLogging = logger.isLoggable(Level.FINEST);
         for (int bytesSkipped = 0; bytesSkipped < valueLength;) {
             // Ensure that we have a packet to read from.
             if (!ensurePayload())
@@ -7268,7 +7276,7 @@ final class TDSReader implements Serializable {
             if (bytesToSkip > currentPacket.payloadLength - payloadOffset)
                 bytesToSkip = currentPacket.payloadLength - payloadOffset;
 
-            if (logger.isLoggable(Level.FINEST))
+            if (isLogging)
                 logger.finest(toString() + " Skipping " + bytesToSkip + " bytes from offset " + payloadOffset);
 
             bytesSkipped += bytesToSkip;
@@ -7465,12 +7473,21 @@ final class TDSReader implements Serializable {
     }
 
     private int readDaysIntoCE() throws SQLServerException {
-        byte[] value = new byte[TDS.DAYS_INTO_CE_LENGTH];
-        readBytes(value, 0, value.length);
-
-        int daysIntoCE = 0;
-        for (int i = 0; i < value.length; i++)
-            daysIntoCE |= ((value[i] & 0xFF) << (8 * i));
+        // Fast path: read the 3-byte value directly from the current TDS packet.
+        // Falls back to the existing cross-packet logic when necessary.
+        final int length = TDS.DAYS_INTO_CE_LENGTH;
+        int daysIntoCE;
+        if (payloadOffset + length <= currentPacket.payloadLength) {
+            final byte[] p = currentPacket.payload;
+            final int off = payloadOffset;
+            daysIntoCE = (p[off] & 0xFF) | ((p[off + 1] & 0xFF) << 8) | ((p[off + 2] & 0xFF) << 16);
+            payloadOffset += length;
+        } else {
+            final byte[] value = readWrappedBytes(length);
+            daysIntoCE = 0;
+            for (int i = 0; i < length; i++)
+                daysIntoCE |= ((value[i] & 0xFF) << (8 * i));
+        }
 
         // Theoretically should never encounter a value that is outside of the valid date range
         if (daysIntoCE < 0)

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -1842,8 +1842,11 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         deletedCurrentRow = false;
         if (lastColumnIndex >= 1) {
             initializeNullCompressedColumns();
-            // Discard columns up to, but not including, the last indexed column
-            for (int columnIndex = 1; columnIndex < lastColumnIndex; ++columnIndex)
+
+            // Clear accessed columns to release DTV state for reuse on the next row.
+            // Math.min guards against out-of-bounds if lastColumnIndex exceeds columns.length.
+            int clearUpTo = Math.min(lastColumnIndex, columns.length + 1);
+            for (int columnIndex = 1; columnIndex < clearUpTo; ++columnIndex)
                 getColumn(columnIndex).clear();
 
             // Skip and discard the remainder of the last indexed column

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -213,23 +213,7 @@ final class Util {
 
     static BigDecimal readBigDecimal(byte[] valueBytes, int valueLength, int scale) {
         int sign = (0 == valueBytes[0]) ? -1 : 1;
-        int magnitudeLength = valueLength - 1;
-
-        // Fast path for DECIMAL/NUMERIC values whose unscaled magnitude fits in a long.
-        // Assemble the little-endian magnitude directly and create a compact
-        // BigDecimal without allocating an intermediate byte[] or BigInteger.
-        // Values that do not fit fall back to the BigInteger-based path.
-        if (magnitudeLength <= 8) {
-            long magnitude = 0;
-            for (int i = magnitudeLength; i >= 1; i--)
-                magnitude = (magnitude << 8) | (valueBytes[i] & 0xFFL);
-
-            if (magnitude >= 0)
-                return BigDecimal.valueOf(sign * magnitude, scale);
-        }
-
-        // Fallback for larger values: reverse the little-endian magnitude and construct the BigDecimal through BigInteger.
-        byte[] magnitude = new byte[magnitudeLength];
+        byte[] magnitude = new byte[valueLength - 1];
         for (int i = 1; i <= magnitude.length; i++)
             magnitude[magnitude.length - i] = valueBytes[i];
         return new BigDecimal(new BigInteger(sign, magnitude), scale);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -213,7 +213,23 @@ final class Util {
 
     static BigDecimal readBigDecimal(byte[] valueBytes, int valueLength, int scale) {
         int sign = (0 == valueBytes[0]) ? -1 : 1;
-        byte[] magnitude = new byte[valueLength - 1];
+        int magnitudeLength = valueLength - 1;
+
+        // Fast path for DECIMAL/NUMERIC values whose unscaled magnitude fits in a long.
+        // Assemble the little-endian magnitude directly and create a compact
+        // BigDecimal without allocating an intermediate byte[] or BigInteger.
+        // Values that do not fit fall back to the BigInteger-based path.
+        if (magnitudeLength <= 8) {
+            long magnitude = 0;
+            for (int i = magnitudeLength; i >= 1; i--)
+                magnitude = (magnitude << 8) | (valueBytes[i] & 0xFFL);
+
+            if (magnitude >= 0)
+                return BigDecimal.valueOf(sign * magnitude, scale);
+        }
+
+        // Fallback for larger values: reverse the little-endian magnitude and construct the BigDecimal through BigInteger.
+        byte[] magnitude = new byte[magnitudeLength];
         for (int i = 1; i <= magnitude.length; i++)
             magnitude[magnitude.length - i] = valueBytes[i];
         return new BigDecimal(new BigInteger(sign, magnitude), scale);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3893,10 +3893,13 @@ final class ServerDTVImpl extends DTVImpl {
                     //   - !isAdaptive               : adaptive paths wrap the stream for user code
                     //   - jdbcType.isTextual()      : non-textual targets need convertStringToObject
                     //                                 to trim/parse the value
+                    //   - CLOB/NCLOB excluded        : although textual, getClob()/getNClob() must
+                    //                                 return a SQLServerClob/SQLServerNClob, not a String
                     if (valueLength > 0 && valueLength <= 4000
                             && StreamType.NONE == streamGetterArgs.streamType
                             && !streamGetterArgs.isAdaptive
-                            && jdbcType.isTextual()) {
+                            && jdbcType.isTextual()
+                            && JDBCType.CLOB != jdbcType && JDBCType.NCLOB != jdbcType) {
                         byte[] bytes = new byte[valueLength];
                         tdsReader.readBytes(bytes, 0, valueLength);
                         convertedValue = new String(bytes, typeInfo.getCharset());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -133,6 +133,15 @@ final class DTV {
     /** The source (app or server) providing the data for this value. */
     private DTVImpl impl;
 
+    /**
+    * Single-slot cache for reusing a {@link ServerDTVImpl} across row reads,
+    * avoiding repeated allocations on the ResultSet hot path. {@link #clear()}
+    * still resets {@link #impl} to {@code null}, preserving the existing
+    * initialization and null-state semantics. {@link AppDTVImpl} is excluded
+    * because its update-path lifecycle differs from {@link ServerDTVImpl}.
+    */
+    private ServerDTVImpl pooledServerImpl;
+
     CryptoMetadata cryptoMeta = null;
     JDBCType jdbcTypeSetByUser = null;
     int valueLength = 0;
@@ -157,20 +166,38 @@ final class DTV {
         impl.setValue(value, javaType);
     }
 
+    /** Returns the pooled {@link ServerDTVImpl} (already reset) or a fresh instance. */
+    private ServerDTVImpl acquireServerImpl() {
+        ServerDTVImpl s = pooledServerImpl;
+        if (null != s) {
+            pooledServerImpl = null;
+            return s;
+        }
+        return new ServerDTVImpl();
+    }
+
     final void clear() {
+        // Pool the outgoing ServerDTVImpl for reuse on the next read, so we
+        // avoid a fresh allocation per column per row. AppDTVImpl is not pooled
+        // (rare update path; would complicate the AppDTV <-> ServerDTV swap).
+        if (impl instanceof ServerDTVImpl) {
+            ServerDTVImpl s = (ServerDTVImpl) impl;
+            s.reset();
+            pooledServerImpl = s;
+        }
         impl = null;
     }
 
     final void skipValue(TypeInfo type, TDSReader tdsReader, boolean isDiscard) throws SQLServerException {
         if (null == impl)
-            impl = new ServerDTVImpl();
+            impl = acquireServerImpl();
 
         impl.skipValue(type, tdsReader, isDiscard);
     }
 
     final void initFromCompressedNull() {
         if (null == impl)
-            impl = new ServerDTVImpl();
+            impl = acquireServerImpl();
 
         impl.initFromCompressedNull();
     }
@@ -250,7 +277,7 @@ final class DTV {
             TypeInfo typeInfo, CryptoMetadata cryptoMetadata, TDSReader tdsReader,
             SQLServerStatement statement) throws SQLServerException {
         if (null == impl) {
-            impl = new ServerDTVImpl();
+            impl = acquireServerImpl();
         } else if (impl.isNull()) {
             return null;
         }
@@ -270,6 +297,13 @@ final class DTV {
      * Called by DTV implementation instances to change to a different DTV implementation.
      */
     void setImpl(DTVImpl impl) {
+        // Preserve an outgoing ServerDTVImpl for reuse when replacing the
+        // current implementation, avoiding a fresh allocation on the next read.
+        if (this.impl instanceof ServerDTVImpl && this.impl != impl) {
+            ServerDTVImpl s = (ServerDTVImpl) this.impl;
+            s.reset();
+            pooledServerImpl = s;
+        }
         this.impl = impl;
     }
 
@@ -3321,6 +3355,19 @@ final class ServerDTVImpl extends DTVImpl {
     private SqlVariant internalVariant;
 
     /**
+     * Resets all wire-side state (length, mark, null indicator, SQL_VARIANT context)
+     * so this instance can be reused for the next row's value. Invoked by
+     * {@link DTV#clear()} on the per-row hot path to avoid allocating a fresh
+     * {@code ServerDTVImpl} for every column of every row.
+     */
+    final void reset() {
+        valueLength = 0;
+        valueMark = null;
+        isNull = false;
+        internalVariant = null;
+    }
+
+    /**
      * Sets the value of the DTV to an app-specified Java type.
      *
      * Generally, the value cannot be stored back into the TDS byte stream (although this could be done for fixed-length
@@ -3833,9 +3880,31 @@ final class ServerDTVImpl extends DTVImpl {
                 // (CHAR/VARCHAR/TEXT/NCHAR/NVARCHAR/NTEXT/BINARY/VARBINARY/IMAGE) -> ANY jdbcType.
                 case CHAR:
                 case VARCHAR:
-                case TEXT:
                 case NCHAR:
                 case NVARCHAR:
+                {
+                    // Fast path: small synchronous rs.getString() reads bytes directly into
+                    // a String, bypassing the SimpleInputStream wrapper and its embedded
+                    // TDSReaderMark / close() machinery (~4 allocations per cell saved).
+                    //
+                    // Guards (all required for byte-identical semantics with the stream path):
+                    //   - valueLength in (0, 4000]  : skips zero-length and overly large values
+                    //   - streamType == NONE        : stream getters need the actual InputStream
+                    //   - !isAdaptive               : adaptive paths wrap the stream for user code
+                    //   - jdbcType.isTextual()      : non-textual targets need convertStringToObject
+                    //                                 to trim/parse the value
+                    if (valueLength > 0 && valueLength <= 4000
+                            && StreamType.NONE == streamGetterArgs.streamType
+                            && !streamGetterArgs.isAdaptive
+                            && jdbcType.isTextual()) {
+                        byte[] bytes = new byte[valueLength];
+                        tdsReader.readBytes(bytes, 0, valueLength);
+                        convertedValue = new String(bytes, typeInfo.getCharset());
+                        break;
+                    }
+                    // Fall through to the stream-based path for large/streaming/non-textual cases.
+                }
+                case TEXT:
                 case NTEXT:
                 case IMAGE:
                 case BINARY:

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -134,11 +134,11 @@ final class DTV {
     private DTVImpl impl;
 
     /**
-     * Single reusable {@link ServerDTVImpl} instance for this column. Because there is one {@link DTV} per column, this
-     * instance is created once per column and reused to fetch every row's value for that column, avoiding a fresh
-     * allocation per row on the ResultSet hot path. {@link #clear()} still resets {@link #impl} to {@code null},
-     * preserving the existing initialization and null-state semantics. {@link AppDTVImpl} is excluded because its
-     * update-path lifecycle differs from {@link ServerDTVImpl}.
+     * A single ServerDTVImpl instance reused for this column. There is one DTV per column, so this instance is created
+     * once (lazily, on the first server read) and reused to fetch every subsequent row's value, avoiding a fresh
+     * allocation per row on the ResultSet hot path. It is reset in acquireServerImpl() before each reuse, so it is
+     * always handed out clean. During an active read, impl points at this same instance. AppDTVImpl is not kept here
+     * because its update-path lifecycle is different from ServerDTVImpl.
      */
     private ServerDTVImpl reusableServerImpl;
 
@@ -166,25 +166,23 @@ final class DTV {
         impl.setValue(value, javaType);
     }
 
-    /** Returns the reusable {@link ServerDTVImpl} (already reset) or a fresh instance if none is retained. */
+    /**
+     * Returns this column's reusable ServerDTVImpl, creating it on first use. The instance is reset here, at the single
+     * point of reuse, so it is always handed out clean regardless of the previous row's state.
+     */
     private ServerDTVImpl acquireServerImpl() {
         ServerDTVImpl s = reusableServerImpl;
         if (null != s) {
-            reusableServerImpl = null;
+            s.reset(); // clear the previous row's state before handing it out
             return s;
         }
-        return new ServerDTVImpl();
+        reusableServerImpl = new ServerDTVImpl();
+        return reusableServerImpl;
     }
 
     final void clear() {
-        // Retain the outgoing ServerDTVImpl for reuse on the next read, so we
-        // avoid a fresh allocation per column per row. AppDTVImpl is not retained
-        // (rare update path; would complicate the AppDTV <-> ServerDTV swap).
-        if (impl instanceof ServerDTVImpl) {
-            ServerDTVImpl s = (ServerDTVImpl) impl;
-            s.reset();
-            reusableServerImpl = s;
-        }
+        // Just clear the active impl reference so isInitialized() and the read-side null checks work as before. The
+        // per-column ServerDTVImpl stays in reusableServerImpl and is reset in acquireServerImpl() before the next row.
         impl = null;
     }
 
@@ -297,13 +295,8 @@ final class DTV {
      * Called by DTV implementation instances to change to a different DTV implementation.
      */
     void setImpl(DTVImpl impl) {
-        // Retain an outgoing ServerDTVImpl for reuse when replacing the
-        // current implementation, avoiding a fresh allocation on the next read.
-        if (this.impl instanceof ServerDTVImpl && this.impl != impl) {
-            ServerDTVImpl s = (ServerDTVImpl) this.impl;
-            s.reset();
-            reusableServerImpl = s;
-        }
+        // No need to save the outgoing ServerDTVImpl here: the per-column instance is already kept in
+        // reusableServerImpl (impl points at it during a server read), so it stays available for the next read.
         this.impl = impl;
     }
 
@@ -3355,10 +3348,9 @@ final class ServerDTVImpl extends DTVImpl {
     private SqlVariant internalVariant;
 
     /**
-     * Resets all wire-side state (length, mark, null indicator, SQL_VARIANT context)
-     * so this instance can be reused for the next row's value. Invoked by
-     * {@link DTV#clear()} on the per-row hot path to avoid allocating a fresh
-     * {@code ServerDTVImpl} for every column of every row.
+     * Resets all wire-side state (length, mark, null indicator, SQL_VARIANT context) so this instance can be reused
+     * for the next row's value. Called from DTV.acquireServerImpl() on the per-row hot path to avoid allocating a
+     * fresh ServerDTVImpl for every column of every row.
      */
     final void reset() {
         valueLength = 0;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -134,12 +134,12 @@ final class DTV {
     private DTVImpl impl;
 
     /**
-    * Single-slot cache for reusing a {@link ServerDTVImpl} across row reads,
-    * avoiding repeated allocations on the ResultSet hot path. {@link #clear()}
-    * still resets {@link #impl} to {@code null}, preserving the existing
-    * initialization and null-state semantics. {@link AppDTVImpl} is excluded
-    * because its update-path lifecycle differs from {@link ServerDTVImpl}.
-    */
+     * Single-slot cache holding this column's {@link ServerDTVImpl}. Because there is one {@link DTV} per column, this
+     * instance is created once per column and reused to fetch every row's value for that column, avoiding a fresh
+     * allocation per row on the ResultSet hot path. {@link #clear()} still resets {@link #impl} to {@code null},
+     * preserving the existing initialization and null-state semantics. {@link AppDTVImpl} is excluded because its
+     * update-path lifecycle differs from {@link ServerDTVImpl}.
+     */
     private ServerDTVImpl pooledServerImpl;
 
     CryptoMetadata cryptoMeta = null;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -134,13 +134,13 @@ final class DTV {
     private DTVImpl impl;
 
     /**
-     * Single-slot cache holding this column's {@link ServerDTVImpl}. Because there is one {@link DTV} per column, this
+     * Single reusable {@link ServerDTVImpl} instance for this column. Because there is one {@link DTV} per column, this
      * instance is created once per column and reused to fetch every row's value for that column, avoiding a fresh
      * allocation per row on the ResultSet hot path. {@link #clear()} still resets {@link #impl} to {@code null},
      * preserving the existing initialization and null-state semantics. {@link AppDTVImpl} is excluded because its
      * update-path lifecycle differs from {@link ServerDTVImpl}.
      */
-    private ServerDTVImpl pooledServerImpl;
+    private ServerDTVImpl reusableServerImpl;
 
     CryptoMetadata cryptoMeta = null;
     JDBCType jdbcTypeSetByUser = null;
@@ -166,24 +166,24 @@ final class DTV {
         impl.setValue(value, javaType);
     }
 
-    /** Returns the pooled {@link ServerDTVImpl} (already reset) or a fresh instance. */
+    /** Returns the reusable {@link ServerDTVImpl} (already reset) or a fresh instance if none is retained. */
     private ServerDTVImpl acquireServerImpl() {
-        ServerDTVImpl s = pooledServerImpl;
+        ServerDTVImpl s = reusableServerImpl;
         if (null != s) {
-            pooledServerImpl = null;
+            reusableServerImpl = null;
             return s;
         }
         return new ServerDTVImpl();
     }
 
     final void clear() {
-        // Pool the outgoing ServerDTVImpl for reuse on the next read, so we
-        // avoid a fresh allocation per column per row. AppDTVImpl is not pooled
+        // Retain the outgoing ServerDTVImpl for reuse on the next read, so we
+        // avoid a fresh allocation per column per row. AppDTVImpl is not retained
         // (rare update path; would complicate the AppDTV <-> ServerDTV swap).
         if (impl instanceof ServerDTVImpl) {
             ServerDTVImpl s = (ServerDTVImpl) impl;
             s.reset();
-            pooledServerImpl = s;
+            reusableServerImpl = s;
         }
         impl = null;
     }
@@ -297,12 +297,12 @@ final class DTV {
      * Called by DTV implementation instances to change to a different DTV implementation.
      */
     void setImpl(DTVImpl impl) {
-        // Preserve an outgoing ServerDTVImpl for reuse when replacing the
+        // Retain an outgoing ServerDTVImpl for reuse when replacing the
         // current implementation, avoiding a fresh allocation on the next read.
         if (this.impl instanceof ServerDTVImpl && this.impl != impl) {
             ServerDTVImpl s = (ServerDTVImpl) this.impl;
             s.reset();
-            pooledServerImpl = s;
+            reusableServerImpl = s;
         }
         this.impl = impl;
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
@@ -371,17 +371,20 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
     }
 
     /**
-     * Reads Always Encrypted {@code varchar}/{@code nvarchar} columns whose decrypted values sit exactly on the
-     * {@code getString()} fast-path byte boundary (see the CHAR/VARCHAR/NCHAR/NVARCHAR case in {@code dtv.java}).
-     * Fills {@code Varchar8000} with 4000 chars (== 4000 bytes) and {@code Nvarchar4000} with 2000 chars (== 4000
-     * bytes) so both charset decoders are exercised at the boundary, then verifies the decrypted values decode
-     * byte-identically.
+     * Guard test confirming Always Encrypted {@code varchar}/{@code nvarchar} columns are unaffected by the
+     * {@code getString()} fast path added to the CHAR/VARCHAR/NCHAR/NVARCHAR case in {@code dtv.java}. Encrypted reads
+     * return from the {@code if (encrypted)} branch in {@code ServerDTVImpl.getValue()} BEFORE the {@code switch} that
+     * contains the fast path, so AE never takes it. This test fills {@code Varchar8000} with 4000 chars (== 4000
+     * bytes) and {@code Nvarchar4000} with 2000 chars (== 4000 bytes) — the same 4000-byte size that would trigger the
+     * fast path on a non-encrypted column — and verifies the decrypted values still decode byte-identically through
+     * the encrypted decode path.
      *
      * @throws Exception
      */
     @ParameterizedTest
     @MethodSource("enclaveParams")
-    public void testCharGetStringFastPathBoundary(String serverName, String url, String protocol) throws Exception {
+    public void testAeCharBoundarySizeDecodesUnaffectedByFastPath(String serverName, String url,
+            String protocol) throws Exception {
         setAEConnectionString(serverName, url, protocol);
 
         try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/JDBCEncryptionDecryptionTest.java
@@ -371,6 +371,41 @@ public class JDBCEncryptionDecryptionTest extends AESetup {
     }
 
     /**
+     * Reads Always Encrypted {@code varchar}/{@code nvarchar} columns whose decrypted values sit exactly on the
+     * {@code getString()} fast-path byte boundary (see the CHAR/VARCHAR/NCHAR/NVARCHAR case in {@code dtv.java}).
+     * Fills {@code Varchar8000} with 4000 chars (== 4000 bytes) and {@code Nvarchar4000} with 2000 chars (== 4000
+     * bytes) so both charset decoders are exercised at the boundary, then verifies the decrypted values decode
+     * byte-identically.
+     *
+     * @throws Exception
+     */
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testCharGetStringFastPathBoundary(String serverName, String url, String protocol) throws Exception {
+        setAEConnectionString(serverName, url, protocol);
+
+        try (SQLServerConnection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                SQLServerStatement stmt = (SQLServerStatement) con.createStatement()) {
+            String[] values = createCharValues(nullable);
+
+            // index 8 == Varchar8000 (1 byte/char -> 4000 chars), index 9 == Nvarchar4000 (2 bytes/char -> 2000 chars).
+            values[8] = makeBoundaryString(4000);
+            values[9] = makeBoundaryString(2000);
+
+            testChars(stmt, cekJks, charTable, values, TestCase.NORMAL, false);
+        }
+    }
+
+    /** Builds a deterministic ASCII string of the given length: char i == 'A' + (i % 26). */
+    private static String makeBoundaryString(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append((char) ('A' + (i % 26)));
+        }
+        return sb.toString();
+    }
+
+    /**
      * Junit test case for char set string for string values for AKV
      * 
      * @throws SQLException

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -2488,9 +2488,9 @@ public class ResultSetTest extends AbstractTest {
     /**
      * White-box guard tests for {@code ServerDTVImpl.reset()}.
      *
-     * {@code ServerDTVImpl} instances are pooled and reused across rows on the read hot path (see {@code DTV.clear()}
-     * / {@code DTV.setImpl()}). {@code reset()} must therefore zero every piece of wire-side state before an instance
-     * is returned to the pool; a field that is added but forgotten in {@code reset()} would leak stale state into the
+     * A single {@code ServerDTVImpl} instance is reused across rows on the read hot path (see {@code DTV.clear()}
+     * / {@code DTV.setImpl()}). {@code reset()} must therefore zero every piece of wire-side state before the instance
+     * is retained for reuse; a field that is added but forgotten in {@code reset()} would leak stale state into the
      * next row. These tests act as a tripwire so any new field forces {@code reset()} to be revisited.
      *
      * The driver types involved ({@code ServerDTVImpl}, {@code TDSReaderMark}, {@code SqlVariant}) are package-private
@@ -2537,7 +2537,7 @@ public class ResultSetTest extends AbstractTest {
          * Tripwire: if the set of mutable instance fields on {@code ServerDTVImpl} changes, this test fails until the
          * new field is (a) cleared in {@code ServerDTVImpl.reset()} and (b) added to {@code expectedResettableFields}.
          * This keeps {@code reset()} in sync with the class as it evolves, guarding against silent stale-state bleed
-         * across rows once instances are pooled.
+         * across rows once the instance is reused.
          */
         @Test
         void resetInventoryStaysInSync() throws Exception {
@@ -2545,7 +2545,7 @@ public class ResultSetTest extends AbstractTest {
             Set<String> actual = new TreeSet<>();
             // Walk the whole class hierarchy (ServerDTVImpl and its superclass DTVImpl) so a mutable per-row field
             // added to the superclass cannot silently bypass this tripwire. Any such field would still need to be
-            // cleared before an instance is pooled.
+            // cleared before the instance is reused.
             for (Class<?> c = implClass; c != null && c != Object.class; c = c.getSuperclass()) {
                 for (Field f : c.getDeclaredFields()) {
                     int mod = f.getModifiers();
@@ -2561,7 +2561,7 @@ public class ResultSetTest extends AbstractTest {
             assertEquals(new TreeSet<>(expectedResettableFields), actual,
                     "ServerDTVImpl (or its DTVImpl superclass) mutable instance fields changed. If you added a "
                             + "field, clear it in ServerDTVImpl.reset() and update expectedResettableFields in this "
-                            + "test so pooled instances cannot leak stale state.");
+                            + "test so the reused instance cannot leak stale state.");
         }
 
         private Object newInstance(Class<?> cls) throws Exception {
@@ -2813,8 +2813,8 @@ public class ResultSetTest extends AbstractTest {
     /**
      * End-to-end tests for the read hot-path optimization in {@code ServerDTVImpl} / {@code DTV} (see {@code dtv.java}):
      * the {@code getString()} fast-path that decodes small {@code CHAR/VARCHAR/NCHAR/NVARCHAR} values directly to a
-     * {@code String}, and the pooling/reuse of {@code ServerDTVImpl} across rows. Each test creates its own table so
-     * the scenarios are independent.
+     * {@code String}, and the reuse of a single {@code ServerDTVImpl} instance across rows. Each test creates its own
+     * table so the scenarios are independent.
      */
     @Nested
     class ReadHotPathTests {
@@ -2952,12 +2952,12 @@ public class ResultSetTest extends AbstractTest {
         }
 
         /**
-         * Null values must not bleed across pooled {@code ServerDTVImpl} instances. Rows alternate non-null / null /
-         * non-null so a pooled impl is reused across the null (NBCROW) boundary; asserts values and {@code wasNull()}
+         * Null values must not bleed across the reused {@code ServerDTVImpl} instance. Rows alternate non-null / null /
+         * non-null so the reused impl crosses the null (NBCROW) boundary; asserts values and {@code wasNull()}
          * per row.
          */
         @Test
-        public void testNullValueDoesNotBleedAcrossPooledRows() throws SQLException {
+        public void testNullValueDoesNotBleedAcrossReusedInstance() throws SQLException {
             try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
                 TestUtils.dropTableIfExists(hotPathTable, stmt);
                 stmt.execute("CREATE TABLE " + hotPathTable
@@ -2993,13 +2993,13 @@ public class ResultSetTest extends AbstractTest {
         }
 
         /**
-         * The updatable-cursor {@code setImpl} swap (ServerDTVImpl {@literal ->} AppDTVImpl) must pool the outgoing impl
-         * without corrupting later reads. Updates a row, advances, and requeries to confirm both the updated and
-         * untouched rows read back correctly.
+         * The updatable-cursor {@code setImpl} swap (ServerDTVImpl {@literal ->} AppDTVImpl) must retain the outgoing
+         * impl for reuse without corrupting later reads. Updates a row, advances, and requeries to confirm both the
+         * updated and untouched rows read back correctly.
          */
         @Test
         @Tag(Constants.xAzureSQLDW)
-        public void testUpdatableCursorImplSwapPooling() throws SQLException {
+        public void testUpdatableCursorImplSwapReuse() throws SQLException {
             try (Connection conn = getConnection();
                     Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
                             ResultSet.CONCUR_UPDATABLE)) {
@@ -3017,9 +3017,9 @@ public class ResultSetTest extends AbstractTest {
                     rs.updateInt(3, 99);
                     rs.updateRow();
 
-                    // Advancing reuses pooled impls for the next row's server values.
+                    // Advancing reuses the retained impl for the next row's server values.
                     assertTrue(rs.next());
-                    assertEquals("beta", rs.getString(2), "second row corrupted after impl swap/pooling");
+                    assertEquals("beta", rs.getString(2), "second row corrupted after impl swap/reuse");
                     assertEquals(20, rs.getInt(3));
                 }
 
@@ -3039,16 +3039,16 @@ public class ResultSetTest extends AbstractTest {
         /**
          * A partially-read adaptive stream obtained on one row must not corrupt the next row after {@code next()}, and
          * a LATE {@code close()} of that retained stream, issued only after the row's {@code ServerDTVImpl} has been
-         * pooled and reused, must be a harmless no-op.
+         * reset and reused, must be a harmless no-op.
          *
          * <p>
-         * This is the core safety property of {@code ServerDTVImpl} pooling. An adaptive {@code SimpleInputStream} /
+         * This is the core safety property of {@code ServerDTVImpl} reuse. An adaptive {@code SimpleInputStream} /
          * {@code PLPInputStream} captures its owning {@code ServerDTVImpl} and, on {@code close()}, calls
          * {@code setPositionAfterStreamed()} which mutates that impl. Because the driver closes the active stream while
-         * moving off the column (which nulls the stream's back-reference to the impl) BEFORE {@code clear()} pools the
-         * impl, any later user-issued {@code close()} cannot reach the pooled instance. This test deliberately retains
-         * the stream across {@code next()} and closes it late to exercise exactly that ordering; the earlier version
-         * closed the stream before advancing and therefore never covered this path.
+         * moving off the column (which nulls the stream's back-reference to the impl) BEFORE {@code clear()} retains the
+         * impl for reuse, any later user-issued {@code close()} cannot reach the reused instance. This test deliberately
+         * retains the stream across {@code next()} and closes it late to exercise exactly that ordering; the earlier
+         * version closed the stream before advancing and therefore never covered this path.
          */
         @Test
         @Tag(Constants.xAzureSQLDW)
@@ -3083,7 +3083,7 @@ public class ResultSetTest extends AbstractTest {
 
                 // Obtain row 1's adaptive stream and partially read it, but DO NOT close it here. The driver
                 // captures the row-1 ServerDTVImpl inside this stream; we retain the reference across next() so
-                // the eventual close() lands after that impl has been pooled and reused for later rows.
+                // the eventual close() lands after that impl has been reset and reused for later rows.
                 InputStream s1 = rs.getBinaryStream(2);
                 byte[] buf = new byte[128];
                 int read = s1.read(buf);
@@ -3093,19 +3093,19 @@ public class ResultSetTest extends AbstractTest {
                 }
 
                 // Advance. The driver closes the still-open row-1 stream while moving off the column, nulling the
-                // stream's back-reference to the impl before that impl is pooled and reused for row 2.
+                // stream's back-reference to the impl before that impl is reset and reused for row 2.
                 assertTrue(rs.next());
                 assertEquals(2, rs.getInt(1));
                 assertArrayEquals("row 2 corrupted after advancing off a partially-read stream", row2,
                         rs.getBytes(2));
 
-                // Late close of the retained row-1 stream. If pooling introduced an aliasing bug this callback
-                // would mutate the pooled impl now backing later rows; it must be a harmless no-op. A second close
+                // Late close of the retained row-1 stream. If reuse introduced an aliasing bug this callback
+                // would mutate the reused impl now backing later rows; it must be a harmless no-op. A second close
                 // must be equally safe (idempotent).
                 s1.close();
                 s1.close();
 
-                // The pooled/reused impl must still be intact for the remaining rows.
+                // The reused impl must still be intact for the remaining rows.
                 assertTrue(rs.next());
                 assertEquals(3, rs.getInt(1));
                 assertArrayEquals("row 3 corrupted by a late stream close()", row3, rs.getBytes(2));
@@ -3114,10 +3114,10 @@ public class ResultSetTest extends AbstractTest {
         }
 
         /**
-         * Scrollable-cursor variant of the pooling-reuse safety check. With a {@code TYPE_SCROLL_INSENSITIVE} cursor,
-         * obtains and partially reads a stream on row 1, scrolls forward (pooling/reusing the impl), then scrolls back
+         * Scrollable-cursor variant of the instance-reuse safety check. With a {@code TYPE_SCROLL_INSENSITIVE} cursor,
+         * obtains and partially reads a stream on row 1, scrolls forward (resetting/reusing the impl), then scrolls back
          * to row 1 and re-reads the full value. The revisited row must decode byte-for-byte identically, proving the
-         * pooled impl reuse does not corrupt values that are re-read after cursor movement.
+         * reused impl does not corrupt values that are re-read after cursor movement.
          */
         @Test
         @Tag(Constants.xAzureSQLDW)

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -2543,20 +2543,25 @@ public class ResultSetTest extends AbstractTest {
         void resetInventoryStaysInSync() throws Exception {
             Class<?> implClass = Class.forName(SERVER_DTV_IMPL);
             Set<String> actual = new TreeSet<>();
-            for (Field f : implClass.getDeclaredFields()) {
-                int mod = f.getModifiers();
-                // Skip static and final members (constants such as STREAMCONSUMED and any synthetic fields); they do
-                // not hold per-row state and are therefore not reset() responsibilities.
-                if (Modifier.isStatic(mod) || Modifier.isFinal(mod) || f.isSynthetic()) {
-                    continue;
+            // Walk the whole class hierarchy (ServerDTVImpl and its superclass DTVImpl) so a mutable per-row field
+            // added to the superclass cannot silently bypass this tripwire. Any such field would still need to be
+            // cleared before an instance is pooled.
+            for (Class<?> c = implClass; c != null && c != Object.class; c = c.getSuperclass()) {
+                for (Field f : c.getDeclaredFields()) {
+                    int mod = f.getModifiers();
+                    // Skip static and final members (constants such as STREAMCONSUMED and any synthetic fields); they
+                    // do not hold per-row state and are therefore not reset() responsibilities.
+                    if (Modifier.isStatic(mod) || Modifier.isFinal(mod) || f.isSynthetic()) {
+                        continue;
+                    }
+                    actual.add(f.getName());
                 }
-                actual.add(f.getName());
             }
 
             assertEquals(new TreeSet<>(expectedResettableFields), actual,
-                    "ServerDTVImpl mutable instance fields changed. If you added a field, clear it in "
-                            + "ServerDTVImpl.reset() and update expectedResettableFields in this test so pooled "
-                            + "instances cannot leak stale state.");
+                    "ServerDTVImpl (or its DTVImpl superclass) mutable instance fields changed. If you added a "
+                            + "field, clear it in ServerDTVImpl.reset() and update expectedResettableFields in this "
+                            + "test so pooled instances cannot leak stale state.");
         }
 
         private Object newInstance(Class<?> cls) throws Exception {
@@ -3032,18 +3037,29 @@ public class ResultSetTest extends AbstractTest {
         }
 
         /**
-         * An adaptive stream obtained on one row must not corrupt the next row after {@code next()}. Partially reads
-         * row 1's LOB stream, advances (forward-only, adaptive, small {@code packetSize}), then asserts row 2 is
-         * byte-for-byte intact.
+         * A partially-read adaptive stream obtained on one row must not corrupt the next row after {@code next()}, and
+         * a LATE {@code close()} of that retained stream, issued only after the row's {@code ServerDTVImpl} has been
+         * pooled and reused, must be a harmless no-op.
+         *
+         * <p>
+         * This is the core safety property of {@code ServerDTVImpl} pooling. An adaptive {@code SimpleInputStream} /
+         * {@code PLPInputStream} captures its owning {@code ServerDTVImpl} and, on {@code close()}, calls
+         * {@code setPositionAfterStreamed()} which mutates that impl. Because the driver closes the active stream while
+         * moving off the column (which nulls the stream's back-reference to the impl) BEFORE {@code clear()} pools the
+         * impl, any later user-issued {@code close()} cannot reach the pooled instance. This test deliberately retains
+         * the stream across {@code next()} and closes it late to exercise exactly that ordering; the earlier version
+         * closed the stream before advancing and therefore never covered this path.
          */
         @Test
         @Tag(Constants.xAzureSQLDW)
         public void testAdaptiveStreamDoesNotCorruptNextRow() throws Exception {
             byte[] row1 = new byte[6000];
             byte[] row2 = new byte[6000];
+            byte[] row3 = new byte[6000];
             for (int i = 0; i < row1.length; i++) {
                 row1[i] = (byte) (i % 256);
                 row2[i] = (byte) ((i * 7 + 3) % 256);
+                row3[i] = (byte) ((i * 13 + 5) % 256);
             }
 
             try (Connection setupConn = getConnection(); Statement stmt = setupConn.createStatement()) {
@@ -3051,12 +3067,9 @@ public class ResultSetTest extends AbstractTest {
                 stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, b varbinary(max))");
                 try (PreparedStatement pstmt = setupConn
                         .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?)")) {
-                    pstmt.setInt(1, 1);
-                    pstmt.setBytes(2, row1);
-                    pstmt.executeUpdate();
-                    pstmt.setInt(1, 2);
-                    pstmt.setBytes(2, row2);
-                    pstmt.executeUpdate();
+                    insertBinaryRow(pstmt, 1, row1);
+                    insertBinaryRow(pstmt, 2, row2);
+                    insertBinaryRow(pstmt, 3, row3);
                 }
             }
 
@@ -3067,24 +3080,128 @@ public class ResultSetTest extends AbstractTest {
 
                 assertTrue(rs.next());
                 assertEquals(1, rs.getInt(1));
-                // Partially consume row 1's adaptive stream, then advance without finishing it.
-                try (InputStream s1 = rs.getBinaryStream(2)) {
-                    byte[] buf = new byte[128];
-                    int read = s1.read(buf);
-                    assertTrue(read > 0);
-                    for (int i = 0; i < read; i++) {
-                        assertEquals(row1[i], buf[i], "row 1 stream byte " + i + " incorrect");
-                    }
+
+                // Obtain row 1's adaptive stream and partially read it, but DO NOT close it here. The driver
+                // captures the row-1 ServerDTVImpl inside this stream; we retain the reference across next() so
+                // the eventual close() lands after that impl has been pooled and reused for later rows.
+                InputStream s1 = rs.getBinaryStream(2);
+                byte[] buf = new byte[128];
+                int read = s1.read(buf);
+                assertTrue(read > 0);
+                for (int i = 0; i < read; i++) {
+                    assertEquals(row1[i], buf[i], "row 1 stream byte " + i + " incorrect");
                 }
 
-                // Advance: row 2 must read back intact, with no bytes bled from the pooled/reused row-1 state.
+                // Advance. The driver closes the still-open row-1 stream while moving off the column, nulling the
+                // stream's back-reference to the impl before that impl is pooled and reused for row 2.
                 assertTrue(rs.next());
                 assertEquals(2, rs.getInt(1));
-                byte[] actual2 = rs.getBytes(2);
-                assertNotNull(actual2);
-                assertArrayEquals("row 2 corrupted after advancing off a partially-read stream", row2, actual2);
+                assertArrayEquals("row 2 corrupted after advancing off a partially-read stream", row2,
+                        rs.getBytes(2));
+
+                // Late close of the retained row-1 stream. If pooling introduced an aliasing bug this callback
+                // would mutate the pooled impl now backing later rows; it must be a harmless no-op. A second close
+                // must be equally safe (idempotent).
+                s1.close();
+                s1.close();
+
+                // The pooled/reused impl must still be intact for the remaining rows.
+                assertTrue(rs.next());
+                assertEquals(3, rs.getInt(1));
+                assertArrayEquals("row 3 corrupted by a late stream close()", row3, rs.getBytes(2));
                 assertFalse(rs.next());
             }
+        }
+
+        /**
+         * Scrollable-cursor variant of the pooling-reuse safety check. With a {@code TYPE_SCROLL_INSENSITIVE} cursor,
+         * obtains and partially reads a stream on row 1, scrolls forward (pooling/reusing the impl), then scrolls back
+         * to row 1 and re-reads the full value. The revisited row must decode byte-for-byte identically, proving the
+         * pooled impl reuse does not corrupt values that are re-read after cursor movement.
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testScrollableCursorStreamReuseDoesNotCorrupt() throws Exception {
+            byte[] row1 = new byte[6000];
+            byte[] row2 = new byte[6000];
+            for (int i = 0; i < row1.length; i++) {
+                row1[i] = (byte) ((i * 3 + 1) % 256);
+                row2[i] = (byte) ((i * 11 + 9) % 256);
+            }
+
+            try (Connection setupConn = getConnection(); Statement stmt = setupConn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, b varbinary(max))");
+                try (PreparedStatement pstmt = setupConn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?)")) {
+                    insertBinaryRow(pstmt, 1, row1);
+                    insertBinaryRow(pstmt, 2, row2);
+                }
+            }
+
+            try (Connection conn = PrepUtil.getConnection(connectionString);
+                    Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+                            ResultSet.CONCUR_READ_ONLY);
+                    ResultSet rs = stmt.executeQuery("SELECT id, b FROM " + hotPathTable + " ORDER BY id")) {
+
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+                // Partially read row 1's stream, then scroll forward without finishing it.
+                try (InputStream s1 = rs.getBinaryStream(2)) {
+                    byte[] buf = new byte[128];
+                    assertTrue(s1.read(buf) > 0);
+                }
+
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1));
+                assertArrayEquals("row 2 corrupted on scrollable cursor", row2, rs.getBytes(2));
+
+                // Scroll back to row 1 and re-read the full value: it must be intact after the impl was reused.
+                assertTrue(rs.previous());
+                assertEquals(1, rs.getInt(1));
+                assertArrayEquals("row 1 corrupted after scrolling back on a scrollable cursor", row1,
+                        rs.getBytes(2));
+            }
+        }
+
+        /**
+         * Verifies fixed-width {@code CHAR(n)} / {@code NCHAR(n)} values decode identically through the getString()
+         * fast path and preserve the trailing-space padding SQL Server sends on the wire. The narrow-column tests use
+         * {@code char(1)} / {@code nchar(4)}; this widens to {@code char(10)} / {@code nchar(10)} to confirm the direct
+         * {@code new String(bytes, charset)} decode retains all padding bytes rather than trimming them.
+         */
+        @Test
+        public void testGetStringCharPaddingPreserved() throws Exception {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (c char(10), nc nchar(10))");
+                try (PreparedStatement pstmt = conn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?)")) {
+                    pstmt.setString(1, "abc");
+                    pstmt.setString(2, "xy");
+                    pstmt.executeUpdate();
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT c, nc FROM " + hotPathTable)) {
+                    assertTrue(rs.next());
+                    // SQL Server right-pads fixed-width CHAR/NCHAR to the declared width; getString() must return
+                    // the padded value, and the fast path must match the stream path byte-for-byte.
+                    assertEquals("abc" + repeat(' ', 7), rs.getString(1), "char(10) padding not preserved");
+                    assertEquals("xy" + repeat(' ', 8), rs.getString(2), "nchar(10) padding not preserved");
+                }
+            }
+        }
+
+        private void insertBinaryRow(PreparedStatement pstmt, int id, byte[] value) throws SQLException {
+            pstmt.setInt(1, id);
+            pstmt.setBytes(2, value);
+            pstmt.executeUpdate();
+        }
+
+        private String repeat(char c, int count) {
+            char[] chars = new char[count];
+            Arrays.fill(chars, c);
+            return new String(chars);
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -33,7 +35,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Statement;
@@ -44,8 +45,12 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.TreeSet;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
@@ -2481,6 +2486,125 @@ public class ResultSetTest extends AbstractTest {
     }
 
     /**
+     * White-box guard tests for {@code ServerDTVImpl.reset()}.
+     *
+     * {@code ServerDTVImpl} instances are pooled and reused across rows on the read hot path (see {@code DTV.clear()}
+     * / {@code DTV.setImpl()}). {@code reset()} must therefore zero every piece of wire-side state before an instance
+     * is returned to the pool; a field that is added but forgotten in {@code reset()} would leak stale state into the
+     * next row. These tests act as a tripwire so any new field forces {@code reset()} to be revisited.
+     *
+     * The driver types involved ({@code ServerDTVImpl}, {@code TDSReaderMark}, {@code SqlVariant}) are package-private
+     * in {@code com.microsoft.sqlserver.jdbc}, so these tests reach them via reflection. They run purely in-process and
+     * do not require a SQL Server connection.
+     */
+    @Nested
+    class ServerDTVImplResetTests {
+
+        private static final String SERVER_DTV_IMPL = "com.microsoft.sqlserver.jdbc.ServerDTVImpl";
+        private static final String TDS_READER_MARK = "com.microsoft.sqlserver.jdbc.TDSReaderMark";
+        private static final String SQL_VARIANT = "com.microsoft.sqlserver.jdbc.SqlVariant";
+
+        /**
+         * The mutable per-row instance fields that {@code reset()} is responsible for clearing. When adding a field to
+         * {@code ServerDTVImpl}, update BOTH this set and {@code ServerDTVImpl.reset()} together.
+         */
+        private final Set<String> expectedResettableFields = new HashSet<>(
+                Arrays.asList("valueLength", "valueMark", "isNull", "internalVariant"));
+
+        /**
+         * Sets every known field to a non-default value, calls {@code reset()}, and asserts each is back to its type's
+         * default. This verifies {@code reset()} actually clears the state it is supposed to.
+         */
+        @Test
+        void resetClearsAllKnownState() throws Exception {
+            Class<?> implClass = Class.forName(SERVER_DTV_IMPL);
+            Object impl = newInstance(implClass);
+
+            setField(implClass, impl, "valueLength", 4242);
+            setField(implClass, impl, "valueMark", newTdsReaderMark());
+            setField(implClass, impl, "isNull", true);
+            setField(implClass, impl, "internalVariant", newSqlVariant());
+
+            invokeReset(implClass, impl);
+
+            assertEquals(0, getField(implClass, impl, "valueLength"), "valueLength was not cleared by reset()");
+            assertNull("valueMark was not cleared by reset()", getField(implClass, impl, "valueMark"));
+            assertEquals(Boolean.FALSE, getField(implClass, impl, "isNull"), "isNull was not cleared by reset()");
+            assertNull("internalVariant was not cleared by reset()", getField(implClass, impl, "internalVariant"));
+        }
+
+        /**
+         * Tripwire: if the set of mutable instance fields on {@code ServerDTVImpl} changes, this test fails until the
+         * new field is (a) cleared in {@code ServerDTVImpl.reset()} and (b) added to {@code expectedResettableFields}.
+         * This keeps {@code reset()} in sync with the class as it evolves, guarding against silent stale-state bleed
+         * across rows once instances are pooled.
+         */
+        @Test
+        void resetInventoryStaysInSync() throws Exception {
+            Class<?> implClass = Class.forName(SERVER_DTV_IMPL);
+            Set<String> actual = new TreeSet<>();
+            for (Field f : implClass.getDeclaredFields()) {
+                int mod = f.getModifiers();
+                // Skip static and final members (constants such as STREAMCONSUMED and any synthetic fields); they do
+                // not hold per-row state and are therefore not reset() responsibilities.
+                if (Modifier.isStatic(mod) || Modifier.isFinal(mod) || f.isSynthetic()) {
+                    continue;
+                }
+                actual.add(f.getName());
+            }
+
+            assertEquals(new TreeSet<>(expectedResettableFields), actual,
+                    "ServerDTVImpl mutable instance fields changed. If you added a field, clear it in "
+                            + "ServerDTVImpl.reset() and update expectedResettableFields in this test so pooled "
+                            + "instances cannot leak stale state.");
+        }
+
+        private Object newInstance(Class<?> cls) throws Exception {
+            java.lang.reflect.Constructor<?> ctor = cls.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
+        }
+
+        private Object newTdsReaderMark() throws Exception {
+            Class<?> markClass = Class.forName(TDS_READER_MARK);
+            // TDSReaderMark(TDSPacket packet, int payloadOffset)
+            for (java.lang.reflect.Constructor<?> ctor : markClass.getDeclaredConstructors()) {
+                if (ctor.getParameterCount() == 2) {
+                    ctor.setAccessible(true);
+                    return ctor.newInstance(null, 7);
+                }
+            }
+            throw new IllegalStateException("Could not find TDSReaderMark(packet, offset) constructor");
+        }
+
+        private Object newSqlVariant() throws Exception {
+            Class<?> variantClass = Class.forName(SQL_VARIANT);
+            // SqlVariant(int baseType)
+            java.lang.reflect.Constructor<?> ctor = variantClass.getDeclaredConstructor(int.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(0);
+        }
+
+        private void invokeReset(Class<?> cls, Object target) throws Exception {
+            java.lang.reflect.Method reset = cls.getDeclaredMethod("reset");
+            reset.setAccessible(true);
+            reset.invoke(target);
+        }
+
+        private void setField(Class<?> cls, Object target, String name, Object value) throws Exception {
+            Field f = cls.getDeclaredField(name);
+            f.setAccessible(true);
+            f.set(target, value);
+        }
+
+        private Object getField(Class<?> cls, Object target, String name) throws Exception {
+            Field f = cls.getDeclaredField(name);
+            f.setAccessible(true);
+            return f.get(target);
+        }
+    }
+
+    /**
      * Reads a wide (fat) table of 10 rows and 601 columns and asserts the exact value of every cell using the
      * type-specific getter. Each row repeats a group of 20 differently-typed columns 30 times, exercising the
      * ResultSet read path across integer, string, decimal, floating-point, money, datetime and GUID types.
@@ -2489,7 +2613,6 @@ public class ResultSetTest extends AbstractTest {
      */
     @Nested
     class WideRowReadTests {
-
         private static final int GROUP_COUNT = 30; // 20 columns per group
         private static final int COLS_PER_GROUP = 20;
         private static final int NUM_COLUMNS = 1 + GROUP_COUNT * COLS_PER_GROUP;
@@ -2563,7 +2686,8 @@ public class ResultSetTest extends AbstractTest {
                 stmt.setFetchSize(3); // small fetch so the wide rows span multiple round-trips
                 try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + wideTable + " ORDER BY [ID]")) {
                     ResultSetMetaData md = rs.getMetaData();
-                    assertEquals(NUM_COLUMNS, md.getColumnCount());                    // Verify column order/schema, not just the count, so an accidental reorder is caught early.
+                    assertEquals(NUM_COLUMNS, md.getColumnCount());
+                    // Verify column order/schema, not just the count, so an accidental reorder is caught early.
                     assertEquals("ID", md.getColumnName(1));
                     assertEquals("C_INT_1", md.getColumnName(2));
                     assertEquals("C_UID_30", md.getColumnName(NUM_COLUMNS));
@@ -2678,6 +2802,289 @@ public class ResultSetTest extends AbstractTest {
 
         private Timestamp vSmalldatetime(int s) {
             return new Timestamp((1_600_000_020L + s * 60L) * 1000L); // whole minutes
+        }
+    }
+
+    /**
+     * End-to-end tests for the read hot-path optimization in {@code ServerDTVImpl} / {@code DTV} (see {@code dtv.java}):
+     * the {@code getString()} fast-path that decodes small {@code CHAR/VARCHAR/NCHAR/NVARCHAR} values directly to a
+     * {@code String}, and the pooling/reuse of {@code ServerDTVImpl} across rows. Each test creates its own table so
+     * the scenarios are independent.
+     */
+    @Nested
+    class ReadHotPathTests {
+
+        private final String hotPathTable = AbstractSQLGenerator
+                .escapeIdentifier(RandomUtil.getIdentifier("ReadHotPath"));
+
+        @AfterEach
+        public void dropHotPathTable() throws Exception {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+            }
+        }
+
+        /** Builds a deterministic ASCII string of the requested length: char i == 'A' + (i % 26). */
+        private String makeString(int length) {
+            StringBuilder sb = new StringBuilder(length);
+            for (int i = 0; i < length; i++) {
+                sb.append((char) ('A' + (i % 26)));
+            }
+            return sb.toString();
+        }
+
+        /**
+         * {@code getString()} on {@code varchar} at the fast-path byte boundary. Length 4000 uses the direct-decode
+         * fast path, 4001 falls through to the stream path; both must return byte-identical content.
+         */
+        @Test
+        public void testGetStringVarcharBoundary() throws SQLException {
+            int[] lengths = {1, 3999, 4000, 4001, 8000}; // straddles the (0,4000] fast-path guard
+            String[] values = new String[lengths.length];
+
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, v varchar(8000))");
+
+                try (PreparedStatement pstmt = conn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?)")) {
+                    for (int i = 0; i < lengths.length; i++) {
+                        values[i] = makeString(lengths[i]);
+                        pstmt.setInt(1, i);
+                        pstmt.setString(2, values[i]);
+                        pstmt.executeUpdate();
+                    }
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT id, v FROM " + hotPathTable + " ORDER BY id")) {
+                    int i = 0;
+                    while (rs.next()) {
+                        String actual = rs.getString(2);
+                        assertNotNull(actual, "varchar length " + lengths[i] + " returned null");
+                        assertEquals(lengths[i], actual.length(), "varchar length mismatch for row " + i);
+                        assertEquals(values[i], actual, "varchar content mismatch for length " + lengths[i]);
+                        i++;
+                    }
+                    assertEquals(lengths.length, i, "row count mismatch");
+                }
+            }
+        }
+
+        /**
+         * {@code getString()} on {@code nvarchar} at the fast-path byte boundary. 2000 chars == 4000 bytes (fast path),
+         * 2001 chars == 4002 bytes (stream fallback); a non-ASCII char exercises the UTF-16 decode.
+         */
+        @Test
+        public void testGetStringNvarcharBoundary() throws SQLException {
+            int[] charLengths = {1, 1999, 2000, 2001, 4000}; // byte lengths: 2, 3998, 4000, 4002, 8000
+            String[] values = new String[charLengths.length];
+
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, v nvarchar(4000))");
+
+                try (PreparedStatement pstmt = conn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?)")) {
+                    for (int i = 0; i < charLengths.length; i++) {
+                        // Prefix with a non-ASCII BMP char, pad the rest so the total char count is exact.
+                        String body = "\u00e9" + makeString(charLengths[i] - 1);
+                        values[i] = charLengths[i] == 1 ? "\u00e9" : body;
+                        pstmt.setInt(1, i);
+                        pstmt.setNString(2, values[i]);
+                        pstmt.executeUpdate();
+                    }
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT id, v FROM " + hotPathTable + " ORDER BY id")) {
+                    int i = 0;
+                    while (rs.next()) {
+                        String actual = rs.getNString(2);
+                        assertNotNull(actual, "nvarchar char-length " + charLengths[i] + " returned null");
+                        assertEquals(charLengths[i], actual.length(), "nvarchar length mismatch for row " + i);
+                        assertEquals(values[i], actual, "nvarchar content mismatch for char-length " + charLengths[i]);
+                        i++;
+                    }
+                    assertEquals(charLengths.length, i, "row count mismatch");
+                }
+            }
+        }
+
+        /**
+         * A single {@code getString()} value whose bytes span multiple TDS packets (small {@code packetSize}). Verifies
+         * the fast-path decode ({@literal <=} 4000 bytes) and the stream fallback ({@literal >} 4000) both cross packet
+         * boundaries correctly.
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetStringAcrossPacketBoundary() throws SQLException {
+            String fastPathValue = makeString(3000); // <= 4000 bytes -> fast path, but spans many 512-byte packets
+            String streamValue = makeString(6000); // > 4000 bytes -> SimpleInputStream fallback
+
+            try (Connection setupConn = getConnection(); Statement stmt = setupConn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, v varchar(8000))");
+                try (PreparedStatement pstmt = setupConn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?)")) {
+                    pstmt.setInt(1, 0);
+                    pstmt.setString(2, fastPathValue);
+                    pstmt.executeUpdate();
+                    pstmt.setInt(1, 1);
+                    pstmt.setString(2, streamValue);
+                    pstmt.executeUpdate();
+                }
+            }
+
+            // Small packet size forces the wide values to fragment across many TDS packets.
+            try (Connection conn = PrepUtil.getConnection(connectionString + ";packetSize=512");
+                    Statement stmt = conn.createStatement();
+                    ResultSet rs = stmt.executeQuery("SELECT id, v FROM " + hotPathTable + " ORDER BY id")) {
+                assertTrue(rs.next());
+                assertEquals(fastPathValue, rs.getString(2), "fast-path value corrupted across packet boundary");
+                assertTrue(rs.next());
+                assertEquals(streamValue, rs.getString(2), "stream-path value corrupted across packet boundary");
+                assertFalse(rs.next());
+            }
+        }
+
+        /**
+         * Null values must not bleed across pooled {@code ServerDTVImpl} instances. Rows alternate non-null / null /
+         * non-null so a pooled impl is reused across the null (NBCROW) boundary; asserts values and {@code wasNull()}
+         * per row.
+         */
+        @Test
+        public void testNullValueDoesNotBleedAcrossPooledRows() throws SQLException {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable
+                        + " (id int PRIMARY KEY, i int, s varchar(50), d decimal(18,4))");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (0, 111, 'first', 12.3400)");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (1, NULL, NULL, NULL)");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (2, 333, 'third', 56.7800)");
+
+                try (ResultSet rs = stmt.executeQuery("SELECT id, i, s, d FROM " + hotPathTable + " ORDER BY id")) {
+                    assertTrue(rs.next());
+                    assertEquals(111, rs.getInt(2));
+                    assertFalse(rs.wasNull());
+                    assertEquals("first", rs.getString(3));
+                    assertEquals(new BigDecimal("12.3400"), rs.getBigDecimal(4));
+
+                    assertTrue(rs.next());
+                    assertEquals(0, rs.getInt(2));
+                    assertTrue(rs.wasNull(), "int should be null on row 2");
+                    assertNull("varchar should be null on row 2", rs.getString(3));
+                    assertTrue(rs.wasNull());
+                    assertNull("decimal should be null on row 2", rs.getBigDecimal(4));
+                    assertTrue(rs.wasNull());
+
+                    assertTrue(rs.next());
+                    assertEquals(333, rs.getInt(2), "stale value bled into row 3 int");
+                    assertFalse(rs.wasNull(), "row 3 int wrongly reported null (stale isNull)");
+                    assertEquals("third", rs.getString(3), "stale value bled into row 3 varchar");
+                    assertEquals(new BigDecimal("56.7800"), rs.getBigDecimal(4));
+
+                    assertFalse(rs.next());
+                }
+            }
+        }
+
+        /**
+         * The updatable-cursor {@code setImpl} swap (ServerDTVImpl {@literal ->} AppDTVImpl) must pool the outgoing impl
+         * without corrupting later reads. Updates a row, advances, and requeries to confirm both the updated and
+         * untouched rows read back correctly.
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testUpdatableCursorImplSwapPooling() throws SQLException {
+            try (Connection conn = getConnection();
+                    Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+                            ResultSet.CONCUR_UPDATABLE)) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, s varchar(50), n int)");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (1, 'alpha', 10)");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (2, 'beta', 20)");
+
+                try (ResultSet rs = stmt.executeQuery("SELECT id, s, n FROM " + hotPathTable + " ORDER BY id")) {
+                    assertTrue(rs.next());
+                    // Read server values first (populates ServerDTVImpl), then swap via updateXxx.
+                    assertEquals("alpha", rs.getString(2));
+                    assertEquals(10, rs.getInt(3));
+                    rs.updateString(2, "ALPHA-UPDATED");
+                    rs.updateInt(3, 99);
+                    rs.updateRow();
+
+                    // Advancing reuses pooled impls for the next row's server values.
+                    assertTrue(rs.next());
+                    assertEquals("beta", rs.getString(2), "second row corrupted after impl swap/pooling");
+                    assertEquals(20, rs.getInt(3));
+                }
+
+                // Requery to confirm the update persisted and no stale state leaked.
+                try (ResultSet rs = stmt.executeQuery("SELECT id, s, n FROM " + hotPathTable + " ORDER BY id")) {
+                    assertTrue(rs.next());
+                    assertEquals("ALPHA-UPDATED", rs.getString(2));
+                    assertEquals(99, rs.getInt(3));
+                    assertTrue(rs.next());
+                    assertEquals("beta", rs.getString(2));
+                    assertEquals(20, rs.getInt(3));
+                    assertFalse(rs.next());
+                }
+            }
+        }
+
+        /**
+         * An adaptive stream obtained on one row must not corrupt the next row after {@code next()}. Partially reads
+         * row 1's LOB stream, advances (forward-only, adaptive, small {@code packetSize}), then asserts row 2 is
+         * byte-for-byte intact.
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testAdaptiveStreamDoesNotCorruptNextRow() throws Exception {
+            byte[] row1 = new byte[6000];
+            byte[] row2 = new byte[6000];
+            for (int i = 0; i < row1.length; i++) {
+                row1[i] = (byte) (i % 256);
+                row2[i] = (byte) ((i * 7 + 3) % 256);
+            }
+
+            try (Connection setupConn = getConnection(); Statement stmt = setupConn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, b varbinary(max))");
+                try (PreparedStatement pstmt = setupConn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?)")) {
+                    pstmt.setInt(1, 1);
+                    pstmt.setBytes(2, row1);
+                    pstmt.executeUpdate();
+                    pstmt.setInt(1, 2);
+                    pstmt.setBytes(2, row2);
+                    pstmt.executeUpdate();
+                }
+            }
+
+            try (Connection conn = PrepUtil
+                    .getConnection(connectionString + ";responseBuffering=adaptive;packetSize=512");
+                    Statement stmt = conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+                    ResultSet rs = stmt.executeQuery("SELECT id, b FROM " + hotPathTable + " ORDER BY id")) {
+
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+                // Partially consume row 1's adaptive stream, then advance without finishing it.
+                try (InputStream s1 = rs.getBinaryStream(2)) {
+                    byte[] buf = new byte[128];
+                    int read = s1.read(buf);
+                    assertTrue(read > 0);
+                    for (int i = 0; i < read; i++) {
+                        assertEquals(row1[i], buf[i], "row 1 stream byte " + i + " incorrect");
+                    }
+                }
+
+                // Advance: row 2 must read back intact, with no bytes bled from the pooled/reused row-1 state.
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1));
+                byte[] actual2 = rs.getBytes(2);
+                assertNotNull(actual2);
+                assertArrayEquals("row 2 corrupted after advancing off a partially-read stream", row2, actual2);
+                assertFalse(rs.next());
+            }
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -2462,4 +2462,206 @@ public class ResultSetTest extends AbstractTest {
             }
         }
     }
+
+    /**
+     * Reads a wide (fat) table of 10 rows and 601 columns and asserts the exact value of every cell using the
+     * type-specific getter. Each row repeats a group of 20 differently-typed columns 30 times, exercising the
+     * ResultSet read path across integer, string, decimal, floating-point, money, datetime and GUID types.
+     * Every non-null decimal(18,0) value uses an 8-byte magnitude and every decimal(38,4) value uses a
+     * larger-than-8-byte magnitude, so both decimal decode paths are covered.
+     */
+    @Nested
+    class WideRowReadTests {
+
+        private static final int GROUP_COUNT = 30; // 20 columns per group
+        private static final int COLS_PER_GROUP = 20;
+        private static final int NUM_COLUMNS = 1 + GROUP_COUNT * COLS_PER_GROUP;
+        private static final int ROW_COUNT = 10;
+
+        // Column name/type pairs making up one repeating group.
+        private final String[] colNames = {"C_INT", "C_BIGINT", "C_SMALLINT", "C_TINYINT", "C_BIT", "C_CHAR",
+                "C_VARCHAR", "C_NCHAR", "C_NVARCHAR", "C_DEC18", "C_DEC38", "C_NUMERIC", "C_FLOAT", "C_REAL", "C_MONEY",
+                "C_SMALLMONEY", "C_DATETIME", "C_DATETIME2", "C_SMALLDATETIME", "C_UID"};
+        private final String[] colTypes = {"int", "bigint", "smallint", "tinyint", "bit", "char(1)", "varchar(64)",
+                "nchar(4)", "nvarchar(32)", "decimal(18,0)", "decimal(38,4)", "numeric(10,2)", "float", "real", "money",
+                "smallmoney", "datetime", "datetime2", "smalldatetime", "uniqueidentifier"};
+
+        // decimal(18,0) 18-digit value fits an 8-byte magnitude; decimal(38,4) 29-digit value needs more.
+        private final BigDecimal dec18 = new BigDecimal("123456789012345678");
+        private final BigDecimal dec38 = new BigDecimal("1234567890123456789012345.6789");
+        private final String uid = "6F9619FF-8B86-D011-B42D-00CF4FC964FF";
+
+        private final String wideTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("WideRow"));
+
+        @BeforeEach
+        public void createTable() throws Exception {
+            StringBuilder create = new StringBuilder("CREATE TABLE ").append(wideTable)
+                    .append(" ([ID] int NOT NULL PRIMARY KEY");
+            StringBuilder insert = new StringBuilder("INSERT INTO ").append(wideTable).append(" VALUES (?");
+            for (int g = 1; g <= GROUP_COUNT; g++) {
+                for (int i = 0; i < COLS_PER_GROUP; i++) {
+                    create.append(", [").append(colNames[i]).append('_').append(g).append("] ").append(colTypes[i]);
+                    insert.append(",?");
+                }
+            }
+            create.append(")");
+            insert.append(")");
+
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(wideTable, stmt);
+                stmt.execute(create.toString());
+            }
+            try (Connection conn = getConnection();
+                    PreparedStatement pstmt = conn.prepareStatement(insert.toString())) {
+                for (int row = 1; row <= ROW_COUNT; row++) {
+                    int col = 1;
+                    pstmt.setInt(col++, row);
+                    for (int g = 1; g <= GROUP_COUNT; g++) {
+                        int s = seed(row, g);
+                        pstmt.setInt(col++, s);
+                        pstmt.setLong(col++, vLong(s));
+                        pstmt.setShort(col++, vShort(s));
+                        pstmt.setByte(col++, vByte(s));
+                        pstmt.setBoolean(col++, vBit(s));
+                        pstmt.setString(col++, vChar(s));
+                        pstmt.setString(col++, vVarchar(s));
+                        pstmt.setString(col++, vNchar(s));
+                        pstmt.setString(col++, vNvarchar(s));
+                        pstmt.setBigDecimal(col++, dec18);
+                        pstmt.setBigDecimal(col++, dec38);
+                        pstmt.setBigDecimal(col++, vNumeric(s));
+                        pstmt.setDouble(col++, vFloat(s));
+                        pstmt.setFloat(col++, vReal(s));
+                        pstmt.setBigDecimal(col++, vMoney(s));
+                        pstmt.setBigDecimal(col++, vSmallMoney(s));
+                        pstmt.setTimestamp(col++, vDatetime(s));
+                        pstmt.setTimestamp(col++, vDatetime2(s));
+                        pstmt.setTimestamp(col++, vSmalldatetime(s));
+                        pstmt.setString(col++, uid);
+                    }
+                    pstmt.addBatch();
+                }
+                pstmt.executeBatch();
+            }
+        }
+
+        @AfterEach
+        public void dropTable() throws Exception {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(wideTable, stmt);
+            }
+        }
+
+        @Test
+        public void testWideRowMultiTypeRead() throws SQLException {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                stmt.setFetchSize(3); // small fetch so the wide rows span multiple round-trips
+                try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + wideTable + " ORDER BY [ID]")) {
+                    assertEquals(NUM_COLUMNS, rs.getMetaData().getColumnCount());
+
+                    int rowsRead = 0;
+                    while (rs.next()) {
+                        int row = rs.getInt(1);
+                        rowsRead++;
+                        int col = 2;
+                        for (int g = 1; g <= GROUP_COUNT; g++) {
+                            int s = seed(row, g);
+                            String m = " at row " + row + " group " + g;
+                            assertEquals(s, rs.getInt(col++), "int" + m);
+                            assertEquals(vLong(s), rs.getLong(col++), "bigint" + m);
+                            assertEquals(vShort(s), rs.getShort(col++), "smallint" + m);
+                            assertEquals(vByte(s), rs.getByte(col++), "tinyint" + m);
+                            assertEquals(vBit(s), rs.getBoolean(col++), "bit" + m);
+                            assertEquals(vChar(s), rs.getString(col++), "char" + m);
+                            assertEquals(vVarchar(s), rs.getString(col++), "varchar" + m);
+                            assertEquals(vNchar(s), rs.getString(col++), "nchar" + m);
+                            assertEquals(vNvarchar(s), rs.getString(col++), "nvarchar" + m);
+                            assertEquals(dec18, rs.getBigDecimal(col++), "decimal(18,0)" + m);
+                            assertEquals(dec38, rs.getBigDecimal(col++), "decimal(38,4)" + m);
+                            assertEquals(vNumeric(s), rs.getBigDecimal(col++), "numeric" + m);
+                            assertEquals(vFloat(s), rs.getDouble(col++), 0.0, "float" + m);
+                            assertEquals(vReal(s), rs.getFloat(col++), 0.0f, "real" + m);
+                            assertEquals(vMoney(s), rs.getBigDecimal(col++), "money" + m);
+                            assertEquals(vSmallMoney(s), rs.getBigDecimal(col++), "smallmoney" + m);
+                            assertEquals(vDatetime(s), rs.getTimestamp(col++), "datetime" + m);
+                            assertEquals(vDatetime2(s), rs.getTimestamp(col++), "datetime2" + m);
+                            assertEquals(vSmalldatetime(s), rs.getTimestamp(col++), "smalldatetime" + m);
+                            assertEquals(uid, rs.getString(col++), "uniqueidentifier" + m);
+                        }
+                    }
+                    assertEquals(ROW_COUNT, rowsRead);
+                }
+            }
+        }
+
+        private int seed(int row, int group) {
+            return row * 31 + group;
+        }
+
+        private long vLong(int s) {
+            return s * 100000L + 12345L;
+        }
+
+        private short vShort(int s) {
+            return (short) (s % 20000);
+        }
+
+        private byte vByte(int s) {
+            return (byte) (s % 100);
+        }
+
+        private boolean vBit(int s) {
+            return s % 2 == 0;
+        }
+
+        private String vChar(int s) {
+            return s % 2 == 0 ? "A" : "B";
+        }
+
+        private String vVarchar(int s) {
+            return "v" + s;
+        }
+
+        private String vNchar(int s) {
+            return "n" + String.format("%03d", s % 1000); // exactly 4 chars, no nchar padding
+        }
+
+        private String vNvarchar(int s) {
+            return "w" + s;
+        }
+
+        private BigDecimal vNumeric(int s) {
+            return new BigDecimal(s + ".25");
+        }
+
+        private double vFloat(int s) {
+            return s + 0.5;
+        }
+
+        private float vReal(int s) {
+            return s + 0.25f;
+        }
+
+        private BigDecimal vMoney(int s) {
+            return new BigDecimal(s + ".1234");
+        }
+
+        private BigDecimal vSmallMoney(int s) {
+            return new BigDecimal((s % 1000) + ".5000");
+        }
+
+        private Timestamp vDatetime(int s) {
+            return new Timestamp((1_600_000_000L + s * 7L) * 1000L); // whole seconds
+        }
+
+        private Timestamp vDatetime2(int s) {
+            Timestamp ts = new Timestamp((1_600_000_000L + s * 11L) * 1000L);
+            ts.setNanos(123456700); // multiple of 100ns, exact for datetime2(7)
+            return ts;
+        }
+
+        private Timestamp vSmalldatetime(int s) {
+            return new Timestamp((1_600_000_020L + s * 60L) * 1000L); // whole minutes
+        }
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -31,6 +31,7 @@ import java.sql.DriverManager;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
@@ -84,6 +85,22 @@ public class ResultSetTest extends AbstractTest {
     private static final int expectedErrorCode = 8134;
 
     static final String uuid = UUID.randomUUID().toString();
+
+    /*
+     * Shared constants for WideRowReadTests. Declared here (top-level class) rather than in the @Nested inner class
+     * because a non-static @Nested class cannot declare non-constant static fields (arrays, BigDecimal) on jre8.
+     */
+    private static final String[] WIDE_COL_NAMES = {"C_INT", "C_BIGINT", "C_SMALLINT", "C_TINYINT", "C_BIT", "C_CHAR",
+            "C_VARCHAR", "C_NCHAR", "C_NVARCHAR", "C_DEC18", "C_DEC38", "C_NUMERIC", "C_FLOAT", "C_REAL", "C_MONEY",
+            "C_SMALLMONEY", "C_DATETIME", "C_DATETIME2", "C_SMALLDATETIME", "C_UID"};
+    private static final String[] WIDE_COL_TYPES = {"int", "bigint", "smallint", "tinyint", "bit", "char(1)",
+            "varchar(64)", "nchar(4)", "nvarchar(32)", "decimal(18,0)", "decimal(38,4)", "numeric(10,2)", "float",
+            "real", "money", "smallmoney", "datetime", "datetime2", "smalldatetime", "uniqueidentifier"};
+
+    // decimal(18,0) 18-digit value fits an 8-byte magnitude; decimal(38,4) 29-digit value needs more.
+    private static final BigDecimal DEC18 = new BigDecimal("123456789012345678");
+    private static final BigDecimal DEC38 = new BigDecimal("1234567890123456789012345.6789");
+    private static final String UID = "6F9619FF-8B86-D011-B42D-00CF4FC964FF";
 
     @BeforeAll
     public static void setupTests() throws Exception {
@@ -2478,19 +2495,6 @@ public class ResultSetTest extends AbstractTest {
         private static final int NUM_COLUMNS = 1 + GROUP_COUNT * COLS_PER_GROUP;
         private static final int ROW_COUNT = 10;
 
-        // Column name/type pairs making up one repeating group.
-        private final String[] colNames = {"C_INT", "C_BIGINT", "C_SMALLINT", "C_TINYINT", "C_BIT", "C_CHAR",
-                "C_VARCHAR", "C_NCHAR", "C_NVARCHAR", "C_DEC18", "C_DEC38", "C_NUMERIC", "C_FLOAT", "C_REAL", "C_MONEY",
-                "C_SMALLMONEY", "C_DATETIME", "C_DATETIME2", "C_SMALLDATETIME", "C_UID"};
-        private final String[] colTypes = {"int", "bigint", "smallint", "tinyint", "bit", "char(1)", "varchar(64)",
-                "nchar(4)", "nvarchar(32)", "decimal(18,0)", "decimal(38,4)", "numeric(10,2)", "float", "real", "money",
-                "smallmoney", "datetime", "datetime2", "smalldatetime", "uniqueidentifier"};
-
-        // decimal(18,0) 18-digit value fits an 8-byte magnitude; decimal(38,4) 29-digit value needs more.
-        private final BigDecimal dec18 = new BigDecimal("123456789012345678");
-        private final BigDecimal dec38 = new BigDecimal("1234567890123456789012345.6789");
-        private final String uid = "6F9619FF-8B86-D011-B42D-00CF4FC964FF";
-
         private final String wideTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("WideRow"));
 
         @BeforeEach
@@ -2500,7 +2504,8 @@ public class ResultSetTest extends AbstractTest {
             StringBuilder insert = new StringBuilder("INSERT INTO ").append(wideTable).append(" VALUES (?");
             for (int g = 1; g <= GROUP_COUNT; g++) {
                 for (int i = 0; i < COLS_PER_GROUP; i++) {
-                    create.append(", [").append(colNames[i]).append('_').append(g).append("] ").append(colTypes[i]);
+                    create.append(", [").append(WIDE_COL_NAMES[i]).append('_').append(g).append("] ")
+                            .append(WIDE_COL_TYPES[i]);
                     insert.append(",?");
                 }
             }
@@ -2527,8 +2532,8 @@ public class ResultSetTest extends AbstractTest {
                         pstmt.setString(col++, vVarchar(s));
                         pstmt.setString(col++, vNchar(s));
                         pstmt.setString(col++, vNvarchar(s));
-                        pstmt.setBigDecimal(col++, dec18);
-                        pstmt.setBigDecimal(col++, dec38);
+                        pstmt.setBigDecimal(col++, DEC18);
+                        pstmt.setBigDecimal(col++, DEC38);
                         pstmt.setBigDecimal(col++, vNumeric(s));
                         pstmt.setDouble(col++, vFloat(s));
                         pstmt.setFloat(col++, vReal(s));
@@ -2537,7 +2542,7 @@ public class ResultSetTest extends AbstractTest {
                         pstmt.setTimestamp(col++, vDatetime(s));
                         pstmt.setTimestamp(col++, vDatetime2(s));
                         pstmt.setTimestamp(col++, vSmalldatetime(s));
-                        pstmt.setString(col++, uid);
+                        pstmt.setString(col++, UID);
                     }
                     pstmt.addBatch();
                 }
@@ -2557,7 +2562,18 @@ public class ResultSetTest extends AbstractTest {
             try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
                 stmt.setFetchSize(3); // small fetch so the wide rows span multiple round-trips
                 try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + wideTable + " ORDER BY [ID]")) {
-                    assertEquals(NUM_COLUMNS, rs.getMetaData().getColumnCount());
+                    ResultSetMetaData md = rs.getMetaData();
+                    assertEquals(NUM_COLUMNS, md.getColumnCount());                    // Verify column order/schema, not just the count, so an accidental reorder is caught early.
+                    assertEquals("ID", md.getColumnName(1));
+                    assertEquals("C_INT_1", md.getColumnName(2));
+                    assertEquals("C_UID_30", md.getColumnName(NUM_COLUMNS));
+                    for (int g = 1; g <= GROUP_COUNT; g++) {
+                        for (int i = 0; i < COLS_PER_GROUP; i++) {
+                            int idx = 1 + (g - 1) * COLS_PER_GROUP + i + 1;
+                            assertEquals(WIDE_COL_NAMES[i] + "_" + g, md.getColumnName(idx),
+                                    "column name mismatch at index " + idx);
+                        }
+                    }
 
                     int rowsRead = 0;
                     while (rs.next()) {
@@ -2566,27 +2582,27 @@ public class ResultSetTest extends AbstractTest {
                         int col = 2;
                         for (int g = 1; g <= GROUP_COUNT; g++) {
                             int s = seed(row, g);
-                            String m = " at row " + row + " group " + g;
-                            assertEquals(s, rs.getInt(col++), "int" + m);
-                            assertEquals(vLong(s), rs.getLong(col++), "bigint" + m);
-                            assertEquals(vShort(s), rs.getShort(col++), "smallint" + m);
-                            assertEquals(vByte(s), rs.getByte(col++), "tinyint" + m);
-                            assertEquals(vBit(s), rs.getBoolean(col++), "bit" + m);
-                            assertEquals(vChar(s), rs.getString(col++), "char" + m);
-                            assertEquals(vVarchar(s), rs.getString(col++), "varchar" + m);
-                            assertEquals(vNchar(s), rs.getString(col++), "nchar" + m);
-                            assertEquals(vNvarchar(s), rs.getString(col++), "nvarchar" + m);
-                            assertEquals(dec18, rs.getBigDecimal(col++), "decimal(18,0)" + m);
-                            assertEquals(dec38, rs.getBigDecimal(col++), "decimal(38,4)" + m);
-                            assertEquals(vNumeric(s), rs.getBigDecimal(col++), "numeric" + m);
-                            assertEquals(vFloat(s), rs.getDouble(col++), 0.0, "float" + m);
-                            assertEquals(vReal(s), rs.getFloat(col++), 0.0f, "real" + m);
-                            assertEquals(vMoney(s), rs.getBigDecimal(col++), "money" + m);
-                            assertEquals(vSmallMoney(s), rs.getBigDecimal(col++), "smallmoney" + m);
-                            assertEquals(vDatetime(s), rs.getTimestamp(col++), "datetime" + m);
-                            assertEquals(vDatetime2(s), rs.getTimestamp(col++), "datetime2" + m);
-                            assertEquals(vSmalldatetime(s), rs.getTimestamp(col++), "smalldatetime" + m);
-                            assertEquals(uid, rs.getString(col++), "uniqueidentifier" + m);
+                            String message = " at row " + row + " group " + g;
+                            assertEquals(s, rs.getInt(col++), "int" + message);
+                            assertEquals(vLong(s), rs.getLong(col++), "bigint" + message);
+                            assertEquals(vShort(s), rs.getShort(col++), "smallint" + message);
+                            assertEquals(vByte(s), rs.getByte(col++), "tinyint" + message);
+                            assertEquals(vBit(s), rs.getBoolean(col++), "bit" + message);
+                            assertEquals(vChar(s), rs.getString(col++), "char" + message);
+                            assertEquals(vVarchar(s), rs.getString(col++), "varchar" + message);
+                            assertEquals(vNchar(s), rs.getString(col++), "nchar" + message);
+                            assertEquals(vNvarchar(s), rs.getString(col++), "nvarchar" + message);
+                            assertEquals(DEC18, rs.getBigDecimal(col++), "decimal(18,0)" + message);
+                            assertEquals(DEC38, rs.getBigDecimal(col++), "decimal(38,4)" + message);
+                            assertEquals(vNumeric(s), rs.getBigDecimal(col++), "numeric" + message);
+                            assertEquals(vFloat(s), rs.getDouble(col++), 0.0, "float" + message);
+                            assertEquals(vReal(s), rs.getFloat(col++), 0.0f, "real" + message);
+                            assertEquals(vMoney(s), rs.getBigDecimal(col++), "money" + message);
+                            assertEquals(vSmallMoney(s), rs.getBigDecimal(col++), "smallmoney" + message);
+                            assertEquals(vDatetime(s), rs.getTimestamp(col++), "datetime" + message);
+                            assertEquals(vDatetime2(s), rs.getTimestamp(col++), "datetime2" + message);
+                            assertEquals(vSmalldatetime(s), rs.getTimestamp(col++), "smalldatetime" + message);
+                            assertEquals(UID, rs.getString(col++), "uniqueidentifier" + message);
                         }
                     }
                     assertEquals(ROW_COUNT, rowsRead);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/resultset/ResultSetStateTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/resultset/ResultSetStateTest.java
@@ -13,11 +13,14 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.InputStream;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,6 +66,13 @@ public class ResultSetStateTest extends AbstractTest {
     private static final StateKey IS_UPDATABLE = () -> "isUpdatable";
     private static final StateKey IS_SCROLLABLE = () -> "isScrollable";
     private static final StateKey ROW_DELETED = () -> "rowDeleted";
+
+    // State keys used by the pooling / stream-aliasing tests (PR #2974 read hot-path).
+    private static final StateKey RETAINED_STREAM = () -> "retainedStream";
+    private static final StateKey RETAINED_EXPECTED = () -> "retainedExpected";
+    // Row on which the single-access LOB column ("b") was last touched, so no two actions read it twice on the same
+    // row (which would throw R_dataAlreadyAccessed on a forward-only adaptive cursor). -1 = not yet touched.
+    private static final StateKey B_ACCESSED_ROW = () -> "bAccessedRow";
 
     @BeforeAll
     static void setupTests() throws Exception {
@@ -127,7 +137,239 @@ public class ResultSetStateTest extends AbstractTest {
         }
     }
 
-    /** Verifies current row data against expected DataCache values. */
+    /**
+     * MBT pooling-reuse across wire types (PR #2974 read hot-path): randomized navigation over a table mixing
+     * VARCHAR, NVARCHAR, DECIMAL and a nullable INT, validating value and wasNull() every row. Catches a pooled
+     * ServerDTVImpl that fails to reset valueLength/isNull between the 1-byte and 2-byte charset fast paths,
+     * decimal decode, and null/non-null cells.
+     */
+    @Test
+    @DisplayName("Randomized Pooling Reuse Across Types and NULLs")
+    void testPoolingReuseAcrossTypesAndNulls() throws SQLException {
+        Assumptions.assumeTrue(connectionString != null, "No database connection configured");
+
+        StateMachineTest sm = new StateMachineTest("PoolingReuse");
+        DataCache cache = sm.getDataCache();
+
+        cache.updateValue(0, CLOSED.key(), false);
+        cache.updateValue(0, ON_VALID_ROW.key(), false);
+        cache.updateValue(0, CURRENT_ROW.key(), 0);
+
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(TABLE_NAME, stmt);
+            stmt.execute("CREATE TABLE " + TABLE_NAME
+                    + " (id INT PRIMARY KEY, name VARCHAR(50), nname NVARCHAR(100), dec DECIMAL(18,4), nval INT NULL)");
+
+            try (PreparedStatement pstmt = connection
+                    .prepareStatement("INSERT INTO " + TABLE_NAME + " VALUES (?, ?, ?, ?, ?)")) {
+                for (int i = 1; i <= 10; i++) {
+                    String name = "Row" + i;
+                    // Non-ASCII char forces the UTF-16 decoder on the NVARCHAR fast path.
+                    String nname = "N\u00e9" + i;
+                    BigDecimal dec = new BigDecimal(i * 100 + ".1234");
+                    // Every third row stores NULL to force NBCROW null-compression and null-bleed reuse.
+                    Integer nval = (i % 3 == 0) ? null : i * 7;
+
+                    pstmt.setInt(1, i);
+                    pstmt.setString(2, name);
+                    pstmt.setNString(3, nname);
+                    pstmt.setBigDecimal(4, dec);
+                    if (nval == null) {
+                        pstmt.setNull(5, java.sql.Types.INTEGER);
+                    } else {
+                        pstmt.setInt(5, nval);
+                    }
+                    pstmt.executeUpdate();
+
+                    Map<String, Object> row = new HashMap<>();
+                    row.put("id", i);
+                    row.put("name", name);
+                    row.put("nname", nname);
+                    row.put("dec", dec);
+                    row.put("nval", nval);
+                    cache.addRow(row);
+                }
+            }
+        }
+
+        try (Connection conn = PrepUtil.getConnection(connectionString);
+                Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+                ResultSet rs = stmt.executeQuery("SELECT * FROM " + TABLE_NAME + " ORDER BY id")) {
+
+            cache.updateValue(0, RS.key(), rs);
+
+            sm.addAction(new NextAction(10));
+            sm.addAction(new PreviousAction(8));
+            sm.addAction(new FirstAction(5));
+            sm.addAction(new LastAction(5));
+            sm.addAction(new AbsoluteAction(6));
+            sm.addAction(new GetStringColumnAction("name", 8));
+            sm.addAction(new GetStringColumnAction("nname", 8)); // NVARCHAR fast path
+            sm.addAction(new GetBigDecimalColumnAction("dec", 6)); // decimal decode reuse
+            sm.addAction(new GetNullableIntAction("nval", 8)); // null-bleed across pooled reuse
+            sm.addAction(new CloseAction(1));
+
+            Result result = Engine.run(sm).withMaxActions(150).execute();
+
+            System.out.println("Pooling-reuse test: " + result.actionCount + " actions");
+            assertTrue(result.isSuccess(), "Pooling reuse across types/NULLs should complete successfully");
+        }
+    }
+
+    /**
+     * MBT stream-aliasing under pooling (PR #2974): on a forward-only adaptive cursor, randomly retains a binary
+     * stream (partial read, no close), advances so its ServerDTVImpl is pooled and reused, then closes the retained
+     * stream late. The late close must be a harmless no-op; every full read validates the current row against the
+     * DataCache so any aliasing corruption surfaces immediately.
+     */
+    @Test
+    @DisplayName("Randomized Stream Aliasing Under Pooling")
+    void testStreamAliasingUnderPooling() throws SQLException {
+        Assumptions.assumeTrue(connectionString != null, "No database connection configured");
+
+        StateMachineTest sm = new StateMachineTest("StreamAliasing");
+        DataCache cache = sm.getDataCache();
+
+        cache.updateValue(0, CLOSED.key(), false);
+        cache.updateValue(0, ON_VALID_ROW.key(), false);
+        cache.updateValue(0, CURRENT_ROW.key(), 0);
+
+        final int rowCount = 12;
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(TABLE_NAME, stmt);
+            stmt.execute("CREATE TABLE " + TABLE_NAME + " (id INT PRIMARY KEY, name VARCHAR(50), b VARBINARY(MAX))");
+
+            try (PreparedStatement pstmt = connection
+                    .prepareStatement("INSERT INTO " + TABLE_NAME + " VALUES (?, ?, ?)")) {
+                for (int i = 1; i <= rowCount; i++) {
+                    String name = "Row" + i;
+                    byte[] b = makeBytes(i, 3000);
+                    pstmt.setInt(1, i);
+                    pstmt.setString(2, name);
+                    pstmt.setBytes(3, b);
+                    pstmt.executeUpdate();
+
+                    Map<String, Object> row = new HashMap<>();
+                    row.put("id", i);
+                    row.put("name", name);
+                    row.put("b", b);
+                    cache.addRow(row);
+                }
+            }
+        }
+
+        // Forward-only + adaptive response buffering is the configuration that returns adaptive streams whose late
+        // close() mutates the (now pooled) impl - exactly the aliasing path under test.
+        try (Connection conn = PrepUtil.getConnection(connectionString + ";responseBuffering=adaptive;packetSize=512");
+                Statement stmt = conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+                ResultSet rs = stmt.executeQuery("SELECT id, name, b FROM " + TABLE_NAME + " ORDER BY id")) {
+
+            cache.updateValue(0, RS.key(), rs);
+            cache.updateValue(0, B_ACCESSED_ROW.key(), -1);
+
+            sm.addAction(new ForwardNextAction(10)); // advance; validates only id + name (leaves the LOB to b-actions)
+            sm.addAction(new RetainBinaryStreamAction("b", 8)); // retain, partial read, DO NOT close
+            sm.addAction(new LateCloseRetainedStreamAction(6)); // close the retained stream late (no-op expected)
+            sm.addAction(new GetStringColumnAction("name", 8)); // synchronous getString on the (possibly reused) impl
+            sm.addAction(new GetBytesColumnAction("b", 6)); // full binary read validates row integrity
+
+            Result result = Engine.run(sm).withMaxActions(150).execute();
+
+            System.out.println("Stream-aliasing test: " + result.actionCount + " actions");
+            assertTrue(result.isSuccess(), "Stream aliasing under pooling should complete successfully");
+        }
+    }
+
+    /**
+     * MBT pooling reuse via the NBCROW null-compression path (PR #2974): a default result set with several nullable
+     * INT columns emits null-compressed rows, so null cells reach the pool through initFromCompressedNull() rather
+     * than a value read. Randomly reads string and nullable-int columns, asserting value and wasNull() every row to
+     * catch a pooled impl leaking a stale isNull across the compressed-null boundary.
+     */
+    @Test
+    @DisplayName("Randomized Pooling Reuse With NBCROW NULLs")
+    void testPoolingReuseWithNbcRowNulls() throws SQLException {
+        Assumptions.assumeTrue(connectionString != null, "No database connection configured");
+
+        StateMachineTest sm = new StateMachineTest("NbcRowPooling");
+        DataCache cache = sm.getDataCache();
+
+        cache.updateValue(0, CLOSED.key(), false);
+        cache.updateValue(0, ON_VALID_ROW.key(), false);
+        cache.updateValue(0, CURRENT_ROW.key(), 0);
+
+        final int rowCount = 20;
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(TABLE_NAME, stmt);
+            stmt.execute("CREATE TABLE " + TABLE_NAME
+                    + " (id INT PRIMARY KEY, name VARCHAR(50), a INT NULL, b INT NULL, c INT NULL)");
+
+            try (PreparedStatement pstmt = connection
+                    .prepareStatement("INSERT INTO " + TABLE_NAME + " VALUES (?, ?, ?, ?, ?)")) {
+                for (int i = 1; i <= rowCount; i++) {
+                    String name = "Row" + i;
+                    // Vary which columns are NULL per row so the null-compression bitmap changes and pooled impls are
+                    // reused across mixed null/non-null cells.
+                    Integer a = (i % 2 == 0) ? null : i;
+                    Integer b = (i % 3 == 0) ? null : i * 2;
+                    Integer c = (i % 4 == 0) ? null : i * 3;
+
+                    pstmt.setInt(1, i);
+                    pstmt.setString(2, name);
+                    setNullableInt(pstmt, 3, a);
+                    setNullableInt(pstmt, 4, b);
+                    setNullableInt(pstmt, 5, c);
+                    pstmt.executeUpdate();
+
+                    Map<String, Object> row = new HashMap<>();
+                    row.put("id", i);
+                    row.put("name", name);
+                    row.put("a", a);
+                    row.put("b", b);
+                    row.put("c", c);
+                    cache.addRow(row);
+                }
+            }
+        }
+
+        // Default result set (no scroll/updatable) -> NBCROW null compression is used.
+        try (Connection conn = PrepUtil.getConnection(connectionString);
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT id, name, a, b, c FROM " + TABLE_NAME + " ORDER BY id")) {
+
+            cache.updateValue(0, RS.key(), rs);
+
+            sm.addAction(new ForwardNextAction(10));
+            sm.addAction(new GetStringColumnAction("name", 6));
+            sm.addAction(new GetNullableIntAction("a", 8));
+            sm.addAction(new GetNullableIntAction("b", 8));
+            sm.addAction(new GetNullableIntAction("c", 8));
+
+            Result result = Engine.run(sm).withMaxActions(200).execute();
+
+            System.out.println("NBCROW-pooling test: " + result.actionCount + " actions");
+            assertTrue(result.isSuccess(), "Pooling reuse with NBCROW NULLs should complete successfully");
+        }
+    }
+
+    private static void setNullableInt(PreparedStatement pstmt, int idx, Integer v) throws SQLException {
+        if (v == null) {
+            pstmt.setNull(idx, java.sql.Types.INTEGER);
+        } else {
+            pstmt.setInt(idx, v);
+        }
+    }
+
+    /** Builds a deterministic byte[] of the given length: byte j == (seed * 31 + j) mod 256. */
+    private static byte[] makeBytes(int seed, int length) {
+        byte[] b = new byte[length];
+        for (int j = 0; j < length; j++) {
+            b[j] = (byte) ((seed * 31 + j) % 256);
+        }
+        return b;
+    }
+
+
     private static void verifyCurrentRow(Action action, ResultSet rs) throws SQLException {
         DataCache cache = action.getDataCache();
         if (cache == null || cache.getRowCount() <= 1) {
@@ -149,8 +391,19 @@ public class ResultSetStateTest extends AbstractTest {
             Object expected = entry.getValue();
             Object actual = rs.getObject(columnName);
 
-            action.assertExpected(actual, expected,
-                    String.format("Row %d column '%s' mismatch", currentRow, columnName));
+            if (expected instanceof byte[] || actual instanceof byte[]) {
+                // byte[] must be compared by content, not reference.
+                action.assertExpected(Arrays.equals((byte[]) expected, (byte[]) actual), true,
+                        String.format("Row %d column '%s' byte[] mismatch", currentRow, columnName));
+            } else if (expected instanceof BigDecimal && actual instanceof BigDecimal) {
+                // Compare decimals scale-insensitively.
+                action.assertExpected(((BigDecimal) expected).compareTo((BigDecimal) actual) == 0, true,
+                        String.format("Row %d column '%s' decimal mismatch: expected %s got %s", currentRow,
+                                columnName, expected, actual));
+            } else {
+                action.assertExpected(actual, expected,
+                        String.format("Row %d column '%s' mismatch", currentRow, columnName));
+            }
         }
     }
 
@@ -444,7 +697,300 @@ public class ResultSetStateTest extends AbstractTest {
         }
     }
 
+    // ==================== PR #2974 read hot-path pooling actions ====================
+
+    /**
+     * Forward-only advance validating only the fixed-length columns (id, name). It leaves the single-access LOB
+     * column to the dedicated stream/getBytes actions so a row's LOB is never accessed twice (which would throw
+     * R_dataAlreadyAccessed on a forward-only adaptive cursor).
+     */
+    private static class ForwardNextAction extends Action {
+
+        ForwardNextAction(int weight) {
+            super("forwardNext", weight);
+        }
+
+        @Override
+        public boolean canRun() {
+            return !isState(CLOSED);
+        }
+
+        @Override
+        public void run() throws SQLException {
+            ResultSet rs = (ResultSet) getState(RS);
+            boolean valid = rs.next();
+            setState(ON_VALID_ROW, valid);
+            setState(CURRENT_ROW, valid ? rs.getRow() : 0);
+            setState(ROW_DELETED, false);
+            System.out.println("forwardNext() -> " + valid + (valid ? " row=" + getStateInt(CURRENT_ROW) : ""));
+        }
+
+        @Override
+        public void validate() throws SQLException {
+            if (!isState(ON_VALID_ROW) || !hasDataCache()) {
+                return;
+            }
+            ResultSet rs = (ResultSet) getState(RS);
+            int currentRow = getStateInt(CURRENT_ROW);
+            if (currentRow >= 1 && currentRow < dataCache.getRowCount()) {
+                assertExpected(rs.getInt("id"), ((Number) dataCache.getValue(currentRow, "id")).intValue(),
+                        String.format("id mismatch at row %d", currentRow));
+                Object expectedName = dataCache.getValue(currentRow, "name");
+                if (expectedName != null) {
+                    assertExpected(rs.getString("name"), expectedName.toString(),
+                            String.format("name mismatch at row %d", currentRow));
+                }
+            }
+        }
+    }
+
+    /** Reads getString(column) and validates against DataCache. Exercises the getString() fast path. */
+    private static class GetStringColumnAction extends Action {
+        private final String column;
+        private String lastValue;
+
+        GetStringColumnAction(String column, int weight) {
+            super("getString[" + column + "]", weight);
+            this.column = column;
+        }
+
+        @Override
+        public boolean canRun() {
+            return !isState(CLOSED) && isState(ON_VALID_ROW) && !isState(ROW_DELETED);
+        }
+
+        @Override
+        public void run() throws SQLException {
+            ResultSet rs = (ResultSet) getState(RS);
+            lastValue = rs.getString(column);
+        }
+
+        @Override
+        public void validate() throws SQLException {
+            if (!hasDataCache())
+                return;
+            int currentRow = getStateInt(CURRENT_ROW);
+            if (currentRow >= 1 && currentRow < dataCache.getRowCount()) {
+                Object expected = dataCache.getValue(currentRow, column);
+                String expectedStr = (expected == null) ? null : expected.toString();
+                assertExpected(lastValue, expectedStr,
+                        String.format("getString('%s') mismatch at row %d", column, currentRow));
+            }
+        }
+    }
+
+    /** Reads getBigDecimal(column) and validates (scale-insensitive) against DataCache. Exercises decimal decode. */
+    private static class GetBigDecimalColumnAction extends Action {
+        private final String column;
+        private BigDecimal lastValue;
+
+        GetBigDecimalColumnAction(String column, int weight) {
+            super("getBigDecimal[" + column + "]", weight);
+            this.column = column;
+        }
+
+        @Override
+        public boolean canRun() {
+            return !isState(CLOSED) && isState(ON_VALID_ROW) && !isState(ROW_DELETED);
+        }
+
+        @Override
+        public void run() throws SQLException {
+            ResultSet rs = (ResultSet) getState(RS);
+            lastValue = rs.getBigDecimal(column);
+        }
+
+        @Override
+        public void validate() throws SQLException {
+            if (!hasDataCache())
+                return;
+            int currentRow = getStateInt(CURRENT_ROW);
+            if (currentRow >= 1 && currentRow < dataCache.getRowCount()) {
+                Object expected = dataCache.getValue(currentRow, column);
+                if (expected == null) {
+                    assertExpected(lastValue, null,
+                            String.format("getBigDecimal('%s') expected NULL at row %d", column, currentRow));
+                } else {
+                    assertTrue(lastValue != null && ((BigDecimal) expected).compareTo(lastValue) == 0,
+                            String.format("getBigDecimal('%s') mismatch at row %d: expected %s got %s", column,
+                                    currentRow, expected, lastValue));
+                }
+            }
+        }
+    }
+
+    /** Reads a nullable INT via getObject and validates value and wasNull(); guards against stale pooled isNull. */
+    private static class GetNullableIntAction extends Action {
+        private final String column;
+        private Object lastValue;
+        private boolean lastWasNull;
+
+        GetNullableIntAction(String column, int weight) {
+            super("getNullableInt[" + column + "]", weight);
+            this.column = column;
+        }
+
+        @Override
+        public boolean canRun() {
+            return !isState(CLOSED) && isState(ON_VALID_ROW) && !isState(ROW_DELETED);
+        }
+
+        @Override
+        public void run() throws SQLException {
+            ResultSet rs = (ResultSet) getState(RS);
+            lastValue = rs.getObject(column);
+            lastWasNull = rs.wasNull();
+        }
+
+        @Override
+        public void validate() throws SQLException {
+            if (!hasDataCache())
+                return;
+            int currentRow = getStateInt(CURRENT_ROW);
+            if (currentRow >= 1 && currentRow < dataCache.getRowCount()) {
+                Object expected = dataCache.getValue(currentRow, column);
+                boolean expectedNull = (expected == null);
+                assertExpected(lastWasNull, expectedNull,
+                        String.format("wasNull('%s') mismatch at row %d (stale pooled isNull?)", column, currentRow));
+                if (expectedNull) {
+                    assertExpected(lastValue, null,
+                            String.format("getObject('%s') expected NULL at row %d", column, currentRow));
+                } else {
+                    assertExpected(((Number) lastValue).intValue(), ((Number) expected).intValue(),
+                            String.format("getObject('%s') mismatch at row %d", column, currentRow));
+                }
+            }
+        }
+    }
+
+    /** Reads getBytes(column) fully and validates against DataCache. Confirms row integrity after pooled reuse. */
+    private static class GetBytesColumnAction extends Action {
+        private final String column;
+
+        GetBytesColumnAction(String column, int weight) {
+            super("getBytes[" + column + "]", weight);
+            this.column = column;
+        }
+
+        @Override
+        public boolean canRun() {
+            if (isState(CLOSED) || !isState(ON_VALID_ROW) || isState(ROW_DELETED)) {
+                return false;
+            }
+            // Do not re-read the single-access LOB column on a row where it was already touched (streamed or read);
+            // that would throw R_dataAlreadyAccessed on a forward-only adaptive cursor.
+            return getStateInt(B_ACCESSED_ROW) != getStateInt(CURRENT_ROW);
+        }
+
+        @Override
+        public void run() throws SQLException {
+            ResultSet rs = (ResultSet) getState(RS);
+            byte[] actual = rs.getBytes(column);
+            setState(B_ACCESSED_ROW, getStateInt(CURRENT_ROW));
+
+            if (hasDataCache()) {
+                int currentRow = getStateInt(CURRENT_ROW);
+                if (currentRow >= 1 && currentRow < dataCache.getRowCount()) {
+                    byte[] expected = (byte[]) dataCache.getValue(currentRow, column);
+                    assertTrue(Arrays.equals(expected, actual),
+                            String.format("getBytes('%s') mismatch at row %d (aliasing corruption?)", column,
+                                    currentRow));
+                }
+            }
+        }
+    }
+
+    /** Obtains a binary stream, partially reads/verifies its prefix, and retains it unclosed for a later late close. */
+    private static class RetainBinaryStreamAction extends Action {
+        private final String column;
+
+        RetainBinaryStreamAction(String column, int weight) {
+            super("retainStream[" + column + "]", weight);
+            this.column = column;
+        }
+
+        @Override
+        public boolean canRun() {
+            // Only one retained stream at a time, on a valid row, and only if the single-access LOB column has not
+            // already been touched on this row.
+            return !isState(CLOSED) && isState(ON_VALID_ROW) && !isState(ROW_DELETED)
+                    && null == getState(RETAINED_STREAM) && getStateInt(B_ACCESSED_ROW) != getStateInt(CURRENT_ROW);
+        }
+
+        @Override
+        public void run() throws Exception {
+            ResultSet rs = (ResultSet) getState(RS);
+            int currentRow = getStateInt(CURRENT_ROW);
+
+            InputStream in = rs.getBinaryStream(column);
+            setState(B_ACCESSED_ROW, currentRow);
+            if (in == null) {
+                return;
+            }
+
+            byte[] expected = hasDataCache() && currentRow >= 1 && currentRow < dataCache.getRowCount()
+                    ? (byte[]) dataCache.getValue(currentRow, column)
+                    : null;
+
+            // Partially consume and verify the prefix, but DO NOT close.
+            byte[] buf = new byte[137];
+            int read = in.read(buf);
+            if (expected != null && read > 0) {
+                for (int i = 0; i < read; i++) {
+                    assertExpected(buf[i], expected[i],
+                            String.format("retained stream byte %d mismatch at row %d", i, currentRow));
+                }
+            }
+
+            setState(RETAINED_STREAM, in);
+            setState(RETAINED_EXPECTED, expected);
+            System.out.println("retainStream(" + column + ") at row " + currentRow + " read=" + read);
+        }
+    }
+
+    /** Closes a retained stream late, after its row was advanced past and its impl pooled/reused; must be a no-op. */
+    private static class LateCloseRetainedStreamAction extends Action {
+
+        LateCloseRetainedStreamAction(int weight) {
+            super("lateCloseStream", weight);
+        }
+
+        @Override
+        public boolean canRun() {
+            return null != getState(RETAINED_STREAM);
+        }
+
+        @Override
+        public void run() throws Exception {
+            InputStream in = (InputStream) getState(RETAINED_STREAM);
+            // Late close must not throw and must not corrupt any pooled/reused impl. Second close must be idempotent.
+            in.close();
+            in.close();
+            setState(RETAINED_STREAM, null);
+            setState(RETAINED_EXPECTED, null);
+            System.out.println("lateCloseStream() - no-op expected");
+        }
+
+        @Override
+        public void validate() throws SQLException {
+            // If still positioned on a valid row, confirm it is intact after the late close.
+            if (isState(CLOSED) || !isState(ON_VALID_ROW) || isState(ROW_DELETED) || !hasDataCache()) {
+                return;
+            }
+            ResultSet rs = (ResultSet) getState(RS);
+            int currentRow = getStateInt(CURRENT_ROW);
+            if (currentRow >= 1 && currentRow < dataCache.getRowCount()) {
+                Object expectedName = dataCache.getValue(currentRow, "name");
+                if (expectedName != null) {
+                    assertExpected(rs.getString("name"), expectedName.toString(),
+                            String.format("row %d corrupted by a late stream close()", currentRow));
+                }
+            }
+        }
+    }
+
     private static void createTestTable(Connection conn, String tableName, int rows) throws SQLException {
+
         try (Statement stmt = conn.createStatement()) {
             TestUtils.dropTableIfExists(tableName, stmt);
             stmt.execute("CREATE TABLE " + tableName


### PR DESCRIPTION
## Summary

This PR introduces six targeted ResultSet read-path optimizations for allocation-heavy wide-row workloads. The changes reduce allocation churn, streamline common reader operations, and eliminate unnecessary wrapper objects for synchronous `getString()` calls while preserving the existing lazy decoding architecture and specialized code paths.

ResultSet bulk-read workloads incur substantial per-column allocation overhead from transient reader state and wrapper objects. On wide result sets, these short-lived allocations create significant young-generation GC pressure and reduce throughput.

**Measured result** on a 601-column × 1M-row × 200-iteration scan with 400 runs (default + fetchSize=512):

| Metric | Baseline driver | This PR | Improvement |
|---|---|---|---|
| Average fetch (ms) | 52,158 | **47,651** | **8.64 % faster** |
| Median fetch (ms) | 51,423 | **46,976** | **8.65 % faster** |
| P95 fetch (ms) | 58,239 | **52,756** | **9.41 % faster** |
| Max fetch (ms) | 80,500 | **62,374** | **22.52 % faster** |
| Standard deviation (ms) | 3,344 | **2,704** | **19.14 % lower** |
| Spikes > 55 s | 53 | **15** | **72 % fewer** |
| Spikes > 60 s | 15 | **5** | **67 % fewer** |
| Spikes > 65 s | 3 | **0** | **100 % fewer** |
| Throughput (rows/sec) | 19,173 | **20,986** | **9.5 % higher** |

The tail-latency improvement is a notable secondary benefit: fewer allocations slow young-generation growth, reduce minor GC frequency, and shrink the GC-induced latency tail. The largest baseline outlier in this dataset reached 80.5 seconds; this PR's worst case was 62.4 seconds,18 seconds lower. The observed latency range narrowed from 33.4 seconds to 18.4 seconds (−45%).

## Key improvements

* Reuse a single `ServerDTVImpl` instance per column across rows.
* Add inline fast paths for common `IOBuffer` operations.
* Eliminate unnecessary stream wrapper allocations for common synchronous `getString()` calls.
* Reduce logging overhead in byte-copy loops.
* Harden `ResultSet` row cleanup bounds.
* Preserve existing behavior for streaming, adaptive, encrypted, and cursor-based code paths.

---

## Changes

### 1. Reuse a single `ServerDTVImpl` instance per-column (`dtv.java`)

Every column's `DTV` instance allocates a fresh `ServerDTVImpl` on first access (`DTV.getValue()`, `DTV.skipValue()`, `DTV.initFromCompressedNull()`), then discards it when `DTV.clear()` sets `impl = null` at end of row. On the benchmark workload, this translates into tens of billions of short-lived ServerDTVImpl allocations.

A single reusable-instance field (`reusableServerImpl`) on each `DTV` holds one `ServerDTVImpl` for the column's lifetime. The helper `acquireServerImpl()` creates it on first use and, on every reuse, calls `reset()` (zeroing its four wire-state fields) before handing it out, so it is always clean. During an active read, `impl` points at this same instance. `DTV.clear()` simply resets `impl` to `null` at end of row (the reusable instance stays put), and `setImpl()` needs no special handling on the `ServerDTVImpl → AppDTVImpl` swap because the instance is already retained.

```java
private ServerDTVImpl reusableServerImpl;

final void clear() {
    impl = null;                                      // preserve isInitialized() contract; instance stays retained
}

private ServerDTVImpl acquireServerImpl() {
    ServerDTVImpl s = reusableServerImpl;
    if (null != s) {
        s.reset();                                    // zero wire-state before reuse
        return s;
    }
    reusableServerImpl = new ServerDTVImpl();          // create once on first use
    return reusableServerImpl;
}

void setImpl(DTVImpl impl) {
    this.impl = impl;                                 // instance already held in reusableServerImpl
}
```

`ServerDTVImpl.reset()` zeros the same four fields the constructor initializes (`valueLength`, `valueMark`, `isNull`, `internalVariant`), so a reused instance is externally indistinguishable from a fresh one.

**Net effect:** one reusable ServerDTVImpl per DTV instead of one allocation per accessed column per row.

**Safety.** The external contract of `isInitialized()` is preserved because `impl` is still cleared to `null` after `clear()`; the reusable instance is only returned on the *next* read-side call, and it is `reset()` at that single point before use. The reusable instance is per-DTV (one per column per ResultSet), so there is no cross-column or cross-row aliasing and no thread sharing. Only `ServerDTVImpl` is reused; `AppDTVImpl` is not, on the updatable-row swap, `impl` is replaced with a fresh `AppDTVImpl` while the `ServerDTVImpl` remains retained for the next read.

---

### 2. Inline fast path for `readUnsignedByte()` (`IOBuffer.java`)

Every `BYTELENTYPE` column's length prefix (e.g. `char(1)`, `varchar(64)`, nullable `int`/`float`/`decimal`) goes through `readUnsignedByte()`, which unconditionally invokes `ensurePayload()`. In the common case the current packet already contains payload data, making
`ensurePayload()` a no-op. Add an inline `payloadOffset < currentPacket.payloadLength` check before the call, mirroring the pattern already in place for `readShort()`, `readInt()`, and `readLong()`:

```java
final int readUnsignedByte() throws SQLServerException {
    if (payloadOffset < currentPacket.payloadLength) {
        return currentPacket.payload[payloadOffset++] & 0xFF;
    }
    if (!ensurePayload()) throwInvalidTDS();
    return currentPacket.payload[payloadOffset++] & 0xFF;
}
```

**Safety.** Identical semantics. The slow path is preserved verbatim for packet-boundary cases.

---

### 3. Zero-copy fast path for `readDaysIntoCE()` (`IOBuffer.java`)

`readDaysIntoCE()` is called for every `DATE`, `DATETIME2`, `DATETIMEOFFSET` column. The original allocates a `byte[3]`, calls `readBytes()` to fill it, then loops to reassemble the 3 bytes into an `int`, a method-call chain and an allocation per call. Read the 3 bytes directly from the current packet payload when available; fall back to the existing cross-packet path otherwise:

```java
private int readDaysIntoCE() throws SQLServerException {
    final int length = TDS.DAYS_INTO_CE_LENGTH;     // 3
    int daysIntoCE;
    if (payloadOffset + length <= currentPacket.payloadLength) {
        final byte[] p = currentPacket.payload;
        final int off = payloadOffset;
        daysIntoCE = (p[off]     & 0xFF)
                   | ((p[off + 1] & 0xFF) <<  8)
                   | ((p[off + 2] & 0xFF) << 16);
        payloadOffset += length;
    } else {
        // Slow path: same as before. Uses the shared per-reader scratch buffer,
        // so neither path allocates per call.
        final byte[] value = readWrappedBytes(length);
        daysIntoCE = 0;
        for (int i = 0; i < length; i++)
            daysIntoCE |= ((value[i] & 0xFF) << (8 * i));
    }
    if (daysIntoCE < 0) throwInvalidTDS();
    return daysIntoCE;
}
```

**Safety.** Output is equivalent to the existing implementation. The fallback is the original code unchanged.

---

### 4. Hoist `isLoggable()` out of the `readBytes()` and `readSkipBytes()` loops (`IOBuffer.java`)

`readBytes()` and `readSkipBytes()` are the byte-copy and byte-skip loops used by every variable-length column read and skip. Both inner bodies did `if (logger.isLoggable(Level.FINEST))` on every iteration, one volatile read per packet copied or skipped, never constant-folded by the JIT. Hoist the check to a `final boolean` local before the loop in both methods, avoiding repeated logger.isLoggable() checks within the loop.

```java
final void readBytes(byte[] value, int valueOffset, int valueLength) throws SQLServerException {
    final boolean isLogging = logger.isLoggable(Level.FINEST);  // hoisted
    for (int bytesRead = 0; bytesRead < valueLength;) {
        ...
        if (isLogging) logger.finest(...);
        ...
    }
}

final void readSkipBytes(int valueLength) throws SQLServerException {
    final boolean isLogging = logger.isLoggable(Level.FINEST);  // hoisted
    for (int bytesSkipped = 0; bytesSkipped < valueLength;) {
        ...
        if (isLogging) logger.finest(...);
        ...
    }
}
```

**Safety.** The only observable difference is that FINEST logging toggled *during* a single call to either method would not affect subsequent iterations of that call. Logging configuration is set at startup in any real deployment; this is the standard Java logging-performance idiom and the two methods are now symmetric.

---

### 5. Tighter loop bound in `discardCurrentRow()` (`SQLServerResultSet.java`)

When `next()` advances to the next row, `discardCurrentRow()` iterates through previously-accessed columns calling `column.clear()`. The original loop bound was `lastColumnIndex` without a defensive check against `columns.length`, leaving open an `ArrayIndexOutOfBoundsException` in edge cases (server cursor with rowstat column under unusual access patterns). Use `Math.min(lastColumnIndex, columns.length + 1)` as the loop bound:

```java
int clearUpTo = Math.min(lastColumnIndex, columns.length + 1);
for (int columnIndex = 1; columnIndex < clearUpTo; ++columnIndex)
    getColumn(columnIndex).clear();
```

**Safety.** Identical work in the normal case, strictly safer bounds.

---

### 6. Bypass `SimpleInputStream` for small synchronous string reads (`dtv.java`)

A major source of transient allocation pressure on this workload. For `rs.getString()` on a CHAR/VARCHAR/NCHAR/NVARCHAR column, `ServerDTVImpl.getValue()` allocates:

1. `new SimpleInputStream(tdsReader, valueLength, ...)` : ~48 bytes including `BaseInputStream` fields
2. A `TDSReaderMark` inside `BaseInputStream`'s constructor: ~24 bytes
3. A second `TDSReaderMark` when the stream's `close()` invokes `setPositionAfterStreamed()`: ~24 bytes
4. The destination `byte[valueLength]` inside `stream.getBytes()`

…all so that `convertStreamToObject` can call `new String(stream.getBytes(), charset)` and return the string. The stream and both marks are immediately discarded. On a workload with ~40 % string columns this creates substantial transient allocation traffic.

When the call is provably a small synchronous `getString()`, i.e., all five of the following hold:

| Guard | Required because |
|---|---|
| `valueLength > 0 && valueLength <= 4000` | Truly large values stay on the streaming path (avoid one-shot huge allocations); zero-length cells stay on the regular path |
| `streamGetterArgs.streamType == StreamType.NONE` | Stream getters (`getBinaryStream` / `getAsciiStream` / `getCharacterStream`) must return the wrapped stream to the caller |
| `!streamGetterArgs.isAdaptive` | Adaptive paths wrap the stream in `BufferedReader`/etc. and hand it to user code |
| `jdbcType.isTextual()` | Non-textual targets (e.g. `getInt()` on a VARCHAR) require `convertStringToObject` to `trim()`/`parse()` the string |
| `jdbcType != CLOB && jdbcType != NCLOB` | Although textual, `getClob()` / `getNClob()` must return a `SQLServerClob` / `SQLServerNClob` (from the stream path), not a `String` |

…read the bytes directly and construct the `String` inline:

```java
case CHAR:
case VARCHAR:
case NCHAR:
case NVARCHAR: {
    if (valueLength > 0 && valueLength <= 4000
            && StreamType.NONE == streamGetterArgs.streamType
            && !streamGetterArgs.isAdaptive
            && jdbcType.isTextual()
            && JDBCType.CLOB != jdbcType && JDBCType.NCLOB != jdbcType) {
        byte[] bytes = new byte[valueLength];
        tdsReader.readBytes(bytes, 0, valueLength);
        convertedValue = new String(bytes, typeInfo.getCharset());
        break;
    }
    // Fall through to the stream-based path below for large/streaming/non-textual/LOB cases.
}
case TEXT:
case NTEXT:
case IMAGE:
case BINARY:
case VARBINARY:
case TIMESTAMP:
case VECTOR: {
    convertedValue = DDC.convertStreamToObject(
            new SimpleInputStream(tdsReader, valueLength, streamGetterArgs, this),
            typeInfo, jdbcType, streamGetterArgs);
    break;
}
```

When all guards hold (the dominant `rs.getString()` shape), **4 allocations + ~6 method calls per string cell collapse to 1 allocation + 1 method call**.

**Safety.** The guarded execution paths through `DDC.convertStreamToObject` were traced and verified to produce equivalent behavior.

* For textual JDBC types with `streamType == NONE` and `!isAdaptive`, the original ultimately executes `convertStringToObject(new String(stream.getBytes(), charset), charset, jdbcType, NONE)` whose default branch (for textual targets) returns the `String` as-is. The fast path builds the same `String` with the same `charset`.
* `CLOB` / `NCLOB` targets are explicitly excluded so `getClob()` / `getNClob()` (and `getObject(i, Clob.class)` / `getObject(i, NClob.class)`) continue to return `SQLServerClob` / `SQLServerNClob` from the stream path rather than a `String`.
* The Java `switch` fall-through is intentional and is explicitly documented in an inline comment so reviewers do not flag it as a bug.
* All other cell-handling cases (`TEXT`, `NTEXT`, `IMAGE`, `BINARY`, `VARBINARY`, `TIMESTAMP`, `VECTOR`) are untouched.
---

## Why this is safe to land

1. **No public-API changes.** No new methods, no signature changes, no contract changes.
2. **All existing slow paths are preserved unchanged.** Every fast path is gated on a condition that defaults to the original code path whenever the optimization does not apply. Packet-boundary reads, large values, streaming/adaptive access, non-textual conversions, encrypted columns, LOBs, PLP types, scrollable/updatable cursors, and server cursors all continue through the existing implementations.
3. **The reusable `ServerDTVImpl` instance is per-DTV, single-threaded by construction.** Each `DTV` belongs to a single column of a single result set; no cross-column or cross-row aliasing is possible. The instance is `reset()` at the single point of reuse (`acquireServerImpl()`) before being handed out, and `impl == null` between rows preserves the read-side null checks, so a stale value can never leak into the next row.
4. **The `String` fast path is behaviorally equivalent.** Traced through every branch of `convertStreamToObject` for the guarded inputs; The resulting `String` is equivalent to the existing implementation for the guarded inputs.
5. The optimized hot paths eliminate or reuse transient objects where possible and do not introduce additional allocation-heavy intermediate structures.
6. **Defaults unchanged.** No new connection property, no opt-in flag. The optimized paths are used automatically whenever their guard conditions are satisfied.

---

## Benchmark results

### Methodology

* **Workload:** `SELECT *` over a 601-column table mixing numeric, string, decimal, and datetime columns
* **Volume:** 1,000,000 rows × 200 iterations per run
* **Sample size:** 400 runs per build per configuration
* **Configurations:** default fetch size + `fetchSize=512`
* **Builds compared:** stock mssql-jdbc (baseline) and this PR
* **Environment:** single VM, warmed JVM, no other load


### Combined (default + 512 fetchSize, 400 runs each)

| Metric | Baseline | **This PR** |
|---|---|---|
| Average (ms) | 52,158 | **47,651**  |
| Median (ms) | 51,423 | **46,976**  |
| Min (ms) | 47,062 | **43,984**  |
| Max (ms) | 80,500 | **62,374**  |
| Range (ms) | 33,438 | **18,390**  |
| P90 (ms) | 55,841 | **50,304**  |
| P95 (ms) | 58,239 | **52,756**  |
| StdDev (ms) | 3,344 | **2,704**  |
| CV % | 6.41 % | **5.67 %**  |
| Spikes > 55 s | 53 | **15**  |
| Spikes > 60 s | 15 | **5**  |
| Spikes > 65 s | 3 | **0**  |
| Throughput (rows/sec) | 19,173 | **20,986**  |

### Observations

1. The **~9 % mean reduction is uniform** across both fetch-size configurations (−8.74 % default, −8.53 % at 512), confirming the changes target per-cell decoding cost rather than network batching.
2. **100 % of `> 65 s` outliers are eliminated** (3 → 0), consistent with reduced allocation pressure in young generation GC regions.
3. **Throughput rises +9.5 %** (19,173 → 20,986 rows/sec).

---

## Testing

* **Existing test suite:** all unit and integration tests pass against this PR.
* **Benchmark validation:** the 400-run benchmark above was executed end-to-end against a live SQL Server instance with both the baseline and PR builds; the ~9 % improvement was reproduced across multiple runs.
* Added WideRowReadTests nested class in ResultSetTest that reads a fat table (10 rows x 601 columns) and asserts the exact value of every cell via type-specific getters. Covers 20 SQL types including both decimal decode paths: decimal(18,0) with an 8-byte magnitude and decimal(38,4) with a larger-than-8-byte magnitude.