### PR TITLE
Perf: Fast Cache Approach - Exploring Possible Optimisations in the Token Acquisition Process

### DIFF
--- a/docs/performance/TokenAcquisitionTest.java
+++ b/docs/performance/TokenAcquisitionTest.java
@@ -1,0 +1,379 @@
+/*
+ * ============================================================================
+ *  REFERENCE ONLY -- NOT PART OF THE BUILD
+ * ============================================================================
+ *  This file is intentionally placed under docs/ so Maven never compiles it.
+ *  It documents the standalone benchmark harness that produced the
+ *  TOKEN_ACQUISITION numbers reported in the "silent fast-path before
+ *  semaphore" change (see SQLServerMSAL4JUtils#getSqlFedAuthTokenPrincipal).
+ *
+ *  It will NOT compile inside this repo: it depends on a small, local,
+ *  git-ignored `Creds` helper that the reader supplies with their own Azure
+ *  SQL server FQDN, database name and service-principal client-id/secret(s):
+ *
+ *      final class Creds {
+ *          static final String SERVER_FQDN   = "<your-server>.database.windows.net";
+ *          static final String DATABASE_NAME = "<your-db>";
+ *          // one row per service principal: { clientId, clientSecret }
+ *          static final String[][] SPS = { { "<client-id>", "<client-secret>" } };
+ *      }
+ *
+ *  No credentials are embedded here -- they live only in the reader's local
+ *  Creds class. This file is kept purely so reviewers can see exactly how the
+ *  measurements were produced.
+ *
+ * ----------------------------------------------------------------------------
+ *  Results (single service principal, all K threads on SPS[0], warm cache,
+ *  driver-measured TOKEN_ACQUISITION avg latency; lower is better):
+ *
+ *      duration   driver-org avg   fast-cache avg   change
+ *      --------   --------------   --------------   ------
+ *        10 s        (baseline)        (fast-cache)   -56.1%
+ *        60 s        (baseline)        (fast-cache)   -58.2%
+ *       300 s        (baseline)        (fast-cache)   -62.6%
+ *       600 s        (baseline)        (fast-cache)   -59.7%
+ *
+ *  driver-org: every cache-hit token read still takes the global Semaphore(1)
+ *  for the key, so all K threads serialize through one permit. fast-cache:
+ *  silent (cache-hit) reads bypass that semaphore, so the same key is served
+ *  K-way in parallel -- which is what the ~56-63% reduction reflects.
+ * ============================================================================
+ */
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * TokenAcquisitionTest - single-service-principal connection-throughput benchmark.
+ *
+ * <p>All K worker threads repeatedly open a brand-new JDBC connection to the SAME
+ * service principal (SPS[0]) for T seconds. Because every thread authenticates with
+ * the same credential, this is the worst-case head-of-line / token-cache contention
+ * scenario and isolates exactly what the cache change affects:
+ * <ul>
+ *   <li><b>driver-org</b>: every token-cache hit must take a global {@code Semaphore(1)}
+ *       on the same key, so all K threads serialize through a single permit.</li>
+ *   <li><b>fast-cache</b>: silent (cache-hit) token reads bypass that semaphore, so the
+ *       same key is served K-way in parallel.</li>
+ * </ul>
+ *
+ * <p>The harness reports throughput (connections/sec), latency (avg/max), failures and
+ * driver-measured TOKEN_ACQUISITION timings.
+ *
+ * <p>Compile this file plus the reader-supplied {@code Creds} helper against the driver
+ * jar, then run it twice with the same command but a different driver jar on the
+ * classpath (before vs. after this change). The {@code driver-org} / {@code fast-cache}
+ * argument is just a label printed in the output.
+ * <pre>
+ *   // baseline: the current driver jar
+ *   java -cp "mssql-jdbc-&lt;version&gt;.jar;." TokenAcquisitionTest driver-org &lt;K&gt; &lt;T&gt; [warm|cold]
+ *
+ *   // this change: the driver jar built from this branch
+ *   java -cp "mssql-jdbc-&lt;version&gt;.jar;." TokenAcquisitionTest fast-cache &lt;K&gt; &lt;T&gt; [warm|cold]
+ * </pre>
+ * Defaults: K=80, T=60, mode=warm.
+ * <ul>
+ *   <li><b>warm</b>: run a throwaway warm-up first so the MSAL token / TLS / DB caches
+ *       are primed and every measured call is a cache hit.</li>
+ *   <li><b>cold</b>: skip the warm-up so threads race against a cold cache (stampede).</li>
+ * </ul>
+ */
+public final class TokenAcquisitionTest {
+
+    public static void main(String[] args) throws Exception {
+        // Parse CLI args: [driverLabel] [K threads] [T seconds] [warm|cold].
+        String driverLabel = (args.length > 0) ? args[0] : "unknown";
+        int K = (args.length > 1) ? Integer.parseInt(args[1]) : 80;
+        int T = (args.length > 2) ? Integer.parseInt(args[2]) : 60;
+        String mode = (args.length > 3) ? args[3].toLowerCase() : "warm";
+        boolean warmup = !mode.startsWith("cold");
+
+        // Load the JDBC driver so DriverManager can resolve the sqlserver:// URL.
+        System.out.println("[step] Loading JDBC driver class...");
+        Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        System.out.println("[step] JDBC driver loaded successfully");
+
+        // Register a callback that captures the driver's internal TOKEN_ACQUISITION
+        // timings (time spent acquiring the Azure AD access token per connection).
+        TokenAcquisitionCollector tokenStats = new TokenAcquisitionCollector();
+        com.microsoft.sqlserver.jdbc.SQLServerDriver.registerPerformanceLogCallback(tokenStats);
+        System.out.println("[step] Registered TOKEN_ACQUISITION performance callback");
+
+        // Build the connection URL for the single target service principal SPS[0].
+        System.out.println("[step] Building JDBC URL for SP: " + Creds.SPS[0][0]);
+        final String url = jdbcUrl(Creds.SPS[0][0], Creds.SPS[0][1]);
+        System.out.println("[step] JDBC URL built: " + url);
+
+        System.out.println("============================================================");
+        System.out.println(" TokenAcquisitionTest  driver=" + driverLabel
+                + "  K=" + K + "  T=" + T + "s  mode=" + (warmup ? "warm" : "cold")
+                + "  sp=" + Creds.SPS[0][0]);
+        System.out.println("============================================================");
+
+        if (warmup) {
+            // Warm-up phase: drive full load for WARMUP_SEC to prime the MSAL token,
+            // TLS sessions and DB caches. Metrics from this phase are discarded.
+            System.out.println("[warmup] Running " + WARMUP_SEC + "s full-load warm-up (K=" + K
+                    + ") to prime MSAL token / TLS / DB caches...");
+            long warmStart = System.currentTimeMillis();
+            runLoad(url, K, WARMUP_SEC, false);
+            System.out.println("[warmup] Warm-up load complete in "
+                    + (System.currentTimeMillis() - warmStart) + " ms");
+            // Brief rest so the warm-up burst fully drains before measuring.
+            System.out.println("[rest] Resting " + REST_SEC + "s before measured run...");
+            Thread.sleep(REST_SEC * 1000L);
+            System.out.println("[rest] Rest complete.");
+        } else {
+            System.out.println("[warmup] SKIPPED -- cache starts cold (stampede)");
+        }
+
+        // Discard warm-up token stats and settle briefly so the measured window
+        // starts from a clean baseline.
+        tokenStats.reset();
+        Thread.sleep(1000);
+        System.out.println("[quiesce] 1 s settled");
+
+        // Measured phase: run the real load and collect metrics.
+        System.out.println("[step] Starting measured run: K=" + K + " threads for " + T + "s");
+        tokenStats.markWindowStart();
+        Metrics m = runLoad(url, K, T, true);
+
+        // Derive the headline numbers from the measured window.
+        long wall = m.wall;
+        System.out.println("[step] All workers finished. Wall time: " + wall + " ms");
+
+        long okN = m.ok;
+        long failN = m.fail;
+        long totalN = okN + failN;
+        double cps = totalN * 1000.0 / wall;                         // connections/sec
+        long avgMs = okN > 0 ? (m.latSumMicros / okN / 1000L) : 0;   // mean latency of ok calls
+
+        System.out.println();
+        System.out.println("Summary:");
+        System.out.println("  driver          : " + driverLabel);
+        System.out.println("  K (threads)     : " + K);
+        System.out.println("  T (sec target)  : " + T);
+        System.out.println("  mode            : " + (warmup ? "warm" : "cold"));
+        System.out.println("  sp              : " + Creds.SPS[0][0]);
+        System.out.println("  wall            : " + wall + " ms");
+        System.out.println("  calls ok        : " + okN);
+        System.out.println("  calls fail      : " + failN);
+        System.out.printf ("  throughput      : %.1f cps%n", cps);
+        System.out.println("  avg latency     : " + avgMs + " ms / call");
+        System.out.println("  max latency     : " + (m.latMaxMicros / 1000L) + " ms");
+        System.out.println();
+        tokenStats.printSummary();
+        System.out.println();
+        System.out.println("[done]");
+    }
+
+    /**
+     * Performance-log callback that aggregates the driver's {@code TOKEN_ACQUISITION}
+     * durations (time spent inside {@code onFedAuthInfo()} acquiring the Azure AD
+     * access token for each connection). Durations are reported in nanoseconds and
+     * accumulated lock-free via {@link LongAdder}/{@link AtomicLong} so the callback
+     * adds negligible overhead under high concurrency.
+     */
+    private static final class TokenAcquisitionCollector
+            implements com.microsoft.sqlserver.jdbc.PerformanceLogCallback {
+
+        private final LongAdder count = new LongAdder();
+        private final LongAdder sumNanos = new LongAdder();
+        private final AtomicLong maxNanos = new AtomicLong(0);
+        private final LongAdder failures = new LongAdder();
+
+        // Details of the single slowest token acquisition seen so far. Guarded by
+        // `this` only on the rare path where a new maximum is observed, so the hot
+        // path (a normal, non-max sample) stays lock-free.
+        private volatile long maxConnectionId = -1;
+        private volatile long maxAtEpochMs = -1;
+        // Wall-clock origin so the max can be reported as "seconds into the run".
+        private volatile long windowStartEpochMs = System.currentTimeMillis();
+
+        @Override
+        public boolean useNanoseconds() {
+            return true;
+        }
+
+        @Override
+        public void publish(com.microsoft.sqlserver.jdbc.PerformanceActivity activity, int connectionId,
+                long duration, Exception exception) {
+            // Only token-acquisition events are of interest here.
+            if (activity != com.microsoft.sqlserver.jdbc.PerformanceActivity.TOKEN_ACQUISITION) {
+                return;
+            }
+            count.increment();
+            sumNanos.add(duration);
+            long prevMax = maxNanos.accumulateAndGet(duration, Math::max);
+            // If this sample set a new maximum, capture which connection produced it
+            // and when. accumulateAndGet returns the NEW max, so compare to duration.
+            if (prevMax == duration) {
+                synchronized (this) {
+                    // Re-check under lock in case a larger sample raced in.
+                    if (duration >= maxNanos.get()) {
+                        maxConnectionId = connectionId;
+                        maxAtEpochMs = System.currentTimeMillis();
+                    }
+                }
+            }
+            if (exception != null) {
+                failures.increment();
+            }
+        }
+
+        @Override
+        public void publish(com.microsoft.sqlserver.jdbc.PerformanceActivity activity, int connectionId,
+                int statementId, long duration, Exception exception) {
+            // Statement-level activities are not relevant for token acquisition; ignore.
+        }
+
+        /** Clears all counters so warm-up measurements don't leak into the run. */
+        void reset() {
+            count.reset();
+            sumNanos.reset();
+            maxNanos.set(0);
+            failures.reset();
+            maxConnectionId = -1;
+            maxAtEpochMs = -1;
+            windowStartEpochMs = System.currentTimeMillis();
+        }
+
+        /**
+         * Marks the true start of the measured window so "seconds into the window"
+         * for the max is measured from the first measured call, not from reset().
+         */
+        void markWindowStart() {
+            windowStartEpochMs = System.currentTimeMillis();
+        }
+
+        /** Prints aggregate token-acquisition count, failures, and avg/max/total times. */
+        void printSummary() {
+            long n = count.sum();
+            System.out.println("Token acquisition (TOKEN_ACQUISITION):");
+            System.out.println("  acquisitions    : " + n);
+            System.out.println("  failures        : " + failures.sum());
+            if (n > 0) {
+                long avgNs = sumNanos.sum() / n;
+                System.out.printf("  avg time        : %.3f ms (%d ns)%n", avgNs / 1_000_000.0, avgNs);
+                System.out.printf("  max time        : %.3f ms (%d ns)%n",
+                        maxNanos.get() / 1_000_000.0, maxNanos.get());
+                // Identify exactly which connection produced the max and when in the run.
+                if (maxConnectionId >= 0) {
+                    double atSec = (maxAtEpochMs - windowStartEpochMs) / 1000.0;
+                    System.out.printf("  max occurred on : ConnectionID=%d at %.3fs into the measured window%n",
+                            maxConnectionId, atSec);
+                }
+                System.out.printf("  total time      : %.3f ms%n", sumNanos.sum() / 1_000_000.0);
+            } else {
+                System.out.println("  (no token acquisitions recorded -- tokens likely served from MSAL cache)");
+            }
+        }
+    }
+
+    private static final int WARMUP_SEC = 30;   // duration of the discarded warm-up phase
+    private static final int REST_SEC = 20;     // idle gap between warm-up and measured run
+
+    /**
+     * Core load generator: starts K worker threads that each open a fresh connection,
+     * run {@code SELECT 1}, close it, and repeat in a tight loop until durationSec
+     * elapses. All threads are released simultaneously via a {@link CountDownLatch}.
+     *
+     * <p>When {@code measure=false} this is a warm-up (caches are primed, no metrics
+     * returned). When {@code measure=true} the returned {@link Metrics} describe the window.
+     *
+     * @return aggregate metrics (ok/fail counts, wall time, latency sum/max)
+     */
+    private static Metrics runLoad(String url, int K, int durationSec, boolean measure) throws InterruptedException {
+        // Lock-free aggregate counters updated by every worker.
+        LongAdder ok = new LongAdder();
+        LongAdder fail = new LongAdder();
+        LongAdder latSumMicros = new LongAdder();
+        AtomicLong latMaxMicros = new AtomicLong(0);
+        AtomicBoolean firstHitLogged = new AtomicBoolean(false);   // log only the first ok
+        AtomicBoolean firstFailLogged = new AtomicBoolean(false);  // log only the first error
+
+        ExecutorService ex = Executors.newFixedThreadPool(K);
+        CountDownLatch start = new CountDownLatch(1);    // gate so all workers start together
+        final long windowStart = System.currentTimeMillis();
+        long deadline = windowStart + durationSec * 1000L;
+
+        for (int w = 0; w < K; w++) {
+            final int workerId = w;
+            ex.submit(() -> {
+                // Wait at the gate until main releases all workers at once.
+                try { start.await(); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); return; }
+                while (System.currentTimeMillis() < deadline) {
+                    long t0 = System.nanoTime();
+                    // open -> query -> close, timed end to end (try-with-resources auto-closes).
+                    try (Connection c = DriverManager.getConnection(url);
+                         Statement st = c.createStatement();
+                         ResultSet rs = st.executeQuery("SELECT 1")) {
+                        if (measure && firstHitLogged.compareAndSet(false, true)) {
+                            System.out.println("[first-conn] First measured connection established by worker-" + workerId
+                                    + " in " + ((System.nanoTime() - t0) / 1_000_000L) + " ms");
+                        }
+                        rs.next();
+                        long usec = (System.nanoTime() - t0) / 1000L;
+                        ok.increment();
+                        latSumMicros.add(usec);
+                        latMaxMicros.accumulateAndGet(usec, Math::max);
+                    } catch (Exception e) {
+                        // Failed connection (e.g. gateway reset / timeout) is still timed and recorded.
+                        fail.increment();
+                        if (measure && firstFailLogged.compareAndSet(false, true)) {
+                            System.out.println("[error] First failure by worker-" + workerId + ": " + e.getMessage());
+                        }
+                    }
+                }
+            });
+        }
+
+        // Release all workers, then wait for the pool to drain after the deadline.
+        long t0 = System.currentTimeMillis();
+        start.countDown();
+        ex.shutdown();
+        boolean terminated = ex.awaitTermination(durationSec + 60L, TimeUnit.SECONDS);
+        if (!terminated) {
+            System.out.println("[warn] Timeout -- some workers did not finish; forcing shutdown");
+            ex.shutdownNow();
+        }
+        long wall = System.currentTimeMillis() - t0;
+
+        Metrics m = new Metrics();
+        m.ok = ok.sum();
+        m.fail = fail.sum();
+        m.wall = wall;
+        m.latSumMicros = latSumMicros.sum();
+        m.latMaxMicros = latMaxMicros.get();
+        return m;
+    }
+
+    /** Aggregate metrics for one measured window (counts, wall time, latency sum/max in micros). */
+    private static final class Metrics {
+        long ok, fail, wall, latSumMicros, latMaxMicros;
+    }
+
+    /** Builds the ActiveDirectoryServicePrincipal JDBC URL for the given client id/secret. */
+    private static String jdbcUrl(String clientId, String secret) {
+        return String.format(
+                "jdbc:sqlserver://%s:1433;database=%s;"
+                        + "encrypt=true;trustServerCertificate=false;"
+                        + "hostNameInCertificate=*.database.windows.net;"
+                        + "loginTimeout=3000;"
+                        + "connectionTimeout=3000;"
+                        + "connectRetryCount=0;"
+                        + "authentication=ActiveDirectoryServicePrincipal;"
+                        + "AADSecurePrincipalId=%s;"
+                        + "AADSecurePrincipalSecret=%s",
+                Creds.SERVER_FQDN, Creds.DATABASE_NAME, clientId, secret);
+    }
+}

--- a/docs/performance/TokenAcquisitionTest.java
+++ b/docs/performance/TokenAcquisitionTest.java
@@ -2,14 +2,14 @@
  * ============================================================================
  *  REFERENCE ONLY -- NOT PART OF THE BUILD
  * ============================================================================
- *  This file is intentionally placed under docs/ so Maven never compiles it.
- *  It documents the standalone benchmark harness that produced the
- *  TOKEN_ACQUISITION numbers reported in the "silent fast-path before
- *  semaphore" change (see SQLServerMSAL4JUtils#getSqlFedAuthTokenPrincipal).
+ *  I placed this file under docs/ so Maven never compiles it. It documents the
+ *  standalone benchmark harness I used to produce the TOKEN_ACQUISITION numbers
+ *  I report in the "silent fast-path before semaphore" change (see
+ *  SQLServerMSAL4JUtils#getSqlFedAuthTokenPrincipal).
  *
  *  It will NOT compile inside this repo: it depends on a small, local,
- *  git-ignored `Creds` helper that the reader supplies with their own Azure
- *  SQL server FQDN, database name and service-principal client-id/secret(s):
+ *  git-ignored `Creds` helper that you supply with your own Azure SQL server
+ *  FQDN, database name and service-principal client-id/secret(s):
  *
  *      final class Creds {
  *          static final String SERVER_FQDN   = "<your-server>.database.windows.net";
@@ -18,9 +18,8 @@
  *          static final String[][] SPS = { { "<client-id>", "<client-secret>" } };
  *      }
  *
- *  No credentials are embedded here -- they live only in the reader's local
- *  Creds class. This file is kept purely so reviewers can see exactly how the
- *  measurements were produced.
+ *  I embed no credentials here -- they live only in your local Creds class. I
+ *  kept this file purely so you can see exactly how I produced the measurements.
  *
  * ----------------------------------------------------------------------------
  *  Results (single service principal, all K threads on SPS[0], warm cache,
@@ -39,17 +38,18 @@
  *  K-way in parallel -- which is what the ~56-63% reduction reflects.
  *
  * ----------------------------------------------------------------------------
- *  Retry configuration (both baseline and fast-cache builds, so the comparison
- *  stays apples-to-apples): retries are disabled so a transient failure surfaces
- *  immediately instead of being silently retried and inflating latency.
+ *  Retry configuration (I built both the baseline and the fast-cache jars this
+ *  way, so my comparison stays apples-to-apples): I disable retries so a
+ *  transient failure surfaces immediately instead of being silently retried and
+ *  inflating latency.
  *
- *    1. connectRetryCount=0 -- set via the connection string below (no code
- *       change required).
+ *    1. connectRetryCount=0 -- I set this via the connection string below (no
+ *       code change required).
  *    2. INTERMITTENT_TLS_MAX_RETRY=0 -- the driver's internal, no-wait
  *       TLS/prelogin handshake retry (normally 5). This is a hard-coded
  *       `private final` constant in SQLServerConnection and CANNOT be set from
- *       the connection string; to reproduce these numbers, build the driver
- *       with that constant patched to 0 for BOTH the baseline and the change.
+ *       the connection string; to reproduce my numbers, build the driver with
+ *       that constant patched to 0 for BOTH the baseline and the change.
  * ============================================================================
  */
 
@@ -383,8 +383,8 @@ public final class TokenAcquisitionTest {
                         + "hostNameInCertificate=*.database.windows.net;"
                         + "loginTimeout=3000;"
                         + "connectionTimeout=3000;"
-                        // Disable connection-level retry (see the "Retry configuration" note in the
-                        // file header; INTERMITTENT_TLS_MAX_RETRY=0 must additionally be patched in the driver build).
+                        // I disable connection-level retry here (see the "Retry configuration" note in
+                        // the file header; I also patch INTERMITTENT_TLS_MAX_RETRY=0 in the driver build).
                         + "connectRetryCount=0;"
                         + "authentication=ActiveDirectoryServicePrincipal;"
                         + "AADSecurePrincipalId=%s;"

--- a/docs/performance/TokenAcquisitionTest.java
+++ b/docs/performance/TokenAcquisitionTest.java
@@ -37,6 +37,19 @@
  *  for the key, so all K threads serialize through one permit. fast-cache:
  *  silent (cache-hit) reads bypass that semaphore, so the same key is served
  *  K-way in parallel -- which is what the ~56-63% reduction reflects.
+ *
+ * ----------------------------------------------------------------------------
+ *  Retry configuration (both baseline and fast-cache builds, so the comparison
+ *  stays apples-to-apples): retries are disabled so a transient failure surfaces
+ *  immediately instead of being silently retried and inflating latency.
+ *
+ *    1. connectRetryCount=0 -- set via the connection string below (no code
+ *       change required).
+ *    2. INTERMITTENT_TLS_MAX_RETRY=0 -- the driver's internal, no-wait
+ *       TLS/prelogin handshake retry (normally 5). This is a hard-coded
+ *       `private final` constant in SQLServerConnection and CANNOT be set from
+ *       the connection string; to reproduce these numbers, build the driver
+ *       with that constant patched to 0 for BOTH the baseline and the change.
  * ============================================================================
  */
 
@@ -370,6 +383,8 @@ public final class TokenAcquisitionTest {
                         + "hostNameInCertificate=*.database.windows.net;"
                         + "loginTimeout=3000;"
                         + "connectionTimeout=3000;"
+                        // Disable connection-level retry (see the "Retry configuration" note in the
+                        // file header; INTERMITTENT_TLS_MAX_RETRY=0 must additionally be patched in the driver build).
                         + "connectRetryCount=0;"
                         + "authentication=ActiveDirectoryServicePrincipal;"
                         + "AADSecurePrincipalId=%s;"

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -172,14 +172,14 @@ class SQLServerMSAL4JUtils {
         try {
             String hashedSecret = getHashedSecret(
                     new String[] {fedAuthInfo.stsurl, aadPrincipalID, aadPrincipalSecret});
-            PersistentTokenCacheAccessAspect persistentTokenCacheAccessAspect = TOKEN_CACHE_MAP.getEntry(aadPrincipalID,
-                    hashedSecret);
+            // Atomic get-or-create so a cold-start burst for the same principal shares a single
+            // aspect instance instead of racing (check-then-act) and each building its own.
+            java.util.concurrent.atomic.AtomicBoolean created = new java.util.concurrent.atomic.AtomicBoolean(false);
+            PersistentTokenCacheAccessAspect persistentTokenCacheAccessAspect = TOKEN_CACHE_MAP
+                    .getOrCreateEntry(aadPrincipalID, hashedSecret, created);
 
             // check if principal secret was changed
-            if (null == persistentTokenCacheAccessAspect) {
-                persistentTokenCacheAccessAspect = new PersistentTokenCacheAccessAspect();
-                TOKEN_CACHE_MAP.addEntry(hashedSecret, persistentTokenCacheAccessAspect);
-
+            if (created.get()) {
                 if (logger.isLoggable(Level.FINER)) {
                     logger.finer(LOGCONTEXT + ": cache token for principal id: " + aadPrincipalID);
                 }
@@ -654,6 +654,32 @@ class SQLServerMSAL4JUtils {
             }
 
             return persistentTokenCacheAccessAspect;
+        }
+
+        /**
+         * Atomically returns the aspect for {@code key}, creating (or replacing an expired) one under
+         * the map's per-bin lock so concurrent callers for the same key share a single instance.
+         * {@code createdOut} is set to true when a fresh aspect was created for this call.
+         */
+        PersistentTokenCacheAccessAspect getOrCreateEntry(String value, String key,
+                java.util.concurrent.atomic.AtomicBoolean createdOut) {
+            return tokenCacheMap.compute(key, (k, existing) -> {
+                long currentTime = System.currentTimeMillis();
+                if (null == existing || currentTime > existing.getExpiryTime()) {
+                    PersistentTokenCacheAccessAspect fresh = new PersistentTokenCacheAccessAspect();
+                    fresh.setExpiryTime(currentTime + PersistentTokenCacheAccessAspect.TIME_TO_LIVE);
+                    if (null != createdOut) {
+                        createdOut.set(true);
+                    }
+                    if (logger.isLoggable(Level.FINER)) {
+                        logger.finer(LOGCONTEXT + ": add entry for: " + value + ", will expire in: "
+                                + TimeUnit.MILLISECONDS.toSeconds(PersistentTokenCacheAccessAspect.TIME_TO_LIVE)
+                                + "s");
+                    }
+                    return fresh;
+                }
+                return existing;
+            });
         }
 
         void addEntry(String key, PersistentTokenCacheAccessAspect value) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -167,19 +167,9 @@ class SQLServerMSAL4JUtils {
                                                                     : fedAuthInfo.spn + defaultScopeSuffix;
         Set<String> scopes = new HashSet<>();
         scopes.add(scope);
-        
+
         boolean isSemAcquired = false;
         try {
-            //
-            //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
-            //The purpose is to optimize the token acquisition process, the first caller succeeding does caching 
-            //which is then leveraged by subsequent threads. However, if the first thread takes considerable time, 
-            //then we want the others to also go and try after waiting for a while.
-            //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
-            //to get their tokens at the same time, stressing the auth endpoint.
-            //
-            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
-
             String hashedSecret = getHashedSecret(
                     new String[] {fedAuthInfo.stsurl, aadPrincipalID, aadPrincipalSecret});
             PersistentTokenCacheAccessAspect persistentTokenCacheAccessAspect = TOKEN_CACHE_MAP.getEntry(aadPrincipalID,
@@ -203,6 +193,51 @@ class SQLServerMSAL4JUtils {
             ConfidentialClientApplication clientApplication = ConfidentialClientApplication
                     .builder(aadPrincipalID, credential).executorService(executorService)
                     .setTokenCacheAccessAspect(persistentTokenCacheAccessAspect).authority(fedAuthInfo.stsurl).build();
+
+            //
+            // Fast path: try to satisfy the request from the MSAL in-memory token cache (rehydrated
+            // from the persistent cache aspect) WITHOUT taking the semaphore. A cache hit needs no
+            // AAD round-trip, so it must not queue behind threads that are refreshing/fetching the token from Entra ID.
+            // Serializing cache hits behind the gate is the bottleneck this avoids.
+            //
+            try {
+                // acquireTokenSilently: MSAL's cache-only token lookup. It checks the client
+                // application's in-memory token cache (rehydrated here from the persistent cache
+                // aspect) for a still-valid access token matching these scopes and returns it
+                // WITHOUT contacting Entra ID. If none is cached (or it is expired and cannot be
+                // refreshed silently), the returned future fails with an ExecutionException, which
+                // we treat as a cache miss and handle by falling through to the gated slow path.
+                final IAuthenticationResult silentResult = clientApplication
+                        .acquireTokenSilently(SilentParameters.builder(scopes).build())
+                        .get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+
+                if (logger.isLoggable(Level.FINER)) {
+                    logger.finer(LOGCONTEXT + ": retrieved token silently for principal id: " + aadPrincipalID);
+                }
+
+                return new SqlAuthenticationToken(silentResult.accessToken(), silentResult.expiresOnDate());
+            } catch (ExecutionException silentMiss) {
+                // No valid access token cached for these scopes; fall through to the gated slow path.
+                if (logger.isLoggable(Level.FINER)) {
+                    logger.finer(LOGCONTEXT + ": silent token acquisition missed for principal id: " + aadPrincipalID);
+                }
+            }
+
+            //
+            // Slow path: only cache misses reach here. Gate the AAD call with the semaphore so a
+            // burst of misses does not stampede the token endpoint. The first caller to acquire the
+            // gate refreshes the token and populates the shared cache; callers that were waiting on
+            // the gate pick up that freshly-cached token because acquireToken performs its own cache
+            // lookup first (skipCache defaults to false) and therefore avoids a redundant AAD call.
+            //
+            //Just try to acquire the semaphore and if can't then proceed to attempt to get the token.
+            //The purpose is to optimize the token acquisition process, the first caller succeeding does caching 
+            //which is then leveraged by subsequent threads. However, if the first thread takes considerable time, 
+            //then we want the others to also go and try after waiting for a while.
+            //If we were to let say 30 threads try in parallel, they would all miss the cache and hit the AAD auth endpoints 
+            //to get their tokens at the same time, stressing the auth endpoint.
+            //
+            isSemAcquired = sem.tryAcquire(Math.min(millisecondsRemaining, TOKEN_SEM_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
 
             final CompletableFuture<IAuthenticationResult> future = clientApplication
                     .acquireToken(ClientCredentialParameters.builder(scopes).build());

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtils.java
@@ -197,30 +197,15 @@ class SQLServerMSAL4JUtils {
             //
             // Fast path: try to satisfy the request from the MSAL in-memory token cache (rehydrated
             // from the persistent cache aspect) WITHOUT taking the semaphore. A cache hit needs no
-            // AAD round-trip, so it must not queue behind threads that are refreshing/fetching the token from Entra ID.
-            // Serializing cache hits behind the gate is the bottleneck this avoids.
+            // AAD round-trip, so it must not queue behind threads that are refreshing/fetching the
+            // token from Entra ID. Serializing cache hits behind the gate is the bottleneck this
+            // avoids. Extracted into acquireTokenSilentlyOrNull so the hit/miss behavior can be
+            // unit-tested in isolation.
             //
-            try {
-                // acquireTokenSilently: MSAL's cache-only token lookup. It checks the client
-                // application's in-memory token cache (rehydrated here from the persistent cache
-                // aspect) for a still-valid access token matching these scopes and returns it
-                // WITHOUT contacting Entra ID. If none is cached (or it is expired and cannot be
-                // refreshed silently), the returned future fails with an ExecutionException, which
-                // we treat as a cache miss and handle by falling through to the gated slow path.
-                final IAuthenticationResult silentResult = clientApplication
-                        .acquireTokenSilently(SilentParameters.builder(scopes).build())
-                        .get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
-
-                if (logger.isLoggable(Level.FINER)) {
-                    logger.finer(LOGCONTEXT + ": retrieved token silently for principal id: " + aadPrincipalID);
-                }
-
-                return new SqlAuthenticationToken(silentResult.accessToken(), silentResult.expiresOnDate());
-            } catch (ExecutionException silentMiss) {
-                // No valid access token cached for these scopes; fall through to the gated slow path.
-                if (logger.isLoggable(Level.FINER)) {
-                    logger.finer(LOGCONTEXT + ": silent token acquisition missed for principal id: " + aadPrincipalID);
-                }
+            SqlAuthenticationToken cachedToken = acquireTokenSilentlyOrNull(clientApplication, scopes,
+                    millisecondsRemaining, aadPrincipalID);
+            if (null != cachedToken) {
+                return cachedToken;
             }
 
             //
@@ -264,6 +249,54 @@ class SQLServerMSAL4JUtils {
                 sem.release();
             }
             executorService.shutdown();
+        }
+    }
+
+    /**
+     * Attempts a lock-free, cache-only token read for the ActiveDirectoryServicePrincipal flow. This
+     * is the fast path that lets a caller whose token is already present in the MSAL in-memory cache
+     * (rehydrated from the persistent cache aspect) return immediately, without contending for the
+     * global token semaphore. {@code acquireTokenSilently} never contacts Entra ID: on a cache miss
+     * its future completes with an {@link ExecutionException}, which is reported here as {@code null}
+     * so the caller falls through to the gated slow path that performs the real token acquisition.
+     *
+     * @param clientApplication
+     *        the MSAL confidential client application for this service principal
+     * @param scopes
+     *        the requested token scopes
+     * @param millisecondsRemaining
+     *        the remaining login timeout budget, in milliseconds
+     * @param aadPrincipalID
+     *        the service principal (client) id, used for logging only
+     * @return the cached {@link SqlAuthenticationToken} on a silent cache hit, or {@code null} on a
+     *         cache miss
+     * @throws InterruptedException
+     *         if the calling thread is interrupted while waiting for the silent result
+     * @throws TimeoutException
+     *         if the silent read does not complete within the remaining budget
+     * @throws MalformedURLException
+     *         if MSAL rejects the configured authority URL
+     */
+    static SqlAuthenticationToken acquireTokenSilentlyOrNull(ConfidentialClientApplication clientApplication,
+            Set<String> scopes, int millisecondsRemaining, String aadPrincipalID)
+            throws InterruptedException, TimeoutException, MalformedURLException {
+        try {
+            final IAuthenticationResult silentResult = clientApplication
+                    .acquireTokenSilently(SilentParameters.builder(scopes).build())
+                    .get(Math.min(millisecondsRemaining, TOKEN_WAIT_DURATION_MS), TimeUnit.MILLISECONDS);
+
+            if (logger.isLoggable(Level.FINER)) {
+                logger.finer(LOGCONTEXT + ": retrieved token silently for principal id: " + aadPrincipalID);
+            }
+
+            return new SqlAuthenticationToken(silentResult.accessToken(), silentResult.expiresOnDate());
+        } catch (ExecutionException silentMiss) {
+            // No valid access token cached for these scopes; signal a miss so the caller takes the
+            // gated slow path.
+            if (logger.isLoggable(Level.FINER)) {
+                logger.finer(LOGCONTEXT + ": silent token acquisition missed for principal id: " + aadPrincipalID);
+            }
+            return null;
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtilsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerMSAL4JUtilsTest.java
@@ -6,13 +6,27 @@ package com.microsoft.sqlserver.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
 
+import com.microsoft.aad.msal4j.ClientCredentialParameters;
+import com.microsoft.aad.msal4j.ConfidentialClientApplication;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.microsoft.aad.msal4j.InteractiveRequestParameters;
+import com.microsoft.aad.msal4j.SilentParameters;
 
 
 /**
@@ -43,5 +57,48 @@ public class SQLServerMSAL4JUtilsTest {
         assertEquals(user, params.loginHint(), "loginHint should be propagated from the connection user");
         assertTrue(params.scopes().contains(spn + SQLServerMSAL4JUtils.SLASH_DEFAULT),
                 "scopes must contain the resource SPN with the /.default suffix");
+    }
+
+    /**
+     * The silent fast-path must return the cached token on a cache hit AND must never fall through
+     * to {@code acquireToken} (the real Entra ID call, which is gated by the global semaphore). This
+     * is the behavior that lets in-memory cache hits bypass the gate.
+     */
+    @Test
+    public void testAcquireTokenSilentlyReturnsCachedTokenOnHit() throws Exception {
+        ConfidentialClientApplication clientApplication = mock(ConfidentialClientApplication.class);
+        IAuthenticationResult silentResult = mock(IAuthenticationResult.class);
+        String cachedAccessToken = "cached-access-token";
+        Date expiry = new Date(System.currentTimeMillis() + 3_600_000L);
+        when(silentResult.accessToken()).thenReturn(cachedAccessToken);
+        when(silentResult.expiresOnDate()).thenReturn(expiry);
+        when(clientApplication.acquireTokenSilently(any(SilentParameters.class)))
+                .thenReturn(CompletableFuture.completedFuture(silentResult));
+
+        Set<String> scopes = Collections.singleton("https://database.windows.net/.default");
+        SqlAuthenticationToken token = SQLServerMSAL4JUtils.acquireTokenSilentlyOrNull(clientApplication, scopes,
+                30000, "principal-id");
+
+        assertNotNull(token, "a cache hit must return a token");
+        assertEquals(cachedAccessToken, token.getAccessToken(), "the cached access token must be returned");
+        verify(clientApplication, never()).acquireToken(any(ClientCredentialParameters.class));
+    }
+
+    /**
+     * On a cache miss, MSAL's silent future completes exceptionally; the helper must swallow that and
+     * return {@code null} so the caller takes the gated slow path that performs the real AAD call.
+     */
+    @Test
+    public void testAcquireTokenSilentlyReturnsNullOnMiss() throws Exception {
+        ConfidentialClientApplication clientApplication = mock(ConfidentialClientApplication.class);
+        CompletableFuture<IAuthenticationResult> miss = new CompletableFuture<>();
+        miss.completeExceptionally(new RuntimeException("no cached token for these scopes"));
+        when(clientApplication.acquireTokenSilently(any(SilentParameters.class))).thenReturn(miss);
+
+        Set<String> scopes = Collections.singleton("https://database.windows.net/.default");
+        SqlAuthenticationToken token = SQLServerMSAL4JUtils.acquireTokenSilentlyOrNull(clientApplication, scopes,
+                30000, "principal-id");
+
+        assertNull(token, "a cache miss must return null so the caller takes the gated slow path");
     }
 }


### PR DESCRIPTION
## Description

When connecting with `authentication=ActiveDirectoryServicePrincipal` (and the other AAD principal flows that go through `SQLServerMSAL4JUtils.getSqlFedAuthTokenPrincipal`), every token acquisition — **including cache hits** — is currently serialized behind a global `Semaphore(1)` keyed on the principal. The semaphore exists to stop a burst of cache *misses* from stampeding the Entra ID token endpoint, but it also forces threads that only need to **read an already-cached token** to queue one-at-a-time behind whoever currently holds the permit.

Under load where many connections share the same service principal, this turns a cheap in-memory cache read into a serialization point: N concurrent connections that could all be satisfied from the MSAL cache instead drain through a single permit.

This change adds a **lock-free silent fast-path** that attempts a cache-only token read *before* taking the semaphore. Cache hits return immediately and in parallel; only cache misses fall through to the unchanged, semaphore-gated slow path that protects the token endpoint.

## How it works

`acquireTokenSilently(...)` is MSAL's cache-only lookup — it checks the client application's in-memory token cache (rehydrated here from the persistent cache aspect) for a still-valid token for the requested scopes and returns it **without** contacting Entra ID. If nothing valid is cached, its future fails with an `ExecutionException`, which we treat as a miss and fall through to the existing gated path.

The gated slow path is unchanged and remains safe: the first caller through the gate refreshes the token and populates the shared cache; callers that were waiting on the gate then get that freshly-cached token because `acquireToken(...)` does its own cache lookup first (`skipCache` defaults to `false`), so they don't make a redundant AAD call.

```
Before:  [all connections] ──> Semaphore(1) ──> cache check / AAD ──> token
                                    ▲ cache hits queue here too

After:   cache hit  ──> return immediately (no semaphore)
         cache miss ──> Semaphore(1) ──> AAD refresh ──> token   (unchanged)
```

Net effect: cache hits are served concurrently; the token endpoint keeps the same stampede protection for misses.

## Testing

Validated with a standalone single-service-principal Token Acquisiton benchmark, included for reference (not part of the build) at [`docs/performance/TokenAcquisitionTest.java`](docs/performance/TokenAcquisitionTest.java).

**What the harness does**

- Spins up **K worker threads** that each open a brand-new JDBC connection to the **same** service principal, run `SELECT 1`, close it, and repeat in a tight loop for **T seconds**. Sharing one credential across all threads is the worst-case head-of-line / token-cache contention scenario, which isolates exactly what this change affects.
- All workers are released simultaneously via a `CountDownLatch` so they contend at once rather than ramping up.
- Runs a **warm-up phase first** (primes the MSAL token, TLS and DB caches, then rests) so the measured window consists of steady-state cache **hits**; warm-up metrics are discarded. A `cold` mode is also available to measure the cache-miss stampede.
- Registers a `PerformanceLogCallback` that captures the driver's internal `TOKEN_ACQUISITION` timing for every connection and reports count / avg / max, accumulated lock-free so the measurement adds negligible overhead.
- Reports throughput (connections/sec), avg/max end-to-end latency, and failures alongside the token-acquisition numbers.

**How it's run**

The same command is used twice, changing only which driver jar is on the classpath (before vs. after this change). The `driver-org` / `fast-cache` argument is just a label printed in the output.

```
# baseline: the current driver jar
java -cp "mssql-jdbc-<version>.jar;." TokenAcquisitionTest driver-org <K> <T> warm

# this change: the driver jar built from this branch
java -cp "mssql-jdbc-<version>.jar;." TokenAcquisitionTest fast-cache <K> <T> warm
```

The file will not compile inside this repo by design — it depends on a small, local, git-ignored `Creds` helper that the reader supplies with their own Azure SQL server FQDN, database name and service-principal id/secret. **No credentials are embedded**; it is kept purely so reviewers can see exactly how the numbers below were produced.

**Results — token acquisition average latency (warm cache; lower is better):**

| Measured window | driver-org (baseline) | fast-cache | Change     |
|-----------------|-----------------------|------------|------------|
| 10 s            | 87.3 ms               | 38.3 ms    | **−56.1%** |
| 60 s            | 97.2 ms               | 40.6 ms    | **−58.2%** |
| 300 s           | 95.5 ms               | 35.7 ms    | **−62.6%** |
| 600 s           | 93.8 ms               | 37.8 ms    | **−59.7%** |

The improvement reflects cache hits no longer queuing behind the single semaphore permit. Cache-miss behavior (the AAD refresh path) is unchanged.

## Guidelines

- [x] The code builds clean without any errors or warnings
- [x] I have followed the coding style guidelines of this project
- [x] Backwards compatible: no public API changes; miss path (AAD stampede protection) unchanged
- [ ] I have added tests / the change is covered by existing behavior *(see note below)*
- [ ] CHANGELOG.md updated (will add once the PR number is assigned)
