### PR TITLE
Avoid head-of-line blocking on cached AAD token reads (silent fast-path before semaphore) Avoid head-of-line blocking on cached AAD token reads (silent fast-path before semaphore)

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -167,19 +167,9 @@ class SQLServerMSAL4JUtils {
                                                                     : fedAuthInfo.spn + defaultScopeSuffix;
         Set<String> scopes = new HashSet<>();
         scopes.add(scope);
-        
+
         boolean isSemAcquired = false;
         try {
-            //
-            //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
-            //The purpose is to optimize the token acquisition process, the first caller succeeding does caching 
-            //which is then leveraged by subsequent threads. However, if the first thread takes considerable time, 
-            //then we want the others to also go and try after waiting for a while.
-            //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
-            //to get their tokens at the same time, stressing the auth endpoint.
-            //
-            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
-
             String hashedSecret = getHashedSecret(
                     new String[] {fedAuthInfo.stsurl, aadPrincipalID, aadPrincipalSecret});
             PersistentTokenCacheAccessAspect persistentTokenCacheAccessAspect = TOKEN_CACHE_MAP.getEntry(aadPrincipalID,
@@ -203,6 +193,34 @@ class SQLServerMSAL4JUtils {
             ConfidentialClientApplication clientApplication = ConfidentialClientApplication
                     .builder(aadPrincipalID, credential).executorService(executorService)
                     .setTokenCacheAccessAspect(persistentTokenCacheAccessAspect).authority(fedAuthInfo.stsurl).build();
+
+            //
+            // Fast path: try to satisfy the request from the MSAL in-memory token cache (rehydrated
+            // from the persistent cache aspect) WITHOUT taking the semaphore. A cache hit needs no
+            // AAD round-trip, so it must not queue behind threads that are refreshing/fetching the
+            // token from Entra ID. Serializing cache hits behind the gate is the bottleneck this avoids.
+            //
+            SqlAuthenticationToken cachedToken = acquireTokenSilentlyOrNull(clientApplication, scopes,
+                    millisecondsRemaining, aadPrincipalID);
+            if (null != cachedToken) {
+                return cachedToken;
+            }
+
+            //
+            // Slow path: only cache misses reach here. Gate the AAD call with the semaphore so a
+            // burst of misses does not stampede the token endpoint. The first caller to acquire the
+            // gate refreshes the token and populates the shared cache; callers that were waiting on
+            // the gate pick up that freshly-cached token because acquireToken performs its own cache
+            // lookup first (skipCache defaults to false) and therefore avoids a redundant AAD call.
+            //
+            //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
+            //The purpose is to optimize the token acquisition process, the first caller succeeding does caching 
+            //which is then leveraged by subsequent threads. However, if the first thread takes considerable time, 
+            //then we want the others to also go and try after waiting for a while.
+            //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
+            //to get their tokens at the same time, stressing the auth endpoint.
+            //
+            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             final CompletableFuture<IAuthenticationResult> future = clientApplication
                     .acquireToken(ClientCredentialParameters.builder(scopes).build());
@@ -229,6 +247,54 @@ class SQLServerMSAL4JUtils {
                 sem.release();
             }
             executorService.shutdown();
+        }
+    }
+
+    /**
+     * Attempts a lock-free, cache-only token read for the ActiveDirectoryServicePrincipal flow. This
+     * is the fast path that lets a caller whose token is already present in the MSAL in-memory cache
+     * (rehydrated from the persistent cache aspect) return immediately, without contending for the
+     * global token semaphore. {@code acquireTokenSilently} never contacts Entra ID: on a cache miss
+     * its future completes with an {@link ExecutionException}, which is reported here as {@code null}
+     * so the caller falls through to the gated slow path that performs the real token acquisition.
+     *
+     * @param clientApplication
+     *        the MSAL confidential client application for this service principal
+     * @param scopes
+     *        the requested token scopes
+     * @param millisecondsRemaining
+     *        the remaining login timeout budget, in milliseconds
+     * @param aadPrincipalID
+     *        the service principal (client) id, used for logging only
+     * @return the cached {@link SqlAuthenticationToken} on a silent cache hit, or {@code null} on a
+     *         cache miss
+     * @throws InterruptedException
+     *         if the calling thread is interrupted while waiting for the silent result
+     * @throws TimeoutException
+     *         if the silent read does not complete within the remaining budget
+     * @throws MalformedURLException
+     *         if MSAL rejects the configured authority URL
+     */
+    static SqlAuthenticationToken acquireTokenSilentlyOrNull(ConfidentialClientApplication clientApplication,
+            Set<String> scopes, int millisecondsRemaining, String aadPrincipalID)
+            throws InterruptedException, TimeoutException, MalformedURLException {
+        try {
+            final IAuthenticationResult silentResult = clientApplication
+                    .acquireTokenSilently(SilentParameters.builder(scopes).build())
+                    .get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+
+            if (logger.isLoggable(Level.FINER)) {
+                logger.finer(LOGCONTEXT + ": retrieved token silently for principal id: " + aadPrincipalID);
+            }
+
+            return new SqlAuthenticationToken(silentResult.accessToken(), silentResult.expiresOnDate());
+        } catch (ExecutionException silentMiss) {
+            // No valid access token cached for these scopes; signal a miss so the caller takes the
+            // gated slow path.
+            if (logger.isLoggable(Level.FINER)) {
+                logger.finer(LOGCONTEXT + ": silent token acquisition missed for principal id: " + aadPrincipalID);
+            }
+            return null;
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtilsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtilsTest.java
@@ -6,13 +6,28 @@ package com.microsoft.sqlserver.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.jupiter.api.Test;
 
+import com.microsoft.aad.msal4j.ClientCredentialParameters;
+import com.microsoft.aad.msal4j.ConfidentialClientApplication;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.microsoft.aad.msal4j.InteractiveRequestParameters;
+import com.microsoft.aad.msal4j.SilentParameters;
 
 
 /**
@@ -43,5 +58,53 @@ public class SQLServerMSAL4JUtilsTest {
         assertEquals(user, params.loginHint(), "loginHint should be propagated from the connection user");
         assertTrue(params.scopes().contains(spn + SQLServerMSAL4JUtils.SLASH_DEFAULT),
                 "scopes must contain the resource SPN with the /.default suffix");
+    }
+
+    /**
+     * Fast-path cache hit: when the MSAL client already holds a valid access token,
+     * {@link SQLServerMSAL4JUtils#acquireTokenSilentlyOrNull} must return it directly and must NOT
+     * fall through to a real Entra ID token acquisition. This is the head-of-line-blocking
+     * optimization: cache hits are served without taking the global token semaphore.
+     */
+    @Test
+    public void testAcquireTokenSilentlyReturnsCachedTokenOnHit() throws Exception {
+        ConfidentialClientApplication clientApplication = mock(ConfidentialClientApplication.class);
+        IAuthenticationResult silentResult = mock(IAuthenticationResult.class);
+        Date expiresOn = new Date(System.currentTimeMillis() + 3_600_000L);
+        when(silentResult.accessToken()).thenReturn("cached-access-token");
+        when(silentResult.expiresOnDate()).thenReturn(expiresOn);
+        when(clientApplication.acquireTokenSilently(any(SilentParameters.class)))
+                .thenReturn(CompletableFuture.completedFuture(silentResult));
+
+        Set<String> scopes = Collections.singleton("https://database.windows.net/.default");
+
+        SqlAuthenticationToken token = SQLServerMSAL4JUtils.acquireTokenSilentlyOrNull(clientApplication, scopes,
+                20000, "test-principal-id");
+
+        assertNotNull(token, "a silent cache hit must return a token");
+        assertEquals("cached-access-token", token.getAccessToken(), "the cached access token must be returned");
+        assertEquals(expiresOn, token.getExpiresOn(), "the cached token expiry must be preserved");
+        verify(clientApplication, never()).acquireToken(any(ClientCredentialParameters.class));
+    }
+
+    /**
+     * Fast-path cache miss: when no valid token is cached, MSAL's silent future completes with an
+     * {@link ExecutionException}. {@link SQLServerMSAL4JUtils#acquireTokenSilentlyOrNull} must
+     * translate that into {@code null} so the caller falls through to the gated slow path that
+     * performs the real Entra ID token acquisition.
+     */
+    @Test
+    public void testAcquireTokenSilentlyReturnsNullOnMiss() throws Exception {
+        ConfidentialClientApplication clientApplication = mock(ConfidentialClientApplication.class);
+        CompletableFuture<IAuthenticationResult> missFuture = new CompletableFuture<>();
+        missFuture.completeExceptionally(new IllegalStateException("no cached token for scopes"));
+        when(clientApplication.acquireTokenSilently(any(SilentParameters.class))).thenReturn(missFuture);
+
+        Set<String> scopes = Collections.singleton("https://database.windows.net/.default");
+
+        SqlAuthenticationToken token = SQLServerMSAL4JUtils.acquireTokenSilentlyOrNull(clientApplication, scopes,
+                20000, "test-principal-id");
+
+        assertNull(token, "a silent cache miss must return null so the caller takes the gated slow path");
     }
 }


### PR DESCRIPTION
## Description

`ActiveDirectoryServicePrincipal` token acquisition serializes **every** call on a single JVM-wide `Semaphore(1)`. The gate exists to stop a burst of cold callers from stampeding the Entra ID (AAD) token endpoint, but it also forces callers whose token is **already cached in memory** to queue behind whichever thread currently holds the permit — turning a fast, no-network cache read into a head-of-line-blocked operation under concurrency.

This PR adds a **lock-free silent fast-path** in `SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal`. Before taking the semaphore, the caller attempts `acquireTokenSilently(...)` — MSAL's cache-only read that never contacts AAD. On a cache **hit** the token is returned immediately without touching the gate; on a cache **miss** the code falls through to the unchanged gated slow path, preserving the existing AAD-stampede protection.

- **API changes / backwards compatibility:** None. No public API, connection property, or default behavior change. Cache misses behave exactly as before.
- **Who benefits:** Applications opening many concurrent connections with `authentication=ActiveDirectoryServicePrincipal`, especially connection pools reusing a warm token.

## How it works

```
Before:  [ acquire semaphore ] -> cache lookup -> (hit OR AAD call) -> release
         every call serializes on the gate, even in-memory cache hits

After:   silent cache read (NO lock)
           ├─ hit  -> return immediately                                    <- the fix
           └─ miss -> [ acquire semaphore ] -> cache check / AAD call -> release   (unchanged)
```

On a miss, only the first caller to win the gate makes the real AAD call; callers that queued behind it fall into `acquireToken`'s own internal cache lookup (`skipCache` defaults to `false`) and pick up the token the winner just cached, so they do not issue a redundant AAD request.

The silent read is extracted into a package-private helper `acquireTokenSilentlyOrNull(...)` so it can be unit-tested in isolation. Behavior is otherwise identical — `InterruptedException`, `TimeoutException`, and `MalformedURLException` propagate to the same existing catch blocks.

## Testing

**Unit tests** added to `SQLServerMSAL4JUtilsTest` (offline, no server or Azure credentials; MSAL client mocked via Mockito, consistent with `SQLServerBulkCopyTest`/`SQLServerSQLXMLTest`):

| Test | Verifies |
|---|---|
| `testAcquireTokenSilentlyReturnsCachedTokenOnHit` | On a cache hit the cached token is returned **and** `acquireToken` (the real AAD call) is never invoked — the semaphore is bypassed |
| `testAcquireTokenSilentlyReturnsNullOnMiss` | On a cache miss the helper returns `null` so the caller takes the gated slow path |

All existing tests continue to pass.

### Performance test methodology

Measured using the driver's **built-in `PerformanceLogCallback`** (the same `TOKEN_ACQUISITION` activity added in #2706) — no external timing. A callback is registered with `useNanoseconds()` returning `true`, and every connection's `TOKEN_ACQUISITION` duration is aggregated.

| Item | Value |
|---|---|
| Workload | K threads each loop: open connection → `SELECT 1` → close, all on the **same** service principal (worst-case semaphore contention) |
| Auth | `authentication=ActiveDirectoryServicePrincipal` |
| K (threads) | 60 |
| Mode | warm (token pre-cached before the measured window) |
| Retries | disabled (`connectRetryCount=0`) so failures surface immediately |
| Durations | 10s / 60s / 300s / 600s, 1 iteration each |
| Target | Azure SQL Database |
| Metric source | driver's `TOKEN_ACQUISITION` via `PerformanceLogCallback` (ns precision) |
| Baseline | current `main` (global `Semaphore(1)`), unmodified |

Reproducible by anyone: register a `PerformanceLogCallback`, run the workload above against both the current driver and this branch, and compare the `TOKEN_ACQUISITION` durations.

**Token acquisition avg (ms) — lower is better**

| Duration | Baseline | This PR | Improvement |
|---:|---:|---:|:--:|
| 10s | 87.3 | 38.3 | **−56.1%** |
| 60s | 97.2 | 40.6 | **−58.2%** |
| 300s | 95.5 | 35.7 | **−62.6%** |
| 600s | 93.8 | 37.8 | **−59.7%** |

**Avg connection latency (ms) — lower is better**

| Duration | Baseline | This PR | Improvement |
|---:|---:|---:|:--:|
| 10s | 145 | 119 | **−17.9%** |
| 60s | 158 | 136 | **−13.9%** |
| 300s | 156 | 131 | **−16.0%** |
| 600s | 154 | 134 | **−13.0%** |

Token acquisition is **~56–63% cheaper** across all durations because cache hits skip the global semaphore. In the baseline, all K=60 threads serialize on one permit, so every cache hit still waits ~95 ms even though the token is already cached. Raw per-duration data available on request.

## Guidelines

Reviewed the contribution guidelines, code of conduct, best practices, coding guidelines, and review process.
