### PR TITLE
Enable vector float16 tests to run on AzureDB

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
@@ -44,6 +44,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.vectorJsonTest;
 
@@ -72,6 +73,7 @@ import microsoft.sql.Vector.VectorDimensionType;
 @vectorJsonTest
 @Tag(Constants.vectorTest)
 @Tag(Constants.vectorFloat16Test)
+@AzureDB
 public class VectorFloat16Test extends VectorTest {
 
     @Override
@@ -495,6 +497,7 @@ public class VectorFloat16Test extends VectorTest {
     @DisplayName("Mixed FLOAT32 + FLOAT16 Vector Tests")
     @Tag(Constants.vectorTest)
     @Tag(Constants.vectorFloat16Test)
+    @AzureDB
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class MixedVectorTypeTest {
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorUtilityTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorUtilityTest.java
@@ -31,6 +31,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.vectorJsonTest;
 
@@ -247,6 +248,7 @@ public class VectorUtilityTest extends AbstractTest {
     @RunWith(JUnitPlatform.class)
     @DisplayName("Vector Negotiation Tests")
     @Tag(Constants.vectorFloat16Test)
+    @AzureDB
     public static class VectorNegotiationTest extends AbstractTest {
 
         @BeforeAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/bulkcopy/VectorFloat16BulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/bulkcopy/VectorFloat16BulkCopyTest.java
@@ -45,6 +45,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
+import com.microsoft.sqlserver.testframework.AzureDB;
 import com.microsoft.sqlserver.testframework.Constants;
 import com.microsoft.sqlserver.testframework.vectorJsonTest;
 
@@ -74,6 +75,7 @@ import microsoft.sql.Vector.VectorDimensionType;
 @vectorJsonTest
 @Tag(Constants.vectorTest)
 @Tag(Constants.vectorFloat16Test)
+@AzureDB
 public class VectorFloat16BulkCopyTest extends VectorBulkCopyTest {
 
     @Override
@@ -132,6 +134,7 @@ public class VectorFloat16BulkCopyTest extends VectorBulkCopyTest {
     @DisplayName("Mixed FLOAT32 + FLOAT16 Bulk Copy Tests")
     @Tag(Constants.vectorTest)
     @Tag(Constants.vectorFloat16Test)
+    @AzureDB
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class MixedVectorTypeBulkCopyTest {
 


### PR DESCRIPTION
Enable vector float16 tests to run on AzureDB