### PR TITLE
Fix CallableStatement named-parameter setObject dropping scale for temporal types and stream lengths

### DIFF
--- a/docs/parameter-hints/setObject-scaleOrLength.md
+++ b/docs/parameter-hints/setObject-scaleOrLength.md
@@ -102,7 +102,11 @@ The same 6 bounded variable-length types are supported:
 | `Types.VARBINARY` | `varbinary(8000)` | `varbinary(N)` | Binary equivalent |
 | `Types.BINARY` | `varbinary(8000)` | `varbinary(N)` | Maps to VARBINARY on wire |
 
-For all other types (INT, DECIMAL, CLOB, etc.), the `scaleOrLength` parameter is ignored per JDBC specification.
+For all other types the `scaleOrLength` parameter is not treated as a length hint. Note that it retains its
+pre-existing JDBC meaning where applicable: it is still the scale for `DECIMAL`/`NUMERIC` and for the temporal
+types (`TIMESTAMP`, `TIME`, `DATETIMEOFFSET`), and the stream length for `InputStream`/`Reader` values. This
+applies equally to the ordinal `SQLServerPreparedStatement.setObject(int, ...)` overloads and the named-parameter
+`SQLServerCallableStatement.setObject(String, ...)` overloads.
 
 ## Behavior and Semantics
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -2011,19 +2011,28 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "setObject",
                     new Object[] {parameterName, value, sqlType, decimals});
         checkClosed();
-        // decimals - for java.sql.Types.DECIMAL or java.sql.Types.NUMERIC types,
-        // this is the number of digits after the decimal point.
+        // decimals - for java.sql.Types.DECIMAL, java.sql.Types.NUMERIC or temporal types,
+        // this is the number of digits after the decimal point. For Java Object types
+        // InputStream and Reader, this is the length of the data in the stream or reader.
         // For supported short character/binary SQL types (VARCHAR, CHAR, NVARCHAR, NCHAR,
         // VARBINARY, BINARY), this is treated as application-provided length hint AND enforced
         // as a maximum length constraint.
         // Precedence: defineParameterType() hint (if present) takes priority over this value.
         // For all other types, this value will be ignored.
+        Integer precision = null;
+        if (microsoft.sql.Types.VECTOR == sqlType && value instanceof Vector) {
+            precision = ((Vector) value).getDimensionCount();
+        }
+
         setObject(setterGetParam(findColumn(parameterName)), value, JavaType.of(value), JDBCType.of(sqlType),
                 (java.sql.Types.NUMERIC == sqlType || java.sql.Types.DECIMAL == sqlType
+                        || java.sql.Types.TIMESTAMP == sqlType || java.sql.Types.TIME == sqlType
+                        || microsoft.sql.Types.DATETIMEOFFSET == sqlType || InputStream.class.isInstance(value)
+                        || Reader.class.isInstance(value) || microsoft.sql.Types.VECTOR == sqlType
                         || java.sql.Types.VARCHAR == sqlType || java.sql.Types.CHAR == sqlType
                         || java.sql.Types.NVARCHAR == sqlType || java.sql.Types.NCHAR == sqlType
                         || java.sql.Types.VARBINARY == sqlType || java.sql.Types.BINARY == sqlType) ? decimals : null,
-                null, false, findColumn(parameterName), null);
+                precision, false, findColumn(parameterName), null);
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "setObject");
         }
@@ -2045,8 +2054,9 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                     new Object[] {parameterName, value, sqlType, decimals, forceEncrypt});
         checkClosed();
 
-        // scale - for java.sql.Types.DECIMAL or java.sql.Types.NUMERIC types,
-        // this is the number of digits after the decimal point.
+        // scale - for java.sql.Types.DECIMAL, java.sql.Types.NUMERIC or temporal types,
+        // this is the number of digits after the decimal point. For Java Object types
+        // InputStream and Reader, this is the length of the data in the stream or reader.
         // For supported short character/binary SQL types (VARCHAR, CHAR, NVARCHAR, NCHAR,
         // VARBINARY, BINARY), this is treated as application-provided length hint AND enforced
         // as a maximum length constraint.
@@ -2054,10 +2064,13 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         // For all other types, this value will be ignored.
         setObject(setterGetParam(findColumn(parameterName)), value, JavaType.of(value), JDBCType.of(sqlType),
                 (java.sql.Types.NUMERIC == sqlType || java.sql.Types.DECIMAL == sqlType
+                        || java.sql.Types.TIMESTAMP == sqlType || java.sql.Types.TIME == sqlType
+                        || microsoft.sql.Types.DATETIMEOFFSET == sqlType || InputStream.class.isInstance(value)
+                        || Reader.class.isInstance(value)
                         || java.sql.Types.VARCHAR == sqlType || java.sql.Types.CHAR == sqlType
                         || java.sql.Types.NVARCHAR == sqlType || java.sql.Types.NCHAR == sqlType
-                        || java.sql.Types.VARBINARY == sqlType || java.sql.Types.BINARY == sqlType) ? decimals : null, null,
-                forceEncrypt, findColumn(parameterName), null);
+                        || java.sql.Types.VARBINARY == sqlType || java.sql.Types.BINARY == sqlType) ? decimals : null,
+                null, forceEncrypt, findColumn(parameterName), null);
 
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "setObject");

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -2011,6 +2011,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
             loggerExternal.entering(getClassNameLogging(), "setObject",
                     new Object[] {parameterName, value, sqlType, decimals});
         checkClosed();
+
         // decimals - for java.sql.Types.DECIMAL, java.sql.Types.NUMERIC or temporal types,
         // this is the number of digits after the decimal point. For Java Object types
         // InputStream and Reader, this is the length of the data in the stream or reader.
@@ -2055,7 +2056,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                     new Object[] {parameterName, value, sqlType, decimals, forceEncrypt});
         checkClosed();
 
-        // scale - for java.sql.Types.DECIMAL, java.sql.Types.NUMERIC or temporal types,
+        // decimals - for java.sql.Types.DECIMAL, java.sql.Types.NUMERIC or temporal types,
         // this is the number of digits after the decimal point. For Java Object types
         // InputStream and Reader, this is the length of the data in the stream or reader.
         // For supported short character/binary SQL types (VARCHAR, CHAR, NVARCHAR, NCHAR,
@@ -2063,15 +2064,20 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         // as a maximum length constraint.
         // Precedence: defineParameterType() hint (if present) takes priority over this value.
         // For all other types, this value will be ignored.
+        Integer precision = null;
+        if (microsoft.sql.Types.VECTOR == sqlType && value instanceof Vector) {
+            precision = ((Vector) value).getDimensionCount();
+        }
+
         setObject(setterGetParam(findColumn(parameterName)), value, JavaType.of(value), JDBCType.of(sqlType),
                 (java.sql.Types.NUMERIC == sqlType || java.sql.Types.DECIMAL == sqlType
                         || java.sql.Types.TIMESTAMP == sqlType || java.sql.Types.TIME == sqlType
                         || microsoft.sql.Types.DATETIMEOFFSET == sqlType || InputStream.class.isInstance(value)
-                        || Reader.class.isInstance(value)
+                        || Reader.class.isInstance(value) || microsoft.sql.Types.VECTOR == sqlType
                         || java.sql.Types.VARCHAR == sqlType || java.sql.Types.CHAR == sqlType
                         || java.sql.Types.NVARCHAR == sqlType || java.sql.Types.NCHAR == sqlType
                         || java.sql.Types.VARBINARY == sqlType || java.sql.Types.BINARY == sqlType) ? decimals : null,
-                null, forceEncrypt, findColumn(parameterName), null);
+                precision, forceEncrypt, findColumn(parameterName), null);
 
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "setObject");

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -2033,6 +2033,7 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                         || java.sql.Types.NVARCHAR == sqlType || java.sql.Types.NCHAR == sqlType
                         || java.sql.Types.VARBINARY == sqlType || java.sql.Types.BINARY == sqlType) ? decimals : null,
                 precision, false, findColumn(parameterName), null);
+
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "setObject");
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -54,6 +54,7 @@ import microsoft.sql.DateTimeOffset;
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
+@Tag(Constants.alwaysEncrypted)
 public class CallableStatementTest extends AESetup {
 
     private static String multiStatementsProcedure = AbstractSQLGenerator

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -54,7 +54,6 @@ import microsoft.sql.DateTimeOffset;
 @Tag(Constants.xAzureSQLDW)
 @Tag(Constants.xAzureSQLDB)
 @Tag(Constants.reqExternalSetup)
-@Tag(Constants.alwaysEncrypted)
 public class CallableStatementTest extends AESetup {
 
     private static String multiStatementsProcedure = AbstractSQLGenerator

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -2634,4 +2634,59 @@ public class CallableStatementTest extends AESetup {
             fail(e.getMessage());
         }
     }
+
+    /**
+     * Compares PreparedStatement and CallableStatement behavior for TIMESTAMP (datetime2)
+     * with explicit scale under Always Encrypted. Both paths should honor scale=2 and
+     * produce identical results — validates the fix for the regression where
+     * CallableStatement's named-parameter setObject was dropping the scale.
+     */
+    @Test
+    public void testTimestampScaleWithPreparedVsCallable() throws Exception {
+        String tsTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("tsScaleTest"));
+        String tsProc = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("tsScaleProc"));
+
+        try (Connection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                Statement stmt = con.createStatement()) {
+            TestUtils.dropProcedureIfExists(tsProc, stmt);
+            TestUtils.dropTableIfExists(tsTable, stmt);
+
+            stmt.execute("CREATE TABLE " + tsTable + " (id INT IDENTITY, ts datetime2(2))");
+            stmt.execute("CREATE PROCEDURE " + tsProc
+                    + " @ts datetime2(2) AS BEGIN INSERT INTO " + tsTable + " (ts) VALUES (@ts); END");
+
+            Timestamp testValue = Timestamp.valueOf("2025-06-15 10:30:45.12");
+
+            // PreparedStatement path: setObject with scale=2
+            try (PreparedStatement ps = con.prepareStatement("INSERT INTO " + tsTable + " (ts) VALUES (?)")) {
+                ps.setObject(1, testValue, java.sql.Types.TIMESTAMP, 2);
+                ps.execute();
+            }
+
+            // CallableStatement path: setObject(name, value, type, scale)
+            try (SQLServerCallableStatement cs = (SQLServerCallableStatement) con
+                    .prepareCall("{call " + tsProc + "(?)}")) {
+                cs.setObject("@ts", testValue, java.sql.Types.TIMESTAMP, 2);
+                cs.execute();
+            }
+
+            // Verify both rows produce the same value
+            try (ResultSet rs = stmt.executeQuery("SELECT ts FROM " + tsTable + " ORDER BY id")) {
+                assertTrue(rs.next(), "Expected first row (PreparedStatement insert)");
+                Timestamp psResult = rs.getTimestamp(1);
+
+                assertTrue(rs.next(), "Expected second row (CallableStatement insert)");
+                Timestamp csResult = rs.getTimestamp(1);
+
+                assertEquals(psResult, csResult,
+                        "PreparedStatement and CallableStatement should produce identical results");
+            }
+        } finally {
+            try (Connection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                    Statement stmt = con.createStatement()) {
+                TestUtils.dropProcedureIfExists(tsProc, stmt);
+                TestUtils.dropTableIfExists(tsTable, stmt);
+            }
+        }
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/CallableStatementTest.java
@@ -300,6 +300,8 @@ public class CallableStatementTest extends AESetup {
         createMixedProcedureDateScale();
         testMixedProcedureDateScaleInorder("{call " + outputProcedureDateScale + "(?,?,?,?,?,?)}");
         testMixedProcedureDateScaleWithParameterName("{call " + outputProcedureDateScale + "(?,?,?,?,?,?)}");
+        testMixedProcedureDateScaleWithParameterNameSetObject(
+                "{call " + outputProcedureDateScale + "(?,?,?,?,?,?)}");
     }
 
     @ParameterizedTest
@@ -2579,6 +2581,44 @@ public class CallableStatementTest extends AESetup {
             callableStatement.setTimestamp("p1", (Timestamp) dateValues.get(4), 2);
             callableStatement.setTime("p3", (Time) dateValues.get(5), 2);
             callableStatement.setDateTimeOffset("p5", (DateTimeOffset) dateValues.get(6), 2);
+            callableStatement.execute();
+
+            assertEquals(callableStatement.getTimestamp(1), callableStatement.getTimestamp(2),
+                    TestResource.getResource("R_outputParamFailed"));
+
+            assertEquals(callableStatement.getTime(3), callableStatement.getTime(4),
+                    TestResource.getResource("R_outputParamFailed"));
+
+            assertEquals(callableStatement.getDateTimeOffset(5), callableStatement.getDateTimeOffset(6),
+                    TestResource.getResource("R_outputParamFailed"));
+
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that the scale supplied to the named-parameter
+     * {@link SQLServerCallableStatement#setObject(String, Object, int, int)} overload is honored for temporal
+     * types under Always Encrypted. When the scale is dropped, the driver declares the parameter with the
+     * default fractional seconds scale (7) and the server rejects the call with an operand type clash against
+     * the encrypted datetime2(2)/time(2)/datetimeoffset(2) column.
+     */
+    private void testMixedProcedureDateScaleWithParameterNameSetObject(String sql) throws SQLException {
+
+        try (Connection con = PrepUtil.getConnection(AETestConnectionString, AEInfo);
+                SQLServerCallableStatement callableStatement = (SQLServerCallableStatement) TestUtils
+                        .getCallableStmt(con, sql, stmtColEncSetting)) {
+
+            callableStatement.registerOutParameter("p1", java.sql.Types.TIMESTAMP, 2);
+            callableStatement.registerOutParameter("p2", java.sql.Types.TIMESTAMP, 2);
+            callableStatement.registerOutParameter("p3", java.sql.Types.TIME, 2);
+            callableStatement.registerOutParameter("p4", java.sql.Types.TIME, 2);
+            callableStatement.registerOutParameter("p5", microsoft.sql.Types.DATETIMEOFFSET, 2);
+            callableStatement.registerOutParameter("p6", microsoft.sql.Types.DATETIMEOFFSET, 2);
+            callableStatement.setObject("p1", dateValues.get(4), java.sql.Types.TIMESTAMP, 2);
+            callableStatement.setObject("p3", dateValues.get(5), java.sql.Types.TIME, 2);
+            callableStatement.setObject("p5", dateValues.get(6), microsoft.sql.Types.DATETIMEOFFSET, 2);
             callableStatement.execute();
 
             assertEquals(callableStatement.getTimestamp(1), callableStatement.getTimestamp(2),


### PR DESCRIPTION
### Summary

`SQLServerCallableStatement`'s named-parameter `setObject` overloads discard the caller-supplied `decimals` argument for temporal types (`TIME`, `TIMESTAMP`, `DATETIMEOFFSET`), for `InputStream`/`Reader` stream lengths, and for `VECTOR`. Under Always Encrypted this is a hard failure; without AE it is silent scale loss.

There are **two distinct defects** here with very different ages. Both are fixed.

| Overload | Broken since | Nature |
| --- | --- | --- |
| `setObject(String, Object, int sqlType, int decimals)` | [#2960](https://github.com/microsoft/mssql-jdbc/pull/2960), 13.5.1 | **Regression** — worked correctly for ~10 years |
| `setObject(String, Object, int sqlType, int decimals, boolean forceEncrypt)` | `cfba660a` (initial open-source drop, Nov 2016) | **Long-standing latent bug**, never covered by a test |

---

### Defect 1 — regression introduced by #2960

Before #2960 the four-argument overload passed `decimals` through **unconditionally**; there was no filter at all:

```java
setObject(setterGetParam(findColumn(parameterName)), value, JavaType.of(value), JDBCType.of(sqlType), decimals,
        null, false, findColumn(parameterName), null);
```

#2960 introduced the character/binary length-hint feature and, in doing so, replaced that pass-through with an allow-list:

```java
setObject(setterGetParam(findColumn(parameterName)), value, JavaType.of(value), JDBCType.of(sqlType),
        (java.sql.Types.NUMERIC == sqlType || java.sql.Types.DECIMAL == sqlType
                || java.sql.Types.VARCHAR == sqlType || java.sql.Types.CHAR == sqlType
                || java.sql.Types.NVARCHAR == sqlType || java.sql.Types.NCHAR == sqlType
                || java.sql.Types.VARBINARY == sqlType || java.sql.Types.BINARY == sqlType) ? decimals : null,
        null, false, findColumn(parameterName), null);
```

The accompanying comment — *"For all other types, this value will be ignored"* — captures the behaviour change exactly. The change reads like an extension of an existing allow-list, but there was no list to extend: it converted *pass everything* into *pass eight types*, silently dropping `TIMESTAMP`, `TIME`, `DATETIMEOFFSET`, stream lengths and `VECTOR`.

The ordinal `SQLServerPreparedStatement.setObject(int, Object, int, int)` overload has listed the temporal types explicitly since 2016 and was correctly left intact by #2960, which is why only the named-parameter `CallableStatement` path regressed.

### Defect 2 — pre-existing gap in the `forceEncrypt` overload

The `forceEncrypt` sibling has never honoured temporal scale. From the initial open-source commit (`cfba660a`, 9 Nov 2016):

```java
setObject(setterGetParam(findColumn(sCol)), o, JavaType.of(o), JDBCType.of(n),
        (java.sql.Types.NUMERIC == n || java.sql.Types.DECIMAL == n) ? Integer.valueOf(m) : null,
        null, forceEncrypt, findColumn(sCol), null);
```

So this has been broken for the entire public history of the driver:

```java
cstmt.setObject("@t", timeValue, java.sql.Types.TIME, 0, true);   // encrypted time(0) column
```

It went unnoticed because `forceEncrypt` is used almost exclusively with the typed setters (`setTime`, `setTimestamp`, `setDateTimeOffset`), which carry scale by a different route, and because no test exercised named-parameter `setObject` with a temporal scale. This PR closes it at the same time, since leaving the two overloads inconsistent would be worse than fixing both.

---

### Why this manifests as `Operand type clash` under AE

`Parameter.setValue` only sets `userProvidesScale` / `outScale` when a non-null scale is supplied. The Always Encrypted branch of `Parameter.setTypeDefinition` is the only place that emits an explicit scale:

```java
case TIME:
    if (param.shouldHonorAEForParameter && !(null == param.getCryptoMetadata() && param.renewDefinition)) {
        if (userProvidesScale) {
            param.typeDefinition = SSType.TIME.toString() + "(" + outScale + ")";   // time(0)
        } else {
            param.typeDefinition = SSType.TIME.toString() + "(" + valueLength + ")"; // time(7)
        }
    } else {
        param.typeDefinition = con.getSendTimeAsDatetime() ? SSType.DATETIME.toString()
                                                           : SSType.TIME.toString();  // no scale at all
    }
```

With the scale dropped, `userProvidesScale` is false and `valueLength` defaults to 7, so the parameter is declared as `time(7)` against a `time(0)` encrypted column. AE forbids implicit conversion — the ciphertext is derived from the normalised plaintext of that exact type — so the server rejects the batch:

```
Operand type clash: time(7) encrypted with (encryption_type = 'DETERMINISTIC',
encryption_algorithm_name = 'AEAD_AES_256_CBC_HMAC_SHA_256', ...) is incompatible with
time(0) encrypted with (encryption_type = 'DETERMINISTIC', ...)
```

Without AE the non-AE branch declares a bare `time` / `datetime2`, the server implicitly converts to the column type, and the defect is invisible — the requested scale is simply discarded. `datetime2` and `datetimeoffset` parameters, stream lengths and vector dimension counts are affected in the same way.

Defect 1 was caught by the internal legacy FX `statement-AE-Ahmad` suite (`TCBatching.testBatchDML`, the `CALLABLESTATEMENT` variations), which reaches the named-parameter path only on some random seeds — hence the intermittent signal.

---

### Changes

**`SQLServerCallableStatement`**

Both named-parameter overloads now have `TIMESTAMP`, `TIME`, `DATETIMEOFFSET`, `InputStream`/`Reader` and `VECTOR` restored to the scale/length allow-list, matching the ordinal `SQLServerPreparedStatement.setObject(int, Object, int, int)` overload, and both derive the `VECTOR` dimension count for `precision` the same way.

- `setObject(String, Object, int, int)` — fixes Defect 1.
- `setObject(String, Object, int, int, boolean forceEncrypt)` — fixes Defect 2.

The two method bodies are now byte-identical apart from the `forceEncrypt` argument itself, so the two APIs can no longer drift apart:

```java
setObject(setterGetParam(findColumn(parameterName)), value, JavaType.of(value), JDBCType.of(sqlType),
        (java.sql.Types.NUMERIC == sqlType || java.sql.Types.DECIMAL == sqlType
                || java.sql.Types.TIMESTAMP == sqlType || java.sql.Types.TIME == sqlType
                || microsoft.sql.Types.DATETIMEOFFSET == sqlType || InputStream.class.isInstance(value)
                || Reader.class.isInstance(value) || microsoft.sql.Types.VECTOR == sqlType
                || java.sql.Types.VARCHAR == sqlType || java.sql.Types.CHAR == sqlType
                || java.sql.Types.NVARCHAR == sqlType || java.sql.Types.NCHAR == sqlType
                || java.sql.Types.VARBINARY == sqlType || java.sql.Types.BINARY == sqlType) ? decimals : null,
        precision, forceEncrypt, findColumn(parameterName), null);
```

The character/binary length-hint behaviour introduced by #2960 is unchanged, as is its precedence relative to `defineParameterType()`. `setObject(String, Object, SQLType, int)` and its `forceEncrypt` sibling delegate to these methods and are fixed as a result. No new imports are required.

**`AlwaysEncrypted/CallableStatementTest`** — added `testMixedProcedureDateScaleWithParameterNameSetObject`, wired into `testMixedProcedureDateScale`. It reuses the existing `datetime2(2)` / `time(2)` / `datetimeoffset(2)` encrypted procedure but drives it through `setObject(name, value, Types.TIME, 2)` rather than the typed setters.

That coverage gap is why CI missed both defects:

- `PrecisionScaleTest` exercises `setObject(..., Types.TIME, scale)` only on the ordinal `PreparedStatement` path.
- `testMixedProcedureDateScaleWithParameterName` exercises named parameters only via `setTime` / `setTimestamp` / `setDateTimeOffset`.

Nothing covered named-parameter `setObject` with a temporal scale, on either overload.

**`docs/parameter-hints/setObject-scaleOrLength.md`** — corrected the statement that `scaleOrLength` is ignored for all types outside the six character/binary types; it still carries scale for `DECIMAL`/`NUMERIC` and the temporal types, and stream length for `InputStream`/`Reader`, on both the ordinal and named overloads.

### Known remaining gap (out of scope)

The newer five-argument overloads still omit the temporal types on **both** classes:

- `SQLServerPreparedStatement.setObject(int, Object, int, Integer precision, int scale[, boolean forceEncrypt])`
- `SQLServerCallableStatement.setObject(String, Object, int, Integer precision, int scale[, boolean forceEncrypt])`

These are a separate pre-existing issue and are deliberately not touched here to keep this PR reviewable. Happy to file a follow-up.

### Testing

- `mvn -DskipTests test-compile` passes.
- Needs a run of the `AlwaysEncrypted` suite (`CallableStatementTest`, `PrecisionScaleTest`) against an AE-configured server — these require `reqExternalSetup` and were not run locally.
