### PR TITLE
 Add tls-unique channel binding support for Kerberos and NTLM

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -85,7 +85,6 @@ import com.microsoft.sqlserver.jdbc.dataclassification.SensitivityClassification
 import microsoft.sql.Vector;
 
 final class TDS {
-    // application protocol
     static final String PROTOCOL_TDS80 = "tds/8.0"; // TLS-first connections
 
     // TDS versions
@@ -661,6 +660,9 @@ final class TDSChannel implements Serializable {
 
     // Socket for SSL-encrypted communications with SQL Server
     private transient SSLSocket sslSocket;
+
+    // tls-unique channel binding data from the completed TLS handshake.
+    static byte[] channelBindingInfo = null;
 
     /*
      * Socket providing the communications interface to the driver. For SSL-encrypted connections, this is the SSLSocket
@@ -1938,6 +1940,8 @@ final class TDSChannel implements Serializable {
                 con.addWarning(warningMsg);
             }
 
+            setChannelBindingInfo();
+
             if (logger.isLoggable(Level.FINER))
                 logger.finer(toString() + " SSL enabled");
 
@@ -2001,6 +2005,45 @@ final class TDSChannel implements Serializable {
                 con.terminate(SQLServerException.DRIVER_ERROR_SSL_FAILED, form.format(msgArgs), e);
             }
         }
+    }
+
+    private void setChannelBindingInfo() {
+        channelBindingInfo = createChannelBindingInfo(null == sslSocket ? null : sslSocket.getSession());
+    }
+
+    static byte[] createChannelBindingInfo(javax.net.ssl.SSLSession session) {
+        if (null == session) {
+            return null;
+        }
+
+        byte[] tlsUnique = null;
+        try {
+            Class<?> clazz = Class.forName("javax.net.ssl.ExtendedSSLSession");
+            if (!clazz.isInstance(session)) {
+                return null;
+            }
+
+            java.lang.reflect.Method method = clazz.getMethod("getTlsUniqueChannelBinding");
+            Object value = method.invoke(session);
+            if (value instanceof byte[]) {
+                tlsUnique = (byte[]) value;
+            }
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+                | InvocationTargetException e) {
+            if (logger.isLoggable(Level.FINER)) {
+                logger.finer("getTlsUniqueChannelBinding is not supported on this platform.");
+            }
+            return null;
+        }
+
+        if (null == tlsUnique || 0 == tlsUnique.length) {
+            return null;
+        }
+
+        byte[] prefix = "tls-unique:".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] channelBinding = Arrays.copyOf(prefix, prefix.length + tlsUnique.length);
+        System.arraycopy(tlsUnique, 0, channelBinding, prefix.length, tlsUnique.length);
+        return channelBinding;
     }
 
     /**
@@ -6750,6 +6793,7 @@ final class TDSWriter {
             }
         }
     }
+
 }
 
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -2023,31 +2023,31 @@ final class TDSChannel implements Serializable {
                 return null;
             }
 
-            // Try getTlsUniqueClientFirstFinishedVerifyData() first (client's Finished
-            // verify_data,
-            // preferred per RFC 5929 tls-unique for the initiating side).
-            // Fall back to getTlsUniqueFirstFinishedVerifyData() if the former is not
-            // available.
-            java.lang.reflect.Method method = null;
-            try {
-                method = clazz.getMethod("getTlsUniqueClientFirstFinishedVerifyData");
+            // Prefer the client's Finished verify_data for the initiating side.
+            java.lang.reflect.Method method = getTlsUniqueMethod(clazz, "getTlsUniqueClientFirstFinishedVerifyData");
+            if (null == method) {
+                method = getTlsUniqueMethod(clazz, "getTlsUniqueFirstFinishedVerifyData");
+            }
+
+            if (null == method) {
                 if (logger.isLoggable(Level.FINER)) {
-                    logger.finer("Using getTlsUniqueClientFirstFinishedVerifyData for tls-unique channel binding.");
+                    logger.finer("tls-unique channel binding methods are not supported on this platform.");
                 }
-            } catch (NoSuchMethodException e) {
-                if (logger.isLoggable(Level.FINER)) {
-                    logger.finer(
-                            "getTlsUniqueClientFirstFinishedVerifyData not found, falling back to getTlsUniqueFirstFinishedVerifyData.");
-                }
-                method = clazz.getMethod("getTlsUniqueFirstFinishedVerifyData");
+                return null;
+            }
+
+            if (logger.isLoggable(Level.FINER)) {
+                logger.finer("Using " + method.getName() + " for tls-unique channel binding.");
             }
 
             Object value = method.invoke(session);
             if (value instanceof byte[]) {
                 tlsUnique = (byte[]) value;
+                if (logger.isLoggable(Level.FINER)) {
+                    logger.finer("tls-unique verify_data received: " + tlsUnique.length + " bytes.");
+                }
             }
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-                | InvocationTargetException e) {
+        } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException e) {
             if (logger.isLoggable(Level.FINER)) {
                 logger.finer("tls-unique channel binding methods are not supported on this platform.");
             }
@@ -2062,6 +2062,14 @@ final class TDSChannel implements Serializable {
         byte[] channelBinding = Arrays.copyOf(prefix, prefix.length + tlsUnique.length);
         System.arraycopy(tlsUnique, 0, channelBinding, prefix.length, tlsUnique.length);
         return channelBinding;
+    }
+
+    private static java.lang.reflect.Method getTlsUniqueMethod(Class<?> clazz, String methodName) {
+        try {
+            return clazz.getMethod(methodName);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -662,7 +662,7 @@ final class TDSChannel implements Serializable {
     private transient SSLSocket sslSocket;
 
     // tls-unique channel binding data from the completed TLS handshake.
-    static byte[] channelBindingInfo = null;
+    private byte[] channelBindingInfo = null;
 
     /*
      * Socket providing the communications interface to the driver. For SSL-encrypted connections, this is the SSLSocket
@@ -2008,7 +2008,19 @@ final class TDSChannel implements Serializable {
     }
 
     private void setChannelBindingInfo() {
+        clearChannelBindingInfo();
         channelBindingInfo = createChannelBindingInfo(null == sslSocket ? null : sslSocket.getSession());
+    }
+
+    byte[] getChannelBindingInfo() {
+        return null == channelBindingInfo ? null : Arrays.copyOf(channelBindingInfo, channelBindingInfo.length);
+    }
+
+    void clearChannelBindingInfo() {
+        if (null != channelBindingInfo) {
+            Arrays.fill(channelBindingInfo, (byte) 0);
+            channelBindingInfo = null;
+        }
     }
 
     static byte[] createChannelBindingInfo(javax.net.ssl.SSLSession session) {
@@ -2318,6 +2330,8 @@ final class TDSChannel implements Serializable {
     }
 
     final void close() {
+        clearChannelBindingInfo();
+
         if (null != sslSocket)
             disableSSL();
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -2046,6 +2046,8 @@ final class TDSChannel implements Serializable {
                 if (logger.isLoggable(Level.FINER)) {
                     logger.finer("tls-unique verify_data received: " + tlsUnique.length + " bytes.");
                 }
+            } else if (logger.isLoggable(Level.FINER)) {
+                logger.finer("tls-unique verify_data was not available.");
             }
         } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException e) {
             if (logger.isLoggable(Level.FINER)) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -2023,7 +2023,25 @@ final class TDSChannel implements Serializable {
                 return null;
             }
 
-            java.lang.reflect.Method method = clazz.getMethod("getTlsUniqueChannelBinding");
+            // Try getTlsUniqueClientFirstFinishedVerifyData() first (client's Finished
+            // verify_data,
+            // preferred per RFC 5929 tls-unique for the initiating side).
+            // Fall back to getTlsUniqueFirstFinishedVerifyData() if the former is not
+            // available.
+            java.lang.reflect.Method method = null;
+            try {
+                method = clazz.getMethod("getTlsUniqueClientFirstFinishedVerifyData");
+                if (logger.isLoggable(Level.FINER)) {
+                    logger.finer("Using getTlsUniqueClientFirstFinishedVerifyData for tls-unique channel binding.");
+                }
+            } catch (NoSuchMethodException e) {
+                if (logger.isLoggable(Level.FINER)) {
+                    logger.finer(
+                            "getTlsUniqueClientFirstFinishedVerifyData not found, falling back to getTlsUniqueFirstFinishedVerifyData.");
+                }
+                method = clazz.getMethod("getTlsUniqueFirstFinishedVerifyData");
+            }
+
             Object value = method.invoke(session);
             if (value instanceof byte[]) {
                 tlsUnique = (byte[]) value;
@@ -2031,7 +2049,7 @@ final class TDSChannel implements Serializable {
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
                 | InvocationTargetException e) {
             if (logger.isLoggable(Level.FINER)) {
-                logger.finer("getTlsUniqueChannelBinding is not supported on this platform.");
+                logger.finer("tls-unique channel binding methods are not supported on this platform.");
             }
             return null;
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.logging.Level;
 
 import org.ietf.jgss.ChannelBinding;
@@ -24,9 +25,6 @@ import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
 
-import static com.microsoft.sqlserver.jdbc.TDSChannel.channelBindingInfo;
-
-
 /**
  * KerbAuthentication for integrated authentication.
  */
@@ -36,6 +34,7 @@ final class KerbAuthentication extends SSPIAuthentication {
 
     private final SQLServerConnection con;
     private final String spn;
+    private byte[] channelBindingInfo;
 
     private final GSSManager manager = GSSManager.getInstance();
     private LoginContext lc = null;
@@ -334,9 +333,15 @@ final class KerbAuthentication extends SSPIAuthentication {
     }
 
     // Package visible members below.
-    KerbAuthentication(SQLServerConnection con, String address, int port) {
+    KerbAuthentication(SQLServerConnection con, String address, int port, byte[] channelBindingInfo) {
         this.con = con;
         this.spn = null != con ? getSpn(con) : null;
+        this.channelBindingInfo = null == channelBindingInfo ? null : Arrays.copyOf(channelBindingInfo,
+                channelBindingInfo.length);
+    }
+
+    KerbAuthentication(SQLServerConnection con, String address, int port) {
+        this(con, address, port, null);
     }
 
     /**
@@ -347,11 +352,16 @@ final class KerbAuthentication extends SSPIAuthentication {
      * @param impersonatedUserCred
      */
     KerbAuthentication(SQLServerConnection con, String address, int port, GSSCredential impersonatedUserCred,
-            boolean isUserCreated, boolean useDefaultNativeGSSCredential) {
-        this(con, address, port);
+            boolean isUserCreated, boolean useDefaultNativeGSSCredential, byte[] channelBindingInfo) {
+        this(con, address, port, channelBindingInfo);
         this.peerCredentials = impersonatedUserCred;
         this.isUserCreatedCredential = isUserCreated;
         this.useDefaultNativeGSSCredential = useDefaultNativeGSSCredential;
+    }
+
+    KerbAuthentication(SQLServerConnection con, String address, int port, GSSCredential impersonatedUserCred,
+            boolean isUserCreated, boolean useDefaultNativeGSSCredential) {
+        this(con, address, port, impersonatedUserCred, isUserCreated, useDefaultNativeGSSCredential, null);
     }
 
     byte[] generateClientContext(byte[] pin, boolean[] done) throws SQLServerException {
@@ -385,6 +395,11 @@ final class KerbAuthentication extends SSPIAuthentication {
             // to eat previous login errors if caused before which is more useful to the user than the cleanup errors.
             if (authLogger.isLoggable(Level.FINE)) {
                 authLogger.fine(toString() + " Release of the credentials failed GSSException: " + e);
+            }
+        } finally {
+            if (null != channelBindingInfo) {
+                Arrays.fill(channelBindingInfo, (byte) 0);
+                channelBindingInfo = null;
             }
         }
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/KerbAuthentication.java
@@ -12,6 +12,7 @@ import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 
+import org.ietf.jgss.ChannelBinding;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
@@ -22,6 +23,8 @@ import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
+
+import static com.microsoft.sqlserver.jdbc.TDSChannel.channelBindingInfo;
 
 
 /**
@@ -65,6 +68,9 @@ final class KerbAuthentication extends SSPIAuthentication {
             if (null != peerCredentials) {
                 peerContext = manager.createContext(remotePeerName, kerberos, peerCredentials,
                         GSSContext.DEFAULT_LIFETIME);
+                if (null != channelBindingInfo) {
+                    peerContext.setChannelBinding(new ChannelBinding(channelBindingInfo));
+                }
                 peerContext.requestCredDeleg(false);
                 peerContext.requestMutualAuth(true);
                 peerContext.requestInteg(true);
@@ -158,6 +164,10 @@ final class KerbAuthentication extends SSPIAuthentication {
                 }
                 peerContext = manager.createContext(remotePeerName, kerberos, peerCredentials,
                         GSSContext.DEFAULT_LIFETIME);
+
+                if (null != channelBindingInfo) {
+                    peerContext.setChannelBinding(new ChannelBinding(channelBindingInfo));
+                }
 
                 // The following flags should be inline with our native implementation.
                 peerContext.requestCredDeleg(true);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
@@ -648,6 +648,8 @@ final class NTLMAuthentication extends SSPIAuthentication {
 
     private void calculateChannelBindingMD5Hash() throws SQLServerException {
         try {
+            // This consumes the per-authentication CBT value, NTLM currently calls it once
+            // per auth exchange.
             if (null == channelBindingInfo || 0 == channelBindingInfo.length) {
                 msvAvChannelBindings = null;
                 return;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
@@ -163,11 +163,10 @@ final class NTLMAuthentication extends SSPIAuthentication {
     private static final short NTLM_AVID_MSVAVCHANNELBINDING = 0x000a;
 
     /**
-     * Section 2.2.2.1 AV_PAIR - MsvAvChannelBindings.
-     *
-     * MD5 hashed channel binding info. By default, an all-zero byte array means no channel binding.
+     * MD5 hashed channel binding info. Null means no channel binding AV_PAIR will
+     * be sent.
      */
-    private byte[] msvAvChannelBindings = new byte[16];
+    private byte[] msvAvChannelBindings = null;
 
     /**
      * Section 2.2.2.1 AV_PAIR
@@ -550,6 +549,8 @@ final class NTLMAuthentication extends SSPIAuthentication {
         time.putLong((TimeUnit.SECONDS.toNanos(Instant.now().getEpochSecond() + WINDOWS_EPOCH_DIFF)) / 100);
         byte[] currentTime = time.array();
 
+        calculateChannelBindingMD5Hash();
+
         // allocate token buffer
         ByteBuffer token = ByteBuffer
                 .allocate(NTLM_CLIENT_CHALLENGE_RESPONSE_TYPE.length + NTLM_CLIENT_CHALLENGE_RESERVED1.length
@@ -557,7 +558,10 @@ final class NTLMAuthentication extends SSPIAuthentication {
                         + NTLM_CLIENT_CHALLENGE_RESERVED3.length + context.targetInfo.length
                         + /* add MIC */ NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH + NTLM_AVID_MSVAVFLAGS_LEN
                 + /* add SPN */ NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH + context.spnUbytes.length
-                + /* add channel binding */ NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH + msvAvChannelBindings.length)
+                        + /* add channel binding */ ((null != msvAvChannelBindings)
+                                ? NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH
+                                        + msvAvChannelBindings.length
+                                : 0))
                 .order(ByteOrder.LITTLE_ENDIAN);
 
         token.put(NTLM_CLIENT_CHALLENGE_RESPONSE_TYPE);
@@ -594,11 +598,12 @@ final class NTLMAuthentication extends SSPIAuthentication {
         token.putShort((short) context.spnUbytes.length);
         token.put(context.spnUbytes, 0, context.spnUbytes.length);
 
-        // Channel binding
-        calculateChannelBindingMD5Hash();
-        token.putShort(NTLM_AVID_MSVAVCHANNELBINDING);
-        token.putShort((short) msvAvChannelBindings.length);
-        token.put(msvAvChannelBindings, 0, msvAvChannelBindings.length);
+        if (null != msvAvChannelBindings) {
+            // Channel binding
+            token.putShort(NTLM_AVID_MSVAVCHANNELBINDING);
+            token.putShort((short) msvAvChannelBindings.length);
+            token.put(msvAvChannelBindings, 0, msvAvChannelBindings.length);
+        }
 
         // EOL
         token.putShort(NTLM_AVID_MSVAVEOL);
@@ -629,7 +634,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
     private void calculateChannelBindingMD5Hash() {
         try {
             if (null == channelBindingInfo || 0 == channelBindingInfo.length) {
-                Arrays.fill(msvAvChannelBindings, (byte) 0);
+                msvAvChannelBindings = null;
                 return;
             }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
@@ -8,6 +8,7 @@ package com.microsoft.sqlserver.jdbc;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
 import java.time.Instant;
@@ -20,6 +21,8 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 import mssql.security.provider.MD4;
+
+import static com.microsoft.sqlserver.jdbc.TDSChannel.channelBindingInfo;
 
 
 /**
@@ -144,6 +147,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
      * NTLM_AVID_MSVAVTIMESTAMP       FILETIME structure that contains the server local time (ALWAYS present in CHALLENGE_MESSAGE
      * NTLM_AVID_MSVAVSINGLEHOST      Single Host Data structure  (not currently used)
      * NTLM_AVID_MSVAVTARGETNAME      SPN of the target server in unicode (not currently used)
+    * NTLM_AVID_MSVAVCHANNELBINDING  the MD5 hash of the channel binding info
      * </pre>
      */
     private static final short NTLM_AVID_MSVAVEOL = 0x0000;
@@ -156,6 +160,14 @@ final class NTLMAuthentication extends SSPIAuthentication {
     private static final short NTLM_AVID_MSVAVTIMESTAMP = 0x0007;
     private static final short NTLM_AVID_MSVAVSINGLEHOST = 0x0008;
     private static final short NTLM_AVID_MSVAVTARGETNAME = 0x0009;
+    private static final short NTLM_AVID_MSVAVCHANNELBINDING = 0x000a;
+
+    /**
+     * Section 2.2.2.1 AV_PAIR - MsvAvChannelBindings.
+     *
+     * MD5 hashed channel binding info. By default, an all-zero byte array means no channel binding.
+     */
+    private byte[] msvAvChannelBindings = new byte[16];
 
     /**
      * Section 2.2.2.1 AV_PAIR
@@ -544,7 +556,8 @@ final class NTLMAuthentication extends SSPIAuthentication {
                         + NTLM_CLIENT_CHALLENGE_RESERVED2.length + currentTime.length + NTLM_CLIENT_NONCE_LENGTH
                         + NTLM_CLIENT_CHALLENGE_RESERVED3.length + context.targetInfo.length
                         + /* add MIC */ NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH + NTLM_AVID_MSVAVFLAGS_LEN
-                        + /* add SPN */ NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH + context.spnUbytes.length)
+                + /* add SPN */ NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH + context.spnUbytes.length
+                + /* add channel binding */ NTLM_AVID_LENGTH + NTLM_AVLEN_LENGTH + msvAvChannelBindings.length)
                 .order(ByteOrder.LITTLE_ENDIAN);
 
         token.put(NTLM_CLIENT_CHALLENGE_RESPONSE_TYPE);
@@ -581,6 +594,12 @@ final class NTLMAuthentication extends SSPIAuthentication {
         token.putShort((short) context.spnUbytes.length);
         token.put(context.spnUbytes, 0, context.spnUbytes.length);
 
+        // Channel binding
+        calculateChannelBindingMD5Hash();
+        token.putShort(NTLM_AVID_MSVAVCHANNELBINDING);
+        token.putShort((short) msvAvChannelBindings.length);
+        token.put(msvAvChannelBindings, 0, msvAvChannelBindings.length);
+
         // EOL
         token.putShort(NTLM_AVID_MSVAVEOL);
         token.putShort((short) 0);
@@ -605,6 +624,27 @@ final class NTLMAuthentication extends SSPIAuthentication {
         SecretKeySpec keySpec = new SecretKeySpec(key, "HmacMD5"); // CodeQL [SM05136] HmacMD5 is required for NTLM support
         context.mac.init(keySpec);
         return context.mac.doFinal(data);
+    }
+
+    private void calculateChannelBindingMD5Hash() {
+        try {
+            if (null == channelBindingInfo || 0 == channelBindingInfo.length) {
+                Arrays.fill(msvAvChannelBindings, (byte) 0);
+                return;
+            }
+
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            md5.update(new byte[4]); // Initiator address
+            md5.update(new byte[4]); // Initiator address length
+            md5.update(new byte[4]); // Acceptor address
+            md5.update(new byte[4]); // Acceptor address length
+            md5.update(new byte[] {(byte) channelBindingInfo.length, (byte) 0, (byte) 0, (byte) 0});
+            md5.update(channelBindingInfo);
+
+            msvAvChannelBindings = md5.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
@@ -22,9 +22,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import mssql.security.provider.MD4;
 
-import static com.microsoft.sqlserver.jdbc.TDSChannel.channelBindingInfo;
-
-
 /**
  * Provides an implementation of NTLMv2 authentication
  * 
@@ -167,6 +164,8 @@ final class NTLMAuthentication extends SSPIAuthentication {
      * be sent.
      */
     private byte[] msvAvChannelBindings = null;
+
+    private byte[] channelBindingInfo = null;
 
     /**
      * Section 2.2.2.1 AV_PAIR
@@ -345,10 +344,18 @@ final class NTLMAuthentication extends SSPIAuthentication {
      *         if error occurs
      */
     NTLMAuthentication(final SQLServerConnection con, final String domainName, final String userName,
-            final byte[] passwordHash, final String workstation) throws SQLServerException {
+            final byte[] passwordHash, final String workstation, final byte[] channelBindingInfo)
+            throws SQLServerException {
+        this.channelBindingInfo = null == channelBindingInfo ? null : Arrays.copyOf(channelBindingInfo,
+                channelBindingInfo.length);
         if (null == context) {
             this.context = new NTLMContext(con, domainName, userName, passwordHash, workstation);
         }
+    }
+
+    NTLMAuthentication(final SQLServerConnection con, final String domainName, final String userName,
+            final byte[] passwordHash, final String workstation) throws SQLServerException {
+        this(con, domainName, userName, passwordHash, workstation, null);
     }
 
     /**
@@ -376,6 +383,14 @@ final class NTLMAuthentication extends SSPIAuthentication {
     @Override
     void releaseClientContext() {
         context = null;
+        if (null != channelBindingInfo) {
+            Arrays.fill(channelBindingInfo, (byte) 0);
+            channelBindingInfo = null;
+        }
+        if (null != msvAvChannelBindings) {
+            Arrays.fill(msvAvChannelBindings, (byte) 0);
+            msvAvChannelBindings = null;
+        }
     }
 
     /**
@@ -543,7 +558,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
      *        client challenge nonce
      * @return client challenge blob
      */
-    private byte[] generateClientChallengeBlob(final byte[] clientNonce) {
+    private byte[] generateClientChallengeBlob(final byte[] clientNonce) throws SQLServerException {
         // timestamp is number of 100 nanosecond ticks since Windows Epoch
         ByteBuffer time = ByteBuffer.allocate(NTLM_TIMESTAMP_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
         time.putLong((TimeUnit.SECONDS.toNanos(Instant.now().getEpochSecond() + WINDOWS_EPOCH_DIFF)) / 100);
@@ -631,7 +646,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
         return context.mac.doFinal(data);
     }
 
-    private void calculateChannelBindingMD5Hash() {
+    private void calculateChannelBindingMD5Hash() throws SQLServerException {
         try {
             if (null == channelBindingInfo || 0 == channelBindingInfo.length) {
                 msvAvChannelBindings = null;
@@ -648,7 +663,12 @@ final class NTLMAuthentication extends SSPIAuthentication {
 
             msvAvChannelBindings = md5.digest();
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            throw new SQLServerException("Failed to calculate NTLM channel binding hash.", e);
+        } finally {
+            if (null != channelBindingInfo) {
+                Arrays.fill(channelBindingInfo, (byte) 0);
+                channelBindingInfo = null;
+            }
         }
     }
 
@@ -745,7 +765,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
      * @throws InvalidKeyException
      *         if error getting hash due to invalid key
      */
-    private byte[] computeResponse(final byte[] responseKeyNT) throws InvalidKeyException {
+    private byte[] computeResponse(final byte[] responseKeyNT) throws InvalidKeyException, SQLServerException {
         // get random client challenge nonce
         byte[] clientNonce = new byte[NTLM_CLIENT_NONCE_LENGTH];
         ThreadLocalRandom.current().nextBytes(clientNonce);
@@ -769,7 +789,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
      * @throws InvalidKeyException
      *         if error getting hash due to invalid key
      */
-    private byte[] getNtChallengeResp() throws InvalidKeyException {
+    private byte[] getNtChallengeResp() throws InvalidKeyException, SQLServerException {
         byte[] responseKeyNT = ntowfv2();
         return computeResponse(responseKeyNT);
     }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -6298,6 +6298,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     private void logon(LogonCommand command) throws SQLServerException {
         SSPIAuthentication authentication = null;
+        byte[] channelBindingInfo = null != tdsChannel ? tdsChannel.getChannelBindingInfo() : null;
 
         if (integratedSecurity) {
             if (AuthenticationScheme.NATIVE_AUTHENTICATION == intAuthScheme) {
@@ -6307,10 +6308,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 if (null != impersonatedUserCred || useDefaultGSSCredential) {
                     authentication = new KerbAuthentication(this, currentConnectPlaceHolder.getServerName(),
                             currentConnectPlaceHolder.getPortNumber(), impersonatedUserCred, isUserCreatedCredential,
-                            useDefaultGSSCredential);
+                            useDefaultGSSCredential, channelBindingInfo);
                 } else {
                     authentication = new KerbAuthentication(this, currentConnectPlaceHolder.getServerName(),
-                            currentConnectPlaceHolder.getPortNumber());
+                            currentConnectPlaceHolder.getPortNumber(), channelBindingInfo);
                 }
             } else if (ntlmAuthentication) {
                 if (null == ntlmPasswordHash) {
@@ -6322,8 +6323,14 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                 authentication = new NTLMAuthentication(this,
                         activeConnectionProperties.getProperty(SQLServerDriverStringProperty.DOMAIN.toString()),
                         activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString()),
-                        ntlmPasswordHash, hostName);
+                        ntlmPasswordHash, hostName, channelBindingInfo);
             }
+        }
+        if (null != channelBindingInfo) {
+            Arrays.fill(channelBindingInfo, (byte) 0);
+        }
+        if (null != tdsChannel) {
+            tdsChannel.clearChannelBindingInfo();
         }
         /*
          * If the workflow being used is Active Directory Password or Active Directory Integrated and server's prelogin

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelBindingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelBindingTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 
-class TDSChannelChannelBindingTest {
+class TDSChannelBindingTest {
 
     @Test
     void createChannelBindingInfoReturnsNullWhenSessionIsNull() {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelChannelBindingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelChannelBindingTest.java
@@ -1,0 +1,69 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+
+package com.microsoft.sqlserver.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import javax.net.ssl.SSLSession;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+class TDSChannelChannelBindingTest {
+
+    @Test
+    void createChannelBindingInfoPrefixesTlsUniqueData() throws ClassNotFoundException {
+        assumeTrue(isTlsUniqueChannelBindingMethodAvailable(),
+                "Skipping because getTlsUniqueChannelBinding is not available on this JDK");
+
+        byte[] tlsUnique = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+        SSLSession session = createExtendedSessionMock(tlsUnique);
+        byte[] channelBinding = TDSChannel.createChannelBindingInfo(session);
+
+        assertArrayEquals(new byte[] {'t', 'l', 's', '-', 'u', 'n', 'i', 'q', 'u', 'e', ':', 1, 2, 3, 4, 5, 6, 7, 8,
+                9, 10, 11, 12}, channelBinding);
+    }
+
+    @Test
+    void createChannelBindingInfoReturnsNullWhenTlsUniqueAbsent() throws ClassNotFoundException {
+        SSLSession session = createExtendedSessionMock(null);
+        assertNull(TDSChannel.createChannelBindingInfo(session));
+    }
+
+    @Test
+    void createChannelBindingInfoReturnsNullWhenJdkDoesNotSupportTlsUniqueChannelBinding() {
+        if (isTlsUniqueChannelBindingMethodAvailable()) {
+            return;
+        }
+
+        assertNull(TDSChannel.createChannelBindingInfo(Mockito.mock(SSLSession.class)));
+    }
+
+    private static SSLSession createExtendedSessionMock(byte[] tlsUnique) throws ClassNotFoundException {
+        Class<?> extendedSessionClass = Class.forName("javax.net.ssl.ExtendedSSLSession");
+        Object mock = Mockito.mock(extendedSessionClass, invocation -> {
+            if ("getTlsUniqueChannelBinding".equals(invocation.getMethod().getName())) {
+                return tlsUnique;
+            }
+            return Answers.RETURNS_DEFAULTS.answer(invocation);
+        });
+        return (SSLSession) mock;
+    }
+
+    private static boolean isTlsUniqueChannelBindingMethodAvailable() {
+        try {
+            Class<?> extendedSessionClass = Class.forName("javax.net.ssl.ExtendedSSLSession");
+            extendedSessionClass.getMethod("getTlsUniqueChannelBinding");
+            return true;
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelChannelBindingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelChannelBindingTest.java
@@ -18,9 +18,9 @@ import org.mockito.Mockito;
 class TDSChannelChannelBindingTest {
 
     @Test
-    void createChannelBindingInfoPrefixesTlsUniqueData() throws ClassNotFoundException {
-        assumeTrue(isTlsUniqueChannelBindingMethodAvailable(),
-                "Skipping because getTlsUniqueChannelBinding is not available on this JDK");
+    void createChannelBindingInfoPrefixesClientFirstFinishedVerifyData() throws ClassNotFoundException {
+        assumeTrue(isTlsUniqueClientFirstFinishedVerifyDataMethodAvailable(),
+                "Skipping because getTlsUniqueClientFirstFinishedVerifyData is not available on this JDK");
 
         byte[] tlsUnique = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
@@ -38,8 +38,8 @@ class TDSChannelChannelBindingTest {
     }
 
     @Test
-    void createChannelBindingInfoReturnsNullWhenJdkDoesNotSupportTlsUniqueChannelBinding() {
-        if (isTlsUniqueChannelBindingMethodAvailable()) {
+    void createChannelBindingInfoReturnsNullWhenJdkDoesNotSupportTlsUniqueClientFirstFinishedVerifyData() {
+        if (isTlsUniqueClientFirstFinishedVerifyDataMethodAvailable()) {
             return;
         }
 
@@ -49,7 +49,10 @@ class TDSChannelChannelBindingTest {
     private static SSLSession createExtendedSessionMock(byte[] tlsUnique) throws ClassNotFoundException {
         Class<?> extendedSessionClass = Class.forName("javax.net.ssl.ExtendedSSLSession");
         Object mock = Mockito.mock(extendedSessionClass, invocation -> {
-            if ("getTlsUniqueChannelBinding".equals(invocation.getMethod().getName())) {
+            if ("getTlsUniqueClientFirstFinishedVerifyData".equals(invocation.getMethod().getName())) {
+                return tlsUnique;
+            }
+            if ("getTlsUniqueFirstFinishedVerifyData".equals(invocation.getMethod().getName())) {
                 return tlsUnique;
             }
             return Answers.RETURNS_DEFAULTS.answer(invocation);
@@ -57,10 +60,10 @@ class TDSChannelChannelBindingTest {
         return (SSLSession) mock;
     }
 
-    private static boolean isTlsUniqueChannelBindingMethodAvailable() {
+    private static boolean isTlsUniqueClientFirstFinishedVerifyDataMethodAvailable() {
         try {
             Class<?> extendedSessionClass = Class.forName("javax.net.ssl.ExtendedSSLSession");
-            extendedSessionClass.getMethod("getTlsUniqueChannelBinding");
+            extendedSessionClass.getMethod("getTlsUniqueClientFirstFinishedVerifyData");
             return true;
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             return false;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelChannelBindingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/TDSChannelChannelBindingTest.java
@@ -6,8 +6,19 @@
 package com.microsoft.sqlserver.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import javax.net.ssl.SSLSession;
 
@@ -18,9 +29,19 @@ import org.mockito.Mockito;
 class TDSChannelChannelBindingTest {
 
     @Test
-    void createChannelBindingInfoPrefixesClientFirstFinishedVerifyData() throws ClassNotFoundException {
-        assumeTrue(isTlsUniqueClientFirstFinishedVerifyDataMethodAvailable(),
-                "Skipping because getTlsUniqueClientFirstFinishedVerifyData is not available on this JDK");
+    void createChannelBindingInfoReturnsNullWhenSessionIsNull() {
+        assertNull(TDSChannel.createChannelBindingInfo(null));
+    }
+
+    @Test
+    void createChannelBindingInfoReturnsNullWhenSessionIsNotExtended() {
+        assertNull(TDSChannel.createChannelBindingInfo(Mockito.mock(SSLSession.class)));
+    }
+
+    @Test
+    void createChannelBindingInfoPrefixesTlsUniqueChannelBinding() throws ClassNotFoundException {
+        assumeTrue(isTlsUniqueChannelBindingMethodAvailable(),
+                "Skipping because getTlsUniqueChannelBinding is not available on this JDK");
 
         byte[] tlsUnique = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
@@ -33,26 +54,67 @@ class TDSChannelChannelBindingTest {
 
     @Test
     void createChannelBindingInfoReturnsNullWhenTlsUniqueAbsent() throws ClassNotFoundException {
+        assumeTrue(isTlsUniqueChannelBindingMethodAvailable(),
+                "Skipping because getTlsUniqueChannelBinding is not available on this JDK");
+
         SSLSession session = createExtendedSessionMock(null);
         assertNull(TDSChannel.createChannelBindingInfo(session));
     }
 
     @Test
-    void createChannelBindingInfoReturnsNullWhenJdkDoesNotSupportTlsUniqueClientFirstFinishedVerifyData() {
-        if (isTlsUniqueClientFirstFinishedVerifyDataMethodAvailable()) {
+    void createChannelBindingInfoReturnsNullWhenTlsUniqueIsEmpty() throws ClassNotFoundException {
+        assumeTrue(isTlsUniqueChannelBindingMethodAvailable(),
+                "Skipping because getTlsUniqueChannelBinding is not available on this JDK");
+
+        SSLSession session = createExtendedSessionMock(new byte[0]);
+        assertNull(TDSChannel.createChannelBindingInfo(session));
+    }
+
+    @Test
+    void createChannelBindingInfoReturnsNullWhenJdkDoesNotSupportTlsUniqueChannelBinding() {
+        if (isTlsUniqueChannelBindingMethodAvailable()) {
             return;
         }
 
         assertNull(TDSChannel.createChannelBindingInfo(Mockito.mock(SSLSession.class)));
     }
 
+    @Test
+    void ntlmAuthenticationUsesPerContextChannelBindingInfo() throws Exception {
+        byte[] firstChannelBinding = new byte[] {'t', 'l', 's', '-', 'u', 'n', 'i', 'q', 'u', 'e', ':', 1, 2, 3};
+        byte[] secondChannelBinding = new byte[] {'t', 'l', 's', '-', 'u', 'n', 'i', 'q', 'u', 'e', ':', 4, 5, 6};
+
+        NTLMAuthentication first = new NTLMAuthentication(null, "DOMAIN", "user", new byte[16], "host",
+                firstChannelBinding);
+        NTLMAuthentication second = new NTLMAuthentication(null, "DOMAIN", "user", new byte[16], "host",
+                secondChannelBinding);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            Future<byte[]> firstHash = executor.submit(() -> calculateNtlmChannelBindingHash(first, ready, start));
+            Future<byte[]> secondHash = executor.submit(() -> calculateNtlmChannelBindingHash(second, ready, start));
+
+            ready.await();
+            start.countDown();
+
+            byte[] firstResult = firstHash.get();
+            byte[] secondResult = secondHash.get();
+            assertArrayEquals(expectedNtlmChannelBindingHash(firstChannelBinding), firstResult);
+            assertArrayEquals(expectedNtlmChannelBindingHash(secondChannelBinding), secondResult);
+            assertFalse(Arrays.equals(firstResult, secondResult));
+        } finally {
+            first.releaseClientContext();
+            second.releaseClientContext();
+            executor.shutdownNow();
+        }
+    }
+
     private static SSLSession createExtendedSessionMock(byte[] tlsUnique) throws ClassNotFoundException {
         Class<?> extendedSessionClass = Class.forName("javax.net.ssl.ExtendedSSLSession");
         Object mock = Mockito.mock(extendedSessionClass, invocation -> {
-            if ("getTlsUniqueClientFirstFinishedVerifyData".equals(invocation.getMethod().getName())) {
-                return tlsUnique;
-            }
-            if ("getTlsUniqueFirstFinishedVerifyData".equals(invocation.getMethod().getName())) {
+            if ("getTlsUniqueChannelBinding".equals(invocation.getMethod().getName())) {
                 return tlsUnique;
             }
             return Answers.RETURNS_DEFAULTS.answer(invocation);
@@ -60,13 +122,41 @@ class TDSChannelChannelBindingTest {
         return (SSLSession) mock;
     }
 
-    private static boolean isTlsUniqueClientFirstFinishedVerifyDataMethodAvailable() {
+    private static boolean isTlsUniqueChannelBindingMethodAvailable() {
         try {
             Class<?> extendedSessionClass = Class.forName("javax.net.ssl.ExtendedSSLSession");
-            extendedSessionClass.getMethod("getTlsUniqueClientFirstFinishedVerifyData");
+            extendedSessionClass.getMethod("getTlsUniqueChannelBinding");
             return true;
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             return false;
         }
+    }
+
+    private static byte[] calculateNtlmChannelBindingHash(NTLMAuthentication authentication, CountDownLatch ready,
+            CountDownLatch start) throws Exception {
+        Method calculateHash = NTLMAuthentication.class.getDeclaredMethod("calculateChannelBindingMD5Hash");
+        calculateHash.setAccessible(true);
+        Field msvAvChannelBindings = NTLMAuthentication.class.getDeclaredField("msvAvChannelBindings");
+        msvAvChannelBindings.setAccessible(true);
+
+        ready.countDown();
+        start.await();
+        try {
+            calculateHash.invoke(authentication);
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
+        return (byte[]) msvAvChannelBindings.get(authentication);
+    }
+
+    private static byte[] expectedNtlmChannelBindingHash(byte[] channelBindingInfo) throws Exception {
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        md5.update(new byte[4]);
+        md5.update(new byte[4]);
+        md5.update(new byte[4]);
+        md5.update(new byte[4]);
+        md5.update(new byte[] {(byte) channelBindingInfo.length, (byte) 0, (byte) 0, (byte) 0});
+        md5.update(channelBindingInfo);
+        return md5.digest();
     }
 }


### PR DESCRIPTION
**Summary**
This PR adds `tls-unique` channel binding support (RFC 5929) in the JDBC driver so TLS Finished `verify_data` can be incorporated into Java authentication flows used for Extended Protection and related integrations.

**What changed**
The driver now captures `tls-unique` channel binding data from the completed TLS handshake and uses it in authentication paths that support channel binding.

- `TDSChannel` extracts channel binding bytes from `ExtendedSSLSession` after the TLS handshake completes.
- The implementation prefers `getTlsUniqueClientFirstFinishedVerifyData()` and falls back to `getTlsUniqueFirstFinishedVerifyData()` when needed.
- The captured value is normalized as `tls-unique:<verify_data>` per RFC 5929 handling in the client.
- Kerberos integrated authentication now sets GSS channel binding when `tls-unique` data is available.
- NTLM authentication now includes the `MsvAvChannelBindings` AV pair using the MD5 hash of the channel binding structure.
- If the runtime does not expose the required JSSE methods, or if `tls-unique` is unavailable, the driver falls back to the existing no-channel-binding behavior.

**Compatibility**
No driver behavior changes unless the runtime exposes `tls-unique` data and it is enabled in JSSE.

- `sun.security.ssl.enableTlsUniqueChannelBinding` remains disabled by default, so this stays opt-in.
- Existing TLS, Kerberos, and NTLM flows continue unchanged when the feature is unavailable or not enabled.
- On unsupported JDKs or platforms, the driver safely preserves prior behavior.

**Documentation**
Channel Binding issue details doc:
https://github.com/microsoft/mssql-jdbc/wiki/Channel-Binding-Feature-Summary