### PR TITLE
Make troubleshooting/debugging custom accessTokenCallbackClass possible

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -5954,7 +5954,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
             } catch (Exception e) {
                 MessageFormat form = new MessageFormat(
                         SQLServerException.getErrString("R_InvalidAccessTokenCallbackClass"));
-                throw new SQLServerException(form.format(new Object[] {accessTokenCallbackClass}), e.getCause());
+                throw new SQLServerException(form.format(new Object[] {accessTokenCallbackClass}), e);
             }
         } else if (authenticationString.equals(SqlAuthentication.NOT_SPECIFIED.toString())
                 && null != accessTokenCallback) {


### PR DESCRIPTION
When troubleshooting a problem with a custom accessTokenCallbackClass, the relevant exception may be missed because of a call to getCause().  If the exception doesn't have a cause exception, it will leave no chained exception to the SQLServerException(), effectively eliminating effective troubleshooting information.  If it does have a cause exception, it should still be listed as the logging prints out the stack trace will all the caused by traces.