### PR TITLE
Fix | Flaky test fixes: RequestBoundaryMethodsTest.testThreads hang and MessageHandlerTest timing bounds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -686,6 +686,24 @@
 					<argLine>${argLine} -Xmx1024m -Djava.library.path=${dllPath}
 					</argLine>
 					<excludedGroups>${excludedGroups}</excludedGroups>
+					<!--
+						Diagnostics for intermittent CI hangs where a forked test JVM does not exit
+						after its last test class completes (observed on the linux SQL2025 legs, e.g.
+						right after DatabaseMetaDataTest / JDBC43Test), leaving the job to hang until
+						the 3-hour pipeline timeout. Hypothesis: a non-daemon worker in
+						SocketFinder.threadPoolExecutor (created with the default, non-daemon
+						ThreadFactory) is left blocked on a socket operation and keeps the JVM alive.
+
+						These bounds make Surefire kill a stuck fork and write a thread dump to
+						target/surefire-reports/*.dumpstream instead of hanging, so the next
+						occurrence positively identifies the offending thread. Values are generous
+						relative to a normal run (~9 min per leg) and can be tuned.
+						- forkedProcessExitTimeoutInSeconds: max wait for a fork to exit AFTER its
+						  last test finishes; targets the post-suite shutdown hang directly.
+						- forkedProcessTimeoutInSeconds: hard cap on total fork run time, as a backstop.
+					-->
+					<forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
+					<forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -686,16 +686,6 @@
 					<argLine>${argLine} -Xmx1024m -Djava.library.path=${dllPath}
 					</argLine>
 					<excludedGroups>${excludedGroups}</excludedGroups>
-					<!--
-						Backstop against a forked test JVM that never exits, which previously left CI
-						jobs hanging until the 3-hour pipeline timeout. If a fork exceeds this cap,
-						Surefire terminates it and writes target/surefire-reports/*.dumpstream, turning
-						a job-killing hang into a normal, retryable failure. This is defense-in-depth
-						(generous vs. a normal leg of ~9 min); the known root cause (a worker thread
-						failing before counting down a latch in RequestBoundaryMethodsTest.testThreads)
-						is fixed directly in that test in this change.
-					-->
-					<forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -687,22 +687,14 @@
 					</argLine>
 					<excludedGroups>${excludedGroups}</excludedGroups>
 					<!--
-						Diagnostics for intermittent CI hangs where a forked test JVM does not exit
-						after its last test class completes (observed on the linux SQL2025 legs, e.g.
-						right after DatabaseMetaDataTest / JDBC43Test), leaving the job to hang until
-						the 3-hour pipeline timeout. Hypothesis: a non-daemon worker in
-						SocketFinder.threadPoolExecutor (created with the default, non-daemon
-						ThreadFactory) is left blocked on a socket operation and keeps the JVM alive.
-
-						These bounds make Surefire kill a stuck fork and write a thread dump to
-						target/surefire-reports/*.dumpstream instead of hanging, so the next
-						occurrence positively identifies the offending thread. Values are generous
-						relative to a normal run (~9 min per leg) and can be tuned.
-						- forkedProcessExitTimeoutInSeconds: max wait for a fork to exit AFTER its
-						  last test finishes; targets the post-suite shutdown hang directly.
-						- forkedProcessTimeoutInSeconds: hard cap on total fork run time, as a backstop.
+						Backstop against a forked test JVM that never exits, which previously left CI
+						jobs hanging until the 3-hour pipeline timeout. If a fork exceeds this cap,
+						Surefire terminates it and writes target/surefire-reports/*.dumpstream, turning
+						a job-killing hang into a normal, retryable failure. This is defense-in-depth
+						(generous vs. a normal leg of ~9 min); the known root cause (a worker thread
+						failing before counting down a latch in RequestBoundaryMethodsTest.testThreads)
+						is fixed directly in that test in this change.
 					-->
-					<forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
 					<forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
 				</configuration>
 			</plugin>

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
@@ -384,19 +384,30 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
             int originalNetworkTimeout = sharedVariables.con.getNetworkTimeout();
             int originalHoldability = sharedVariables.con.getHoldability();
             sharedVariables.con.beginRequest();
+            // Run the workers as daemon threads so that if one ever blocks (e.g. on a socket read)
+            // it can never keep the forked test JVM alive after this method returns. A wedged,
+            // non-daemon test thread is exactly what previously hung CI jobs until the pipeline
+            // timeout, so this guarantees the fork can always exit regardless of worker state.
+            thread1.setDaemon(true);
+            thread2.setDaemon(true);
+            thread3.setDaemon(true);
             thread1.start();
             thread2.start();
             thread3.start();
-            // Bound the wait so a worker that fails before completing cannot hang the test JVM
-            // indefinitely. Previously each worker only counted the latch down on its success
+            // Bound the wait so a worker that fails or blocks before completing cannot hang the
+            // test indefinitely. Previously each worker only counted the latch down on its success
             // path, so an uncaught error (e.g. a read timeout from the 100 ms network timeout set
-            // above) left the latch above zero and main blocked forever on latch.await(), which
-            // kept the forked test JVM alive and hung CI jobs until the multi-hour pipeline timeout.
+            // above) left the latch above zero and main blocked forever on latch.await().
             if (!latch.await(30, TimeUnit.SECONDS)) {
-                fail("testThreads timed out waiting for worker threads to finish");
+                // Best-effort: interrupt the stragglers so they can unwind promptly.
+                thread1.interrupt();
+                thread2.interrupt();
+                thread3.interrupt();
+                fail("testThreads timed out after 30s waiting for worker threads to finish");
             }
             if (null != workerError.get()) {
-                fail("A worker thread failed: " + workerError.get());
+                // Propagate the worker's throwable as the cause so its stack trace is preserved.
+                throw new AssertionError("A worker thread failed", workerError.get());
             }
             sharedVariables.con.endRequest();
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/RequestBoundaryMethodsTest.java
@@ -23,6 +23,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -330,6 +332,7 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
 
         final Variables sharedVariables = new Variables();
         final CountDownLatch latch = new CountDownLatch(3);
+        final AtomicReference<Throwable> workerError = new AtomicReference<>();
         try {
             sharedVariables.con = getConnection();
             assumeTrue(TestUtils.isJDBC43OrGreater(sharedVariables.con));
@@ -338,10 +341,10 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
                     try {
                         sharedVariables.con.setNetworkTimeout(null, 100);
                         sharedVariables.con.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
+                    } catch (Throwable t) {
+                        workerError.compareAndSet(null, t);
+                    } finally {
                         latch.countDown();
-                    } catch (SQLException e) {
-                        e.printStackTrace();
-                        Thread.currentThread().interrupt();
                     }
                 }
             };
@@ -353,11 +356,11 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
                         try (ResultSet rs = sharedVariables.stmt.executeQuery("SELECT 1")) {
                             rs.next();
                             assertEquals(1, rs.getInt(1));
-                            latch.countDown();
                         }
-                    } catch (SQLException e) {
-                        e.printStackTrace();
-                        Thread.currentThread().interrupt();
+                    } catch (Throwable t) {
+                        workerError.compareAndSet(null, t);
+                    } finally {
+                        latch.countDown();
                     }
                 }
             };
@@ -369,13 +372,12 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
                         try (ResultSet rs = sharedVariables.pstmt.executeQuery()) {
                             rs.next();
                             assertEquals(1, rs.getInt(1));
-                            latch.countDown();
                         }
-                    } catch (SQLException e) {
-                        e.printStackTrace();
-                        Thread.currentThread().interrupt();
+                    } catch (Throwable t) {
+                        workerError.compareAndSet(null, t);
+                    } finally {
+                        latch.countDown();
                     }
-
                 }
             };
 
@@ -385,7 +387,17 @@ public class RequestBoundaryMethodsTest extends AbstractTest {
             thread1.start();
             thread2.start();
             thread3.start();
-            latch.await();
+            // Bound the wait so a worker that fails before completing cannot hang the test JVM
+            // indefinitely. Previously each worker only counted the latch down on its success
+            // path, so an uncaught error (e.g. a read timeout from the 100 ms network timeout set
+            // above) left the latch above zero and main blocked forever on latch.await(), which
+            // kept the forked test JVM alive and hung CI jobs until the multi-hour pipeline timeout.
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                fail("testThreads timed out waiting for worker threads to finish");
+            }
+            if (null != workerError.get()) {
+                fail("A worker thread failed: " + workerError.get());
+            }
             sharedVariables.con.endRequest();
 
             assertEquals(originalNetworkTimeout, sharedVariables.con.getNetworkTimeout());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/messageHandler/MessageHandlerTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/messageHandler/MessageHandlerTest.java
@@ -450,7 +450,13 @@ public class MessageHandlerTest extends AbstractTest {
             // numOfCalls to the message handler should be: #
             assertEquals(doSqlLoopCount, testMsgHandler.numOfCalls, "Number of message calls to the message handler.");
 
-            // Loop all received messages and check that they are within a second (+-200ms)
+            // The stored procedure emits one feedback message per loop iteration, spaced ~1000 ms
+            // apart by WAITFOR DELAY '00:00:01'. Verify the driver streams them as they arrive
+            // (rather than buffering all of them until the procedure completes). We compare
+            // client-side receipt timestamps, which carry significant jitter (network, GC, thread
+            // scheduling) on loaded CI agents, so the bounds are deliberately generous: historical
+            // CI runs showed legitimate gaps as low as ~466 ms. A buffered/all-at-once regression
+            // would instead produce gaps of only a few milliseconds, which the lower bound catches.
             long prevTime = 0;
             for (Entry<String, Long> entry : testMsgHandler.feedbackMsgTs.entrySet()) {
                 if (prevTime == 0) {
@@ -459,9 +465,9 @@ public class MessageHandlerTest extends AbstractTest {
                 }
 
                 long msDiff = entry.getValue() - prevTime;
-                if (msDiff < 800 || msDiff > 1200) {
-                    fail("Received Messages is to far apart. They should be approx 1000 ms. msDiff=" + msDiff
-                            + " Message=|" + entry.getKey() + "|.");
+                if (msDiff < 300 || msDiff > 2000) {
+                    fail("Received messages were not spaced as expected (~1000 ms; allowed 300-2000 ms). msDiff="
+                            + msDiff + " Message=|" + entry.getKey() + "|.");
                 }
 
                 prevTime = entry.getValue();


### PR DESCRIPTION
## Summary

Fixes two independent flaky/hanging tests in the CI suite. Both surface only under load on CI agents; neither reproduces reliably locally. No production code changes — test-only.

## 1. `RequestBoundaryMethodsTest.testThreads` — could hang a CI job for 3 hours

A `jstack` of a wedged CI fork (build 159872) caught the cause: the fork's `main` thread was parked forever, with **no worker threads left** in the dump:

```
"main" WAITING (parking)
  - parking to wait for <a java.util.concurrent.CountDownLatch$Sync>
  at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:230)
  at com.microsoft.sqlserver.jdbc.connection.RequestBoundaryMethodsTest.testThreads(RequestBoundaryMethodsTest.java:388)
```

`testThreads` starts three workers and waits on a `CountDownLatch(3)` with no timeout. Each worker called `latch.countDown()` **only on its success path**; the `catch` just logged and interrupted. The test also sets a 100 ms network timeout on the shared connection, so on a loaded agent a worker's query can hit `SocketTimeoutException: Read timed out`, throw, skip `countDown()`, and leave `main` blocked forever. The forked JVM then never exits, so Maven's parent waits on it and the job hangs until the pipeline timeout kills the orphaned `java` process. (This also explains why earlier triage blamed whichever class ran last per fork, e.g. `DatabaseMetaDataTest` / `JDBC43Test` — red herrings from other forks.)

**Fix:** each worker now always `countDown()`s in a `finally` and records the first failure in an `AtomicReference<Throwable>`. `main` waits with a bounded `latch.await(30, TimeUnit.SECONDS)` and calls `fail(...)` on timeout or on a recorded worker error, so a worker failure becomes a normal, retryable test failure instead of an indefinite hang.

## 2. `MessageHandlerTest.testMsgHandlerWithProcedureFeedback` — over-tight timing window

The test runs a proc that emits one feedback message per loop iteration, spaced ~1000 ms apart by `WAITFOR DELAY '00:00:01'`, and asserts each consecutive gap is `800 <= msDiff <= 1200` (±200 ms). But it measures **client-side receipt** timestamps (`System.currentTimeMillis()`), not the server's pacing, so network/GC/scheduling jitter on loaded agents routinely compresses a gap below 800 ms.

Historical CI failures back this up — every recorded failure is a low-side breach:

| Metric | Value |
|---|---|
| Failing `msDiff` range | **466 – 790 ms** (24 data points, 7 builds) |
| Failures below the 800 ms floor | 24 / 24 |
| Failures above the 1200 ms ceiling | 0 (never) |

**Fix:** widen the window to `300 <= msDiff <= 2000`. The floor stays far above the ~0–50 ms gaps an all-at-once (buffered) delivery regression would produce, so the test still catches that bug; the wider band tolerates the observed jitter (and the complementary gap expansion a lower floor can unmask). The misleading failure message (a low `msDiff` is *too close*, not "too far apart") is corrected.

## Note on the earlier Surefire timeout

An earlier revision of this branch added `forkedProcessTimeoutInSeconds` as a diagnostic backstop. That has been **reverted** (the pom is unchanged vs `main`). The pipeline's new 60-minute Maven task timeout plus jstack log afterwards is the authoritative diagnostic; a Surefire fork timeout is redundant when longer than the task timeout and actively pre-empts jstack (no live process to attach to) when shorter.

## Testing

- `mvn -Pjre11 test-compile` clean; pom is unchanged vs `main`.
- `RequestBoundaryMethodsTest#testThreads` and `MessageHandlerTest#testMsgHandlerWithProcedureFeedback` both pass against SQL Server 2022.
