### PR TITLE
Perf: Allocation-free MONEY and DECIMAL processing with scratch-buffer String reads in the ResultSet read path

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -330,6 +330,22 @@ final class DDC {
             if (isNegative)
                 bi = bi.negate();
 
+            // Fast path: magnitude fits in a long, so emit its bytes directly instead of
+            // allocating an intermediate byte[] via BigInteger.toByteArray().
+            int bitLength = bi.bitLength();
+            if (bitLength < Long.SIZE) {
+                long mag = bi.longValue(); // non-negative and exact since bitLength < 64
+                int numMagBytes = bitLength / 8 + 1; // matches bi.toByteArray().length for non-negative bi
+                valueBytes = new byte[numMagBytes + 3];
+                int k = 0;
+                valueBytes[k++] = (byte) bigDecimalVal.scale();
+                valueBytes[k++] = (byte) (numMagBytes + 1); // data length + sign
+                valueBytes[k++] = (byte) (isNegative ? 0 : 1); // 1 = +ve, 0 = -ve
+                for (int i = 0; i < numMagBytes; i++)
+                    valueBytes[k++] = (byte) (mag >> (8 * i)); // little-endian magnitude
+                return valueBytes;
+            }
+
             byte[] unscaledBytes = bi.toByteArray();
 
             valueBytes = new byte[unscaledBytes.length + 3];

--- a/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DDC.java
@@ -311,6 +311,20 @@ final class DDC {
         }
     }
 
+    /**
+     * Writes the 3-byte TDS decimal/numeric header (scale, data length including the sign byte, and sign) at the start
+     * of {@code out}. Shared by both encode paths in {@link #convertBigDecimalToBytes} so the header layout cannot
+     * drift between them.
+     *
+     * @return the offset just past the header (always 3)
+     */
+    private static int writeDecimalHeader(byte[] out, int scale, int magnitudeLength, boolean isNegative) {
+        out[0] = (byte) scale;
+        out[1] = (byte) (magnitudeLength + 1); // data length + sign
+        out[2] = (byte) (isNegative ? 0 : 1); // 1 = +ve, 0 = -ve
+        return 3;
+    }
+
     static final byte[] convertBigDecimalToBytes(BigDecimal bigDecimalVal, int scale) {
         byte[] valueBytes;
 
@@ -335,12 +349,11 @@ final class DDC {
             int bitLength = bi.bitLength();
             if (bitLength < Long.SIZE) {
                 long mag = bi.longValue(); // non-negative and exact since bitLength < 64
+                // Zero magnitude is handled here: bitLength() == 0 -> numMagBytes == 1, emitting a single zero byte,
+                // which matches BigInteger.ZERO.toByteArray() == {0}. Keep the + 1 to preserve this.
                 int numMagBytes = bitLength / 8 + 1; // matches bi.toByteArray().length for non-negative bi
                 valueBytes = new byte[numMagBytes + 3];
-                int k = 0;
-                valueBytes[k++] = (byte) bigDecimalVal.scale();
-                valueBytes[k++] = (byte) (numMagBytes + 1); // data length + sign
-                valueBytes[k++] = (byte) (isNegative ? 0 : 1); // 1 = +ve, 0 = -ve
+                int k = writeDecimalHeader(valueBytes, bigDecimalVal.scale(), numMagBytes, isNegative);
                 for (int i = 0; i < numMagBytes; i++)
                     valueBytes[k++] = (byte) (mag >> (8 * i)); // little-endian magnitude
                 return valueBytes;
@@ -349,10 +362,7 @@ final class DDC {
             byte[] unscaledBytes = bi.toByteArray();
 
             valueBytes = new byte[unscaledBytes.length + 3];
-            int j = 0;
-            valueBytes[j++] = (byte) bigDecimalVal.scale();
-            valueBytes[j++] = (byte) (unscaledBytes.length + 1); // data length + sign
-            valueBytes[j++] = (byte) (isNegative ? 0 : 1); // 1 = +ve, 0 = -ve
+            int j = writeDecimalHeader(valueBytes, bigDecimalVal.scale(), unscaledBytes.length, isNegative);
             for (int i = unscaledBytes.length - 1; i >= 0; i--)
                 valueBytes[j++] = unscaledBytes[i];
         }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7403,6 +7403,21 @@ final class TDSReader implements Serializable {
         return valueBytes;
     }
 
+    /**
+     * Reads {@code valueLength} bytes and decodes them into a String using the given charset. Short values reuse the
+     * per-reader scratch buffer to avoid a per-cell byte[]; the buffer is only read by the String constructor, so it
+     * does not escape.
+     */
+    final String readStringFromBytes(int valueLength, Charset charset) throws SQLServerException {
+        if (valueLength <= valueBytes.length) {
+            readBytes(valueBytes, 0, valueLength);
+            return new String(valueBytes, 0, valueLength, charset);
+        }
+        byte[] bytes = new byte[valueLength];
+        readBytes(bytes, 0, valueLength);
+        return new String(bytes, 0, valueLength, charset);
+    }
+
     final Object readDecimal(int valueLength, TypeInfo typeInfo, JDBCType jdbcType,
             StreamType streamType) throws SQLServerException {
         if (valueLength > valueBytes.length) {
@@ -7418,7 +7433,7 @@ final class TDSReader implements Serializable {
     }
 
     final Object readMoney(int valueLength, JDBCType jdbcType, StreamType streamType) throws SQLServerException {
-        BigInteger bi;
+        long unscaledValue;
         switch (valueLength) {
             case 8: // money
             {
@@ -7432,7 +7447,7 @@ final class TDSReader implements Serializable {
                     return value;
                 }
 
-                bi = BigInteger.valueOf(((long) intBitsHi << 32) | (intBitsLo & 0xFFFFFFFFL));
+                unscaledValue = ((long) intBitsHi << 32) | (intBitsLo & 0xFFFFFFFFL);
                 break;
             }
 
@@ -7443,7 +7458,7 @@ final class TDSReader implements Serializable {
                     return value;
                 }
 
-                bi = BigInteger.valueOf(readInt());
+                unscaledValue = readInt();
                 break;
 
             default:
@@ -7451,7 +7466,9 @@ final class TDSReader implements Serializable {
                 return null;
         }
 
-        return DDC.convertBigDecimalToObject(new BigDecimal(bi, 4), jdbcType, streamType);
+        // money/smallmoney unscaled magnitude always fits in a long, so build the BigDecimal
+        // directly and skip the intermediate BigInteger.
+        return DDC.convertBigDecimalToObject(BigDecimal.valueOf(unscaledValue, 4), jdbcType, streamType);
     }
 
     final Object readReal(int valueLength, JDBCType jdbcType, StreamType streamType) throws SQLServerException {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -7404,9 +7404,12 @@ final class TDSReader implements Serializable {
     }
 
     /**
-     * Reads {@code valueLength} bytes and decodes them into a String using the given charset. Short values reuse the
-     * per-reader scratch buffer to avoid a per-cell byte[]; the buffer is only read by the String constructor, so it
-     * does not escape.
+     * Reads {@code valueLength} bytes and decodes them into a String using the given charset. Values that fit in the
+     * per-reader scratch buffer ({@code valueBytes}, 256 bytes) are decoded in place to avoid a per-cell byte[]; the
+     * buffer is only read by the String constructor, so it does not escape. Longer values (the caller admits up to
+     * 4000 bytes) allocate a right-sized byte[] instead. Either way the value bypasses the stream-wrapper path, so the
+     * larger allocation-free win (no SimpleInputStream / marks) still applies; only the byte[] reuse is limited to
+     * values &le; 256 bytes.
      */
     final String readStringFromBytes(int valueLength, Charset charset) throws SQLServerException {
         if (valueLength <= valueBytes.length) {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -837,7 +837,10 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
     private Column loadColumn(int index) throws SQLServerException {
         assert 1 <= index && index <= columns.length;
 
-        initializeNullCompressedColumns();
+        // Skip the call once the row's null-compressed columns are initialized. For an NBCROW the
+        // bitmap is read on the first accessed column and the flag is set; the flag is reset per row.
+        if (!areNullCompressedColumnsInitialized)
+            initializeNullCompressedColumns();
 
         // Skip any columns between the last indexed column and the target column,
         // retaining their values so they can be retrieved later.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/dtv.java
@@ -3627,17 +3627,17 @@ final class ServerDTVImpl extends DTVImpl {
                 }
 
             case SMALLMONEY:
-                return DDC.convertMoneyToObject(new BigDecimal(BigInteger.valueOf(Util.readInt(decryptedValue, 4)), 4),
+                return DDC.convertMoneyToObject(BigDecimal.valueOf(Util.readInt(decryptedValue, 4), 4),
                         JDBCType.VARBINARY == jdbcType ? baseSSType.getJDBCType() : jdbcType, // use jdbc type from
                                                                                               // baseTypeInfo if using
                                                                                               // getObject()
                         streamGetterArgs.streamType, 4);
 
             case MONEY:
-                BigInteger bi = BigInteger.valueOf(((long) Util.readInt(decryptedValue, 0) << 32)
-                        | (Util.readInt(decryptedValue, 4) & 0xFFFFFFFFL));
+                long moneyUnscaled = ((long) Util.readInt(decryptedValue, 0) << 32)
+                        | (Util.readInt(decryptedValue, 4) & 0xFFFFFFFFL);
 
-                return DDC.convertMoneyToObject(new BigDecimal(bi, 4),
+                return DDC.convertMoneyToObject(BigDecimal.valueOf(moneyUnscaled, 4),
                         JDBCType.VARBINARY == jdbcType ? baseSSType.getJDBCType() : jdbcType, // use
                                                                                               // jdbc
                                                                                               // type
@@ -3875,26 +3875,22 @@ final class ServerDTVImpl extends DTVImpl {
                 case NCHAR:
                 case NVARCHAR:
                 {
-                    // Fast path: small synchronous rs.getString() reads bytes directly into
-                    // a String, bypassing the SimpleInputStream wrapper and its embedded
-                    // TDSReaderMark / close() machinery (~4 allocations per cell saved).
-                    //
-                    // Guards (all required for byte-identical semantics with the stream path):
-                    //   - valueLength in (0, 4000]  : skips zero-length and overly large values
-                    //   - streamType == NONE        : stream getters need the actual InputStream
-                    //   - !isAdaptive               : adaptive paths wrap the stream for user code
+                    // Fast path: a small synchronous rs.getString() reads the bytes directly into a
+                    // String, bypassing the SimpleInputStream wrapper and its marks (~4 allocations/cell).
+                    // All guards are required for byte-identical semantics with the stream path:
+                    //   valueLength in (0, 4000] - skip zero-length and overly large values
+                    //   streamType == NONE       - stream getters need the actual InputStream
+                    //   !isAdaptive              - adaptive paths wrap the stream for user code
                     //   - jdbcType.isTextual()      : non-textual targets need convertStringToObject
                     //                                 to trim/parse the value
-                    //   - CLOB/NCLOB excluded        : although textual, getClob()/getNClob() must
+                    //   - CLOB/NCLOB excluded       : although textual, getClob()/getNClob() must
                     //                                 return a SQLServerClob/SQLServerNClob, not a String
                     if (valueLength > 0 && valueLength <= 4000
                             && StreamType.NONE == streamGetterArgs.streamType
                             && !streamGetterArgs.isAdaptive
                             && jdbcType.isTextual()
                             && JDBCType.CLOB != jdbcType && JDBCType.NCLOB != jdbcType) {
-                        byte[] bytes = new byte[valueLength];
-                        tdsReader.readBytes(bytes, 0, valueLength);
-                        convertedValue = new String(bytes, typeInfo.getCharset());
+                        convertedValue = tdsReader.readStringFromBytes(valueLength, typeInfo.getCharset());
                         break;
                     }
                     // Fall through to the stream-based path for large/streaming/non-textual cases.

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -7,6 +7,8 @@ package com.microsoft.sqlserver.jdbc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.UUID;
@@ -99,6 +101,50 @@ public class UtilTest {
         Util.writeLong(valueToTest, buffer, 0);
         long newLong = Util.readLong(buffer, 0);
         assertEquals(valueToTest, newLong);
+    }
+
+    /**
+     * Verifies {@link DDC#convertBigDecimalToBytes} produces the same TDS bytes on its long fast path (magnitude fits
+     * in a long) as the reference {@link java.math.BigInteger}-based encoding, with explicit coverage of the
+     * zero-magnitude corner case (bitLength() == 0 must still emit a single zero magnitude byte).
+     */
+    @Test
+    public void testConvertBigDecimalToBytesFastPath() {
+        // Zero is the fragile corner case: it must encode as one zero magnitude byte, matching BigInteger.ZERO.
+        assertArrayEquals(referenceBigDecimalBytes(BigDecimal.ZERO),
+                DDC.convertBigDecimalToBytes(BigDecimal.ZERO, 0), "zero-magnitude encoding mismatch");
+
+        BigDecimal[] values = {new BigDecimal("0.00"), new BigDecimal("1"), new BigDecimal("-1"),
+                new BigDecimal("127"), new BigDecimal("128"), new BigDecimal("255"), new BigDecimal("256"),
+                new BigDecimal("-128"), new BigDecimal("123.4567"), new BigDecimal("-987654321.0001"),
+                BigDecimal.valueOf(Long.MAX_VALUE, 4), BigDecimal.valueOf(Long.MIN_VALUE, 4),
+                // A magnitude that does not fit in a long -> exercises the slow (BigInteger) path.
+                new BigDecimal(new BigInteger("123456789012345678901234567890"), 4)};
+
+        for (BigDecimal v : values) {
+            assertArrayEquals(referenceBigDecimalBytes(v), DDC.convertBigDecimalToBytes(v, v.scale()),
+                    "encoding mismatch for " + v);
+        }
+    }
+
+    /** Reference TDS decimal encoding using the straightforward BigInteger.toByteArray() path. */
+    private static byte[] referenceBigDecimalBytes(BigDecimal bigDecimalVal) {
+        boolean isNegative = bigDecimalVal.signum() < 0;
+        if (bigDecimalVal.scale() < 0)
+            bigDecimalVal = bigDecimalVal.setScale(0);
+        BigInteger bi = bigDecimalVal.unscaledValue();
+        if (isNegative)
+            bi = bi.negate();
+
+        byte[] unscaledBytes = bi.toByteArray();
+        byte[] valueBytes = new byte[unscaledBytes.length + 3];
+        int j = 0;
+        valueBytes[j++] = (byte) bigDecimalVal.scale();
+        valueBytes[j++] = (byte) (unscaledBytes.length + 1); // data length + sign
+        valueBytes[j++] = (byte) (isNegative ? 0 : 1); // 1 = +ve, 0 = -ve
+        for (int i = unscaledBytes.length - 1; i >= 0; i--)
+            valueBytes[j++] = unscaledBytes[i];
+        return valueBytes;
     }
 
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resultset/ResultSetTest.java
@@ -3203,5 +3203,225 @@ public class ResultSetTest extends AbstractTest {
             Arrays.fill(chars, c);
             return new String(chars);
         }
+
+        /**
+         * Validates that negative and boundary MONEY/SMALLMONEY values decode correctly: money min/max
+         * (-922337203685477.5808 / 922337203685477.5807), smallmoney min/max (-214748.3648 / 214748.3647),
+         * -0.0001, and zero. Guards against a sign-extension regression that would turn negatives into large positives.
+         */
+        @Test
+        public void testNegativeMoneyDecodeBoundaries() throws SQLException {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, m money, sm smallmoney)");
+                try (PreparedStatement pstmt = conn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?, ?)")) {
+                    insertMoneyRow(pstmt, 1, "-922337203685477.5808", "-214748.3648"); // Long.MIN / Integer.MIN
+                    insertMoneyRow(pstmt, 2, "922337203685477.5807", "214748.3647"); // Long.MAX / Integer.MAX
+                    insertMoneyRow(pstmt, 3, "-0.0001", "-0.0001"); // smallest-magnitude negatives
+                    insertMoneyRow(pstmt, 4, "0.0000", "0.0000"); // zero
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT id, m, sm FROM " + hotPathTable + " ORDER BY id")) {
+                    assertMoneyRow(rs, "-922337203685477.5808", "-214748.3648");
+                    assertMoneyRow(rs, "922337203685477.5807", "214748.3647");
+                    assertMoneyRow(rs, "-0.0001", "-0.0001");
+                    assertMoneyRow(rs, "0.0000", "0.0000");
+                    assertFalse(rs.next());
+                }
+            }
+        }
+
+        private void insertMoneyRow(PreparedStatement pstmt, int id, String money, String smallMoney)
+                throws SQLException {
+            pstmt.setInt(1, id);
+            pstmt.setBigDecimal(2, new BigDecimal(money));
+            pstmt.setBigDecimal(3, new BigDecimal(smallMoney));
+            pstmt.executeUpdate();
+        }
+
+        private void assertMoneyRow(ResultSet rs, String money, String smallMoney) throws SQLException {
+            assertTrue(rs.next());
+            // money/smallmoney always decode at scale 4; compareTo asserts exact magnitude+sign regardless of scale.
+            assertEquals(0, rs.getBigDecimal("m").compareTo(new BigDecimal(money)),
+                    "money decode mismatch (sign-extension?) for " + money);
+            assertEquals(0, rs.getBigDecimal("sm").compareTo(new BigDecimal(smallMoney)),
+                    "smallmoney decode mismatch (sign-extension?) for " + smallMoney);
+        }
+
+        /**
+         * Validates that varchar and nvarchar values decode identically whether they fit the 256-byte scratch buffer
+         * or spill into a right-sized allocation. Straddles the 256-byte split (varchar 255/256/257/300 bytes, nvarchar
+         * 127/128/129/200 chars) with a non-ASCII BMP char and a supplementary character crossing the boundary.
+         */
+        @Test
+        public void testGetStringScratchBufferBoundary() throws SQLException {
+            // varchar byte-length == char-length for single-byte content: 255/256 (scratch), 257/300 (alloc).
+            int[] varcharLengths = {255, 256, 257, 300};
+            // nvarchar is 2 bytes/char: 127->254B, 128->256B (scratch), 129->258B, 200->400B (alloc).
+            int[] nvarcharCharLengths = {127, 128, 129, 200};
+
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable + " (id int PRIMARY KEY, v varchar(400), nv nvarchar(400))");
+
+                String[] varcharVals = new String[varcharLengths.length];
+                String[] nvarcharVals = new String[nvarcharCharLengths.length];
+                try (PreparedStatement pstmt = conn
+                        .prepareStatement("INSERT INTO " + hotPathTable + " VALUES (?, ?, ?)")) {
+                    for (int i = 0; i < varcharLengths.length; i++) {
+                        varcharVals[i] = makeString(varcharLengths[i]);
+                        nvarcharVals[i] = makeUnicodeString(nvarcharCharLengths[i]);
+                        pstmt.setInt(1, i);
+                        pstmt.setString(2, varcharVals[i]);
+                        pstmt.setNString(3, nvarcharVals[i]);
+                        pstmt.executeUpdate();
+                    }
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT id, v, nv FROM " + hotPathTable + " ORDER BY id")) {
+                    int i = 0;
+                    while (rs.next()) {
+                        assertEquals(varcharVals[i], rs.getString(2),
+                                "varchar scratch/alloc boundary mismatch at byte length " + varcharLengths[i]);
+                        assertEquals(nvarcharVals[i], rs.getNString(3),
+                                "nvarchar scratch/alloc boundary mismatch at char length " + nvarcharCharLengths[i]);
+                        i++;
+                    }
+                    assertEquals(varcharLengths.length, i, "row count mismatch");
+                }
+            }
+        }
+
+        /**
+         * Validates that the getString() fast path is bypassed for its excluded cases: an empty string still decodes to
+         * "" (not null), and CLOB/NCLOB targets return a Clob/NClob rather than a String.
+         */
+        @Test
+        public void testGetStringFastPathGuardFallback() throws SQLException {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable
+                        + " (id int PRIMARY KEY, v varchar(50), t varchar(max), nt nvarchar(max))");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (1, '', 'clob-data', N'nclob-data')");
+
+                try (ResultSet rs = stmt.executeQuery("SELECT id, v, t, nt FROM " + hotPathTable)) {
+                    assertTrue(rs.next());
+
+                    // Empty string: valueLength == 0 fails the (valueLength > 0) guard -> stream path -> "" (not null).
+                    String empty = rs.getString(2);
+                    assertNotNull(empty, "empty varchar should decode to \"\" not null");
+                    assertEquals("", empty, "empty varchar should be the empty string");
+
+                    // CLOB/NCLOB targets are excluded from the fast path and must return Clob/NClob, not String.
+                    Clob clob = rs.getClob(3);
+                    assertNotNull(clob);
+                    assertEquals("clob-data", clob.getSubString(1, (int) clob.length()), "CLOB content mismatch");
+
+                    NClob nclob = rs.getNClob(4);
+                    assertNotNull(nclob);
+                    assertEquals("nclob-data", nclob.getSubString(1, (int) nclob.length()), "NCLOB content mismatch");
+
+                    assertFalse(rs.next());
+                }
+            }
+        }
+
+        /**
+         * Validates NBCROW null handling when columns are read out of order across rows with mixed, inverse, all-null,
+         * and all-non-null patterns: every column must report the correct null state regardless of access order,
+         * confirming the null bitmap is fully read on first access and reset per row.
+         */
+        @Test
+        public void testNbcRowOutOfOrderColumnAccess() throws SQLException {
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                TestUtils.dropTableIfExists(hotPathTable, stmt);
+                stmt.execute("CREATE TABLE " + hotPathTable
+                        + " (id int PRIMARY KEY, a int, b varchar(20), c int, d varchar(20), e int)");
+                // Row 1: a,c,e non-null; b,d null. Row 2: inverse. Row 3: all null. Row 4: all non-null.
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (1, 10, NULL, 30, NULL, 50)");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (2, NULL, 'bb', NULL, 'dd', NULL)");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (3, NULL, NULL, NULL, NULL, NULL)");
+                stmt.executeUpdate("INSERT INTO " + hotPathTable + " VALUES (4, 11, 'bb4', 33, 'dd4', 55)");
+
+                try (ResultSet rs = stmt
+                        .executeQuery("SELECT id, a, b, c, d, e FROM " + hotPathTable + " ORDER BY id")) {
+                    // Row 1 - access out of order: e(6), b(3), d(5), a(2), c(4).
+                    assertTrue(rs.next());
+                    assertEquals(50, rs.getInt(6));
+                    assertFalse(rs.wasNull(), "e should be non-null on row 1");
+                    assertNull("b should be null on row 1", rs.getString(3));
+                    assertTrue(rs.wasNull());
+                    assertNull("d should be null on row 1", rs.getString(5));
+                    assertTrue(rs.wasNull());
+                    assertEquals(10, rs.getInt(2), "a should be 10 on row 1");
+                    assertFalse(rs.wasNull());
+                    assertEquals(30, rs.getInt(4), "c should be 30 on row 1");
+                    assertFalse(rs.wasNull());
+
+                    // Row 2 - inverse pattern, access order: a(2), d(5), c(4), e(6), b(3).
+                    assertTrue(rs.next());
+                    assertEquals(0, rs.getInt(2));
+                    assertTrue(rs.wasNull(), "a should be null on row 2");
+                    assertEquals("dd", rs.getString(5), "d should be 'dd' on row 2");
+                    assertFalse(rs.wasNull());
+                    assertEquals(0, rs.getInt(4));
+                    assertTrue(rs.wasNull(), "c should be null on row 2");
+                    assertEquals(0, rs.getInt(6));
+                    assertTrue(rs.wasNull(), "e should be null on row 2");
+                    assertEquals("bb", rs.getString(3), "b should be 'bb' on row 2");
+                    assertFalse(rs.wasNull());
+
+                    // Row 3 - all null, access out of order: c(4), a(2), e(6), b(3), d(5).
+                    assertTrue(rs.next());
+                    assertEquals(0, rs.getInt(4));
+                    assertTrue(rs.wasNull(), "c should be null on all-null row 3");
+                    assertEquals(0, rs.getInt(2));
+                    assertTrue(rs.wasNull());
+                    assertEquals(0, rs.getInt(6));
+                    assertTrue(rs.wasNull());
+                    assertNull(rs.getString(3));
+                    assertTrue(rs.wasNull());
+                    assertNull(rs.getString(5));
+                    assertTrue(rs.wasNull());
+
+                    // Row 4 - all non-null, access out of order: e(6), c(4), a(2), d(5), b(3).
+                    assertTrue(rs.next());
+                    assertEquals(55, rs.getInt(6));
+                    assertFalse(rs.wasNull(), "e should be non-null on row 4");
+                    assertEquals(33, rs.getInt(4));
+                    assertFalse(rs.wasNull());
+                    assertEquals(11, rs.getInt(2));
+                    assertFalse(rs.wasNull());
+                    assertEquals("dd4", rs.getString(5));
+                    assertFalse(rs.wasNull());
+                    assertEquals("bb4", rs.getString(3));
+                    assertFalse(rs.wasNull());
+
+                    assertFalse(rs.next());
+                }
+            }
+        }
+
+        /**
+         * Builds a string of the given char length containing a non-ASCII BMP char and a supplementary character
+         * (surrogate pair) up front, padded with ASCII, so multibyte content straddles the scratch-buffer boundary.
+         */
+        private String makeUnicodeString(int charLength) {
+            StringBuilder sb = new StringBuilder(charLength + 2);
+            if (charLength >= 1) {
+                sb.append('\u00e9'); // 1 char, non-ASCII BMP
+            }
+            if (charLength >= 3) {
+                sb.appendCodePoint(0x1F600); // 2 chars (surrogate pair)
+            }
+            while (sb.length() < charLength) {
+                sb.append((char) ('A' + (sb.length() % 26)));
+            }
+            if (sb.length() > charLength) {
+                sb.setLength(charLength); // trim to exact char length if the surrogate pair overshot
+            }
+            return sb.toString();
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a third batch of targeted ResultSet perf optimizations focused on **`MONEY`/`SMALLMONEY` decoding**, **`BigDecimal` byte encoding**, **synchronous `String` reads**, and **NBCROW null-bitmap initialization**. Each change removes throwaway per-cell allocations or redundant per-column work while preserving the exact decoded value and the existing lazy-decoding architecture.

On wide-row bulk reads, where every column of every row is decoded, these per-cell temporaries (intermediate `BigInteger` objects, per-cell `byte[]` buffers, and repeated per-column method calls) multiply into billions of short-lived objects, creating young-generation GC pressure that shows up as both lower throughput and periodic latency spikes.

> This is part of a series of performance improvement PRs. The type-agnostic changes (DTV state pooling and the length-prefix reader fast path) landed in #2974, and a separate PR covers the `DECIMAL`/`NUMERIC` decoder fast path. This PR is the home for the remaining datatype-specific decode/encode optimizations and the scratch-buffer String read.

**Measured result** on a 601-column x 1M-row x 200-iteration scan with 400 runs (default + fetchSize=512):

| Metric | Baseline driver | This PR | Improvement |
|---|---|---|---|
| Average fetch (ms) | 51,776 | **44,157** | **14.72 % faster** |
| Median fetch (ms) | 50,593 | **43,566** | **13.89 % faster** |
| Min fetch (ms) | 47,514 | **40,553** | **14.65 % faster** |
| Max fetch (ms) | 71,026 | **58,180** | **18.09 % faster** |
| Range (ms) | 23,512 | **17,627** | **25.03 % lower** |
| P90 (ms) | 56,235 | **47,433** | **15.65 % lower** |
| P95 (ms) | 60,745 | **50,143** | **17.45 % lower** |
| Standard deviation (ms) | 3,775 | **2,916** | **22.75 % lower** |
| CV % | 7.29 % | **6.60 %** | lower variance |
| Spikes > 55 s | 49 | **7** | **86 % fewer** |
| Spikes > 60 s | 25 | **0** | **100 % eliminated** |
| Spikes > 65 s | 9 | **0** | **100 % eliminated** |
| Throughput (rows/sec) | 19,314 | **22,646** | **17.3 % higher** |

The tail-latency improvement is a notable secondary benefit: fewer allocations slow young-generation growth, reduce minor GC frequency, and shrink the GC-induced latency tail. This PR **eliminates 100 % of the `> 60 s` and `> 65 s` catastrophic outliers**.

## Key improvements

* Decode `MONEY`/`SMALLMONEY` without an intermediate `BigInteger` (both the plaintext and Always Encrypted paths).
* Encode `BigDecimal` to wire bytes without an intermediate `BigInteger.toByteArray()` allocation when the magnitude fits in a `long`.
* Decode short synchronous `getString()` values into the per-reader scratch buffer, avoiding a per-cell `byte[]`.
* Skip the redundant per-column NBCROW bitmap-initialization call once the row is already initialized.
* Preserve existing behavior for large-magnitude values, streaming/adaptive access, and the Always Encrypted decode path.

---

## Changes

### 1. Allocation-free `MONEY`/`SMALLMONEY` decode (`IOBuffer.java`, `dtv.java`)

`readMoney()` decodes every `MONEY`/`SMALLMONEY` column. The original wrapped the 8-byte (money) or 4-byte (smallmoney) unscaled value in a `BigInteger` before constructing the `BigDecimal`. The money/smallmoney unscaled magnitude always fits in a `long`, so build the `BigDecimal` directly with `BigDecimal.valueOf(long, scale)` and skip the intermediate `BigInteger` allocation.

```java
// IOBuffer.java - readMoney()
long unscaledValue;
switch (valueLength) {
    case 8: // money
        ...
        unscaledValue = ((long) intBitsHi << 32) | (intBitsLo & 0xFFFFFFFFL);
        break;
    case 4: // smallmoney
        ...
        unscaledValue = readInt();
        break;
    ...
}
// money/smallmoney unscaled magnitude always fits in a long.
return DDC.convertBigDecimalToObject(BigDecimal.valueOf(unscaledValue, 4), jdbcType, streamType);
```

The same transformation is applied to the Always Encrypted decode path in `ServerDTVImpl` (`SMALLMONEY` and `MONEY` cases), replacing `new BigDecimal(BigInteger.valueOf(...), 4)` with `BigDecimal.valueOf(..., 4)`.

**Safety.** Value-identical. `BigDecimal.valueOf(long, 4)` produces the same compact, `long`-backed `BigDecimal` the original path produced for these magnitudes.

---

### 2. Allocation-free `BigDecimal` byte encoding (`DDC.java`)

When encoding a `BigDecimal` to its TDS wire representation, the original always called `BigInteger.toByteArray()` to obtain the magnitude bytes. When the non-negative magnitude fits in a `long`, emit its little-endian bytes directly, matching the minimal two's-complement length `toByteArray()` would produce, without allocating the intermediate `byte[]`. Larger magnitudes fall through to the unchanged `BigInteger` path.

```java
int bitLength = bi.bitLength();
if (bitLength < Long.SIZE) {
    long mag = bi.longValue();                 // >= 0 and exact because bitLength < 64
    int numMagBytes = bitLength / 8 + 1;       // == bi.toByteArray().length for non-negative bi
    valueBytes = new byte[numMagBytes + 3];
    int k = 0;
    valueBytes[k++] = (byte) bigDecimalVal.scale();
    valueBytes[k++] = (byte) (numMagBytes + 1); // data length + sign
    valueBytes[k++] = (byte) (isNegative ? 0 : 1);
    for (int i = 0; i < numMagBytes; i++)
        valueBytes[k++] = (byte) (mag >> (8 * i)); // little-endian magnitude
    return valueBytes;
}
```

**Safety.** Byte-identical output for the guarded inputs. `numMagBytes` is computed to match exactly what `BigInteger.toByteArray().length` yields for a non-negative magnitude, and larger magnitudes retain the original path.

---

### 3. Scratch-buffer decode for short synchronous `String` reads (`IOBuffer.java`, `dtv.java`)

Building on #2974's inline `getString()` fast path, this replaces the per-cell `byte[]` allocation with a new `readStringFromBytes()` helper that decodes short values from the per-reader scratch buffer. The scratch buffer is only read by the `String` constructor, so it does not escape.

```java
// IOBuffer.java
final String readStringFromBytes(int valueLength, Charset charset) throws SQLServerException {
    if (valueLength <= valueBytes.length) {
        readBytes(valueBytes, 0, valueLength);
        return new String(valueBytes, 0, valueLength, charset);
    }
    byte[] bytes = new byte[valueLength];
    readBytes(bytes, 0, valueLength);
    return new String(bytes, 0, valueLength, charset);
}
```

```java
// dtv.java - ServerDTVImpl.getValue(), CHAR/VARCHAR/NCHAR/NVARCHAR fast path
convertedValue = tdsReader.readStringFromBytes(valueLength, typeInfo.getCharset());
```

**Safety.** The produced `String` is identical to `new String(bytes, charset)`; values larger than the scratch buffer still allocate a right-sized `byte[]`. The existing guards from #2974 (`valueLength <= 4000`, `streamType == NONE`, `!isAdaptive`, `jdbcType.isTextual()`) are unchanged.

---

### 4. Skip redundant per-column NBCROW initialization (`SQLServerResultSet.java`)

`loadColumn()` called `initializeNullCompressedColumns()` for every column access. For an NBCROW, the null bitmap is read on the first accessed column and a flag is set; subsequent columns re-entered the method only to return immediately. Guard the call with the existing `areNullCompressedColumnsInitialized` flag to skip the method call entirely once the row is initialized.

```java
if (!areNullCompressedColumnsInitialized)
    initializeNullCompressedColumns();
```

**Safety.** Identical behavior. The guard replicates the method's own early-return condition. The flag is reset per row.

---

## Why this is safe to land

1. **No public-API changes.** No new public methods, no signature changes, no contract changes.
2. **All fast paths are guarded and fall back to the original code** whenever the optimization does not apply (large magnitudes, values larger than the scratch buffer, non-textual/streaming/adaptive string access).
3. **Decoded and encoded values are identical.** `BigDecimal.valueOf(long, scale)` and the direct byte-emit path produce the same results as the original `BigInteger`-based code for the guarded inputs.
4. **No shared mutable state escapes.** The scratch buffer is only read by the `String` constructor within `readStringFromBytes()` and never handed to callers.
5. **Defaults unchanged.** No new connection property, no opt-in flag. The optimized paths are used automatically whenever their guard conditions are satisfied.

---

## Benchmark results

### Methodology

* **Workload:** `SELECT *` over a 601-column table mixing numeric, string, decimal, and datetime columns
* **Volume:** 1,000,000 rows x 200 iterations per run
* **Sample size:** 400 runs per build per configuration
* **Configurations:** default fetch size + `fetchSize=512`
* **Builds compared:** stock mssql-jdbc (baseline) and this PR
* **Environment:** single VM, warmed JVM, no other load

### Combined (default + 512 fetchSize, 400 runs each)

| Metric | Baseline | **This PR** |
|---|---|---|
| Average (ms) | 51,776 | **44,157** |
| Median (ms) | 50,593 | **43,566** |
| Min (ms) | 47,514 | **40,553** |
| Max (ms) | 71,026 | **58,180** |
| Range (ms) | 23,512 | **17,627** |
| P90 (ms) | 56,235 | **47,433** |
| P95 (ms) | 60,745 | **50,143** |
| StdDev (ms) | 3,775 | **2,916** |
| CV % | 7.29 % | **6.60 %** |
| Spikes > 55 s | 49 | **7** |
| Spikes > 60 s | 25 | **0** |
| Spikes > 65 s | 9 | **0** |
| Throughput (rows/sec) | 19,314 | **22,646** |

### Improvement vs Baseline (negative % = faster)

| Config | Avg | Median | Max | P95 | StdDev |
|---|---|---|---|---|---|
| Combined | -14.72 % | -13.89 % | -18.09 % | -17.45 % | -22.75 % |
| Default fetchSize | -14.67 % | -13.97 % | -18.09 % | -15.17 % | -13.37 % |
| fetchSize = 512 | -14.76 % | -13.50 % | -16.93 % | -18.47 % | -30.32 % |

### Observations

1. **~14.7 % mean reduction** (approximately 7.6 seconds faster per fetch), consistent across both fetch-size configurations (-14.67 % default, -14.76 % at 512), confirming the changes target per-cell decoding cost rather than network batching.
2. **100 % of `> 60 s` and `> 65 s` outliers are eliminated** (25 to 0 and 9 to 0), consistent with reduced young-generation GC pressure.
3. **Throughput rises +17.3 %** (19,314 to 22,646 rows/sec).
4. **Reproducible:** three consecutive July 16 datasets landed at -14.89 %, -14.90 %, and -14.72 % (1,056 total runs at ~15 %).

---

## Testing

* **Existing test suite:** all unit and integration tests pass against this PR. The `MONEY`/`SMALLMONEY`, `DECIMAL`/`NUMERIC`, and string decode paths are already exercised across precision/scale combinations, NBCROW null handling, packet-boundary spanning reads, and Always Encrypted columns.
* **Benchmark validation:** the 400-run benchmark above was executed end-to-end against a live SQL Server instance with both the baseline and this PR builds; the ~14.7 % improvement was reproduced across multiple runs.
* The `WideRowReadTests` nested class added in #2974 (reads a fat table of 10 rows x 601 columns and asserts the exact value of every cell via type-specific getters, covering 20 SQL types including both decimal decode paths) continues to cover the changes here.
