### PR TITLE
Bump azure-identity to 1.18.4 and azure-security-keyvault-keys to 4.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,8 +135,8 @@ repositories {
 dependencies {
     implementation 'org.osgi:org.osgi.core:6.0.0',
 			'org.osgi:org.osgi.service.jdbc:1.1.0'
-	compileOnly 'com.azure:azure-security-keyvault-keys:4.10.5',
-			'com.azure:azure-identity:1.18.2',
+	compileOnly 'com.azure:azure-security-keyvault-keys:4.11.1',
+			'com.azure:azure-identity:1.18.4',
 			'org.antlr:antlr4-runtime:4.9.1',
 			'com.google.code.gson:gson:2.11.0',
 			'org.bouncycastle:bcprov-jdk18on:1.79',
@@ -157,8 +157,8 @@ dependencies {
 			'org.eclipse.gemini.blueprint:gemini-blueprint-mock:3.0.0.M01',
 			'com.google.code.gson:gson:2.11.0',
 			'org.bouncycastle:bcprov-jdk18on:1.79',
-			'com.azure:azure-security-keyvault-keys:4.10.5',
-			'com.azure:azure-identity:1.18.2',
+			'com.azure:azure-security-keyvault-keys:4.11.1',
+			'com.azure:azure-identity:1.18.4',
 			'com.h2database:h2:2.2.220'
 
 	// Mockito and Byte Buddy dependencies based on JRE version

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 		<releaseExt>-preview</releaseExt>
 		<!-- Driver Dependencies -->
 		<org.osgi.core.version>6.0.0</org.osgi.core.version>
-		<azure-security-keyvault-keys.version>4.10.5</azure-security-keyvault-keys.version>
-		<azure-identity.version>1.18.2</azure-identity.version>
+		<azure-security-keyvault-keys.version>4.11.1</azure-security-keyvault-keys.version>
+		<azure-identity.version>1.18.4</azure-identity.version>
 		<osgi.jdbc.version>1.1.0</osgi.jdbc.version>
 		<antlr-runtime.version>4.9.3</antlr-runtime.version>
 		<com.google.code.gson.version>2.11.0</com.google.code.gson.version>


### PR DESCRIPTION
# Bump `azure-identity` and `azure-security-keyvault-keys` to resolve transitive Netty and Jackson CVEs

## Summary

Bumps two optional Azure SDK dependencies to their latest stable versions so that the recently patched Netty and Jackson artifacts flow in transitively. No new `dependencyManagement` / `resolutionStrategy.force` overrides are introduced — the upstream releases resolve the outstanding CVE alerts on their own.

| Dependency | Before | After | Released |
|---|---|---|---|
| `com.azure:azure-identity` | 1.18.2 | **1.18.4** | 2026-06-12 |
| `com.azure:azure-security-keyvault-keys` | 4.10.5 | **4.11.1** | 2026-07-02 |

Both are declared with `<optional>true</optional>` (Always Encrypted CMK + federated auth) and are unused by the core driver code path.

## Transitive resolution after the bump

Both target versions bring in the same clean transitive set:

```
azure-identity 1.18.4
├── azure-core-http-netty 1.16.5   → Netty 4.1.135.Final (all 20 Netty CVEs fixed)
├── azure-core 1.58.1               → jackson-core 2.18.6 (GHSA-72hv-8253-57qq fixed)
└── msal4j 1.23.1

azure-security-keyvault-keys 4.11.1
├── azure-core-http-netty 1.16.5   (same)
└── azure-core 1.58.1               (same)
```

## Alerts resolved

| Group | Count | Root artifact | Fixed in |
|---|---|---|---|
| Netty `4.1.130.Final` CVEs | 17 | `azure-core-http-netty` 1.16.3 | `azure-core-http-netty` 1.16.5 (Netty 4.1.135.Final) |
| `netty-resolver-dns` / `netty-codec-dns` 4.1.128.Final CVEs | 3 | `azure-core-http-netty` 1.16.3 | `azure-core-http-netty` 1.16.5 |
| `jackson-core` 2.18.4.1 (GHSA-72hv-8253-57qq) | 1 | `azure-core` 1.57.1 | `azure-core` 1.58.1 (jackson-core 2.18.6) |
| **Total** | **21** | | |

## Changes

Four line edits, split across two build files.

### [pom.xml](pom.xml) — property block

```diff
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
-    <azure-security-keyvault-keys.version>4.10.5</azure-security-keyvault-keys.version>
-    <azure-identity.version>1.18.2</azure-identity.version>
+    <azure-security-keyvault-keys.version>4.11.1</azure-security-keyvault-keys.version>
+    <azure-identity.version>1.18.4</azure-identity.version>
     <osgi.jdbc.version>1.1.0</osgi.jdbc.version>
```

### [build.gradle](build.gradle) — `compileOnly` and `testImplementation` blocks

```diff
-    compileOnly 'com.azure:azure-security-keyvault-keys:4.10.5',
-            'com.azure:azure-identity:1.18.2',
+    compileOnly 'com.azure:azure-security-keyvault-keys:4.11.1',
+            'com.azure:azure-identity:1.18.4',
```

```diff
             'org.bouncycastle:bcprov-jdk18on:1.79',
-            'com.azure:azure-security-keyvault-keys:4.10.5',
-            'com.azure:azure-identity:1.18.2',
+            'com.azure:azure-security-keyvault-keys:4.11.1',
+            'com.azure:azure-identity:1.18.4',
             'com.h2database:h2:2.2.220'
```

## Backward compatibility

- Both artifacts remain `<optional>true</optional>` — no impact on consumers that don't use Always Encrypted with Azure Key Vault or federated authentication.
- `azure-identity` 1.18.2 → 1.18.4 is a patch bump on the same 1.18.x line.
- `azure-security-keyvault-keys` 4.10.5 → 4.11.1 is a minor bump; the public API surface used by the driver (`KeyClient` / `CryptographyClient`) is unchanged.
- Staying on the Netty 4.1.x branch avoids cross-major-version runtime differences.

## References

- `azure-core-http-netty` 1.16.5 release notes — Netty bumped to 4.1.135.Final
- `azure-core` 1.58.1 release notes — jackson-core bumped to 2.18.6
- GHSA-72hv-8253-57qq — `jackson-core` StackOverflowError on deeply nested input
