### PR TITLE
Add cross-driver connection string aliases for unification

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -1151,7 +1151,15 @@ public final class SQLServerDriver implements java.sql.Driver {
             {"userName", SQLServerDriverStringProperty.USER.toString()},
             {"server", SQLServerDriverStringProperty.SERVER_NAME.toString()},
             {"domainName", SQLServerDriverStringProperty.DOMAIN.toString()},
-            {"port", SQLServerDriverIntProperty.PORT_NUMBER.toString()}};
+            {"port", SQLServerDriverIntProperty.PORT_NUMBER.toString()},
+            // Cross-driver connection string unification: accept common spellings used by
+            // SqlClient / ODBC / OLEDB so the same connection string works across drivers.
+            {"uid", SQLServerDriverStringProperty.USER.toString()},
+            {"trusted_connection", SQLServerDriverBooleanProperty.INTEGRATED_SECURITY.toString()},
+            {"app", SQLServerDriverStringProperty.APPLICATION_NAME.toString()},
+            {"connectTimeout", SQLServerDriverIntProperty.LOGIN_TIMEOUT.toString()},
+            {"columnEncryption", SQLServerDriverStringProperty.COLUMN_ENCRYPTION.toString()},
+            {"quotedId", SQLServerDriverStringProperty.QUOTED_IDENTIFIER.toString()}};
 
     private static final String[][] driverPropertyValuesSynonyms = {
             {"ActiveDirectoryMSI", SqlAuthentication.ACTIVE_DIRECTORY_MANAGED_IDENTITY.toString()}};

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -67,6 +67,62 @@ public class UtilTest {
         assertEquals(prt.getProperty("password"), "pasS}");
     }
 
+    /**
+     * Tests that the cross-driver connection string aliases (SqlClient / ODBC / OLEDB spellings) are normalized to the
+     * canonical JDBC property names by {@link Util#parseUrl}.
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testConnectionStringAliasNormalization() throws SQLException {
+        java.util.logging.Logger drLogger = java.util.logging.Logger
+                .getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost;uid=myUser;trusted_connection=true;app=myApp;connectTimeout=45;"
+                + "columnEncryption=Enabled;quotedId=OFF;";
+        Properties prt = Util.parseUrl(constr, drLogger);
+
+        // Each alias must normalize to its canonical property name and the alias itself must not survive.
+        assertEquals("myUser", prt.getProperty("user"));
+        assertEquals(null, prt.getProperty("uid"));
+
+        assertEquals("true", prt.getProperty("integratedSecurity"));
+        assertEquals(null, prt.getProperty("trusted_connection"));
+
+        assertEquals("myApp", prt.getProperty("applicationName"));
+        assertEquals(null, prt.getProperty("app"));
+
+        assertEquals("45", prt.getProperty("loginTimeout"));
+        assertEquals(null, prt.getProperty("connectTimeout"));
+
+        assertEquals("Enabled", prt.getProperty("columnEncryptionSetting"));
+        assertEquals(null, prt.getProperty("columnEncryption"));
+
+        assertEquals("OFF", prt.getProperty("quotedIdentifier"));
+        assertEquals(null, prt.getProperty("quotedId"));
+    }
+
+    /**
+     * Tests that connection string alias normalization is case-insensitive, matching the behavior of the existing
+     * synonym handling in {@link SQLServerDriver#getNormalizedPropertyName}.
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testConnectionStringAliasCaseInsensitive() throws SQLException {
+        java.util.logging.Logger drLogger = java.util.logging.Logger
+                .getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost;UID=myUser;Trusted_Connection=true;APP=myApp;CONNECTTIMEOUT=45;"
+                + "ColumnEncryption=Enabled;QUOTEDID=OFF;";
+        Properties prt = Util.parseUrl(constr, drLogger);
+
+        assertEquals("myUser", prt.getProperty("user"));
+        assertEquals("true", prt.getProperty("integratedSecurity"));
+        assertEquals("myApp", prt.getProperty("applicationName"));
+        assertEquals("45", prt.getProperty("loginTimeout"));
+        assertEquals("Enabled", prt.getProperty("columnEncryptionSetting"));
+        assertEquals("OFF", prt.getProperty("quotedIdentifier"));
+    }
+
     private static String testString = "A ß € 嗨 𝄞 🙂ăѣ𝔠ծềſģȟᎥ𝒋ǩľḿꞑȯ𝘱𝑞𝗋𝘴ȶ𝞄𝜈ψ𝒙𝘆𝚣1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢ȚЦ𝒱Ѡ𝓧ƳȤѧᖯć𝗱ễ𝑓𝙜Ⴙ𝞲𝑗𝒌ļṃŉо𝞎𝒒ᵲꜱ𝙩ừ𝗏ŵ𝒙𝒚ź1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~АḂⲤ𝗗𝖤𝗙ꞠꓧȊ𝐉𝜥ꓡ𝑀𝑵Ǭ𝙿𝑄Ŗ𝑆𝒯𝖴𝘝𝘞ꓫŸ𝜡ả𝘢ƀ𝖼ḋếᵮℊ𝙝Ꭵ𝕛кιṃդⱺ𝓅𝘲𝕣𝖘ŧ𝑢ṽẉ𝘅ყž1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~Ѧ𝙱ƇᗞΣℱԍҤ١𝔍К𝓛𝓜ƝȎ𝚸𝑄Ṛ𝓢ṮṺƲᏔꓫ𝚈𝚭𝜶Ꮟçძ𝑒𝖿𝗀ḧ𝗂𝐣ҝɭḿ𝕟𝐨𝝔𝕢ṛ𝓼тú𝔳ẃ⤬𝝲𝗓1234567890!@#$%^&*()-_=+[{]};:'\",<.>/?~𝖠Β𝒞𝘋𝙴𝓕ĢȞỈ𝕵ꓗʟ𝙼ℕ০𝚸𝗤ՀꓢṰǓⅤ𝔚Ⲭ𝑌𝙕𝘢𝕤";
     private static String testString2 = "ssdfsdflkjh9u0345)*&)(*&%$";
     private static String testString3 = "ss345(*&^%oujdf.';lk2345(*&()*$#~!`1\\]wer><.,/?dfsdflkjh9u0345)*&)(*&%$";


### PR DESCRIPTION
# Add cross-driver connection string aliases for connection unification

## Description

The Microsoft data drivers (SqlClient, ODBC, OLEDB, JDBC, PHP, Python, Rust) each expose the
same underlying SQL Server connection settings under slightly different keyword spellings. This
divergence forces users who target more than one driver to maintain separate connection strings
for the same logical configuration.

This change moves JDBC toward **connection string unification** by teaching the driver to accept
the common SqlClient / ODBC / OLEDB spellings for six frequently used properties, normalizing them
to their canonical JDBC property names. Existing JDBC property names continue to work unchanged.

The additions reuse the driver's existing alias mechanism — the `driverPropertiesSynonyms` table in
`SQLServerDriver`, applied by `getNormalizedPropertyName(...)` during URL / property parsing — so no
new parsing logic is introduced and matching remains case-insensitive.

## Background

`SQLServerDriver` already normalizes a small set of synonyms (`database`, `userName`, `server`,
`domainName`, `port`). A cross-driver keyword matrix comparing SqlClient, ODBC, OLEDB, JDBC, PHP,
Python and Rust identified six additional aliases that other drivers accept but JDBC did not, each
mapping cleanly onto an existing JDBC property:

| Canonical keyword | Alias added | Canonical JDBC property | Also used by |
|-------------------|-------------|-------------------------|--------------|
| UID | `uid` | `user` | SqlClient, ODBC, OLEDB, PHP, Python |
| Trusted_Connection | `trusted_connection` | `integratedSecurity` | SqlClient, ODBC, OLEDB, PHP, Python |
| APP | `app` | `applicationName` | SqlClient, ODBC, OLEDB |
| ConnectTimeout | `connectTimeout` | `loginTimeout` | SqlClient, ODBC, OLEDB, PHP, Python |
| ColumnEncryption | `columnEncryption` | `columnEncryptionSetting` | SqlClient, ODBC, OLEDB |
| QuotedId | `quotedId` | `quotedIdentifier` | ODBC, PHP |

## Changes

Added the six aliases to the existing `driverPropertiesSynonyms` table:

```java
private static final String[][] driverPropertiesSynonyms = {
        {"database", SQLServerDriverStringProperty.DATABASE_NAME.toString()},
        {"userName", SQLServerDriverStringProperty.USER.toString()},
        {"server", SQLServerDriverStringProperty.SERVER_NAME.toString()},
        {"domainName", SQLServerDriverStringProperty.DOMAIN.toString()},
        {"port", SQLServerDriverIntProperty.PORT_NUMBER.toString()},
        // Cross-driver connection string unification: accept common spellings used by
        // SqlClient / ODBC / OLEDB so the same connection string works across drivers.
        {"uid", SQLServerDriverStringProperty.USER.toString()},
        {"trusted_connection", SQLServerDriverBooleanProperty.INTEGRATED_SECURITY.toString()},
        {"app", SQLServerDriverStringProperty.APPLICATION_NAME.toString()},
        {"connectTimeout", SQLServerDriverIntProperty.LOGIN_TIMEOUT.toString()},
        {"columnEncryption", SQLServerDriverStringProperty.COLUMN_ENCRYPTION.toString()},
        {"quotedId", SQLServerDriverStringProperty.QUOTED_IDENTIFIER.toString()}};
```

| File | Change |
|------|--------|
| `src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java` | Added six cross-driver aliases (`uid`, `trusted_connection`, `app`, `connectTimeout`, `columnEncryption`, `quotedId`) to `driverPropertiesSynonyms`, each mapping to its canonical JDBC property. |
| `src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java` | Added two unit tests validating alias normalization and case-insensitive matching via `Util.parseUrl`. |

## Testing

Added two unit tests to `UtilTest` (no SQL Server required); the full `UtilTest` class passes
(`Tests run: 8, Failures: 0, Errors: 0`):

1. `testConnectionStringAliasNormalization` — each alias in a connection string is normalized to its
   canonical JDBC property, and the alias key itself does not survive parsing.
2. `testConnectionStringAliasCaseInsensitive` — the aliases are matched case-insensitively
   (`UID`, `Trusted_Connection`, `APP`, `CONNECTTIMEOUT`, `ColumnEncryption`, `QUOTEDID`), consistent
   with the existing synonym-handling behavior in `getNormalizedPropertyName`.

## Compatibility

- No public API changes.
- Purely additive — all existing JDBC property names and existing synonyms continue to work.
- Aliases are resolved through the pre-existing case-insensitive synonym mechanism; no new parsing
  logic is added.
- Compiles across all JRE profiles (`jre8` through `jre26`); uses only existing driver enums.