### PR TITLE
 Fix NullPointerException in `buildParamTypeDefinitions` on a closed statement

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -517,6 +517,14 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      * @return the required data type definitions.
      */
     private String buildParamTypeDefinitions(Parameter[] params, boolean renewDefinition) throws SQLServerException {
+        if (null == params) {
+            // params is set to null during internalClose(). If we get here, the statement (or its
+            // connection) has been closed. Surface the standard "statement is closed" error instead
+            // of letting a raw NullPointerException escape from params.length below.
+            checkClosed();
+            return "";
+        }
+
         int nCols = params.length;
         if (nCols == 0)
             return "";

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -518,10 +518,11 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      */
     private String buildParamTypeDefinitions(Parameter[] params, boolean renewDefinition) throws SQLServerException {
         if (null == params) {
-            // params is set to null during internalClose(). If we get here, the statement (or its
-            // connection) has been closed. Surface the standard "statement is closed" error instead
-            // of letting a raw NullPointerException escape from params.length below.
-            checkClosed();
+            // params is set to null during closeInternal(). Treat this as a closed statement even if a concurrent close
+            // is racing and the closed flag has not been observed yet.
+            connection.checkClosed();
+            SQLServerException.makeFromDriverError(connection, this,
+                    SQLServerException.getErrString("R_statementIsClosed"), null, false);
             return "";
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -28,6 +30,8 @@ import org.junit.runner.RunWith;
 
 import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
 import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
@@ -518,6 +522,53 @@ public class RegressionTest extends AbstractTest {
                     assertEquals("/'", rs.getString("str"));
                 }
             }
+        }
+    }
+
+    /**
+     * Tests that building the parameter type definitions on a closed statement whose internal parameter array has been
+     * released surfaces a {@link SQLServerException} ("The statement is closed") instead of a raw
+     * {@link NullPointerException}.
+     *
+     * Reproduces https://github.com/microsoft/mssql-jdbc/issues/2994 where a concurrent close nulls out the internal
+     * params array while an execution is in flight.
+     *
+     * @throws Exception
+     *         when an unexpected error occurs
+     */
+    @Test
+    public void testBuildParamTypeDefinitionsOnClosedStatement() throws Exception {
+        PreparedStatement pstmt = connection.prepareStatement("SELECT 1 WHERE 1=?");
+        pstmt.setInt(1, 1);
+
+        // Simulate the concurrent-close race: the internal params array is nulled out.
+        Field inOutParamField = SQLServerPreparedStatement.class.getDeclaredField("inOutParam");
+        inOutParamField.setAccessible(true);
+        inOutParamField.set(pstmt, null);
+
+        // Close the statement so the null guard resolves to the "statement is closed" error.
+        pstmt.close();
+
+        // Parameter is package-private, so locate the private method by name and argument count.
+        Method buildParamTypeDefinitions = null;
+        for (Method m : SQLServerPreparedStatement.class.getDeclaredMethods()) {
+            if ("buildParamTypeDefinitions".equals(m.getName()) && m.getParameterCount() == 2) {
+                buildParamTypeDefinitions = m;
+                break;
+            }
+        }
+        assertTrue(buildParamTypeDefinitions != null, "buildParamTypeDefinitions method not found");
+        buildParamTypeDefinitions.setAccessible(true);
+
+        try {
+            buildParamTypeDefinitions.invoke(pstmt, null, false);
+            fail("Expected SQLServerException for a closed statement, but no exception was thrown.");
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            assertTrue(cause instanceof SQLServerException,
+                    "Expected SQLServerException but got " + (cause == null ? "null" : cause.getClass().getName()));
+            assertTrue(cause.getMessage().contains(TestResource.getResource("R_statementClosed")),
+                    "Unexpected message: " + cause.getMessage());
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
@@ -538,37 +538,28 @@ public class RegressionTest extends AbstractTest {
      */
     @Test
     public void testBuildParamTypeDefinitionsOnClosedStatement() throws Exception {
-        PreparedStatement pstmt = connection.prepareStatement("SELECT 1 WHERE 1=?");
-        pstmt.setInt(1, 1);
+        try (PreparedStatement pstmt = connection.prepareStatement("SELECT 1 WHERE 1=?")) {
+            pstmt.setInt(1, 1);
 
-        // Simulate the concurrent-close race: the internal params array is nulled out.
-        Field inOutParamField = SQLServerPreparedStatement.class.getDeclaredField("inOutParam");
-        inOutParamField.setAccessible(true);
-        inOutParamField.set(pstmt, null);
+            Field inOutParamField = SQLServerPreparedStatement.class.getSuperclass().getDeclaredField("inOutParam");
+            inOutParamField.setAccessible(true);
+            inOutParamField.set(pstmt, null);
 
-        // Close the statement so the null guard resolves to the "statement is closed" error.
-        pstmt.close();
+            Method buildParamTypeDefinitions = SQLServerPreparedStatement.class.getDeclaredMethod(
+                    "buildParamTypeDefinitions", inOutParamField.getType(), boolean.class);
+            buildParamTypeDefinitions.setAccessible(true);
 
-        // Parameter is package-private, so locate the private method by name and argument count.
-        Method buildParamTypeDefinitions = null;
-        for (Method m : SQLServerPreparedStatement.class.getDeclaredMethods()) {
-            if ("buildParamTypeDefinitions".equals(m.getName()) && m.getParameterCount() == 2) {
-                buildParamTypeDefinitions = m;
-                break;
+            try {
+                // Simulate observing the released params array before the closed flag during a concurrent close.
+                buildParamTypeDefinitions.invoke(pstmt, null, false);
+                fail("Expected SQLServerException for a closed statement, but no exception was thrown.");
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                assertTrue(cause instanceof SQLServerException,
+                        "Expected SQLServerException but got " + (cause == null ? "null" : cause.getClass().getName()));
+                assertTrue(cause.getMessage().contains(TestResource.getResource("R_statementClosed")),
+                        "Unexpected message: " + cause.getMessage());
             }
-        }
-        assertTrue(buildParamTypeDefinitions != null, "buildParamTypeDefinitions method not found");
-        buildParamTypeDefinitions.setAccessible(true);
-
-        try {
-            buildParamTypeDefinitions.invoke(pstmt, null, false);
-            fail("Expected SQLServerException for a closed statement, but no exception was thrown.");
-        } catch (InvocationTargetException e) {
-            Throwable cause = e.getCause();
-            assertTrue(cause instanceof SQLServerException,
-                    "Expected SQLServerException but got " + (cause == null ? "null" : cause.getClass().getName()));
-            assertTrue(cause.getMessage().contains(TestResource.getResource("R_statementClosed")),
-                    "Unexpected message: " + cause.getMessage());
         }
     }
 


### PR DESCRIPTION
# Fix NullPointerException in `buildParamTypeDefinitions` on a closed statement (#2994)

## Description

When `PreparedStatement.executeQuery()` (or any execute path) is called after the
underlying statement/connection has been closed, `buildParamTypeDefinitions()` threw a
bare `java.lang.NullPointerException` (`Cannot read the array length because "params" is null`).

The internal parameter array (`inOutParam`) is released during close, so a concurrent
close racing with an in-flight execution leaves `params == null`. The method then
dereferenced `params.length` without a null check.

This change adds a null guard at the top of `buildParamTypeDefinitions` that routes
through `checkClosed()`, so the driver now surfaces the standard
`SQLServerException` — **"The statement is closed."** (or **"The connection is closed."**
when the connection was the one closed) — consistent with every other closed-statement
code path in the driver. A raw `NullPointerException` should never propagate to the
application from inside the driver.

Fixes #2994.

## Root cause

`buildParamTypeDefinitions(Parameter[] params, boolean renewDefinition)` accessed
`params.length` directly:

```java
int nCols = params.length; // NPE when params == null after close
```

`params` (`inOutParam`) is nulled out as part of statement teardown, so a close that
races with execution produced the NPE instead of a proper JDBC exception.

## Fix

Added a null guard that delegates to `checkClosed()`, which throws the appropriate
`SQLServerException`:

```java
private String buildParamTypeDefinitions(Parameter[] params, boolean renewDefinition) throws SQLServerException {
    if (null == params) {
        // params is set to null during internalClose(). If we get here, the statement (or its
        // connection) has been closed. Surface the standard "statement is closed" error instead
        // of letting a raw NullPointerException escape from params.length below.
        checkClosed();
        return "";
    }

    int nCols = params.length;
    ...
}
```

## Changes

| File | Change |
|------|--------|
| `src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java` | Added null guard calling `checkClosed()` at the start of `buildParamTypeDefinitions`. |
| `src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java` | Added `testBuildParamTypeDefinitionsOnClosedStatement` regression test. |

## Testing

Added `testBuildParamTypeDefinitionsOnClosedStatement` to `RegressionTest`, which:

1. Prepares a parameterized statement and sets a parameter.
2. Simulates the concurrent-close race by nulling the internal `inOutParam` array via reflection.
3. Closes the statement.
4. Invokes `buildParamTypeDefinitions` reflectively and asserts a `SQLServerException`
   with the **"The statement is closed."** message is thrown — not a `NullPointerException`.

## Notes

- No public API changes.

