### PR TITLE
Add FLOAT16 vector version negotiation check to TVP write path

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -5688,6 +5688,18 @@ final class TDSWriter {
                     break;
                 
                 case VECTOR:
+                    // TVP columns bypass Parameter.java's type definition logic, so version
+                    // negotiation must be enforced here — this is the only gating point for
+                    // vector columns inside table-valued parameters.
+                    if (con.getNegotiatedVectorVersion() <= 0) {
+                        throw new SQLServerException(
+                                SQLServerException.getErrString("R_vectorNotSupported"), null, 0, null);
+                    }
+                    // scale == 2 means FLOAT16 (2 bytes per dimension); reject when server only supports v1 (FLOAT32)
+                    if (pair.getValue().scale == 2 && con.getNegotiatedVectorVersion() == 1) {
+                        throw new SQLServerException(
+                                SQLServerException.getErrString("R_float16VectorNotSupported"), null, 0, null);
+                    }
                     writeByte(TDSType.VECTOR.byteValue());
                     writeShort((short) (VectorUtils.getVectorLength(pair.getValue().scale,  pair.getValue().precision))); // max length
                     byte scaleByte = (byte) (VectorUtils.getScaleByte(pair.getValue().scale));

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
@@ -217,20 +217,30 @@ public class VectorFloat16Test extends VectorTest {
             Assumptions.assumeTrue(v1Connection.getNegotiatedVectorVersion() >= 1,
                     "Server did not negotiate vector version 1. Skipping test.");
 
-            SQLServerDataTable tvp = new SQLServerDataTable();
-            tvp.addColumnMetadata("c1", microsoft.sql.Types.VECTOR);
-            Float[] data = createTestData(1.0f, 2.0f, 3.0f);
-            tvp.addRow(new Vector(3, VectorDimensionType.FLOAT16, data));
+        String tvpTypeName = RandomUtil.getIdentifier(
+                "Float16VectorTVPType_" + UUID.randomUUID().toString().substring(0, 8));
+        String escapedTvpTypeName = AbstractSQLGenerator.escapeIdentifier(tvpTypeName);
+        try (Statement stmt = v1Connection.createStatement()) {
+            // Use FLOAT32 column definition so the type can be created even when FLOAT16 DDL isn't supported.
+            stmt.executeUpdate("CREATE TYPE " + escapedTvpTypeName + " AS TABLE (c1 VECTOR(3) NULL)");
+        }
 
-            // Use a dummy INSERT via TVP — the error should occur during TVP metadata writing
-            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) v1Connection
-                    .prepareStatement("SELECT * FROM ?")) {
-                pstmt.setStructured(1, null, tvp);
-                pstmt.execute();
-                fail("Expected SQLServerException when sending FLOAT16 vector via TVP on v1 connection.");
-            } catch (SQLServerException e) {
-                assertTrue(e.getMessage().contains("FLOAT16 vector type is not supported"),
-                        "Expected FLOAT16 not supported error, but got: " + e.getMessage());
+        SQLServerDataTable tvp = new SQLServerDataTable();
+        tvp.addColumnMetadata("c1", microsoft.sql.Types.VECTOR);
+        Float[] data = createTestData(1.0f, 2.0f, 3.0f);
+        tvp.addRow(new Vector(3, VectorDimensionType.FLOAT16, data));
+
+        try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) v1Connection
+                .prepareStatement("SELECT * FROM ?;")) {
+            pstmt.setStructured(1, tvpTypeName, tvp);
+            pstmt.execute();
+            fail("Expected SQLServerException when sending FLOAT16 vector via TVP on v1 connection.");
+        } catch (SQLServerException e) {
+            assertTrue(e.getMessage().contains("FLOAT16 vector type is not supported"),
+                    "Expected FLOAT16 not supported error, but got: " + e.getMessage());
+        } finally {
+            try (Statement stmt = v1Connection.createStatement()) {
+                TestUtils.dropTypeIfExists(tvpTypeName, stmt);
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
@@ -206,46 +206,7 @@ public class VectorFloat16Test extends VectorTest {
     }
 
     /**
-     * Tests that sending a FLOAT16 vector via TVP is rejected on a v1 connection.
-     * TVP columns bypass Parameter.java's type definition logic, so the version
-     * negotiation check in writeTVPColumnMetaData is the only gating point.
-     */
-    @Test
-    public void testFloat16VectorTVPRejectedOnV1Connection() throws SQLException {
-        String connStr = connectionString + ";vectorTypeSupport=v1";
-        try (SQLServerConnection v1Connection = (SQLServerConnection) DriverManager.getConnection(connStr)) {
-            Assumptions.assumeTrue(v1Connection.getNegotiatedVectorVersion() >= 1,
-                    "Server did not negotiate vector version 1. Skipping test.");
-
-        String tvpTypeName = RandomUtil.getIdentifier(
-                "Float16VectorTVPType_" + UUID.randomUUID().toString().substring(0, 8));
-        String escapedTvpTypeName = AbstractSQLGenerator.escapeIdentifier(tvpTypeName);
-        try (Statement stmt = v1Connection.createStatement()) {
-            // Use FLOAT32 column definition so the type can be created even when FLOAT16 DDL isn't supported.
-            stmt.executeUpdate("CREATE TYPE " + escapedTvpTypeName + " AS TABLE (c1 VECTOR(3) NULL)");
-        }
-
-        SQLServerDataTable tvp = new SQLServerDataTable();
-        tvp.addColumnMetadata("c1", microsoft.sql.Types.VECTOR);
-        Float[] data = createTestData(1.0f, 2.0f, 3.0f);
-        tvp.addRow(new Vector(3, VectorDimensionType.FLOAT16, data));
-
-        try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) v1Connection
-                .prepareStatement("SELECT * FROM ?;")) {
-            pstmt.setStructured(1, tvpTypeName, tvp);
-            pstmt.execute();
-            fail("Expected SQLServerException when sending FLOAT16 vector via TVP on v1 connection.");
-        } catch (SQLServerException e) {
-            assertTrue(e.getMessage().contains("FLOAT16 vector type is not supported"),
-                    "Expected FLOAT16 not supported error, but got: " + e.getMessage());
-        } finally {
-            try (Statement stmt = v1Connection.createStatement()) {
-                TestUtils.dropTypeIfExists(tvpTypeName, stmt);
-            }
-        }
-    }
-
-    /**
+     * Validates basic vector data insert and retrieve for FLOAT16.
      * FLOAT16 has reduced precision (10-bit mantissa) so values may differ slightly after round-trip.
      */
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
@@ -206,6 +206,87 @@ public class VectorFloat16Test extends VectorTest {
     }
 
     /**
+     * Tests that sending a FLOAT16 vector via TVP is rejected on a v1 connection.
+     * TVP columns bypass Parameter.java's type definition logic, so the version
+     * negotiation check in writeTVPColumnMetaData is the only gating point.
+     */
+    @Test
+    public void testFloat16VectorTVPRejectedOnV1Connection() throws SQLException {
+        String connStr = connectionString + ";vectorTypeSupport=v1";
+        try (SQLServerConnection v1Connection = (SQLServerConnection) DriverManager.getConnection(connStr)) {
+            Assumptions.assumeTrue(v1Connection.getNegotiatedVectorVersion() >= 1,
+                    "Server did not negotiate vector version 1. Skipping test.");
+
+            String tvpTypeName = RandomUtil.getIdentifier(
+                    "Float16VectorTVPType_" + UUID.randomUUID().toString().substring(0, 8));
+            String escapedTvpTypeName = AbstractSQLGenerator.escapeIdentifier(tvpTypeName);
+            try (Statement stmt = v1Connection.createStatement()) {
+                // Use FLOAT32 column definition so the type can be created even when FLOAT16 DDL isn't supported.
+                stmt.executeUpdate("CREATE TYPE " + escapedTvpTypeName + " AS TABLE (c1 VECTOR(3) NULL)");
+            }
+
+            SQLServerDataTable tvp = new SQLServerDataTable();
+            tvp.addColumnMetadata("c1", microsoft.sql.Types.VECTOR);
+            Float[] data = createTestData(1.0f, 2.0f, 3.0f);
+            tvp.addRow(new Vector(3, VectorDimensionType.FLOAT16, data));
+
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) v1Connection
+                    .prepareStatement("SELECT * FROM ?;")) {
+                pstmt.setStructured(1, tvpTypeName, tvp);
+                pstmt.execute();
+                fail("Expected SQLServerException when sending FLOAT16 vector via TVP on v1 connection.");
+            } catch (SQLServerException e) {
+                assertTrue(e.getMessage().contains("FLOAT16 vector type is not supported"),
+                        "Expected FLOAT16 not supported error, but got: " + e.getMessage());
+            } finally {
+                try (Statement stmt = v1Connection.createStatement()) {
+                    TestUtils.dropTypeIfExists(tvpTypeName, stmt);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests that sending any vector via TVP is rejected when vectorTypeSupport=off.
+     * The TVP write path in IOBuffer checks getNegotiatedVectorVersion() <= 0.
+     */
+    @Test
+    public void testVectorTVPRejectedOnV0Connection() throws SQLException {
+        String connStr = connectionString + ";vectorTypeSupport=off";
+        try (SQLServerConnection v0Connection = (SQLServerConnection) DriverManager.getConnection(connStr)) {
+            Assumptions.assumeTrue(v0Connection.getNegotiatedVectorVersion() == 0,
+                    "Expected negotiated vector version 0 for 'off' connection. Skipping test.");
+
+            String tvpTypeName = RandomUtil.getIdentifier(
+                    "VectorTVPTypeOff_" + UUID.randomUUID().toString().substring(0, 8));
+            String escapedTvpTypeName = AbstractSQLGenerator.escapeIdentifier(tvpTypeName);
+            // Create the TVP type using a separate connection that supports vectors
+            try (Statement stmt = connection.createStatement()) {
+                stmt.executeUpdate("CREATE TYPE " + escapedTvpTypeName + " AS TABLE (c1 VECTOR(3) NULL)");
+            }
+
+            SQLServerDataTable tvp = new SQLServerDataTable();
+            tvp.addColumnMetadata("c1", microsoft.sql.Types.VECTOR);
+            Float[] data = createTestData(1.0f, 2.0f, 3.0f);
+            tvp.addRow(new Vector(3, VectorDimensionType.FLOAT32, data));
+
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) v0Connection
+                    .prepareStatement("SELECT * FROM ?;")) {
+                pstmt.setStructured(1, tvpTypeName, tvp);
+                pstmt.execute();
+                fail("Expected SQLServerException when sending vector via TVP on v0 connection.");
+            } catch (SQLServerException e) {
+                assertTrue(e.getMessage().contains("Vector type is not supported"),
+                        "Expected vectorNotSupported error, but got: " + e.getMessage());
+            } finally {
+                try (Statement stmt = connection.createStatement()) {
+                    TestUtils.dropTypeIfExists(tvpTypeName, stmt);
+                }
+            }
+        }
+    }
+
+    /**
      * Validates basic vector data insert and retrieve for FLOAT16.
      * FLOAT16 has reduced precision (10-bit mantissa) so values may differ slightly after round-trip.
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/vector/VectorFloat16Test.java
@@ -206,7 +206,36 @@ public class VectorFloat16Test extends VectorTest {
     }
 
     /**
-     * Validates basic vector data insert and retrieve for FLOAT16.
+     * Tests that sending a FLOAT16 vector via TVP is rejected on a v1 connection.
+     * TVP columns bypass Parameter.java's type definition logic, so the version
+     * negotiation check in writeTVPColumnMetaData is the only gating point.
+     */
+    @Test
+    public void testFloat16VectorTVPRejectedOnV1Connection() throws SQLException {
+        String connStr = connectionString + ";vectorTypeSupport=v1";
+        try (SQLServerConnection v1Connection = (SQLServerConnection) DriverManager.getConnection(connStr)) {
+            Assumptions.assumeTrue(v1Connection.getNegotiatedVectorVersion() >= 1,
+                    "Server did not negotiate vector version 1. Skipping test.");
+
+            SQLServerDataTable tvp = new SQLServerDataTable();
+            tvp.addColumnMetadata("c1", microsoft.sql.Types.VECTOR);
+            Float[] data = createTestData(1.0f, 2.0f, 3.0f);
+            tvp.addRow(new Vector(3, VectorDimensionType.FLOAT16, data));
+
+            // Use a dummy INSERT via TVP — the error should occur during TVP metadata writing
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) v1Connection
+                    .prepareStatement("SELECT * FROM ?")) {
+                pstmt.setStructured(1, null, tvp);
+                pstmt.execute();
+                fail("Expected SQLServerException when sending FLOAT16 vector via TVP on v1 connection.");
+            } catch (SQLServerException e) {
+                assertTrue(e.getMessage().contains("FLOAT16 vector type is not supported"),
+                        "Expected FLOAT16 not supported error, but got: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
      * FLOAT16 has reduced precision (10-bit mantissa) so values may differ slightly after round-trip.
      */
     @Test


### PR DESCRIPTION
## Summary

Adds server version negotiation checks for FLOAT16 vectors in the TVP (table-valued parameter) write path. Previously, this check existed only in the BulkCopy path — TVP columns bypassed `Parameter.java`'s type definition logic and could attempt to send FLOAT16 vector metadata to a v1-only server without validation.

## Changes

- **IOBuffer.java (`writeTVPColumnMetaData`)**: Added version negotiation checks before writing VECTOR type info for TVP columns. Rejects FLOAT16 vectors (scale == 2) when the server only supports vector version 1 (FLOAT32-only), and rejects all vectors when the server doesn't support vectors at all (version 0).

- **VectorFloat16Test.java**: Added `testFloat16VectorTVPRejectedOnV1Connection()` to verify that sending a FLOAT16 vector via TVP on a v1 connection throws the expected `SQLServerException`.

## Motivation

Unlike scalar RPC parameters (which are gated by `VectorUtils.getTypeDefinition()` in `Parameter.java`) and BulkCopy (which has its own checks in `SQLServerBulkCopy.writeTypeInfo()`), individual columns within a TVP had no version validation. This could result in sending unsupported FLOAT16 metadata to the server.

When a user passes a vector as a scalar parameter:
`pstmt.setObject(1, vector, Types.VECTOR);  // → Parameter.java → VectorUtils.getTypeDefinition() → version check`

But when a vector is a column inside a TVP, it takes a completely different code path:
```
SQLServerDataTable tvp = new SQLServerDataTable();
tvp.addColumnMetadata("c1", Types.VECTOR);
tvp.addRow(new Vector(3, VectorDimensionType.FLOAT16, data));
pstmt.setStructured(1, typeName, tvp);  // → IOBuffer.writeTVPColumnMetaData() → NO version check

```
The TVP is a single STRUCTURED parameter. Its inner columns are written directly by writeTVPColumnMetaData() — they never flow through Parameter.java or VectorUtils.getTypeDefinition().

## Failure scenario without the fix
- App connects with vectorTypeSupport=v1 (or server only supports v1)
- App creates a TVP with a VECTOR column and adds a FLOAT16 vector row
- Driver writes scale byte = 0x01 (FLOAT16) into the TDS column metadata for the TVP
- The v1 server receives a FLOAT16 scale byte it doesn't understand
- Server either returns a cryptic error or misinterprets the data

With the fix, the driver throws R_float16VectorNotSupported before writing anything to the wire, giving the user a clear, actionable error message.