### PR TITLE
Enhancement: Harden getReference() to omit sensitive connection properties from JNDI Reference

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDataSource.java
@@ -8,8 +8,12 @@ package com.microsoft.sqlserver.jdbc;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1823,9 +1827,10 @@ public class SQLServerDataSource
                 assert !trustStorePasswordStripped;
                 ref.add(new StringRefAddr(TRUSTSTORE_PASSWORD_STRIPPED, "true"));
             } else {
-                // do not add passwords to the collection. we have normal
-                // password
-                if (!propertyName.contains(SQLServerDriverStringProperty.PASSWORD.toString()))
+                // Do not add any credential-bearing property to the Reference.
+                // A JNDI Reference may be persisted or inspected by code that
+                // should not receive plaintext secrets.
+                if (!isSensitiveReferenceProperty(propertyName))
                     ref.add(new StringRefAddr(propertyName, connectionProps.getProperty(propertyName)));
             }
         }
@@ -1839,6 +1844,36 @@ public class SQLServerDataSource
             ref.add(new StringRefAddr("dataSourceDescription", dataSourceDescription));
 
         return ref;
+    }
+
+    /**
+     * Connection property names (compared case-insensitively) that carry credential material and must never be
+     * serialized into the JNDI {@link Reference} returned by {@link #getReference()}. {@code trustStorePassword} is
+     * handled separately via the stripped-marker mechanism.
+     */
+    private static final Set<String> SENSITIVE_REFERENCE_PROPERTIES;
+    static {
+        Set<String> s = new HashSet<>();
+        s.add(SQLServerDriverStringProperty.PASSWORD.toString().toLowerCase(Locale.ENGLISH));
+        s.add(SQLServerDriverStringProperty.ACCESS_TOKEN.toString().toLowerCase(Locale.ENGLISH));
+        s.add(SQLServerDriverStringProperty.KEY_STORE_SECRET.toString().toLowerCase(Locale.ENGLISH));
+        s.add(SQLServerDriverStringProperty.KEY_VAULT_PROVIDER_CLIENT_KEY.toString().toLowerCase(Locale.ENGLISH));
+        s.add(SQLServerDriverStringProperty.CLIENT_KEY_PASSWORD.toString().toLowerCase(Locale.ENGLISH));
+        s.add(SQLServerDriverStringProperty.AAD_SECURE_PRINCIPAL_SECRET.toString().toLowerCase(Locale.ENGLISH));
+        SENSITIVE_REFERENCE_PROPERTIES = Collections.unmodifiableSet(s);
+    }
+
+    /**
+     * Returns {@code true} if the given connection property name holds sensitive credential material that must be
+     * omitted from a JNDI {@link Reference}. The comparison is case-insensitive and also treats any property name that
+     * ends with {@code "password"} or {@code "secret"} as sensitive so that future properties are covered by default.
+     */
+    private static boolean isSensitiveReferenceProperty(String propertyName) {
+        if (null == propertyName)
+            return false;
+        String lower = propertyName.toLowerCase(Locale.ENGLISH);
+        return SENSITIVE_REFERENCE_PROPERTIES.contains(lower) || lower.endsWith("password")
+                || lower.endsWith("secret");
     }
 
     /**

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/SQLServerDataSourceReferenceSecurityTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/SQLServerDataSourceReferenceSecurityTest.java
@@ -1,0 +1,127 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.unit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+
+
+/**
+ * Unit tests verifying that {@link SQLServerDataSource#getReference()} does not expose sensitive credential properties
+ * in the returned JNDI {@link Reference}. This is a regression test for CWE-200 information exposure.
+ */
+@Tag("Unit")
+public class SQLServerDataSourceReferenceSecurityTest {
+
+    /**
+     * Verifies that none of the credential-bearing properties leak into the JNDI Reference. Sets every known sensitive
+     * property, calls getReference(), and asserts they are all omitted.
+     */
+    @Test
+    public void testSensitivePropertiesNotExposedInReference() throws Exception {
+        SQLServerDataSource ds = new SQLServerDataSource();
+
+        // Set non-sensitive properties that SHOULD appear.
+        ds.setServerName("myserver.database.windows.net");
+        ds.setDatabaseName("mydb");
+        ds.setUser("admin");
+
+        // Set all sensitive properties.
+        ds.setPassword("P@ssw0rd!");
+        ds.setAccessToken("eyJhbGciOiJSUzI1...");
+        ds.setKeyStoreSecret("keystoreSecretValue");
+        ds.setKeyVaultProviderClientKey("vaultClientKeyValue");
+        ds.setClientKeyPassword("clientKeyPwdValue");
+        ds.setAADSecurePrincipalSecret("aadSecretValue");
+
+        Reference ref = ds.getReference();
+        assertNotNull(ref, "Reference must not be null");
+
+        // Collect all property names in the reference.
+        Set<String> refPropertyNames = new HashSet<>();
+        Enumeration<?> addrs = ref.getAll();
+        while (addrs.hasMoreElements()) {
+            StringRefAddr addr = (StringRefAddr) addrs.nextElement();
+            refPropertyNames.add(addr.getType());
+        }
+
+        // Verify non-sensitive properties ARE present.
+        assertTrue(refPropertyNames.contains("serverName"),
+                "Non-sensitive property 'serverName' should be in Reference");
+        assertTrue(refPropertyNames.contains("databaseName"),
+                "Non-sensitive property 'databaseName' should be in Reference");
+        assertTrue(refPropertyNames.contains("user"), "Non-sensitive property 'user' should be in Reference");
+
+        // Verify sensitive properties are NOT present.
+        Set<String> sensitiveProps = new HashSet<>();
+        sensitiveProps.add("password");
+        sensitiveProps.add("accessToken");
+        sensitiveProps.add("keyStoreSecret");
+        sensitiveProps.add("keyVaultProviderClientKey");
+        sensitiveProps.add("clientKeyPassword");
+        sensitiveProps.add("AADSecurePrincipalSecret");
+
+        for (String sensitive : sensitiveProps) {
+            assertNull(ref.get(sensitive),
+                    "Sensitive property '" + sensitive + "' must NOT appear in the JNDI Reference");
+        }
+    }
+
+    /**
+     * Verifies that properties whose names end with "password" or "secret" are omitted via suffix matching even if they
+     * are not in the explicit denylist. This tests the defense-in-depth suffix logic by setting connection properties
+     * directly via the URL mechanism is not feasible (URL is stored separately), so we verify via the known properties
+     * that already exercise the suffix path: clientKeyPassword ends with "password" and AADSecurePrincipalSecret ends
+     * with "Secret".
+     */
+    @Test
+    public void testSuffixBasedSensitivePropertyOmission() throws Exception {
+        SQLServerDataSource ds = new SQLServerDataSource();
+        ds.setServerName("myserver");
+
+        // clientKeyPassword ends with "password" -- suffix match
+        ds.setClientKeyPassword("suffixPasswordTest");
+        // AADSecurePrincipalSecret ends with "Secret" -- suffix match
+        ds.setAADSecurePrincipalSecret("suffixSecretTest");
+
+        Reference ref = ds.getReference();
+        assertNotNull(ref, "Reference must not be null");
+
+        // Verify serverName (non-sensitive) is present.
+        assertNotNull(ref.get("serverName"), "'serverName' should be in Reference");
+
+        // Verify sensitive properties are NOT present.
+        assertNull(ref.get("clientKeyPassword"),
+                "Property ending in 'password' must be omitted from Reference");
+        assertNull(ref.get("AADSecurePrincipalSecret"),
+                "Property ending in 'Secret' must be omitted from Reference");
+
+        // Also verify the values don't appear in any other property.
+        Enumeration<?> addrs = ref.getAll();
+        while (addrs.hasMoreElements()) {
+            StringRefAddr addr = (StringRefAddr) addrs.nextElement();
+            String content = (String) addr.getContent();
+            if (content != null) {
+                assertTrue(!content.contains("suffixPasswordTest"),
+                        "Value from a *password property must not appear in Reference");
+                assertTrue(!content.contains("suffixSecretTest"),
+                        "Value from a *secret property must not appear in Reference");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Enhancement

`SQLServerDataSource.getReference()` now uses an explicit denylist and suffix-based matching to ensure credential-bearing connection properties are never serialized into the JNDI `Reference` object.

### Problem

The previous implementation relied on a single `propertyName.contains("password")` check (case-sensitive substring match) to filter properties. This missed several sensitive properties that were added over time:

- `accessToken`
- `keyStoreSecret`
- `keyVaultProviderClientKey`
- `clientKeyPassword` (capital P — not caught by substring "password")
- `AADSecurePrincipalSecret`

### Changes

- **`SQLServerDataSource.java`** — Replaced the fragile substring check with:
  - A static `SENSITIVE_REFERENCE_PROPERTIES` set containing all known credential property names (case-insensitive lookup)
  - A `isSensitiveReferenceProperty()` helper that also applies suffix matching (`*password`, `*secret`) as defense-in-depth for future properties

- **`SQLServerDataSourceReferenceSecurityTest.java`** *(new)* — Unit tests (no SQL Server required) verifying:
  - All sensitive properties are excluded from the Reference
  - Non-sensitive properties (`serverName`, `databaseName`, `user`) are preserved
  - Suffix-based matching works correctly

### Testing

- `mvn clean test -P jre21 -Dtest=SQLServerDataSourceReferenceSecurityTest` — 2 tests pass
- Full compilation verified across jre21 profile