### PR TITLE
Fix | Login TLS handshake hangs on Android (Conscrypt): read up to maxBytes during SSL handshake

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -1037,8 +1037,15 @@ final class TDSChannel implements Serializable {
         }
 
         void endMessage() throws SQLServerException {
-            // We should only be asked to end the message if we have started one
-            assert messageStarted;
+            // Nothing to flush if no handshake output has been buffered since the last flush.
+            // With the "read up to maxBytes" behavior in SSLHandshakeInputStream.readInternal, the
+            // input stream may ask us to ensure payload again while reading a handshake response
+            // that spans multiple TDS packets. At that point no new output has been written, so
+            // there is nothing to end. (Previously this method asserted messageStarted, which
+            // failed for multi-packet handshake responses, e.g. large server certificate chains.)
+            if (!messageStarted) {
+                return;
+            }
 
             if (logger.isLoggable(Level.FINEST))
                 logger.finest(logContext + " Finishing TDS message");

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -982,13 +982,24 @@ final class TDSChannel implements Serializable {
             ensureSSLPayload();
 
             try {
-                tdsReader.readBytes(b, offset, maxBytes);
+                // Honor the InputStream contract: read UP TO maxBytes, returning the number of
+                // bytes actually read. Previously this blocked until exactly maxBytes were read,
+                // which deadlocks with SSL providers (e.g. Conscrypt on Android) that issue a
+                // single large read for the whole record: the server sends its handshake flight
+                // in fewer bytes and then waits for the client's response, while the driver waits
+                // for more bytes that never come. SunJSSE happened to avoid this by reading in
+                // exact TLS-record-sized chunks.
+                int bytesToRead = Math.min(maxBytes, tdsReader.available());
+                if (bytesToRead < maxBytes && logger.isLoggable(Level.FINEST))
+                    logger.finest(logContext + " Returning " + bytesToRead
+                            + " buffered bytes reported by tdsReader.available() instead of the " + maxBytes
+                            + " requested to avoid blocking");
+                tdsReader.readBytes(b, offset, bytesToRead);
+                return bytesToRead;
             } catch (SQLServerException e) {
                 logger.finer(logContext + " Reading bytes threw exception:" + e.getMessage());
                 throw new IOException(e.getMessage(), e);
             }
-
-            return maxBytes;
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -989,6 +989,15 @@ final class TDSChannel implements Serializable {
                 // in fewer bytes and then waits for the client's response, while the driver waits
                 // for more bytes that never come. SunJSSE happened to avoid this by reading in
                 // exact TLS-record-sized chunks.
+                //
+                // ensureSSLPayload() only guarantees a packet was read, not that it carried any
+                // payload. Guard against a zero-length payload packet so we never return 0 for a
+                // non-zero request, which would violate the InputStream.read contract and can make
+                // SSL engines busy-spin. Reading the next packet is bounded: readPacket() blocks
+                // for server data and terminates on premature EOF, so this cannot spin.
+                while (maxBytes > 0 && 0 == tdsReader.available())
+                    ensureSSLPayload();
+
                 int bytesToRead = Math.min(maxBytes, tdsReader.available());
                 if (bytesToRead < maxBytes && logger.isLoggable(Level.FINEST))
                     logger.finest(logContext + " Returning " + bytesToRead


### PR DESCRIPTION
## Problem description

On Android (which uses Conscrypt as its default TLS provider), establishing a JDBC connection hangs during the login-phase TLS handshake and eventually fails. SQL Server performs a TLS handshake during login even when `encrypt=false`, so both `encrypt=false` and `encrypt=true` are affected. In a shipped (assertions-off) build the connect blocks until `loginTimeout` and throws `SQLServerException: ... could not establish a secure connection ... Read timed out`. In a debuggable build (where the Android Gradle Plugin / d8 force-enables Java assertions) it fails earlier with `AssertionError: numMsgsRcvd:1 should be less than numMsgsSent:1` from `TDSReader.readPacket` — the same root cause, surfaced earlier by an assertion.

Root cause: `TDSChannel.SSLHandshakeInputStream.readInternal(byte[], int, int)` read exactly `maxBytes` (blocking across TDS packets) and always returned `maxBytes`, instead of reading up to `maxBytes` and returning the actual number of bytes read as the `InputStream.read` contract requires. SunJSSE reads the TLS handshake in small, exact record-sized chunks and never requests more than is available, so the defect is masked. Conscrypt issues a single large read (its buffer size, e.g. 16709 bytes); the driver then blocks trying to fill 16709 bytes while the server has already sent its complete handshake flight (~1.5 KB in one TDS packet) and is waiting for the client's next flight — a deadlock.

### Fixes existing GitHub issue

Fixes #2979

## Fix Description

In `SSLHandshakeInputStream.readInternal`, after `ensureSSLPayload()` guarantees at least one buffered TDS packet, read `Math.min(maxBytes, tdsReader.available())` bytes and return the actual count instead of blocking for the full `maxBytes`. `TDSReader.available()` reports only non-blocking buffered bytes, so the handshake input stream now honors the read-up-to contract and hands each buffered chunk to the SSL engine, which can then advance the handshake. A `FINEST` log records when a short read occurs. There is no behavior change for SunJSSE, which already read within a single packet.

## New Public APIs

None.

## Testing

- Reproduced and fixed with the Android instrumented-test reproducer attached to #2979 (Android 14 / API 34 emulator, Conscrypt). With the fix, both `encrypt=false` and `encrypt=true` connect successfully on both the release (assertions-off) and debug (assertions-on) variants.
- Desktop regression matrix (OpenJDK / SunJSSE) against the same SQL Server: `encrypt=false` and `encrypt=true`, with and without `-ea`, all continue to connect successfully — no change in the common path.
- Justification for the automated-test gap: the defect is TLS-provider-specific. The JVM-based test suite runs on SunJSSE, which reads the handshake in record-sized chunks and therefore cannot reproduce Conscrypt's single-large-read behavior, so a JVM unit/integration test cannot exercise the failing path. The existing encryption/connection integration tests continue to guard the SunJSSE path against regressions. Happy to add a targeted test if maintainers can suggest a supported way to inject a large-read SSL engine into the suite.
- ADO test runs:
   - https://sqlclientdrivers.visualstudio.com/mssql-jdbc/_build/results?buildId=160194&view=results
   - https://sqlclientdrivers.visualstudio.com/mssql-jdbc/_build/results?buildId=161468&view=results