### PR TITLE
Fix getGeneratedKeys() returns a non-empty ResultSet for tables without generated keys

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -78,7 +78,13 @@ public class SQLServerStatement implements ISQLServerStatement {
         return wasResponseBufferingSet;
     }
 
-    final static String IDENTITY_QUERY = " select SCOPE_IDENTITY() AS GENERATED_KEYS";
+    /*
+     * The WHERE clause ensures that when the executed statement did not generate any identity value
+     * (for example, an INSERT into a table without an identity column), SCOPE_IDENTITY() returns NULL
+     * and the query yields zero rows. This produces an empty generated-keys ResultSet, as required by
+     * the JDBC specification for Statement.getGeneratedKeys().
+     */
+    final static String IDENTITY_QUERY = " select SCOPE_IDENTITY() AS GENERATED_KEYS where SCOPE_IDENTITY() is not null";
 
     static final String WINDOWS_KEY_STORE_NAME = "MSSQL_CERTIFICATE_STORE";
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/MultiStatementResultTraversalTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/MultiStatementResultTraversalTest.java
@@ -1998,6 +1998,305 @@ public class MultiStatementResultTraversalTest extends AbstractTest {
                 }
             }
         }
+
+        // -----------------------------------------------------------------------------------------
+        //  Section 5.A — No generated keys on a keyless table
+        // -----------------------------------------------------------------------------------------
+
+        /**
+         * Statement.execute of an INSERT with RETURN_GENERATED_KEYS on a table without an identity
+         * column must still surface the INSERT's update count and return an empty generated-keys
+         * ResultSet (before the fix a single NULL row was surfaced).
+         */
+        @Test
+        public void statementExecuteInsertNoIdentityReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0StmtE"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    createPlainTable(stmt, table); // (c1 INT, c2 SMALLINT) - no identity
+
+                    boolean isResultSet = stmt.execute(
+                            "INSERT INTO " + table + " VALUES (1, 1)", Statement.RETURN_GENERATED_KEYS);
+                    assertFalse(isResultSet, "INSERT execute() must return false even with RETURN_GENERATED_KEYS");
+                    assertEquals(1, stmt.getUpdateCount(),
+                            "INSERT update count of 1 must still surface for a keyless table");
+
+                    try (ResultSet keys = stmt.getGeneratedKeys()) {
+                        assertNotNull(keys, "getGeneratedKeys must return a non-null ResultSet");
+                        assertFalse(keys.next(),
+                                "keyless table → getGeneratedKeys() must be EMPTY (no NULL row) per JDBC spec");
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /** Statement.executeUpdate of an INSERT with RETURN_GENERATED_KEYS on a keyless table returns an empty generated-keys ResultSet. */
+        @Test
+        public void statementExecuteUpdateInsertNoIdentityReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0StmtU"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    createPlainTable(stmt, table);
+
+                    int count = stmt.executeUpdate(
+                            "INSERT INTO " + table + " VALUES (1, 1)", Statement.RETURN_GENERATED_KEYS);
+                    assertEquals(1, count, "executeUpdate must return INSERT row count of 1");
+
+                    try (ResultSet keys = stmt.getGeneratedKeys()) {
+                        assertFalse(keys.next(),
+                                "keyless table → getGeneratedKeys() must be EMPTY");
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /** PreparedStatement.execute of an INSERT with RETURN_GENERATED_KEYS on a keyless table returns an empty generated-keys ResultSet. */
+        @Test
+        public void preparedStatementExecuteInsertNoIdentityReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0PSE"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    createPlainTable(stmt, table);
+
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "INSERT INTO " + table + " VALUES (?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                        ps.setInt(1, 1);
+                        ps.setInt(2, 1);
+                        boolean isResultSet = ps.execute();
+                        assertFalse(isResultSet,
+                                "PreparedStatement.execute(INSERT) must return false even with RETURN_GENERATED_KEYS");
+                        assertEquals(1, ps.getUpdateCount(), "INSERT update count must be 1");
+                        try (ResultSet keys = ps.getGeneratedKeys()) {
+                            assertFalse(keys.next(),
+                                    "keyless table → getGeneratedKeys() must be EMPTY");
+                        }
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /** PreparedStatement.executeUpdate of an INSERT with RETURN_GENERATED_KEYS on a keyless table returns an empty generated-keys ResultSet. */
+        @Test
+        public void preparedStatementExecuteUpdateInsertNoIdentityReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0PSU"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    createPlainTable(stmt, table);
+
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "INSERT INTO " + table + " VALUES (?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                        ps.setInt(1, 1);
+                        ps.setInt(2, 1);
+                        assertEquals(1, ps.executeUpdate(), "executeUpdate must return INSERT row count of 1");
+                        try (ResultSet keys = ps.getGeneratedKeys()) {
+                            assertFalse(keys.next(),
+                                    "keyless table → getGeneratedKeys() must be EMPTY");
+                        }
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /**
+         * A multi-row INSERT into a keyless table via executeUpdate with RETURN_GENERATED_KEYS
+         * returns an empty generated-keys ResultSet and does not surface a single NULL row.
+         */
+        @Test
+        public void preparedStatementExecuteUpdateMultiRowInsertNoIdentityReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0Multi"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    createPlainTable(stmt, table);
+
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "INSERT INTO " + table + " VALUES (?, ?), (?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                        ps.setInt(1, 1); ps.setInt(2, 1);
+                        ps.setInt(3, 2); ps.setInt(4, 2);
+                        assertEquals(2, ps.executeUpdate(), "multi-row INSERT must report 2 rows");
+                        try (ResultSet keys = ps.getGeneratedKeys()) {
+                            assertFalse(keys.next(),
+                                    "multi-row INSERT into a keyless table → getGeneratedKeys() must be EMPTY");
+                        }
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /**
+         * Batched inserts into a keyless table with RETURN_GENERATED_KEYS execute cleanly and
+         * persist all rows. getGeneratedKeys after executeBatch is not a supported path in this driver
+         * (it throws even for identity tables), so it is not exercised here.
+         */
+        @Test
+        public void preparedStatementExecuteBatchInsertNoIdentityReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0Batch"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    createPlainTable(stmt, table);
+
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "INSERT INTO " + table + " VALUES (?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                        ps.setInt(1, 1); ps.setInt(2, 1); ps.addBatch();
+                        ps.setInt(1, 2); ps.setInt(2, 2); ps.addBatch();
+                        ps.setInt(1, 3); ps.setInt(2, 3); ps.addBatch();
+                        int[] counts = ps.executeBatch();
+                        assertEquals(3, counts.length,
+                                "batched INSERTs into a keyless table with RETURN_GENERATED_KEYS must "
+                                        + "execute cleanly and report one count per item");
+                    }
+
+                    try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + table)) {
+                        assertTrue(rs.next());
+                        assertEquals(3, rs.getInt(1), "all 3 batched rows must persist");
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /**
+         * Statement.executeLargeUpdate of an INSERT with RETURN_GENERATED_KEYS on a keyless table
+         * returns an empty generated-keys ResultSet (the large-update path is separate).
+         */
+        @Test
+        public void statementExecuteLargeUpdateInsertNoIdentityReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0Large"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    createPlainTable(stmt, table);
+
+                    assertEquals(1L, stmt.executeLargeUpdate(
+                            "INSERT INTO " + table + " VALUES (1, 1)", Statement.RETURN_GENERATED_KEYS),
+                            "executeLargeUpdate must return INSERT row count of 1");
+
+                    try (ResultSet keys = stmt.getGeneratedKeys()) {
+                        assertFalse(keys.next(),
+                                "executeLargeUpdate into a keyless table → getGeneratedKeys() must be EMPTY");
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /**
+         * A non-identity DEFAULT NEWID() column is not an identity key, so an INSERT into such a
+         * table returns an empty generated-keys ResultSet.
+         */
+        @Test
+        public void preparedStatementInsertNoIdentityDefaultNewIdReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0Newid"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    stmt.executeUpdate("CREATE TABLE " + table
+                            + " (id INT NOT NULL, guidCol UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID())");
+
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "INSERT INTO " + table + " (id) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                        ps.setInt(1, 1);
+                        assertEquals(1, ps.executeUpdate(), "INSERT must report 1 row");
+                        try (ResultSet keys = ps.getGeneratedKeys()) {
+                            assertFalse(keys.next(),
+                                    "DEFAULT NEWID() is not an identity key → getGeneratedKeys() must be EMPTY");
+                        }
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /**
+         * A computed column is not an identity key, so an INSERT into a table with a computed column
+         * returns an empty generated-keys ResultSet.
+         */
+        @Test
+        public void preparedStatementInsertNoIdentityComputedColumnReturnsEmptyGeneratedKeys()
+                throws SQLException {
+            String table = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0Comp"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    stmt.executeUpdate("CREATE TABLE " + table + " (id INT NOT NULL, computedCol AS (id + 1))");
+
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "INSERT INTO " + table + " (id) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                        ps.setInt(1, 10);
+                        assertEquals(1, ps.executeUpdate(), "INSERT must report 1 row");
+                        try (ResultSet keys = ps.getGeneratedKeys()) {
+                            assertFalse(keys.next(),
+                                    "a computed column is not an identity key → getGeneratedKeys() must be EMPTY");
+                        }
+                    }
+                } finally {
+                    TestUtils.dropTableIfExists(table, stmt);
+                }
+            }
+        }
+
+        /**
+         * SCOPE_IDENTITY vs @@IDENTITY guard: an INSERT into a keyless table whose AFTER INSERT
+         * trigger inserts into a different identity table must still return an empty generated-keys
+         * ResultSet, because the driver uses scope-limited SCOPE_IDENTITY rather than @@IDENTITY.
+         */
+        @Test
+        public void preparedStatementInsertNoIdentityWithTriggerScopeIdentityGuard()
+                throws SQLException {
+            String tableA = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0TrA")); // keyless
+            String tableB = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0TrB")); // identity
+            String trigger = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("GK0Tr"));
+            try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+                try {
+                    TestUtils.dropTriggerIfExists(trigger, stmt);
+                    TestUtils.dropTableIfExists(tableB, stmt);
+                    TestUtils.dropTableIfExists(tableA, stmt);
+                    createPlainTable(stmt, tableA); // no identity
+                    stmt.executeUpdate("CREATE TABLE " + tableB
+                            + " (id INT NOT NULL IDENTITY(1,1) PRIMARY KEY)");
+                    createInsertTrigger(stmt, trigger, tableA, tableB, false); // trigger inserts into identity tableB
+
+                    try (PreparedStatement ps = conn.prepareStatement(
+                            "INSERT INTO " + tableA + " VALUES (?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                        ps.setInt(1, 1);
+                        ps.setInt(2, 1);
+                        ps.executeUpdate();
+                        try (ResultSet keys = ps.getGeneratedKeys()) {
+                            assertFalse(keys.next(),
+                                    "SCOPE_IDENTITY() is scope-limited: a trigger's nested identity insert must NOT "
+                                            + "leak into getGeneratedKeys() for the keyless outer table");
+                        }
+                    }
+
+                    // Sanity: trigger fired and generated an identity in its own (nested) scope.
+                    try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + tableB)) {
+                        assertTrue(rs.next());
+                        assertEquals(1, rs.getInt(1), "trigger must have inserted exactly one row into the identity table");
+                    }
+                } finally {
+                    TestUtils.dropTriggerIfExists(trigger, stmt);
+                    TestUtils.dropTableIfExists(tableB, stmt);
+                    TestUtils.dropTableIfExists(tableA, stmt);
+                }
+            }
+        }
     }
 
     // =========================================================================================

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -1826,6 +1826,243 @@ public class StatementTest extends AbstractTest {
             }
         }
 
+        /**
+         * Tests that an INSERT into a table that has an IDENTITY column still returns a non-empty
+         * generated-keys ResultSet with the correct key value, covering the positive counterpart to
+         * testGetGeneratedKeysNoIdentityColumn.
+         *
+         * Regression guard for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysWithIdentityColumn() throws Exception {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                stmt.executeUpdate(
+                        "CREATE TABLE " + tableName + " (ID int NOT NULL IDENTITY(1,1) PRIMARY KEY, col2 varchar(32))");
+
+                // PreparedStatement path - must surface the generated identity value.
+                try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO " + tableName + " (col2) VALUES (?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
+                    pstmt.setString(1, "a");
+                    assertEquals(1, pstmt.executeUpdate(), TestResource.getResource("R_valueNotMatch"));
+
+                    try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                        assertTrue(generatedKeys.next(),
+                                "getGeneratedKeys() must return a row for a table with an identity column");
+                        assertEquals(1, generatedKeys.getInt(1), "first identity value must be 1");
+                        assertFalse(generatedKeys.next(), "exactly one generated key must be returned");
+                    }
+                }
+
+                // Statement path - must surface the generated identity value.
+                assertEquals(1, stmt.executeUpdate("INSERT INTO " + tableName + " (col2) VALUES ('b')",
+                        Statement.RETURN_GENERATED_KEYS), TestResource.getResource("R_valueNotMatch"));
+
+                try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                    assertTrue(generatedKeys.next(),
+                            "getGeneratedKeys() must return a row for a table with an identity column");
+                    assertEquals(2, generatedKeys.getInt(1), "second identity value must be 2");
+                    assertFalse(generatedKeys.next(), "exactly one generated key must be returned");
+                }
+            }
+        }
+
+        /**
+         * Tests that a multi-row INSERT into a table without an identity column returns an empty
+         * generated-keys ResultSet and does not surface a single NULL row.
+         *
+         * Regression guard for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysNoIdentityColumnMultiRowInsert() throws Exception {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("CREATE TABLE " + tableName + " (ID int NOT NULL)");
+
+                try (PreparedStatement pstmt = con.prepareStatement(
+                        "INSERT INTO " + tableName + " (ID) VALUES (?), (?)", Statement.RETURN_GENERATED_KEYS)) {
+                    pstmt.setInt(1, 1);
+                    pstmt.setInt(2, 2);
+                    assertEquals(2, pstmt.executeUpdate(), TestResource.getResource("R_valueNotMatch"));
+
+                    try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                        assertFalse(generatedKeys.next(),
+                                "multi-row INSERT into a table without generated keys must return an empty ResultSet");
+                    }
+                }
+            }
+        }
+
+        /**
+         * Tests that batched inserts into a table without an identity column execute cleanly and
+         * persist all rows. getGeneratedKeys after executeBatch is not a supported path in this
+         * driver (it throws even for identity tables), so it is not exercised here.
+         *
+         * Regression guard for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysNoIdentityColumnBatch() throws Exception {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("CREATE TABLE " + tableName + " (ID int NOT NULL)");
+
+                try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO " + tableName + " (ID) VALUES (?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
+                    pstmt.setInt(1, 1);
+                    pstmt.addBatch();
+                    pstmt.setInt(1, 2);
+                    pstmt.addBatch();
+                    pstmt.setInt(1, 3);
+                    pstmt.addBatch();
+                    int[] counts = pstmt.executeBatch();
+                    assertEquals(3, counts.length, TestResource.getResource("R_valueNotMatch"));
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + tableName)) {
+                    assertTrue(rs.next());
+                    assertEquals(3, rs.getInt(1), TestResource.getResource("R_valueNotMatch"));
+                }
+            }
+        }
+
+        /**
+         * Tests that executeLargeUpdate of an INSERT with RETURN_GENERATED_KEYS into a table without
+         * an identity column returns an empty generated-keys ResultSet.
+         *
+         * Regression guard for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysNoIdentityColumnLargeUpdate() throws Exception {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("CREATE TABLE " + tableName + " (ID int NOT NULL)");
+
+                assertEquals(1L, stmt.executeLargeUpdate("INSERT INTO " + tableName + " (ID) VALUES (123456)",
+                        Statement.RETURN_GENERATED_KEYS), TestResource.getResource("R_valueNotMatch"));
+
+                try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                    assertFalse(generatedKeys.next(),
+                            "executeLargeUpdate() into a table without generated keys must return an empty ResultSet");
+                }
+            }
+        }
+
+        /**
+         * Tests that a table whose only server-generated column is a DEFAULT NEWID() column (not an
+         * identity) returns an empty generated-keys ResultSet.
+         *
+         * Regression guard for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysNonIdentityDefaultColumn() throws Exception {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("CREATE TABLE " + tableName
+                        + " (ID int NOT NULL, guidCol uniqueidentifier NOT NULL DEFAULT NEWID())");
+
+                try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO " + tableName + " (ID) VALUES (?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
+                    pstmt.setInt(1, 1);
+                    assertEquals(1, pstmt.executeUpdate(), TestResource.getResource("R_valueNotMatch"));
+
+                    try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                        assertFalse(generatedKeys.next(),
+                                "a DEFAULT NEWID() column is not an identity key - getGeneratedKeys() must be empty");
+                    }
+                }
+            }
+        }
+
+        /**
+         * Tests that a table with a computed column (not an identity) returns an empty
+         * generated-keys ResultSet.
+         *
+         * Regression guard for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysNonIdentityComputedColumn() throws Exception {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                stmt.executeUpdate(
+                        "CREATE TABLE " + tableName + " (ID int NOT NULL, computedCol AS (ID + 1))");
+
+                try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO " + tableName + " (ID) VALUES (?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
+                    pstmt.setInt(1, 10);
+                    assertEquals(1, pstmt.executeUpdate(), TestResource.getResource("R_valueNotMatch"));
+
+                    try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                        assertFalse(generatedKeys.next(),
+                                "a computed column is not an identity key - getGeneratedKeys() must be empty");
+                    }
+                }
+            }
+        }
+
+        /**
+         * Tests the SCOPE_IDENTITY vs @@IDENTITY case: an INSERT into a table without an identity
+         * column whose AFTER INSERT trigger inserts into a different identity table must still return
+         * an empty generated-keys ResultSet, because the driver uses scope-limited SCOPE_IDENTITY
+         * rather than @@IDENTITY.
+         *
+         * Regression guard for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysNoIdentityColumnWithTrigger() throws Exception {
+            String auditTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("TCStmtGKAudit"));
+            String triggerName = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("TCStmtGKTrig"));
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                try {
+                    TestUtils.dropTriggerIfExists(triggerName, stmt);
+                    TestUtils.dropTableIfExists(auditTable, stmt);
+
+                    // Outer table has NO identity column.
+                    stmt.executeUpdate("CREATE TABLE " + tableName + " (ID int NOT NULL)");
+                    // Audit table DOES have an identity column - the trigger writes here in a nested scope.
+                    stmt.executeUpdate("CREATE TABLE " + auditTable
+                            + " (auditId int NOT NULL IDENTITY(1,1) PRIMARY KEY, note varchar(32))");
+                    stmt.executeUpdate("CREATE TRIGGER " + triggerName + " ON " + tableName
+                            + " FOR INSERT AS INSERT INTO " + auditTable + " (note) VALUES ('audited')");
+
+                    try (PreparedStatement pstmt = con.prepareStatement(
+                            "INSERT INTO " + tableName + " (ID) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                        pstmt.setInt(1, 123456);
+                        pstmt.executeUpdate();
+
+                        try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                            assertFalse(generatedKeys.next(),
+                                    "SCOPE_IDENTITY() is scope-limited - a trigger's nested identity insert "
+                                            + "must NOT leak into getGeneratedKeys() for the keyless outer table");
+                        }
+                    }
+
+                    // Sanity check: the trigger really did fire and generate an identity in its own scope.
+                    try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + auditTable)) {
+                        assertTrue(rs.next());
+                        assertEquals(1, rs.getInt(1), "trigger must have inserted exactly one audit row");
+                    }
+                } finally {
+                    TestUtils.dropTriggerIfExists(triggerName, stmt);
+                    TestUtils.dropTableIfExists(auditTable, stmt);
+                }
+            }
+        }
+
         @AfterEach
         public void terminate() throws SQLException {
             try (Statement stmt = connection.createStatement()) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/StatementTest.java
@@ -1783,6 +1783,49 @@ public class StatementTest extends AbstractTest {
             }
         }
 
+        /**
+         * Tests that getGeneratedKeys() returns an empty ResultSet when the target table has no
+         * generated (identity) keys.
+         *
+         * Per the JDBC specification, if the Statement did not generate any keys, an empty ResultSet
+         * must be returned so that a call to ResultSet.next() returns false.
+         *
+         * Regression test for GitHub issue #3000.
+         *
+         * @throws Exception
+         */
+        @Test
+        @Tag(Constants.xAzureSQLDW)
+        public void testGetGeneratedKeysNoIdentityColumn() throws Exception {
+            try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
+                // Table intentionally has no identity/generated key column.
+                stmt.executeUpdate("CREATE TABLE " + tableName + " (ID int NOT NULL)");
+
+                // PreparedStatement path
+                try (PreparedStatement pstmt = con.prepareStatement("INSERT INTO " + tableName + " (ID) VALUES (?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
+                    pstmt.setInt(1, 123456);
+                    int affectedRows = pstmt.executeUpdate();
+                    assertEquals(1, affectedRows, TestResource.getResource("R_valueNotMatch"));
+
+                    try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                        assertFalse(generatedKeys.next(),
+                                "getGeneratedKeys() should return an empty ResultSet for a table without generated keys");
+                    }
+                }
+
+                // Statement path
+                int affectedRows = stmt.executeUpdate("INSERT INTO " + tableName + " (ID) VALUES (654321)",
+                        Statement.RETURN_GENERATED_KEYS);
+                assertEquals(1, affectedRows, TestResource.getResource("R_valueNotMatch"));
+
+                try (ResultSet generatedKeys = stmt.getGeneratedKeys()) {
+                    assertFalse(generatedKeys.next(),
+                            "getGeneratedKeys() should return an empty ResultSet for a table without generated keys");
+                }
+            }
+        }
+
         @AfterEach
         public void terminate() throws SQLException {
             try (Statement stmt = connection.createStatement()) {


### PR DESCRIPTION
## Problem

When executing an `INSERT` with `Statement.RETURN_GENERATED_KEYS` against a table that has **no identity/generated key column**, `getGeneratedKeys()` returned a **non-empty** `ResultSet` — a single row whose only value was `null`:

```java
CREATE TABLE TEST_TABLE (ID INT NOT NULL); // no identity column

try (PreparedStatement ps = c.prepareStatement(
        "INSERT INTO TEST_TABLE(ID) VALUES(?)", Statement.RETURN_GENERATED_KEYS)) {
    ps.setInt(1, 123456);
    ps.executeUpdate();

    try (ResultSet keys = ps.getGeneratedKeys()) {
        keys.next();          // returned true  — should be false
        keys.getObject(1);    // returned null
    }
}
```

Per the [JDBC specification](https://docs.oracle.com/en/java/javase/21/docs/api/java.sql/java/sql/Statement.html#getGeneratedKeys()), if the `Statement` did not generate any keys, an **empty** `ResultSet` must be returned, so that a call to `ResultSet.next()` returns `false`.

## Root cause

The driver does not receive generated keys inline with the `INSERT`. Instead, for an `INSERT` executed with `RETURN_GENERATED_KEYS`, it appends an internal query to the user's statement and exposes that query's result through `getGeneratedKeys()`:

```java
// SQLServerStatement.java
final static String IDENTITY_QUERY = " select SCOPE_IDENTITY() AS GENERATED_KEYS";
```

`SCOPE_IDENTITY()` returns the last identity value generated in the current scope. When the target table has **no identity column**, `SCOPE_IDENTITY()` evaluates to `NULL` — but the `SELECT` still produces **one row** containing that `NULL`. That row was surfaced verbatim through `getGeneratedKeys()`, so `next()` returned `true` and `getObject(1)` returned `null`, violating the spec.

## Fix

Add a `WHERE` clause to the internal identity query so it yields a row **only** when a key was actually generated:

```java
final static String IDENTITY_QUERY =
        " select SCOPE_IDENTITY() AS GENERATED_KEYS where SCOPE_IDENTITY() is not null";
```

- Table **with** identity column → `SCOPE_IDENTITY()` is non-null → the predicate passes → one row is returned (**unchanged behavior**).
- Table **without** identity column → `SCOPE_IDENTITY()` is `NULL` → the predicate filters it out → **zero rows** → empty `ResultSet` → `next()` returns `false` (**spec-compliant**).

## Tests

- Added `testGetGeneratedKeysNoIdentityColumn` in `StatementTest` (`TCStatementParam`), covering both the `PreparedStatement` and `Statement` paths, asserting that `getGeneratedKeys().next()` returns `false` for a table without generated keys.
- Added regression coverage in StatementTest (TCStatementParam) and MultiStatementResultTraversalTest (GeneratedKeysMatrix) validating that getGeneratedKeys() returns an empty ResultSet for tables without a generated key, across:
    1. Statement and PreparedStatement paths, via execute, executeUpdate, and executeLargeUpdate.
    2. Multi-row and batched inserts.
    3. Non-identity server-generated columns (DEFAULT NEWID(), computed columns).
    4. The SCOPE_IDENTITY vs @@IDENTITY case — a trigger inserting into a separate identity table must not leak its key.
    5. A positive check that identity tables still return the correct generated key (unchanged behavior).

Fixes [#3000](https://github.com/microsoft/mssql-jdbc/issues/3000).