### PR TITLE
Suppress CodeQL [SM05136] false positive for protocol-mandated MD5 in NTLM channel binding

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java
@@ -655,7 +655,7 @@ final class NTLMAuthentication extends SSPIAuthentication {
                 return;
             }
 
-            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            MessageDigest md5 = MessageDigest.getInstance("MD5"); // CodeQL [SM05136] MD5 is required by the NTLM protocol (MS-NLMP) for channel binding
             md5.update(new byte[4]); // Initiator address
             md5.update(new byte[4]); // Initiator address length
             md5.update(new byte[4]); // Acceptor address


### PR DESCRIPTION
### Description

CodeQL query `java/weak-crypto-algorithm-or-hash` ([SM05136]) flags the use of MD5 in `NTLMAuthentication.calculateChannelBindingMD5Hash()` at `src/main/java/com/microsoft/sqlserver/jdbc/NTLMAuthentication.java` line 658.

This is a **false positive**. The MD5 usage here is not a security choice, it is **mandated by the NTLM protocol (MS-NLMP)** for computing the `MsvAvChannelBindings` AV_PAIR value (the `gss_channel_bindings_struct` hash). Replacing MD5 with SHA-256 or SHA-512, as the query suggests, would break interoperability with SQL Server's NTLM authentication and is not permitted by the protocol specification.

This change adds an inline CodeQL suppression comment documenting the protocol requirement, consistent with the existing suppression already present on the `hmacMD5(...)` method in the same file.

### Changes

- Added `// CodeQL [SM05136] MD5 is required by the NTLM protocol (MS-NLMP) for channel binding` suppression comment to the `MessageDigest.getInstance("MD5")` call in `calculateChannelBindingMD5Hash()`.

### Notes

- No functional/behavioral change.
- Addresses the [SM05136] findings reported across the `build_mssql_jdbc_jre17`, `build_mssql_jdbc_auth`, and `cumulative_codecov` build jobs, all of which trace back to this single source line (the `sqljdbc_10` path in some reports is a build-time generated copy of this file).

### Testing

- No code behavior changed; existing NTLM authentication tests continue to apply.