### PR TITLE
Enhance Always Encrypted VSM/HGS enclave attestation validation

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -535,6 +535,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_InvalidHealthCert", "Enclave attestation failed, the health report certificate provided in the enclave was not signed by the HGS - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details."},
         {"R_InvalidSignedStatement", "Enclave attestation failed, the statement bytes were not signed by the health certificate - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details."},
         {"R_InvalidDHKeySignature", "Enclave attestation failed, the DH public key signature can't be verified with the enclave public key - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details."},
+        {"R_InvalidEnclaveStatementBinding", "Enclave attestation failed, the signed report did not bind to the enclave public key used for the session - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details."},
         {"R_AasJWTError", "An error occured when retrieving and validating the JSON web token."},
         {"R_AasEhdError", "aas-ehd claim from JWT did not match enclave public key."},
         {"R_VbsRpDataError", "rp_data claim from JWT did not match client nonce."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerVSMEnclaveProvider.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerVSMEnclaveProvider.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.security.SignatureException;
@@ -26,6 +27,7 @@ import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -368,6 +370,34 @@ class VSMAttestationResponse extends BaseAttestationResponse {
         if (!sig.verify(signatureBlob)) {
             SQLServerException.makeFromDriverError(null, this,
                     SQLServerResource.getResource("R_InvalidSignedStatement"), "0", false);
+        }
+
+        // Signature is verified; now confirm the enclave public key is the one committed to by the signed report.
+        validateEnclavePublicKeyBinding(signedStatement);
+    }
+
+    /*
+     * Verifies that the enclave public key matches the value committed to by the signed report. Genuine VBS enclaves
+     * place SHA-256(enclavePK) in the first 32 bytes of the Enclave Data (report data) field, so the two must match.
+     */
+    void validateEnclavePublicKeyBinding(byte[] signedStatement) throws SQLServerException, GeneralSecurityException {
+        final int enclaveDataOffset = 8; // Report Size (4B) + Report Version (4B)
+        final int reportDataLength = 32; // SHA-256 digest length
+
+        if (null == signedStatement || null == enclavePK
+                || signedStatement.length < enclaveDataOffset + reportDataLength) {
+            SQLServerException.makeFromDriverError(null, this,
+                    SQLServerResource.getResource("R_InvalidEnclaveStatementBinding"), "0", false);
+        }
+
+        byte[] reportData = new byte[reportDataLength];
+        System.arraycopy(signedStatement, enclaveDataOffset, reportData, 0, reportDataLength);
+
+        // Enclave Data must equal SHA-256(enclavePK) for the session key to match the attested enclave.
+        byte[] expectedBinding = MessageDigest.getInstance("SHA-256").digest(enclavePK);
+        if (!Arrays.equals(reportData, expectedBinding)) {
+            SQLServerException.makeFromDriverError(null, this,
+                    SQLServerResource.getResource("R_InvalidEnclaveStatementBinding"), "0", false);
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/EnclaveTest.java
@@ -152,6 +152,24 @@ public class EnclaveTest extends AESetup {
     }
 
     /*
+     * Test that a genuine attestation response passes the enclave public key binding check.
+     */
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testValidateStatementBindingGenuine(String serverName, String url, String protocol) throws Exception {
+        EnclavePackageTest.testValidateStatementBindingGenuine();
+    }
+
+    /*
+     * Test that a response whose report data does not match the enclave public key is rejected.
+     */
+    @ParameterizedTest
+    @MethodSource("enclaveParams")
+    public void testValidateStatementBindingKeySwap(String serverName, String url, String protocol) throws Exception {
+        EnclavePackageTest.testValidateStatementBindingKeySwap();
+    }
+
+    /*
      * Negative Test - AEv2 not supported
      */
     @ParameterizedTest

--- a/src/test/java/com/microsoft/sqlserver/jdbc/EnclavePackageTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/EnclavePackageTest.java
@@ -450,6 +450,35 @@ public class EnclavePackageTest extends AbstractTest {
     }
 
     /*
+     * Test that a genuine attestation response passes the enclave public key binding check.
+     */
+    public static void testValidateStatementBindingGenuine() throws SQLServerException {
+        try {
+            VSMAttestationResponse resp = new VSMAttestationResponse(healthReportCertificate);
+            resp.validateStatementSignature();
+        } catch (Exception e) {
+            fail(TestResource.getResource("R_unexpectedException") + e.getMessage());
+        }
+    }
+
+    /*
+     * Test that a response whose report data does not match the enclave public key is rejected.
+     */
+    public static void testValidateStatementBindingKeySwap() throws SQLServerException {
+        try {
+            VSMAttestationResponse resp = new VSMAttestationResponse(healthReportCertificate);
+            // Substitute a different enclave public key so it no longer matches the signed report.
+            resp.enclavePK = "substituted-enclave-public-key".getBytes();
+            resp.validateStatementSignature();
+            fail(TestResource.getResource("R_expectedExceptionNotThrown"));
+        } catch (SQLServerException e) {
+            assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_InvalidEnclaveStatementBinding")));
+        } catch (Exception e) {
+            fail(TestResource.getResource("R_unexpectedException") + e.getMessage());
+        }
+    }
+
+    /*
      * Negative Test - AEv2 not supported
      */
     public static void testAEv2NotSupported(String serverName, String url, String protocol) throws Exception {


### PR DESCRIPTION
**Summary**

This change enhances the Always Encrypted v2 enclave attestation flow for the VSM/HGS provider (`enclaveAttestationProtocol=HGS`) by adding validation of the enclave public key binding, bringing it in line with the AAS provider.

The signed VBS enclave report carries a commitment to the enclave public key in its Enclave Data field. This change validates that the commitment matches the enclave public key used for the session, ensuring the verified attestation report corresponds to the key used during key exchange. The AAS path already performs an equivalent validation.

**Notes**

No public API or connection-string changes. Behavior is unchanged for genuine HGS/VBS deployments (verified end-to-end against a live HGS environment). AAS deployments are unaffected.