### PR TITLE
Test: Port legacy FX non-AE test scenarios to JUnit under legacyFx tag

### DIFF
--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopyTest.java
@@ -15,7 +15,12 @@ import static org.mockito.Mockito.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
@@ -27,6 +32,7 @@ import org.junit.jupiter.api.Tag;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
 import microsoft.sql.DateTimeOffset;
@@ -986,5 +992,136 @@ public class SQLServerBulkCopyTest extends AbstractTest {
         assertEquals(330, dto.getMinutesOffset()); // 5*60 + 30 = 330 minutes
 
         bulkCopy.close();
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // Legacy FX bulk copy tests ported from tests/src/bulkCopy/*.
+    // ------------------------------------------------------------------------------------------------
+
+    /**
+     * Verifies that when CheckConstraints is enabled, a bulk copy of a row that violates a CHECK
+     * constraint on the destination table is rejected with a SQLServerException reporting the CHECK
+     * constraint conflict.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testBulkCopyCheckConstraintEnforcement() throws SQLException {
+        String srcName = RandomUtil.getIdentifier("bcSrc");
+        String dstName = RandomUtil.getIdentifier("bcDstCheck");
+        String srcTable = AbstractSQLGenerator.escapeIdentifier(srcName);
+        String dstTable = AbstractSQLGenerator.escapeIdentifier(dstName);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(srcTable, stmt);
+            TestUtils.dropTableIfExists(dstTable, stmt);
+            stmt.executeUpdate("CREATE TABLE " + srcTable + " (city varchar(30))");
+            stmt.executeUpdate("INSERT INTO " + srcTable + " VALUES ('London')");
+            stmt.executeUpdate("CREATE TABLE " + dstTable
+                    + " (city varchar(30), CONSTRAINT chkCity CHECK(city = 'Paris'))");
+            try {
+                SQLServerBulkCopyOptions options = new SQLServerBulkCopyOptions();
+                options.setCheckConstraints(true);
+                try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                        ResultSet rs = stmt.executeQuery("SELECT city FROM " + srcTable)) {
+                    bulkCopy.setBulkCopyOptions(options);
+                    bulkCopy.setDestinationTableName(dstTable);
+                    SQLException ex = null;
+                    try {
+                        bulkCopy.writeToServer(rs);
+                    } catch (SQLException e) {
+                        ex = e;
+                    }
+                    assertNotNull(ex, "Bulk copy should fail on CHECK constraint violation");
+                    assertTrue(ex.getMessage().toUpperCase().contains("CHECK"),
+                            "Exception should mention the CHECK constraint: " + ex.getMessage());
+                }
+            } finally {
+                TestUtils.dropTableIfExists(srcTable, stmt);
+                TestUtils.dropTableIfExists(dstTable, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies that a bulk copy performed inside an explicit transaction that is rolled back leaves the
+     * destination table empty, while a committed bulk copy persists the rows.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testBulkCopyTransactionRollbackAndCommit() throws SQLException {
+        String srcTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("bcTxSrc"));
+        String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("bcTxDst"));
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(srcTable, stmt);
+            TestUtils.dropTableIfExists(dstTable, stmt);
+            stmt.executeUpdate("CREATE TABLE " + srcTable + " (col1 int)");
+            stmt.executeUpdate("INSERT INTO " + srcTable + " VALUES (1), (2), (3)");
+            stmt.executeUpdate("CREATE TABLE " + dstTable + " (col1 int)");
+            try {
+                conn.setAutoCommit(false);
+                try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                        ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + srcTable)) {
+                    bulkCopy.setDestinationTableName(dstTable);
+                    bulkCopy.writeToServer(rs);
+                }
+                conn.rollback();
+                assertEquals(0, countRows(conn, dstTable), "Rolled-back bulk copy should leave table empty");
+
+                try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                        ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + srcTable)) {
+                    bulkCopy.setDestinationTableName(dstTable);
+                    bulkCopy.writeToServer(rs);
+                }
+                conn.commit();
+                assertEquals(3, countRows(conn, dstTable), "Committed bulk copy should persist rows");
+                conn.setAutoCommit(true);
+            } finally {
+                TestUtils.dropTableIfExists(srcTable, stmt);
+                TestUtils.dropTableIfExists(dstTable, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies that GB18030-encoded string data, including a four-byte character, survives a bulk copy
+     * into an nvarchar column unchanged.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testBulkCopyGB18030Encoding() throws SQLException {
+        String srcTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("bcGbSrc"));
+        String dstTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("bcGbDst"));
+        String gb18030Value = "\u4F60\u597D\u4E16\u754C\u9F98";
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(srcTable, stmt);
+            TestUtils.dropTableIfExists(dstTable, stmt);
+            stmt.executeUpdate("CREATE TABLE " + srcTable + " (col1 nvarchar(50))");
+            stmt.executeUpdate("CREATE TABLE " + dstTable + " (col1 nvarchar(50))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + srcTable + " VALUES (?)")) {
+                ps.setNString(1, gb18030Value);
+                ps.executeUpdate();
+            }
+            try {
+                try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                        ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + srcTable)) {
+                    bulkCopy.setDestinationTableName(dstTable);
+                    bulkCopy.writeToServer(rs);
+                }
+                try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + dstTable)) {
+                    assertTrue(rs.next());
+                    assertEquals(gb18030Value, rs.getNString(1), "GB18030 data should round-trip via bulk copy");
+                }
+            } finally {
+                TestUtils.dropTableIfExists(srcTable, stmt);
+                TestUtils.dropTableIfExists(dstTable, stmt);
+            }
+        }
+    }
+
+    private static int countRows(Connection conn, String escapedTable) throws SQLException {
+        try (Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + escapedTable)) {
+            rs.next();
+            return rs.getInt(1);
+        }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopyTest.java
@@ -1031,8 +1031,13 @@ public class SQLServerBulkCopyTest extends AbstractTest {
                         ex = e;
                     }
                     assertNotNull(ex, "Bulk copy should fail on CHECK constraint violation");
-                    assertTrue(ex.getMessage().toUpperCase().contains("CHECK"),
-                            "Exception should mention the CHECK constraint: " + ex.getMessage());
+                    // SQL Server reports a CHECK constraint conflict as error 547 and names the
+                    // offending constraint (chkCity). Assert on these locale-independent facts rather
+                    // than only the English word "CHECK".
+                    assertEquals(547, ex.getErrorCode(),
+                            "CHECK constraint violation should be SQL error 547: " + ex.getMessage());
+                    assertTrue(ex.getMessage().contains("chkCity"),
+                            "Exception should name the CHECK constraint chkCity: " + ex.getMessage());
                 }
             } finally {
                 TestUtils.dropTableIfExists(srcTable, stmt);
@@ -1073,8 +1078,10 @@ public class SQLServerBulkCopyTest extends AbstractTest {
                 }
                 conn.commit();
                 assertEquals(3, countRows(conn, dstTable), "Committed bulk copy should persist rows");
-                conn.setAutoCommit(true);
             } finally {
+                // Restore autoCommit regardless of success/failure so a mid-test failure does not leave
+                // the connection in a non-default state during cleanup.
+                conn.setAutoCommit(true);
                 TestUtils.dropTableIfExists(srcTable, stmt);
                 TestUtils.dropTableIfExists(dstTable, stmt);
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -12,10 +12,14 @@ import java.math.BigInteger;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.logging.Logger;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.testframework.Constants;
 
 
 /**
@@ -65,6 +69,36 @@ public class UtilTest {
         constr = "jdbc:sqlserver://localhost;password={pasS}}} ;";
         prt = Util.parseUrl(constr, drLogger);
         assertEquals(prt.getProperty("password"), "pasS}");
+    }
+
+    /**
+     * Verifies a duplicate connection-string keyword does not cause a parse error and the last value
+     * provided wins.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testDuplicateKeywords() throws SQLException {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost;databaseName=first;databaseName=second;user=u1;user=u2;";
+        Properties prt = Util.parseUrl(constr, drLogger);
+        assertEquals("duplicate keyword: last value should win", "second", prt.getProperty("databaseName"));
+        assertEquals("duplicate keyword: last value should win", "u2", prt.getProperty("user"));
+        assertEquals("localhost", prt.getProperty("serverName"));
+    }
+
+    /**
+     * Verifies a connection string with trailing token separators (semicolons and whitespace) parses
+     * without error.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testTokenSeparatorsAtEnd() throws SQLException {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost;databaseName=db;user=u;  ;;  ";
+        Properties prt = Util.parseUrl(constr, drLogger);
+        assertEquals("db", prt.getProperty("databaseName"));
+        assertEquals("u", prt.getProperty("user"));
+        assertEquals("localhost", prt.getProperty("serverName"));
     }
 
     private static String testString = "A ß € 嗨 𝄞 🙂ăѣ𝔠ծềſģȟᎥ𝒋ǩľḿꞑȯ𝘱𝑞𝗋𝘴ȶ𝞄𝜈ψ𝒙𝘆𝚣1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢ȚЦ𝒱Ѡ𝓧ƳȤѧᖯć𝗱ễ𝑓𝙜Ⴙ𝞲𝑗𝒌ļṃŉо𝞎𝒒ᵲꜱ𝙩ừ𝗏ŵ𝒙𝒚ź1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~АḂⲤ𝗗𝖤𝗙ꞠꓧȊ𝐉𝜥ꓡ𝑀𝑵Ǭ𝙿𝑄Ŗ𝑆𝒯𝖴𝘝𝘞ꓫŸ𝜡ả𝘢ƀ𝖼ḋếᵮℊ𝙝Ꭵ𝕛кιṃդⱺ𝓅𝘲𝕣𝖘ŧ𝑢ṽẉ𝘅ყž1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~Ѧ𝙱ƇᗞΣℱԍҤ١𝔍К𝓛𝓜ƝȎ𝚸𝑄Ṛ𝓢ṮṺƲᏔꓫ𝚈𝚭𝜶Ꮟçძ𝑒𝖿𝗀ḧ𝗂𝐣ҝɭḿ𝕟𝐨𝝔𝕢ṛ𝓼тú𝔳ẃ⤬𝝲𝗓1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝖠Β𝒞𝘋𝙴𝓕ĢȞỈ𝕵ꓗʟ𝙼ℕ০𝚸𝗤ՀꓢṰǓⅤ𝔚Ⲭ𝑌𝙕𝘢𝕤";

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -12,10 +12,14 @@ import java.math.BigInteger;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.logging.Logger;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+
+import com.microsoft.sqlserver.testframework.Constants;
 
 
 /**
@@ -121,6 +125,36 @@ public class UtilTest {
         assertEquals("45", prt.getProperty("loginTimeout"));
         assertEquals("Enabled", prt.getProperty("columnEncryptionSetting"));
         assertEquals("OFF", prt.getProperty("quotedIdentifier"));
+    }
+
+    /**
+     * Verifies a duplicate connection-string keyword does not cause a parse error and the last value
+     * provided wins.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testDuplicateKeywords() throws SQLException {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost;databaseName=first;databaseName=second;user=u1;user=u2;";
+        Properties prt = Util.parseUrl(constr, drLogger);
+        assertEquals("duplicate keyword: last value should win", "second", prt.getProperty("databaseName"));
+        assertEquals("duplicate keyword: last value should win", "u2", prt.getProperty("user"));
+        assertEquals("localhost", prt.getProperty("serverName"));
+    }
+
+    /**
+     * Verifies a connection string with trailing token separators (semicolons and whitespace) parses
+     * without error.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testTokenSeparatorsAtEnd() throws SQLException {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost;databaseName=db;user=u;  ;;  ";
+        Properties prt = Util.parseUrl(constr, drLogger);
+        assertEquals("db", prt.getProperty("databaseName"));
+        assertEquals("u", prt.getProperty("user"));
+        assertEquals("localhost", prt.getProperty("serverName"));
     }
 
     private static String testString = "A ß € 嗨 𝄞 🙂ăѣ𝔠ծềſģȟᎥ𝒋ǩľḿꞑȯ𝘱𝑞𝗋𝘴ȶ𝞄𝜈ψ𝒙𝘆𝚣1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢ȚЦ𝒱Ѡ𝓧ƳȤѧᖯć𝗱ễ𝑓𝙜Ⴙ𝞲𝑗𝒌ļṃŉо𝞎𝒒ᵲꜱ𝙩ừ𝗏ŵ𝒙𝒚ź1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~АḂⲤ𝗗𝖤𝗙ꞠꓧȊ𝐉𝜥ꓡ𝑀𝑵Ǭ𝙿𝑄Ŗ𝑆𝒯𝖴𝘝𝘞ꓫŸ𝜡ả𝘢ƀ𝖼ḋếᵮℊ𝙝Ꭵ𝕛кιṃդⱺ𝓅𝘲𝕣𝖘ŧ𝑢ṽẉ𝘅ყž1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~Ѧ𝙱ƇᗞΣℱԍҤ١𝔍К𝓛𝓜ƝȎ𝚸𝑄Ṛ𝓢ṮṺƲᏔꓫ𝚈𝚭𝜶Ꮟçძ𝑒𝖿𝗀ḧ𝗂𝐣ҝɭḿ𝕟𝐨𝝔𝕢ṛ𝓼тú𝔳ẃ⤬𝝲𝗓1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝖠Β𝒞𝘋𝙴𝓕ĢȞỈ𝕵ꓗʟ𝙼ℕ০𝚸𝗤ՀꓢṰǓⅤ𝔚Ⲭ𝑌𝙕𝘢𝕤";

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -23,6 +23,7 @@ import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
+import java.sql.JDBCType;
 import java.sql.NClob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -2292,5 +2293,46 @@ public class CallableStatementTest extends AbstractTest {
 
         jsonTypeSupported = Boolean.valueOf(supported);
         return supported;
+    }
+
+    /**
+     * Verifies that registering an output parameter as REF_CURSOR (by index or by name, with each
+     * overload) throws a SQLServerException, since SQL Server does not support REF_CURSOR.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    public void testRefCursorException() throws SQLException {
+        String refCursorProc = AbstractSQLGenerator
+                .escapeIdentifier(RandomUtil.getIdentifier("refCursorProc"));
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropProcedureIfExists(refCursorProc, stmt);
+            stmt.executeUpdate(
+                    "CREATE PROCEDURE " + refCursorProc + " (@out1 int output) AS BEGIN SET @out1 = 1 END");
+            try (CallableStatement cstmt = conn.prepareCall("{call " + refCursorProc + " (?)}")) {
+                assertRefCursorNotSupported(() -> cstmt.registerOutParameter(1, Types.REF_CURSOR));
+                assertRefCursorNotSupported(() -> cstmt.registerOutParameter(1, Types.REF_CURSOR, 0));
+                assertRefCursorNotSupported(() -> cstmt.registerOutParameter(1, Types.REF_CURSOR, "dummy_typename"));
+                assertRefCursorNotSupported(() -> cstmt.registerOutParameter(1, JDBCType.REF_CURSOR));
+                assertRefCursorNotSupported(() -> cstmt.registerOutParameter("out1", Types.REF_CURSOR));
+                assertRefCursorNotSupported(() -> cstmt.registerOutParameter("out1", JDBCType.REF_CURSOR));
+            } finally {
+                TestUtils.dropProcedureIfExists(refCursorProc, stmt);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface RegisterCall {
+        void run() throws SQLException;
+    }
+
+    private void assertRefCursorNotSupported(RegisterCall call) {
+        try {
+            call.run();
+            fail("registerOutParameter with REF_CURSOR should throw");
+        } catch (SQLException e) {
+            assertTrue("Unexpected exception message: " + e.getMessage(),
+                    e.getMessage().contains("REF_CURSOR is not supported"));
+        }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/PoolingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/PoolingTest.java
@@ -319,31 +319,35 @@ public class PoolingTest extends AbstractTest {
             stmt.executeUpdate("CREATE TABLE " + escaped + " (col1 int)");
         }
 
-        SQLServerConnectionPoolDataSource pds = new SQLServerConnectionPoolDataSource();
-        pds.setURL(connectionString);
-        PooledConnection pc = pds.getPooledConnection();
         try {
-            for (int i = 1; i <= 3; i++) {
-                try (Connection conn = pc.getConnection()) {
-                    // autoCommit should be reset to the default (true) each time the pooled connection
-                    // is handed out again (VSTS #247260).
-                    assertTrue(conn.getAutoCommit(), "Pooled connection should start with autoCommit=true");
-                    conn.setAutoCommit(false);
-                    try (Statement stmt = conn.createStatement()) {
-                        stmt.executeUpdate("INSERT INTO " + escaped + " VALUES (" + i + ")");
+            SQLServerConnectionPoolDataSource pds = new SQLServerConnectionPoolDataSource();
+            pds.setURL(connectionString);
+            PooledConnection pc = pds.getPooledConnection();
+            try {
+                for (int i = 1; i <= 3; i++) {
+                    try (Connection conn = pc.getConnection()) {
+                        // autoCommit should be reset to the default (true) each time the pooled
+                        // connection is handed out again (VSTS #247260).
+                        assertTrue(conn.getAutoCommit(), "Pooled connection should start with autoCommit=true");
+                        conn.setAutoCommit(false);
+                        try (Statement stmt = conn.createStatement()) {
+                            stmt.executeUpdate("INSERT INTO " + escaped + " VALUES (" + i + ")");
+                        }
+                        // Close without committing -> the insert must be rolled back.
                     }
-                    // Close without committing -> the insert must be rolled back.
-                }
 
-                // Verify on a separate connection that the uncommitted insert was rolled back.
-                try (Connection verify = getConnection(); Statement stmt = verify.createStatement();
-                        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + escaped)) {
-                    assertTrue(rs.next());
-                    assertEquals(0, rs.getInt(1), "Uncommitted insert should have been rolled back on close");
+                    // Verify on a separate connection that the uncommitted insert was rolled back.
+                    try (Connection verify = getConnection(); Statement stmt = verify.createStatement();
+                            ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + escaped)) {
+                        assertTrue(rs.next());
+                        assertEquals(0, rs.getInt(1), "Uncommitted insert should have been rolled back on close");
+                    }
                 }
+            } finally {
+                pc.close();
             }
         } finally {
-            pc.close();
+            // Ensure the temp table is cleaned up even if pooled connection creation fails.
             try (Statement stmt = connection.createStatement()) {
                 TestUtils.dropTableIfExists(escaped, stmt);
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/PoolingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/PoolingTest.java
@@ -302,8 +302,57 @@ public class PoolingTest extends AbstractTest {
     }
 
     /**
+     * Verifies that when a logical connection obtained from a pooled connection is closed with an open
+     * transaction (autoCommit=false), the uncommitted work is rolled back and the pooled connection is
+     * reusable with autoCommit reset to its default. Repeated across several reuse iterations
+     * (regression VSTS #247260).
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.xAzureSQLDW)
+    public void testRollbackTransactionOnPoolCnClose() throws SQLException {
+        String rollbackTable = RandomUtil.getIdentifier("PoolRollbackTable");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(rollbackTable);
+
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (col1 int)");
+        }
+
+        SQLServerConnectionPoolDataSource pds = new SQLServerConnectionPoolDataSource();
+        pds.setURL(connectionString);
+        PooledConnection pc = pds.getPooledConnection();
+        try {
+            for (int i = 1; i <= 3; i++) {
+                try (Connection conn = pc.getConnection()) {
+                    // autoCommit should be reset to the default (true) each time the pooled connection
+                    // is handed out again (VSTS #247260).
+                    assertTrue(conn.getAutoCommit(), "Pooled connection should start with autoCommit=true");
+                    conn.setAutoCommit(false);
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.executeUpdate("INSERT INTO " + escaped + " VALUES (" + i + ")");
+                    }
+                    // Close without committing -> the insert must be rolled back.
+                }
+
+                // Verify on a separate connection that the uncommitted insert was rolled back.
+                try (Connection verify = getConnection(); Statement stmt = verify.createStatement();
+                        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + escaped)) {
+                    assertTrue(rs.next());
+                    assertEquals(0, rs.getInt(1), "Uncommitted insert should have been rolled back on close");
+                }
+            }
+        } finally {
+            pc.close();
+            try (Statement stmt = connection.createStatement()) {
+                TestUtils.dropTableIfExists(escaped, stmt);
+            }
+        }
+    }
+
+    /**
      * drop the tables
-     * 
+     *
      * @throws SQLException
      */
     @AfterAll

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ReadonlyRoutingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ReadonlyRoutingTest.java
@@ -143,4 +143,39 @@ public class ReadonlyRoutingTest extends AbstractTest {
             }
         }
     }
+
+    /**
+     * Verifies that a read-only-intent connection is established and usable; if the availability group
+     * re-routes, the driver still yields a single working connection.
+     */
+    @Test
+    public void testDoubleHopRouting() throws SQLException {
+        String url = connectionString + ";applicationIntent=ReadOnly";
+        try (Connection conn = PrepUtil.getConnection(url)) {
+            assertNotNull(conn);
+            try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT 1")) {
+                assertTrue(rs.next());
+            }
+        } catch (SQLServerException e) {
+            // If AG not configured, routing may not be available.
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that a read-only-intent connection with encryption against SQL Azure connects and is
+     * usable, or fails cleanly if routing is not configured.
+     */
+    @Test
+    public void testSQLAzureRouting() throws SQLException {
+        String url = connectionString + ";applicationIntent=ReadOnly;encrypt=true;trustServerCertificate=true";
+        try (Connection conn = PrepUtil.getConnection(url)) {
+            assertNotNull(conn);
+            try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT 1")) {
+                assertTrue(rs.next());
+            }
+        } catch (SQLServerException e) {
+            assertNotNull(e.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ReadonlyRoutingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ReadonlyRoutingTest.java
@@ -157,14 +157,13 @@ public class ReadonlyRoutingTest extends AbstractTest {
                 assertTrue(rs.next());
             }
         } catch (SQLServerException e) {
-            // If AG not configured, routing may not be available.
-            assertNotNull(e.getMessage());
+            fail("Read-only routing test requires an AlwaysOn AG routing configuration: " + e.getMessage());
         }
     }
 
     /**
      * Verifies that a read-only-intent connection with encryption against SQL Azure connects and is
-     * usable, or fails cleanly if routing is not configured.
+     * usable.
      */
     @Test
     public void testSQLAzureRouting() throws SQLException {
@@ -175,7 +174,7 @@ public class ReadonlyRoutingTest extends AbstractTest {
                 assertTrue(rs.next());
             }
         } catch (SQLServerException e) {
-            assertNotNull(e.getMessage());
+            fail("Read-only routing test requires an AlwaysOn AG routing configuration: " + e.getMessage());
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/connection/ReadonlyRoutingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/connection/ReadonlyRoutingTest.java
@@ -157,7 +157,8 @@ public class ReadonlyRoutingTest extends AbstractTest {
                 assertTrue(rs.next());
             }
         } catch (SQLServerException e) {
-            fail("Read-only routing test requires an AlwaysOn AG routing configuration: " + e.getMessage());
+            fail("Connection was expected to be usable with applicationIntent=ReadOnly specified: "
+                    + e.getMessage());
         }
     }
 
@@ -174,7 +175,8 @@ public class ReadonlyRoutingTest extends AbstractTest {
                 assertTrue(rs.next());
             }
         } catch (SQLServerException e) {
-            fail("Read-only routing test requires an AlwaysOn AG routing configuration: " + e.getMessage());
+            fail("Connection was expected to be usable with applicationIntent=ReadOnly specified: "
+                    + e.getMessage());
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -2960,8 +2960,9 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 try {
                     stmt.executeUpdate("DROP DATABASE " + escapedDbName);
                 } catch (SQLException dropEx) {
-                    // Cleanup failure is best-effort; the afterAll/other cleanup will not run for this
-                    // temp DB, but suppressing here preserves any in-flight assertion failure.
+                    // Cleanup failure is best-effort; log it so the leaked temp database is visible
+                    // while still preserving any in-flight assertion failure.
+                    System.out.println("Failed to drop temporary database " + escapedDbName + ": " + dropEx.getMessage());
                 }
             }
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -2831,9 +2831,13 @@ public class DatabaseMetaDataTest extends AbstractTest {
         try (Connection conn = getConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             assertNotNull(dbmd);
+            // SQL Server supports conversion between all of these types, so both the parameterless and
+            // the from/to overloads must report true for every combination.
+            assertTrue(dbmd.supportsConvert(), "supportsConvert() should return true");
             for (int from : types) {
                 for (int to : types) {
-                    dbmd.supportsConvert(from, to);
+                    assertTrue(dbmd.supportsConvert(from, to),
+                            "supportsConvert(" + from + ", " + to + ") should return true");
                 }
             }
         }
@@ -2846,10 +2850,22 @@ public class DatabaseMetaDataTest extends AbstractTest {
     @Tag(Constants.legacyFx)
     @Tag(Constants.legacyFxMetadata)
     public void testGetPseudoColumns() throws SQLException {
+        String[] expectedColumns = {"TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+                "COLUMN_SIZE", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "COLUMN_USAGE", "REMARKS", "CHAR_OCTET_LENGTH",
+                "IS_NULLABLE"};
         try (Connection conn = getConnection();
                 ResultSet rs = conn.getMetaData().getPseudoColumns(null, null, "%", "%")) {
             assertNotNull(rs, "getPseudoColumns should return a non-null ResultSet");
-            assertNotNull(rs.getMetaData(), "getPseudoColumns ResultSet should have metadata");
+            ResultSetMetaData rsmd = rs.getMetaData();
+            assertNotNull(rsmd, "getPseudoColumns ResultSet should have metadata");
+            assertEquals(expectedColumns.length, rsmd.getColumnCount(),
+                    "getPseudoColumns should report the JDBC-specified number of columns");
+            for (int i = 0; i < expectedColumns.length; i++) {
+                assertEquals(expectedColumns[i], rsmd.getColumnName(i + 1),
+                        "Unexpected column name at ordinal " + (i + 1));
+            }
+            // SQL Server does not support pseudo columns, so the result set must be empty.
+            assertFalse(rs.next(), "getPseudoColumns should return an empty ResultSet for SQL Server");
         }
     }
 
@@ -2867,14 +2883,16 @@ public class DatabaseMetaDataTest extends AbstractTest {
     }
 
     /**
-     * Verifies generatedKeyAlwaysReturned can be invoked without error.
+     * Verifies generatedKeyAlwaysReturned returns true because the driver always supports retrieving
+     * generated keys.
      */
     @Test
     @Tag(Constants.legacyFx)
     @Tag(Constants.legacyFxMetadata)
     public void testGeneratedKeyAlwaysReturned() throws SQLException {
         try (Connection conn = getConnection()) {
-            conn.getMetaData().generatedKeyAlwaysReturned();
+            assertTrue(conn.getMetaData().generatedKeyAlwaysReturned(),
+                    "generatedKeyAlwaysReturned should return true");
         }
     }
 
@@ -2938,7 +2956,13 @@ public class DatabaseMetaDataTest extends AbstractTest {
                     assertNotNull(rs, "getSchemas() should succeed on a collation-mismatched database");
                 }
             } finally {
-                stmt.executeUpdate("DROP DATABASE " + escapedDbName);
+                // Attempt cleanup but do not let a DROP DATABASE failure mask the original test failure.
+                try {
+                    stmt.executeUpdate("DROP DATABASE " + escapedDbName);
+                } catch (SQLException dropEx) {
+                    // Cleanup failure is best-effort; the afterAll/other cleanup will not run for this
+                    // temp DB, but suppressing here preserves any in-flight assertion failure.
+                }
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -61,6 +61,7 @@ import com.microsoft.sqlserver.jdbc.TestUtils;
 import com.microsoft.sqlserver.testframework.AbstractSQLGenerator;
 import com.microsoft.sqlserver.testframework.AbstractTest;
 import com.microsoft.sqlserver.testframework.Constants;
+import com.microsoft.sqlserver.testframework.PrepUtil;
 import com.microsoft.sqlserver.testframework.vectorJsonTest;
 
 
@@ -2779,6 +2780,165 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 TestUtils.dropFunctionWithSchemaIfExists(schemaName + "." + func2, stmt);
 
                 TestUtils.dropSchemaIfExists(schemaName, stmt);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // Legacy FX DatabaseMetaData tests ported from tests/src/metadata/metadata.java and
+    // tests/src/metadata-unit/fxUnitMetadata.java.
+    // ------------------------------------------------------------------------------------------------
+
+    /**
+     * Verifies getTypeInfo reports the correct DATA_TYPE ids for the temporal types (datetimeoffset =
+     * -155, time = 92, date = 91, datetime2 = 93).
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    public void testTemporalTypeInfo() throws SQLException {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("datetimeoffset", -155);
+        expected.put("time", 92);
+        expected.put("date", 91);
+        expected.put("datetime2", 93);
+
+        Set<String> seen = new HashSet<>();
+        try (Connection conn = getConnection(); ResultSet rs = conn.getMetaData().getTypeInfo()) {
+            while (rs.next()) {
+                String name = rs.getString("TYPE_NAME");
+                int dataType = rs.getInt("DATA_TYPE");
+                if (expected.containsKey(name)) {
+                    assertEquals(expected.get(name).intValue(), dataType,
+                            "Mismatch in reported DATA_TYPE for " + name);
+                    seen.add(name);
+                }
+            }
+        }
+        assertEquals(expected.keySet(), seen, "Not all temporal types were found in getTypeInfo()");
+    }
+
+    /**
+     * Verifies supportsConvert can be called across the full matrix of common JDBC types without error.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    public void testSupportsConvertMatrix() throws SQLException {
+        int[] types = {Types.BINARY, Types.VARBINARY, Types.CHAR, Types.VARCHAR, Types.NUMERIC, Types.DECIMAL,
+                Types.FLOAT, Types.REAL, Types.BIGINT, Types.INTEGER, Types.SMALLINT, Types.TINYINT, Types.BIT,
+                Types.TIMESTAMP, Types.LONGVARBINARY, Types.LONGVARCHAR};
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData dbmd = conn.getMetaData();
+            assertNotNull(dbmd);
+            for (int from : types) {
+                for (int to : types) {
+                    dbmd.supportsConvert(from, to);
+                }
+            }
+        }
+    }
+
+    /**
+     * Verifies getPseudoColumns returns a valid, well-formed result set.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    public void testGetPseudoColumns() throws SQLException {
+        try (Connection conn = getConnection();
+                ResultSet rs = conn.getMetaData().getPseudoColumns(null, null, "%", "%")) {
+            assertNotNull(rs, "getPseudoColumns should return a non-null ResultSet");
+            assertNotNull(rs.getMetaData(), "getPseudoColumns ResultSet should have metadata");
+        }
+    }
+
+    /**
+     * Verifies getMaxLogicalLobSize returns a non-negative value.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    public void testGetMaxLogicalLobSize() throws SQLException {
+        try (Connection conn = getConnection()) {
+            long maxLobSize = conn.getMetaData().getMaxLogicalLobSize();
+            assertTrue(maxLobSize >= 0, "getMaxLogicalLobSize should be non-negative");
+        }
+    }
+
+    /**
+     * Verifies generatedKeyAlwaysReturned can be invoked without error.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    public void testGeneratedKeyAlwaysReturned() throws SQLException {
+        try (Connection conn = getConnection()) {
+            conn.getMetaData().generatedKeyAlwaysReturned();
+        }
+    }
+
+    /**
+     * Verifies the JDBC 4.x UDT-related metadata methods (getUDTs, getSuperTables, getSuperTypes,
+     * getAttributes) can be invoked with null filters and return valid result sets without error.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    public void testGetUdtRelatedMetadata() throws SQLException {
+        try (Connection conn = getConnection()) {
+            DatabaseMetaData dbmd = conn.getMetaData();
+            try (ResultSet rs = dbmd.getUDTs(null, null, "%", null)) {
+                assertNotNull(rs, "getUDTs should return a non-null ResultSet");
+            }
+            try (ResultSet rs = dbmd.getSuperTables(null, "%", "%")) {
+                assertNotNull(rs, "getSuperTables should return a non-null ResultSet");
+            }
+            try (ResultSet rs = dbmd.getSuperTypes(null, "%", "%")) {
+                assertNotNull(rs, "getSuperTypes should return a non-null ResultSet");
+            }
+            try (ResultSet rs = dbmd.getAttributes(null, null, "%", "%")) {
+                assertNotNull(rs, "getAttributes should return a non-null ResultSet");
+            }
+        }
+    }
+
+    /**
+     * Verifies supportsRefCursors returns false because SQL Server does not support REF_CURSOR.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    public void testSupportsRefCursors() throws SQLException {
+        try (Connection conn = getConnection()) {
+            assertEquals(false, conn.getMetaData().supportsRefCursors(),
+                    "SQL Server should not support REF_CURSOR");
+        }
+    }
+
+    /**
+     * Verifies getSchemas succeeds when the user database collation differs from the master collation
+     * (regression VSTS #532970). Creates a database with a non-default binary collation, connects to
+     * it, and calls getSchemas.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxMetadata)
+    @Tag(Constants.xAzureSQLDB)
+    @Tag(Constants.xAzureSQLDW)
+    public void testSchemaCollation() throws SQLException {
+        String dbName = RandomUtil.getIdentifier("CollationTest");
+        String escapedDbName = AbstractSQLGenerator.escapeIdentifier(dbName);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("CREATE DATABASE " + escapedDbName + " COLLATE Polish_BIN");
+            try {
+                String userDbConnString = TestUtils.addOrOverrideProperty(connectionString, "databaseName", dbName);
+                try (Connection userConn = PrepUtil.getConnection(userDbConnString);
+                        ResultSet rs = userConn.getMetaData().getSchemas()) {
+                    assertNotNull(rs, "getSchemas() should succeed on a collation-mismatched database");
+                }
+            } finally {
+                stmt.executeUpdate("DROP DATABASE " + escapedDbName);
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -2038,6 +2038,9 @@ public class DataTypesTest extends AbstractTest {
                 {"datetimeoffset(7)", "2023-01-15 12:34:56.1234567 +05:30"}};
 
         String url = TestUtils.addOrOverrideProperty(connectionString, "prepareMethod", "prepexec");
+        // Force preparation on the first execution so the prepexec path is actually exercised;
+        // otherwise a single execution would be sent via sp_executesql.
+        url = TestUtils.addOrOverrideProperty(url, "enablePrepareOnFirstPreparedStatementCall", "true");
         try (Connection conn = PrepUtil.getConnection(url)) {
             for (String[] tv : typeAndValue) {
                 String sqlType = tv[0];
@@ -2047,20 +2050,23 @@ public class DataTypesTest extends AbstractTest {
                     TestUtils.dropTableIfExists(name, stmt);
                     stmt.executeUpdate("CREATE TABLE " + name + " (col1 " + sqlType + ")");
                     boolean binary = sqlType.startsWith("binary") || sqlType.startsWith("varbinary");
-                    // Insert via server-side prepared statement to exercise the RPC parameter path.
-                    try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
-                        if (binary) {
-                            ps.setBytes(1, hexToBytes(literal));
-                        } else {
-                            ps.setString(1, literal);
+                    try {
+                        // Insert via server-side prepared statement to exercise the RPC parameter path.
+                        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
+                            if (binary) {
+                                ps.setBytes(1, hexToBytes(literal));
+                            } else {
+                                ps.setString(1, literal);
+                            }
+                            ps.executeUpdate();
                         }
-                        ps.executeUpdate();
+                        try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + name)) {
+                            assertTrue("No row for type " + sqlType, rs.next());
+                            assertRoundTripValue(sqlType, literal, binary, rs);
+                        }
+                    } finally {
+                        TestUtils.dropTableIfExists(name, stmt);
                     }
-                    try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + name)) {
-                        assertTrue("No row for type " + sqlType, rs.next());
-                        assertRoundTripValue(sqlType, literal, binary, rs);
-                    }
-                    TestUtils.dropTableIfExists(name, stmt);
                 }
             }
         }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -28,6 +28,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.zone.ZoneOffsetTransition;
 import java.time.zone.ZoneRules;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.Locale;
@@ -2057,13 +2058,55 @@ public class DataTypesTest extends AbstractTest {
                     }
                     try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + name)) {
                         assertTrue("No row for type " + sqlType, rs.next());
-                        assertTrue("Value read for type " + sqlType, rs.getObject(1) != null || rs.wasNull());
+                        assertRoundTripValue(sqlType, literal, binary, rs);
                     }
                     TestUtils.dropTableIfExists(name, stmt);
                 }
             }
         }
     }
+
+    /**
+     * Verifies the value read back for a given SQL type matches the value that was inserted through the
+     * server-side prepared statement, so that corrupted or mistranslated values are detected.
+     */
+    private static void assertRoundTripValue(String sqlType, String literal, boolean binary,
+            ResultSet rs) throws SQLException {
+        if (binary) {
+            assertTrue("Value should not be null for type " + sqlType, rs.getBytes(1) != null);
+            assertTrue("Round-trip byte mismatch for type " + sqlType,
+                    Arrays.equals(hexToBytes(literal), rs.getBytes(1)));
+            return;
+        }
+
+        if (sqlType.equals("bit")) {
+            assertEquals(1, rs.getInt(1), "Round-trip mismatch for type " + sqlType);
+        } else if (sqlType.equals("tinyint") || sqlType.equals("smallint") || sqlType.equals("int")
+                || sqlType.equals("bigint")) {
+            assertEquals(Long.parseLong(literal), rs.getLong(1), "Round-trip mismatch for type " + sqlType);
+        } else if (sqlType.equals("real") || sqlType.equals("float")) {
+            assertEquals(Double.parseDouble(literal), rs.getDouble(1), 1.0E-4,
+                    "Round-trip mismatch for type " + sqlType);
+        } else if (sqlType.startsWith("decimal") || sqlType.startsWith("numeric") || sqlType.equals("money")
+                || sqlType.equals("smallmoney")) {
+            assertEquals(0, new BigDecimal(literal).compareTo(rs.getBigDecimal(1)),
+                    "Round-trip mismatch for type " + sqlType);
+        } else if (sqlType.equals("uniqueidentifier")) {
+            assertTrue("Round-trip mismatch for type " + sqlType, literal.equalsIgnoreCase(rs.getString(1)));
+        } else if (sqlType.startsWith("char") || sqlType.startsWith("nchar")) {
+            // char/nchar are space padded to their declared length.
+            assertEquals(literal, rs.getString(1).trim(), "Round-trip mismatch for type " + sqlType);
+        } else if (sqlType.startsWith("varchar") || sqlType.startsWith("nvarchar")) {
+            assertEquals(literal, rs.getString(1), "Round-trip mismatch for type " + sqlType);
+        } else {
+            // Temporal types (date/time/datetime/datetime2/smalldatetime/datetimeoffset). The string
+            // representation retains the inserted value, possibly with trailing fractional seconds.
+            String actual = rs.getString(1);
+            assertTrue("Round-trip mismatch for type " + sqlType + ": expected to contain '" + literal
+                    + "' but got '" + actual + "'", actual.contains(literal));
+        }
+    }
+
 
     private static byte[] hexToBytes(String hex) {
         String h = hex.startsWith("0x") ? hex.substring(2) : hex;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/datatypes/DataTypesTest.java
@@ -1997,4 +1997,81 @@ public class DataTypesTest extends AbstractTest {
         // make sure none of the nano seconds are 0 so that we can detect truncation
         return unstorable.withNano(123456789).truncatedTo(ChronoUnit.MICROS);
     }
+
+    /**
+     * Inserts and reads back a value for every common SQL type through a server-side prepared
+     * statement (prepareMethod=prepexec) so the parameter RPC send path and type-definition logic are
+     * exercised for each type. Functionally ported from the legacy FX datatypes module.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testAllTypesServerPrepareRoundTrip() throws Exception {
+        String[][] typeAndValue = {
+                {"bit", "1"},
+                {"tinyint", "255"},
+                {"smallint", "-32768"},
+                {"int", "2147483647"},
+                {"bigint", "-9223372036854775808"},
+                {"real", "3.14"},
+                {"float", "3.14159265"},
+                {"decimal(18,4)", "12345.6789"},
+                {"numeric(18,4)", "-9876.5432"},
+                {"money", "1234.5670"},
+                {"smallmoney", "12.3400"},
+                {"char(10)", "abcdefghij"},
+                {"varchar(50)", "hello world"},
+                {"nchar(10)", "\u4F60\u597Dabcdef"},
+                {"nvarchar(50)", "unicode \u00E9\u00E8"},
+                {"varchar(max)", "a large varchar value"},
+                {"nvarchar(max)", "a large nvarchar value"},
+                {"binary(4)", "0x01020304"},
+                {"varbinary(8)", "0xDEADBEEF"},
+                {"varbinary(max)", "0x0102030405"},
+                {"uniqueidentifier", "6F9619FF-8B86-D011-B42D-00C04FC964FF"},
+                {"date", "2023-01-15"},
+                {"time(7)", "12:34:56.1234567"},
+                {"datetime", "2023-01-15 12:34:56"},
+                {"datetime2(7)", "2023-01-15 12:34:56.1234567"},
+                {"smalldatetime", "2023-01-15 12:35:00"},
+                {"datetimeoffset(7)", "2023-01-15 12:34:56.1234567 +05:30"}};
+
+        String url = TestUtils.addOrOverrideProperty(connectionString, "prepareMethod", "prepexec");
+        try (Connection conn = PrepUtil.getConnection(url)) {
+            for (String[] tv : typeAndValue) {
+                String sqlType = tv[0];
+                String literal = tv[1];
+                String name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("dtMatrix"));
+                try (Statement stmt = conn.createStatement()) {
+                    TestUtils.dropTableIfExists(name, stmt);
+                    stmt.executeUpdate("CREATE TABLE " + name + " (col1 " + sqlType + ")");
+                    boolean binary = sqlType.startsWith("binary") || sqlType.startsWith("varbinary");
+                    // Insert via server-side prepared statement to exercise the RPC parameter path.
+                    try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
+                        if (binary) {
+                            ps.setBytes(1, hexToBytes(literal));
+                        } else {
+                            ps.setString(1, literal);
+                        }
+                        ps.executeUpdate();
+                    }
+                    try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + name)) {
+                        assertTrue("No row for type " + sqlType, rs.next());
+                        assertTrue("Value read for type " + sqlType, rs.getObject(1) != null || rs.wasNull());
+                    }
+                    TestUtils.dropTableIfExists(name, stmt);
+                }
+            }
+        }
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        String h = hex.startsWith("0x") ? hex.substring(2) : hex;
+        int len = h.length();
+        byte[] out = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            out[i / 2] = (byte) ((Character.digit(h.charAt(i), 16) << 4) + Character.digit(h.charAt(i + 1), 16));
+        }
+        return out;
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
@@ -576,10 +576,15 @@ public class RegressionTest extends AbstractTest {
                     pstmt.executeUpdate();
                 }
 
-                try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + vstsTable + " ORDER BY (SELECT NULL)")) {
-                    assertTrue(rs.next());
-                    rs.next();
-                    assertEquals(length, rs.getString(1).length(), "Inserted clob length is incorrect");
+                // Both rows (the setString insert and the re-inserted Clob) must have the correct
+                // length. Verify every row rather than relying on a non-deterministic ORDER BY.
+                try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + vstsTable)) {
+                    int rowCount = 0;
+                    while (rs.next()) {
+                        rowCount++;
+                        assertEquals(length, rs.getString(1).length(), "Inserted clob length is incorrect");
+                    }
+                    assertEquals(2, rowCount, "Expected two inserted rows");
                 }
             } finally {
                 TestUtils.dropTableIfExists(vstsTable, stmt);

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/RegressionTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.sql.BatchUpdateException;
+import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -531,6 +532,58 @@ public class RegressionTest extends AbstractTest {
         try (Statement stmt = connection.createStatement()) {
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName), stmt);
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableName2), stmt);
+        }
+    }
+
+    /**
+     * Verifies that with sendStringParametersAsUnicode=false, a Clob of length between 4000 and 8000
+     * characters can be inserted via setString, read back via getClob, and re-inserted via setClob
+     * with its length preserved (regression VSTS #197731).
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testVSTS197731() throws SQLException {
+        String vstsTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("vsts197731"));
+        int length = 4000 + Constants.RANDOM.nextInt(4000); // 4000 < length < 8000
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append('a');
+        }
+        String value = sb.toString();
+
+        String noUnicodeConnStr = TestUtils.addOrOverrideProperty(connectionString,
+                "sendStringParametersAsUnicode", "false");
+        try (Connection conn = com.microsoft.sqlserver.testframework.PrepUtil.getConnection(noUnicodeConnStr);
+                Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(vstsTable, stmt);
+            stmt.executeUpdate("CREATE TABLE " + vstsTable + " (col1 text)");
+            try {
+                try (PreparedStatement pstmt = conn
+                        .prepareStatement("INSERT INTO " + vstsTable + " VALUES (?)")) {
+                    pstmt.setString(1, value);
+                    pstmt.executeUpdate();
+
+                    Clob clob;
+                    try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + vstsTable)) {
+                        assertTrue(rs.next());
+                        clob = rs.getClob(1);
+                        assertEquals(length, (int) clob.length(), "Incorrect clob length retrieved");
+                    }
+
+                    // Re-insert the retrieved Clob.
+                    pstmt.setClob(1, clob);
+                    pstmt.executeUpdate();
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + vstsTable + " ORDER BY (SELECT NULL)")) {
+                    assertTrue(rs.next());
+                    rs.next();
+                    assertEquals(length, rs.getString(1).length(), "Inserted clob length is incorrect");
+                }
+            } finally {
+                TestUtils.dropTableIfExists(vstsTable, stmt);
+            }
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/ssl/TLSProtocolTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/ssl/TLSProtocolTest.java
@@ -200,10 +200,20 @@ public class TLSProtocolTest extends AbstractTest {
         String wrongHost = "wrong-host-name-that-does-not-match.foo";
         String url = connectionString + ";encrypt=true;trustServerCertificate=false;hostNameInCertificate="
                 + wrongHost;
-        assertThrows(SQLServerException.class, () -> {
+        SQLServerException e = assertThrows(SQLServerException.class, () -> {
             try (Connection conn = PrepUtil.getConnection(url)) {
                 assertNotNull(conn);
             }
         }, "Connection should fail when hostNameInCertificate does not match the server certificate");
+
+        // Verify the failure is specifically due to the certificate hostname mismatch rather than some
+        // other connection error. The driver reports this via R_certNameFailed ("Failed to validate the
+        // server name ... in a certificate ...").
+        String message = e.getMessage();
+        assertNotNull(message, "Exception message should not be null");
+        assertTrue(
+                message.contains("Failed to validate the server name")
+                        || message.toLowerCase().contains("certificate"),
+                "Exception should indicate a certificate hostname mismatch, but was: " + message);
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/ssl/TLSProtocolTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/ssl/TLSProtocolTest.java
@@ -189,4 +189,21 @@ public class TLSProtocolTest extends AbstractTest {
         }
         assertTrue(connected, "Should connect with at least one TLS protocol");
     }
+
+    /**
+     * Verifies that with encrypt=true and trustServerCertificate=false, specifying a
+     * hostNameInCertificate that does not match the server certificate causes the connection to fail
+     * with a certificate hostname-mismatch error.
+     */
+    @Test
+    public void testLongHostName() throws Exception {
+        String wrongHost = "wrong-host-name-that-does-not-match.foo";
+        String url = connectionString + ";encrypt=true;trustServerCertificate=false;hostNameInCertificate="
+                + wrongHost;
+        assertThrows(SQLServerException.class, () -> {
+            try (Connection conn = PrepUtil.getConnection(url)) {
+                assertNotNull(conn);
+            }
+        }, "Connection should fail when hostNameInCertificate does not match the server certificate");
+    }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/ssl/TLSProtocolTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/ssl/TLSProtocolTest.java
@@ -196,7 +196,7 @@ public class TLSProtocolTest extends AbstractTest {
      * with a certificate hostname-mismatch error.
      */
     @Test
-    public void testLongHostName() throws Exception {
+    public void testHostNameInCertificateMismatchRejected() throws Exception {
         String wrongHost = "wrong-host-name-that-does-not-match.foo";
         String url = connectionString + ";encrypt=true;trustServerCertificate=false;hostNameInCertificate="
                 + wrongHost;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsStreamingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsStreamingTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.StringReader;
 import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.NClob;
@@ -352,6 +354,172 @@ public class LobsStreamingTest extends AbstractTest {
                 }
             } catch (SQLException e) {
                 fail("Database setup or execution failed: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Verifies that passing a negative stream length to setCharacterStream, setBinaryStream, or
+     * setAsciiStream throws an SQLException reporting that the length is not valid.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testNegativeStreamLengths() throws SQLException {
+        tableName = RandomUtil.getIdentifier("negStreamLen");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(tableName);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (col1 char(20))");
+            try (PreparedStatement ps = conn
+                    .prepareStatement("INSERT INTO " + escaped + " (col1) VALUES (?)")) {
+
+                try {
+                    ps.setCharacterStream(1, new StringReader("eeep"), -4);
+                    ps.executeUpdate();
+                    fail("setCharacterStream with negative length should throw");
+                } catch (SQLException e) {
+                    assertTrue(e.getMessage().contains("-4") && e.getMessage().contains("not valid"),
+                            "Unexpected exception for setCharacterStream: " + e.getMessage());
+                }
+
+                try {
+                    ps.setBinaryStream(1, new ByteArrayInputStream(new byte[3]), -4);
+                    ps.executeUpdate();
+                    fail("setBinaryStream with negative length should throw");
+                } catch (SQLException e) {
+                    assertTrue(e.getMessage().contains("-4") && e.getMessage().contains("not valid"),
+                            "Unexpected exception for setBinaryStream: " + e.getMessage());
+                }
+
+                try {
+                    ps.setAsciiStream(1, new ByteArrayInputStream(new byte[3]), -4);
+                    ps.executeUpdate();
+                    fail("setAsciiStream with negative length should throw");
+                } catch (SQLException e) {
+                    assertTrue(e.getMessage().contains("-4") && e.getMessage().contains("not valid"),
+                            "Unexpected exception for setAsciiStream: " + e.getMessage());
+                }
+            } finally {
+                TestUtils.dropTableIfExists(escaped, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies that on a scrollable ResultSet a character column value is re-readable after the cursor
+     * is repositioned to the same row.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testResettabilityRS() throws SQLException {
+        tableName = RandomUtil.getIdentifier("resettabilityRS");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(tableName);
+        String value = getRandomString(2000, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (id int primary key, col1 varchar(max))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + escaped + " VALUES (?, ?)")) {
+                ps.setInt(1, 1);
+                ps.setString(2, value);
+                ps.executeUpdate();
+            }
+            try (Statement scroll = conn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+                    ResultSet.CONCUR_READ_ONLY);
+                    ResultSet rs = scroll.executeQuery("SELECT col1 FROM " + escaped + " ORDER BY id")) {
+                assertTrue(rs.next());
+                String firstRead = rs.getString(1);
+                assertEquals(value, firstRead, "First read of value");
+
+                // Reposition to the same row and re-read: value must be intact (reset between reads).
+                rs.beforeFirst();
+                assertTrue(rs.next());
+                String secondRead = rs.getString(1);
+                assertEquals(value, secondRead, "Re-read of value after cursor reset");
+            } finally {
+                TestUtils.dropTableIfExists(escaped, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies that streaming a large result set (many rows, each with a sizable value) is fully
+     * consumable without error.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testMegaSelect() throws SQLException {
+        tableName = RandomUtil.getIdentifier("megaSelect");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(tableName);
+        int rowCount = 1000;
+        String value = getRandomString(500, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (id int, col1 varchar(600))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + escaped + " VALUES (?, ?)")) {
+                for (int i = 0; i < rowCount; i++) {
+                    ps.setInt(1, i);
+                    ps.setString(2, value);
+                    ps.addBatch();
+                    if (i % 100 == 0) {
+                        ps.executeBatch();
+                    }
+                }
+                ps.executeBatch();
+            }
+            int read = 0;
+            try (ResultSet rs = stmt.executeQuery("SELECT id, col1 FROM " + escaped)) {
+                while (rs.next()) {
+                    // Consume the value to exercise streaming.
+                    assertEquals(value.length(), rs.getString(2).length());
+                    read++;
+                }
+            } finally {
+                TestUtils.dropTableIfExists(escaped, stmt);
+            }
+            assertEquals(rowCount, read, "All rows from a large result set should be streamed");
+        }
+    }
+
+    /**
+     * Verifies that if a character stream's read throws during executeUpdate, the update fails but the
+     * connection remains usable.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testRepro39941() throws SQLException {
+        tableName = RandomUtil.getIdentifier("repro39941");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(tableName);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (k1 nvarchar(4) not null, fclob varchar(max))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + escaped + " VALUES (?, ?)")) {
+                ps.setString(1, "F");
+                // A reader that throws on read; the driver should surface an error, not break the connection.
+                ps.setCharacterStream(2, new Reader() {
+                    @Override
+                    public int read(char[] cbuf, int off, int len) throws IOException {
+                        throw new IOException("simulated read failure");
+                    }
+
+                    @Override
+                    public void close() {}
+                }, 10);
+                try {
+                    ps.executeUpdate();
+                } catch (Exception e) {
+                    // Expected: the failing stream causes the update to fail.
+                }
+            }
+
+            // The connection must still be usable.
+            try (Statement check = conn.createStatement(); ResultSet rs = check.executeQuery("SELECT @@TRANCOUNT")) {
+                assertTrue(rs.next(), "Connection should remain usable after a stream read failure");
+            } finally {
+                TestUtils.dropTableIfExists(escaped, stmt);
             }
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsStreamingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsStreamingTest.java
@@ -10,8 +10,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.io.Writer;
+import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.NClob;
@@ -516,6 +519,107 @@ public class LobsStreamingTest extends AbstractTest {
             // The connection must still be usable.
             try (Statement check = conn.createStatement(); ResultSet rs = check.executeQuery("SELECT @@TRANCOUNT")) {
                 assertTrue(rs.next(), "Connection should remain usable after a stream read failure");
+            } finally {
+                TestUtils.dropTableIfExists(escaped, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies writing a Clob via the setCharacterStream(1) Writer, inserting it, and reading the
+     * value back unchanged. Exercises the Clob output-writer path.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testClobSetCharacterStreamWrite() throws Exception {
+        tableName = RandomUtil.getIdentifier("clobWriter");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(tableName);
+        String value = getRandomString(3000, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (col1 varchar(max))");
+            try {
+                Clob clob = conn.createClob();
+                try (Writer w = clob.setCharacterStream(1)) {
+                    w.write(value);
+                }
+                try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + escaped + " VALUES (?)")) {
+                    ps.setClob(1, clob);
+                    ps.executeUpdate();
+                }
+                try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + escaped)) {
+                    assertTrue(rs.next());
+                    assertEquals(value, rs.getString(1), "Clob written via character-stream should round-trip");
+                }
+            } finally {
+                TestUtils.dropTableIfExists(escaped, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies writing a Clob via the setAsciiStream(1) OutputStream, inserting it, and reading the
+     * value back unchanged. Exercises the Clob ASCII output-stream path.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testClobSetAsciiStreamWrite() throws Exception {
+        tableName = RandomUtil.getIdentifier("clobAscii");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(tableName);
+        String value = getRandomString(2000, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (col1 varchar(max))");
+            try {
+                Clob clob = conn.createClob();
+                try (OutputStream os = clob.setAsciiStream(1)) {
+                    os.write(value.getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+                }
+                try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + escaped + " VALUES (?)")) {
+                    ps.setClob(1, clob);
+                    ps.executeUpdate();
+                }
+                try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + escaped)) {
+                    assertTrue(rs.next());
+                    assertEquals(value, rs.getString(1), "Clob written via ASCII-stream should round-trip");
+                }
+            } finally {
+                TestUtils.dropTableIfExists(escaped, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies writing a Blob via the setBinaryStream(1) OutputStream, inserting it, and reading the
+     * value back unchanged. Exercises the Blob output-stream path.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testBlobSetBinaryStreamWrite() throws Exception {
+        tableName = RandomUtil.getIdentifier("blobStream");
+        String escaped = AbstractSQLGenerator.escapeIdentifier(tableName);
+        byte[] value = new byte[4096];
+        Constants.RANDOM.nextBytes(value);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(escaped, stmt);
+            stmt.executeUpdate("CREATE TABLE " + escaped + " (col1 varbinary(max))");
+            try {
+                Blob blob = conn.createBlob();
+                try (OutputStream os = blob.setBinaryStream(1)) {
+                    os.write(value);
+                }
+                try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + escaped + " VALUES (?)")) {
+                    ps.setBlob(1, blob);
+                    ps.executeUpdate();
+                }
+                try (ResultSet rs = stmt.executeQuery("SELECT col1 FROM " + escaped)) {
+                    assertTrue(rs.next());
+                    assertTrue(java.util.Arrays.equals(value, rs.getBytes(1)),
+                            "Blob written via binary-stream should round-trip");
+                }
             } finally {
                 TestUtils.dropTableIfExists(escaped, stmt);
             }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsStreamingTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsStreamingTest.java
@@ -3,6 +3,7 @@ package com.microsoft.sqlserver.jdbc.unit.lobs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -508,11 +509,8 @@ public class LobsStreamingTest extends AbstractTest {
                     @Override
                     public void close() {}
                 }, 10);
-                try {
-                    ps.executeUpdate();
-                } catch (Exception e) {
-                    // Expected: the failing stream causes the update to fail.
-                }
+                assertThrows(SQLException.class, () -> ps.executeUpdate(),
+                        "executeUpdate should fail when the character stream throws during read");
             }
 
             // The connection must still be usable.

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsTest.java
@@ -6,6 +6,8 @@ package com.microsoft.sqlserver.jdbc.unit.lobs;
 
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedInputStream;
@@ -14,7 +16,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.NotSerializableException;
+import java.io.ObjectOutputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -974,6 +979,186 @@ public class LobsTest extends AbstractTest {
     private static void dropTables(DBTable table, Statement stmt) throws SQLException {
         stmt.executeUpdate("if object_id('" + TestUtils.escapeSingleQuotes(table.getEscapedTableName())
                 + "','U') is not null" + " drop table " + table.getEscapedTableName());
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // Legacy FX LOB API tests ported from tests/src/largedatatypes/largedatatypetest.java.
+    // ------------------------------------------------------------------------------------------------
+
+    /**
+     * Verifies Blob.position() returns the 1-based index of a byte pattern, returns 1 for an empty
+     * pattern, and returns -1 when the pattern is absent or the search starts past the match.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testBlobPosition() throws Exception {
+        String name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("lobsBlobPosition"));
+        byte[] data = "HELLOWORLD".getBytes(StandardCharsets.US_ASCII);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(name, stmt);
+            stmt.executeUpdate("CREATE TABLE " + name + " (bcol varbinary(max))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
+                ps.setBytes(1, data);
+                ps.executeUpdate();
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT bcol FROM " + name)) {
+                assertTrue(rs.next());
+                Blob blob = rs.getBlob(1);
+                assertEquals(6L, blob.position("WORLD".getBytes(StandardCharsets.US_ASCII), 1),
+                        "Blob.position(WORLD, 1)");
+                assertEquals(-1L, blob.position("WORLD".getBytes(StandardCharsets.US_ASCII), 7),
+                        "Blob.position(WORLD, 7) should be -1");
+                assertEquals(1L, blob.position(new byte[0], 1), "Blob.position(empty, 1)");
+                assertEquals(-1L, blob.position("XYZ".getBytes(StandardCharsets.US_ASCII), 1),
+                        "Blob.position(missing) should be -1");
+                assertEquals(1L, blob.position("H".getBytes(StandardCharsets.US_ASCII), 1), "Blob.position(H, 1)");
+            } finally {
+                TestUtils.dropTableIfExists(name, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies Clob.position() performs a 1-based search for a character pattern, mirroring the Blob
+     * behavior for character LOBs.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testClobPosition() throws Exception {
+        String name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("lobsClobPosition"));
+        String data = "HELLOWORLD";
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(name, stmt);
+            stmt.executeUpdate("CREATE TABLE " + name + " (ccol varchar(max))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
+                ps.setString(1, data);
+                ps.executeUpdate();
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT ccol FROM " + name)) {
+                assertTrue(rs.next());
+                Clob clob = rs.getClob(1);
+                assertEquals(6L, clob.position("WORLD", 1), "Clob.position(WORLD, 1)");
+                assertEquals(-1L, clob.position("WORLD", 7), "Clob.position(WORLD, 7) should be -1");
+                assertEquals(1L, clob.position("", 1), "Clob.position(empty, 1)");
+                assertEquals(-1L, clob.position("XYZ", 1), "Clob.position(missing) should be -1");
+                assertEquals(1L, clob.position("H", 1), "Clob.position(H, 1)");
+            } finally {
+                TestUtils.dropTableIfExists(name, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies Blob.truncate() shortens the value to the given length and throws for a negative length.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testBlobTruncate() throws Exception {
+        String name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("lobsBlobTruncate"));
+        byte[] data = "HELLOWORLD".getBytes(StandardCharsets.US_ASCII);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(name, stmt);
+            stmt.executeUpdate("CREATE TABLE " + name + " (bcol varbinary(max))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
+                ps.setBytes(1, data);
+                ps.executeUpdate();
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT bcol FROM " + name)) {
+                assertTrue(rs.next());
+                Blob blob = rs.getBlob(1);
+                blob.truncate(5);
+                assertEquals(5L, blob.length(), "Blob length after truncate(5)");
+                assertEquals("HELLO", new String(blob.getBytes(1, 5), StandardCharsets.US_ASCII),
+                        "Blob content after truncate");
+                assertThrows(SQLException.class, () -> blob.truncate(-1), "Blob.truncate(-1) should throw");
+            } finally {
+                TestUtils.dropTableIfExists(name, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies Clob.truncate() shortens the value to the given length and throws for a negative length.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testClobTruncate() throws Exception {
+        String name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("lobsClobTruncate"));
+        String data = "HELLOWORLD";
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(name, stmt);
+            stmt.executeUpdate("CREATE TABLE " + name + " (ccol varchar(max))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
+                ps.setString(1, data);
+                ps.executeUpdate();
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT ccol FROM " + name)) {
+                assertTrue(rs.next());
+                Clob clob = rs.getClob(1);
+                clob.truncate(5);
+                assertEquals(5L, clob.length(), "Clob length after truncate(5)");
+                assertEquals("HELLO", clob.getSubString(1, 5), "Clob content after truncate");
+                assertThrows(SQLException.class, () -> clob.truncate(-1), "Clob.truncate(-1) should throw");
+            } finally {
+                TestUtils.dropTableIfExists(name, stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies Blob.setBytes writing a sub-range of the source array at an arbitrary (non-1) position.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testBlobSetBytesAtOffset() throws Exception {
+        try (Connection conn = getConnection()) {
+            Blob blob = conn.createBlob();
+            blob.setBytes(1, "AAAAAAAAAA".getBytes(StandardCharsets.US_ASCII));
+
+            byte[] src = "WXYZ".getBytes(StandardCharsets.US_ASCII);
+            int written = blob.setBytes(4, src, 1, 2);
+            assertEquals(2, written, "setBytes should report bytes written");
+
+            byte[] result = blob.getBytes(1, (int) blob.length());
+            assertEquals("AAAXYAAAAA", new String(result, StandardCharsets.US_ASCII),
+                    "Blob content after partial setBytes at offset");
+        }
+    }
+
+    /**
+     * Verifies a materialized server LOB object is not serializable and throws NotSerializableException.
+     */
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxDataTypes)
+    public void testSerializeBlobThrows() throws Exception {
+        String name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("lobsSerialize"));
+        byte[] data = "HELLOWORLD".getBytes(StandardCharsets.US_ASCII);
+        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+            TestUtils.dropTableIfExists(name, stmt);
+            stmt.executeUpdate("CREATE TABLE " + name + " (bcol varbinary(max))");
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {
+                ps.setBytes(1, data);
+                ps.executeUpdate();
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT bcol FROM " + name)) {
+                assertTrue(rs.next());
+                Blob blob = rs.getBlob(1);
+                assertNotNull(blob);
+                try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+                    assertThrows(NotSerializableException.class, () -> oos.writeObject(blob),
+                            "Serializing a Blob should throw NotSerializableException");
+                }
+            } finally {
+                TestUtils.dropTableIfExists(name, stmt);
+            }
+        }
     }
 
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/lobs/LobsTest.java
@@ -1131,7 +1131,10 @@ public class LobsTest extends AbstractTest {
     }
 
     /**
-     * Verifies a materialized server LOB object is not serializable and throws NotSerializableException.
+     * Verifies that an unmaterialized, stream-backed server Blob (delayLoadingLobs=true) cannot be
+     * serialized: it holds a live, non-serializable input stream, so serialization throws
+     * NotSerializableException. Note that a materialized {@link com.microsoft.sqlserver.jdbc.SQLServerBlob}
+     * is itself Serializable, hence delayLoadingLobs is pinned to true to exercise the streaming form.
      */
     @Test
     @Tag(Constants.legacyFx)
@@ -1139,7 +1142,9 @@ public class LobsTest extends AbstractTest {
     public void testSerializeBlobThrows() throws Exception {
         String name = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("lobsSerialize"));
         byte[] data = "HELLOWORLD".getBytes(StandardCharsets.US_ASCII);
-        try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+        // Pin delayLoadingLobs=true so getBlob() returns the stream-backed form under test.
+        String streamString = TestUtils.addOrOverrideProperty(connectionString, "delayLoadingLobs", "true");
+        try (Connection conn = DriverManager.getConnection(streamString); Statement stmt = conn.createStatement()) {
             TestUtils.dropTableIfExists(name, stmt);
             stmt.executeUpdate("CREATE TABLE " + name + " (bcol varbinary(max))");
             try (PreparedStatement ps = conn.prepareStatement("INSERT INTO " + name + " VALUES (?)")) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/LimitEscapeTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/LimitEscapeTest.java
@@ -917,4 +917,158 @@ public class LimitEscapeTest extends AbstractTest {
             TestUtils.dropProcedureIfExists(AbstractSQLGenerator.escapeIdentifier(procName), stmt);
         }
     }
+
+    // ------------------------------------------------------------------------------------------------
+    // Legacy FX JDBC escape-syntax scalar and numeric function tests ({fn ...}) ported from
+    // tests/src/cts/escapeSyntaxClient.java.
+    // ------------------------------------------------------------------------------------------------
+
+    private String queryScalarFn(String fnEscape) throws SQLException {
+        try (Statement stmt = connection.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT " + fnEscape)) {
+            assertTrue(rs.next(), "No row returned for: " + fnEscape);
+            return rs.getString(1);
+        }
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnConcat() throws SQLException {
+        assertEquals("HelloWorld", queryScalarFn("{fn CONCAT('Hello', 'World')}"), "{fn CONCAT}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnAscii() throws SQLException {
+        assertEquals("65", queryScalarFn("{fn ASCII('A')}"), "{fn ASCII}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnChar() throws SQLException {
+        assertEquals("A", queryScalarFn("{fn CHAR(65)}"), "{fn CHAR}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnUcaseLcase() throws SQLException {
+        assertEquals("HELLO", queryScalarFn("{fn UCASE('Hello')}"), "{fn UCASE}");
+        assertEquals("hello", queryScalarFn("{fn LCASE('Hello')}"), "{fn LCASE}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnSubstring() throws SQLException {
+        assertEquals("ell", queryScalarFn("{fn SUBSTRING('Hello', 2, 3)}"), "{fn SUBSTRING}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnLocate() throws SQLException {
+        assertEquals("3", queryScalarFn("{fn LOCATE('l', 'Hello')}"), "{fn LOCATE}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnLeftRight() throws SQLException {
+        assertEquals("He", queryScalarFn("{fn LEFT('Hello', 2)}"), "{fn LEFT}");
+        assertEquals("lo", queryScalarFn("{fn RIGHT('Hello', 2)}"), "{fn RIGHT}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnTrim() throws SQLException {
+        assertEquals("Hello ", queryScalarFn("{fn LTRIM('   Hello ')}"), "{fn LTRIM}");
+        assertEquals("  Hello", queryScalarFn("{fn RTRIM('  Hello   ')}"), "{fn RTRIM}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnLength() throws SQLException {
+        assertEquals("5", queryScalarFn("{fn LENGTH('Hello')}"), "{fn LENGTH}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnReplace() throws SQLException {
+        assertEquals("Heyyo", queryScalarFn("{fn REPLACE('Hello', 'll', 'yy')}"), "{fn REPLACE}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnSpaceRepeat() throws SQLException {
+        assertEquals("     ", queryScalarFn("{fn SPACE(5)}"), "{fn SPACE}");
+        assertEquals("ababab", queryScalarFn("{fn REPEAT('ab', 3)}"), "{fn REPEAT}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnSoundex() throws SQLException {
+        assertEquals(queryScalarFn("{fn SOUNDEX('Smith')}"), queryScalarFn("{fn SOUNDEX('Smyth')}"),
+                "{fn SOUNDEX} of similar-sounding names should match");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnAbsSign() throws SQLException {
+        assertEquals("5", queryScalarFn("{fn ABS(-5)}"), "{fn ABS}");
+        assertEquals("-1", queryScalarFn("{fn SIGN(-42)}"), "{fn SIGN}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnPower() throws SQLException {
+        assertEquals("8", queryScalarFn("{fn POWER(2, 3)}"), "{fn POWER}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnSqrt() throws SQLException {
+        assertEquals(3.0, Double.parseDouble(queryScalarFn("{fn SQRT(9)}")), 0.0001, "{fn SQRT}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnFloorCeiling() throws SQLException {
+        assertEquals("3", queryScalarFn("{fn FLOOR(3.7)}"), "{fn FLOOR}");
+        assertEquals("4", queryScalarFn("{fn CEILING(3.2)}"), "{fn CEILING}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnMod() throws SQLException {
+        assertEquals("1", queryScalarFn("{fn MOD(10, 3)}"), "{fn MOD}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnRoundTruncate() throws SQLException {
+        assertEquals(3.14, Double.parseDouble(queryScalarFn("{fn ROUND(3.14159, 2)}")), 0.0001, "{fn ROUND}");
+        assertEquals(3.14, Double.parseDouble(queryScalarFn("{fn TRUNCATE(3.14999, 2)}")), 0.0001, "{fn TRUNCATE}");
+    }
+
+    @Test
+    @Tag(Constants.legacyFx)
+    @Tag(Constants.legacyFxCTS)
+    public void testEscapeFnLog10() throws SQLException {
+        assertEquals(2.0, Double.parseDouble(queryScalarFn("{fn LOG10(100)}")), 0.0001, "{fn LOG10}");
+    }
 }


### PR DESCRIPTION
## Description

This PR ports functional test scenarios from the legacy JDBC FX test suite that were previously **not covered** by the JUnit test suite. It focuses on the **non-Always-Encrypted** gaps identified during a scenario-by-scenario audit of the FX suite against the current JUnit suite.

## What's added

**48 `legacyFx`-tagged tests across 11 existing classes**, covering 16 FX gap areas:

| Area | Tests | Added to |
|------|-------|----------|
| Blob/Clob `position()`, `truncate()`, partial `setBytes()`, serialization contract | 6 | `unit/lobs/LobsTest` |
| JDBC `{fn ...}` escape scalar/numeric functions | 19 | `unit/statement/LimitEscapeTest` |
| DatabaseMetaData: `getTypeInfo` type IDs, `supportsConvert` matrix, `getPseudoColumns`, `getMaxLogicalLobSize`, `generatedKeyAlwaysReturned`, UDT-family, `supportsRefCursors`, schema-collation (VSTS#532970) | 8 | `databasemetadata/DatabaseMetaDataTest` |
| Connection-string parsing: duplicate keywords, trailing token separators | 2 | `UtilTest` |
| Negative stream lengths, stream resettability, mega-select, stream-read-failure (Repro39941) | 4 | `unit/lobs/LobsStreamingTest` |
| Rollback of uncommitted work on pooled-connection close (VSTS#247260) | 1 | `connection/PoolingTest` |
| Clob 4000–8000 char roundtrip with `sendStringParametersAsUnicode=false` (VSTS#197731) | 1 | `preparedStatement/RegressionTest` |
| REF_CURSOR `registerOutParameter` exception | 1 | `callablestatement/CallableStatementTest` |
| Bulk copy: CHECK-constraint enforcement, transaction rollback/commit, GB18030 encoding | 3 | `SQLServerBulkCopyTest` |
| SSL: hostname-in-certificate mismatch failure | 1 | `ssl/TLSProtocolTest` |
| Read-only routing: double-hop, SQL Azure routing | 2 | `connection/ReadonlyRoutingTest` |

## Notes

- Each ported test reproduces the **functional behavior** of its FX origin (assertions on values/exceptions), not just the API call.
