### PR TITLE
Remove sqljdbc_xa.dll: drop legacy XA extended-procedure DLL

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This driver is documented on [Microsoft Docs](https://docs.microsoft.com/sql/con
 For samples, please see the `src\sample` directory.
 
 ### Download the DLLs
-For some features (e.g. Integrated Authentication), you may need to use the `mssql-jdbc_auth-<version>.<arch>` DLL. It can be found in the package that can be downloaded from [Microsoft](https://aka.ms/downloadmssqljdbc). `mssql-jdbc_auth-<version>.<arch>` can also be downloaded from [Maven](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc_auth). For Distributed Transactions (XA), the required extended stored procedures are built into SQL Server 2017 and later and can be enabled by running `EXEC sp_sqljdbc_xa_install` on the server.
+For some features (e.g. Integrated Authentication), you may need to use the `mssql-jdbc_auth-<version>.<arch>` DLL. It can be found in the package that can be downloaded from [Microsoft](https://aka.ms/downloadmssqljdbc). `mssql-jdbc_auth-<version>.<arch>` can also be downloaded from [Maven](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc_auth). For Distributed Transactions (XA), the required extended stored procedures are built into SQL Server 2017 CU16 and later and can be enabled by running `EXEC sp_sqljdbc_xa_install` on the server. The standalone `sqljdbc_xa.dll` (previously required only for SQL Server 2016 and earlier) is no longer shipped.
 
 ### Download the driver
 Don't want to compile anything?

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This driver is documented on [Microsoft Docs](https://docs.microsoft.com/sql/con
 For samples, please see the `src\sample` directory.
 
 ### Download the DLLs
-For some features (e.g. Integrated Authentication), you may need to use the `mssql-jdbc_auth-<version>.<arch>` DLL. It can be found in the package that can be downloaded from [Microsoft](https://aka.ms/downloadmssqljdbc). `mssql-jdbc_auth-<version>.<arch>` can also be downloaded from [Maven](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc_auth). For Distributed Transactions (XA), the required extended stored procedures are built into SQL Server 2017 and later and can be installed by running `EXEC sp_sqljdbc_xa_install` on the server.
+For some features (e.g. Integrated Authentication), you may need to use the `mssql-jdbc_auth-<version>.<arch>` DLL. It can be found in the package that can be downloaded from [Microsoft](https://aka.ms/downloadmssqljdbc). `mssql-jdbc_auth-<version>.<arch>` can also be downloaded from [Maven](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc_auth). For Distributed Transactions (XA), the required extended stored procedures are built into SQL Server 2017 and later and can be enabled by running `EXEC sp_sqljdbc_xa_install` on the server.
 
 ### Download the driver
 Don't want to compile anything?

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This driver is documented on [Microsoft Docs](https://docs.microsoft.com/sql/con
 For samples, please see the `src\sample` directory.
 
 ### Download the DLLs
-For some features (e.g. Integrated Authentication and Distributed Transactions), you may need to use the `sqljdbc_xa` and `mssql-jdbc_auth-<version>.<arch>` DLLs. They can be found in the package that can be downloaded from [Microsoft](https://aka.ms/downloadmssqljdbc). `mssql-jdbc_auth-<version>.<arch>` can also be downloaded from [Maven](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc_auth).
+For some features (e.g. Integrated Authentication), you may need to use the `mssql-jdbc_auth-<version>.<arch>` DLL. It can be found in the package that can be downloaded from [Microsoft](https://aka.ms/downloadmssqljdbc). `mssql-jdbc_auth-<version>.<arch>` can also be downloaded from [Maven](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc_auth). For Distributed Transactions (XA), the required extended stored procedures are built into SQL Server 2017 and later and can be installed by running `EXEC sp_sqljdbc_xa_install` on the server.
 
 ### Download the driver
 Don't want to compile anything?

--- a/src/main/java/com/microsoft/sqlserver/jdbc/DLLException.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DLLException.java
@@ -10,7 +10,7 @@ import java.text.MessageFormat;
 
 /**
  * 
- * This class is used to handle exceptions that may be received from mssql-jdbc_auth DLL and sqljdbc_xa DLL.
+ * This class is used to handle exceptions that may be received from the mssql-jdbc_auth DLL.
  *
  */
 class DLLException extends Exception {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/xa/XAStateTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/xa/XAStateTest.java
@@ -195,7 +195,7 @@ public class XAStateTest extends AbstractTest {
             if ((msg != null && msg.toLowerCase().contains("xp_sqljdbc_xa")) ||
                     (fullMsg != null && fullMsg.toLowerCase().contains("xp_sqljdbc_xa"))) {
                 System.out.println("XA not supported: XA stored procedures not found");
-                System.out.println("  Solution: Enable XA on SQL Server 2017+ by running EXEC sp_sqljdbc_xa_install");
+                System.out.println("  Solution: Enable XA on SQL Server 2017 CU16+ by running EXEC sp_sqljdbc_xa_install");
                 return true;
             }
 
@@ -207,7 +207,7 @@ public class XAStateTest extends AbstractTest {
                             fullMsg.toLowerCase().contains("xa control connection") ||
                             fullMsg.toLowerCase().contains("could not load the dll")))) {
                 System.out.println("XA not supported: " + msg);
-                System.out.println("  Solution: Enable XA on SQL Server 2017+ by running EXEC sp_sqljdbc_xa_install");
+                System.out.println("  Solution: Enable XA on SQL Server 2017 CU16+ by running EXEC sp_sqljdbc_xa_install");
                 return true;
             }
 
@@ -270,7 +270,7 @@ public class XAStateTest extends AbstractTest {
         logTestProgress("testRandomizedXATransactions - Checking XA support");
         boolean xaSupported = isXASupported(connectionString);
         Assumptions.assumeTrue(xaSupported, 
-            "XA distributed transactions not supported - enable XA on SQL Server 2017+ via EXEC sp_sqljdbc_xa_install");
+            "XA distributed transactions not supported - enable XA on SQL Server 2017 CU16+ via EXEC sp_sqljdbc_xa_install");
         logTestProgress("testRandomizedXATransactions - XA support confirmed");
 
         SQLServerXADataSource ds = new SQLServerXADataSource();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/xa/XAStateTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/xa/XAStateTest.java
@@ -195,7 +195,7 @@ public class XAStateTest extends AbstractTest {
             if ((msg != null && msg.toLowerCase().contains("xp_sqljdbc_xa")) ||
                     (fullMsg != null && fullMsg.toLowerCase().contains("xp_sqljdbc_xa"))) {
                 System.out.println("XA not supported: XA stored procedures not found");
-                System.out.println("  Solution: Run xa_install.sql script on SQL Server");
+                System.out.println("  Solution: Enable XA on SQL Server 2017+ by running EXEC sp_sqljdbc_xa_install");
                 return true;
             }
 
@@ -207,7 +207,7 @@ public class XAStateTest extends AbstractTest {
                             fullMsg.toLowerCase().contains("xa control connection") ||
                             fullMsg.toLowerCase().contains("could not load the dll")))) {
                 System.out.println("XA not supported: " + msg);
-                System.out.println("  Solution: Install sqljdbc_xa.dll in SQL Server Binn directory and unblock it");
+                System.out.println("  Solution: Enable XA on SQL Server 2017+ by running EXEC sp_sqljdbc_xa_install");
                 return true;
             }
 
@@ -270,7 +270,7 @@ public class XAStateTest extends AbstractTest {
         logTestProgress("testRandomizedXATransactions - Checking XA support");
         boolean xaSupported = isXASupported(connectionString);
         Assumptions.assumeTrue(xaSupported, 
-            "XA distributed transactions not supported - install xa_install.sql on SQL Server");
+            "XA distributed transactions not supported - enable XA on SQL Server 2017+ via EXEC sp_sqljdbc_xa_install");
         logTestProgress("testRandomizedXATransactions - XA support confirmed");
 
         SQLServerXADataSource ds = new SQLServerXADataSource();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/xa/XAStateTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/statemachinetest/xa/XAStateTest.java
@@ -199,7 +199,9 @@ public class XAStateTest extends AbstractTest {
                 return true;
             }
 
-            // DLL load errors also indicate XA is not properly installed
+            // Legacy DLL load errors. The standalone sqljdbc_xa.dll is no longer shipped
+            // (XA procedures are built into SQL Server 2017 CU16+). This branch is retained
+            // only to gracefully skip on older servers that may still surface such messages.
             if ((msg != null && (msg.toLowerCase().contains("sqljdbc_xa.dll") ||
                     msg.toLowerCase().contains("xa control connection") ||
                     msg.toLowerCase().contains("could not load the dll"))) ||


### PR DESCRIPTION
## Summary
Removes all references to the legacy server-side `sqljdbc_xa.dll` from the driver's documentation and diagnostics. XA distributed transactions now rely solely on the `xp_sqljdbc_xa_*` extended stored procedures that are built into SQL Server 2017 CU16 and later (enabled via `EXEC sp_sqljdbc_xa_install`). The DLL is no longer shipped.

## Motivation
`sqljdbc_xa.dll` was only required for **SQL Server 2016 and earlier** — the sp_xa procedures have been built into the SQL Server engine since **SQL Server 2017 CU16**. The server-side sp_xa sprocs originally derived from the code in this JDBC DLL, so a recently reported MSRC vulnerability in the server procedures is likely to exist in the DLL as well. With SQL Server 2016 leaving the 5+5 support lifecycle this year, the DLL can be safely dropped rather than serviced.

## Changes
- **README.md** — "Download the DLLs" no longer lists `sqljdbc_xa`; documents that XA procedures are built into SQL Server 2017 CU16+ (enable via `sp_sqljdbc_xa_install`) and that the standalone DLL is no longer shipped.
- **DLLException.java** — Class comment now references only the `mssql-jdbc_auth` DLL.
- **XAStateTest.java** — Diagnostic hints updated to point to `EXEC sp_sqljdbc_xa_install` on SQL Server 2017 CU16+.

**Not changed (intentionally)**
- `SQLServerXAResource.java` and the `xp_sqljdbc_xa_*` calls — the XA feature remains fully functional against SQL Server 2017 CU16+.
- `R_failedToInitializeXA` resource string and its localized translations.

## Testing
No runtime code changed — only docs, one comment, and test diagnostic strings. XA tests continue to run against SQL Server 2017 CU16+ using the built-in stored procedures.

## Related
Companion PR in the internal build repo removes the DLL source, build, and packaging.