### PR TITLE
Add getCurrentApplicationName to PerformanceLogCallback

### DIFF
--- a/docs/performance-metrics.md
+++ b/docs/performance-metrics.md
@@ -114,6 +114,51 @@ These methods are only valid **inside** a `publish()` invocation. Calling them o
 > do not provide SQL or statement type information. Only the top-level execution activities
 > (`STATEMENT_EXECUTE`, `STATEMENT_PREPEXEC`, `STATEMENT_PREPARE`) populate these values.
 
+#### Accessing the Application Name
+
+Inside a `publish()` callback, `getCurrentApplicationName()` returns the value of the
+`applicationName` connection property for the connection that produced the event. This is
+useful when a single callback is registered for the whole JVM and events arrive from several
+connection pools — set `applicationName` on each pool's data source to tell them apart:
+
+```java
+// Each pool sets its own applicationName, e.g. on the pool's data source:
+//   ds.setApplicationName("orders-pool");
+
+SQLServerDriver.registerPerformanceLogCallback(new PerformanceLogCallback() {
+    @Override
+    public void publish(PerformanceActivity activity, int connectionId, long durationMs,
+            Exception exception) {
+        // Connection-level: PRELOGIN, LOGIN, CONNECTION, TOKEN_ACQUISITION
+        metrics.record(getCurrentApplicationName(), activity, durationMs);
+    }
+
+    @Override
+    public void publish(PerformanceActivity activity, int connectionId, int statementId,
+            long durationMs, Exception exception) {
+        // Statement-level: app name available alongside the existing SQL/type accessors
+        metrics.record(getCurrentApplicationName(), activity, getCurrentUserSql(), durationMs);
+    }
+});
+```
+
+For two pools sharing one registered callback, this yields:
+
+```
+[orders-pool]    Connection  120ms
+[orders-pool]    Execute     SELECT * FROM orders WHERE id = ?    5ms
+[reporting-pool] Execute     SELECT COUNT(*) FROM sales           412ms
+```
+
+Unlike `getCurrentUserSql()`, this value is available for **both** connection-level and
+statement-level activities, including `PRELOGIN`, `LOGIN`, and `CONNECTION`. When the
+`applicationName` property is not set, it returns the driver default,
+`"Microsoft JDBC Driver for SQL Server"`.
+
+Like the other context methods, it is only valid **inside** a `publish()` invocation and
+returns `null` when called outside of one. It also returns `null` in the rare case where a
+connection fails before the connection properties have been parsed.
+
 ### 2. Java Logging Configuration
 
 Configure `java.util.logging` for the performance metrics loggers at `FINE` level:
@@ -322,4 +367,4 @@ try {
 - `SQLServerPreparedStatement.java` - Prepared statement activities
 - `PerformanceActivity.java` - Activity enum definitions
 - `PerformanceLog.java` - Logging infrastructure (ThreadLocal context for userSql/statementType)
-- `PerformanceLogCallback.java` - Callback interface (includes `useNanoseconds()`, `getCurrentUserSql()`, `getCurrentStatementType()`)
+- `PerformanceLogCallback.java` - Callback interface (includes `useNanoseconds()`, `getCurrentUserSql()`, `getCurrentStatementType()`, `getCurrentApplicationName()`)

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLog.java
@@ -23,6 +23,7 @@ class PerformanceLog {
     // ThreadLocal to hold current SQL text and statement type for the duration of a publish callback
     static final ThreadLocal<String> currentUserSql = new ThreadLocal<>();
     static final ThreadLocal<StatementType> currentStatementType = new ThreadLocal<>();
+    static final ThreadLocal<String> currentApplicationName = new ThreadLocal<>();
 
     /**
      * Register a callback for performance log events.
@@ -52,6 +53,7 @@ class PerformanceLog {
 
     public static class Scope implements AutoCloseable {
         private Logger logger;
+        private SQLServerConnection con;
         private int connectionId;
         private int statementId;
         private PerformanceActivity activity;
@@ -64,19 +66,20 @@ class PerformanceLog {
         private String userSql;
 
         // Constructor for connection-level activities
-        public Scope(Logger logger, int connectionId, PerformanceActivity activity) {
-            this(logger, connectionId, 0, null, null, activity);
+        public Scope(Logger logger, SQLServerConnection con, PerformanceActivity activity) {
+            this(logger, con, 0, null, null, activity);
         }
 
         // Constructor for statement-level activities
-        public Scope(Logger logger, int connectionId, int statementId,
+        public Scope(Logger logger, SQLServerConnection con, int statementId,
                      SQLServerStatement stmt, String userSql, PerformanceActivity activity) {
             this.enabled = logger.isLoggable(Level.FINE) || (callback != null);
             this.useNanos = cachedUseNanos;
 
             if (enabled) {
                 this.logger = logger;
-                this.connectionId = connectionId;
+                this.con = con;
+                this.connectionId = (con != null) ? con.getConnectionID() : 0;
                 this.statementId = statementId;
                 this.activity = activity;
                 this.startTime = useNanos ? System.nanoTime() : System.currentTimeMillis();
@@ -100,6 +103,15 @@ class PerformanceLog {
             return "ConnectionID:" + connectionId;
         }
 
+        /**
+         * Resolves the application name lazily, at publish time rather than at scope creation time.
+         * The CONNECTION scope is opened before the connection properties have been parsed, so the
+         * value is not available when the scope is constructed.
+         */
+        private String getApplicationName() {
+            return (con != null) ? con.getApplicationName() : null;
+        }
+
         @Override
         public void close() {
 
@@ -111,9 +123,11 @@ class PerformanceLog {
 
             if (callback != null) {
                 try {
+                    // Set the current context for the callback to access via ThreadLocal during publish
+                    // Note: we set these before calling publish, and remove them afterward to avoid leaking data across calls
+                    currentApplicationName.set(getApplicationName());
+
                     if (stmtHandle != null) {
-                        // Set the current SQL and statement type for the callback to access via ThreadLocal during publish
-                        // Note: we set these before calling publish, and remove them afterward to avoid leaking data across calls
                         currentUserSql.set(userSql);
                         currentStatementType.set(deriveStatementType(stmtHandle));
                     }
@@ -126,6 +140,7 @@ class PerformanceLog {
                 } catch (Exception e) {
                     logger.fine(String.format("Failed to publish performance log: %s", e.getMessage()));
                 } finally {
+                    currentApplicationName.remove();
                     if (stmtHandle != null) {
                         currentUserSql.remove();
                         currentStatementType.remove();
@@ -144,13 +159,13 @@ class PerformanceLog {
         }
     }
 
-    public static Scope createScope(Logger logger, int connectionId, PerformanceActivity activity) {
-        return new Scope(logger, connectionId, activity);
+    public static Scope createScope(Logger logger, SQLServerConnection con, PerformanceActivity activity) {
+        return new Scope(logger, con, activity);
     }
 
-    public static Scope createScope(Logger logger, int connectionId, int statementId,
+    public static Scope createScope(Logger logger, SQLServerConnection con, int statementId,
                                     SQLServerStatement stmt, String userSql, PerformanceActivity activity) {
-        return new Scope(logger, connectionId, statementId, stmt, userSql, activity);
+        return new Scope(logger, con, statementId, stmt, userSql, activity);
     }
 
     // Helper method to derive statement type based on the statement class

--- a/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallback.java
@@ -77,4 +77,21 @@ public interface PerformanceLogCallback {
         return PerformanceLog.currentStatementType.get();
     }
 
+    /**
+     * Returns the application name of the connection associated with the current performance event.
+     * This is the value of the {@code applicationName} connection property, which defaults to
+     * "Microsoft JDBC Driver for SQL Server" when not set. Applications using a connection pool can
+     * set this property on the pool's data source to identify which pool the event originated from.
+     * Unlike {@link #getCurrentUserSql()}, this value is available for both connection-level and
+     * statement-level activities.
+     * Only valid inside a {@link #publish} callback invocation.
+     * Returns {@code null} when called outside {@code publish()}, or when the connection properties
+     * have not been parsed yet (for example, a connection that fails before the property is resolved).
+     *
+     * @return the application name, or null if not available.
+     */
+    default String getCurrentApplicationName() {
+        return PerformanceLog.currentApplicationName.get();
+    }
+
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -2001,6 +2001,19 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
         return connectionID;
     }
 
+    /**
+     * Returns the application name for this connection, used for performance tracking.
+     * Returns null if the connection properties have not been parsed yet, since the
+     * applicationName property is resolved during connectInternal().
+     *
+     * @return the application name, or null if not yet available
+     */
+    final String getApplicationName() {
+        return (null != activeConnectionProperties)
+                ? activeConnectionProperties.getProperty(SQLServerDriverStringProperty.APPLICATION_NAME.toString())
+                : null;
+    }
+
     /** Limit for the size of data (in bytes) returned for value on this connection */
     private int maxFieldSize; // default: 0 --> no limit
 
@@ -2370,7 +2383,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     Connection connect(Properties propsIn, SQLServerPooledConnection pooledConnection) throws SQLServerException {
         try (PerformanceLog.Scope connectScope = PerformanceLog.createScope(PerformanceLog.perfLoggerConnection,
-                connectionID, PerformanceActivity.CONNECTION)) {
+                this, PerformanceActivity.CONNECTION)) {
             try {
                 int loginTimeoutSeconds = SQLServerDriverIntProperty.LOGIN_TIMEOUT.getDefaultValue();
                 if (propsIn != null) {
@@ -3880,7 +3893,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     private void login(String primary, String primaryInstanceName, int primaryPortNumber, String mirror,
             FailoverInfo foActual, int timeout, long timerStart) throws SQLServerException {
         try (PerformanceLog.Scope loginScope = PerformanceLog.createScope(PerformanceLog.perfLoggerConnection,
-                connectionID, PerformanceActivity.LOGIN)) {
+                this, PerformanceActivity.LOGIN)) {
             try {
                 // standardLogin would be false only for db mirroring scenarios. It would be
                 // true
@@ -4510,7 +4523,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      */
     void prelogin(String serverName, int portNumber) throws SQLServerException {
         try (PerformanceLog.Scope preLoginScope = PerformanceLog.createScope(PerformanceLog.perfLoggerConnection,
-                connectionID, PerformanceActivity.PRELOGIN)) {
+                this, PerformanceActivity.PRELOGIN)) {
             try {
                 // Build a TDS Pre-Login packet to send to the server.
                 if ((!authenticationString.equalsIgnoreCase(SqlAuthentication.NOT_SPECIFIED.toString()))
@@ -6921,7 +6934,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     void onFedAuthInfo(SqlFedAuthInfo fedAuthInfo, TDSTokenHandler tdsTokenHandler) throws SQLServerException {
 
         try (PerformanceLog.Scope fedAuthScope = PerformanceLog.createScope(PerformanceLog.perfLoggerConnection,
-                connectionID, PerformanceActivity.TOKEN_ACQUISITION)) {
+                this, PerformanceActivity.TOKEN_ACQUISITION)) {
             try {
                 assert (null != activeConnectionProperties.getProperty(SQLServerDriverStringProperty.USER.toString())
                         && null != activeConnectionProperties

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -806,7 +806,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                 // Track statement execution (PREPEXEC or EXECUTE based on execution path)
                 try (PerformanceLog.Scope executeScope = PerformanceLog.createScope(
                         PerformanceLog.perfLoggerStatement,
-                        connection.getConnectionID(),
+                        connection,
                         getStatementID(),
                         this,
                         userSQL,
@@ -1470,7 +1470,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         // Track sp_prepare execution time
         try (PerformanceLog.Scope prepareScope = PerformanceLog.createScope(
                 PerformanceLog.perfLoggerStatement,
-                connection.getConnectionID(),
+                connection,
                 getStatementID(),
                 this,
                 userSQL,
@@ -3506,7 +3506,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         // Performance tracking: track statement execution time for the entire batch
         try (PerformanceLog.Scope executeScope = PerformanceLog.createScope(
                 PerformanceLog.perfLoggerStatement,
-                connection.getConnectionID(),
+                connection,
                 getStatementID(),
                 this,
                 userSQL,
@@ -3794,7 +3794,7 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
             // Track batch execution time
             try (PerformanceLog.Scope executeScope = PerformanceLog.createScope(
                     PerformanceLog.perfLoggerStatement,
-                    connection.getConnectionID(),
+                    connection,
                     getStatementID(),
                     this,
                     userSQL,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerStatement.java
@@ -378,7 +378,7 @@ public class SQLServerStatement implements ISQLServerStatement {
         if (creationToFirstPacketScope == null) {
             creationToFirstPacketScope = PerformanceLog.createScope(
                 PerformanceLog.perfLoggerStatement, 
-                connection.getConnectionID(), 
+                connection,
                 getStatementID(), 
                 null,
                 null,
@@ -406,7 +406,7 @@ public class SQLServerStatement implements ISQLServerStatement {
         if (firstPacketToFirstResponseScope == null) {
             firstPacketToFirstResponseScope = PerformanceLog.createScope(
                 PerformanceLog.perfLoggerStatement,
-                connection.getConnectionID(),
+                connection,
                 getStatementID(),
                 null,
                 null,
@@ -1104,7 +1104,7 @@ public class SQLServerStatement implements ISQLServerStatement {
             // Track statement execution time
             try (PerformanceLog.Scope executeScope = PerformanceLog.createScope(
                     PerformanceLog.perfLoggerStatement,
-                    connection.getConnectionID(),
+                    connection,
                     getStatementID(),
                     this,
                     sql,
@@ -1203,7 +1203,7 @@ public class SQLServerStatement implements ISQLServerStatement {
         // Track batch execution time
         try (PerformanceLog.Scope executeScope = PerformanceLog.createScope(
                 PerformanceLog.perfLoggerStatement,
-                connection.getConnectionID(),
+                connection,
                 getStatementID(),
                 this,
                 batchStatementString,
@@ -2518,7 +2518,7 @@ public class SQLServerStatement implements ISQLServerStatement {
         // Track cursor execution time
         try (PerformanceLog.Scope executeScope = PerformanceLog.createScope(
                 PerformanceLog.perfLoggerStatement,
-                connection.getConnectionID(),
+                connection,
                 getStatementID(),
                 this,
                 sql,

--- a/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/PerformanceLogCallbackTest.java
@@ -1265,6 +1265,197 @@ class PerformanceLogCallbackTest extends AbstractTest {
     }
 
     /**
+     * Test to validate that getCurrentApplicationName() returns the applicationName connection
+     * property for both connection-level and statement-level activities.
+     */
+    @Test
+    void testApplicationNameInCallback() throws Exception {
+        final String appName = "MyPoolName_" + RandomUtil.getIdentifier("pool");
+        List<String> connectionLevelAppNames = new ArrayList<>();
+        List<String> statementLevelAppNames = new ArrayList<>();
+
+        PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, long durationMs,
+                    Exception exception) {
+                connectionLevelAppNames.add(getCurrentApplicationName());
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, int statementId,
+                    long durationMs, Exception exception) {
+                statementLevelAppNames.add(getCurrentApplicationName());
+            }
+        };
+
+        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
+
+        String connStr = TestUtils.addOrOverrideProperty(connectionString, "applicationName", appName);
+        try (Connection con = PrepUtil.getConnection(connStr);
+             Statement stmt = con.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT 1")) {
+            rs.next();
+        }
+
+        assertTrue(statementLevelAppNames.size() > 0, "Should have received statement-level callbacks");
+        for (String captured : statementLevelAppNames) {
+            assertEquals(appName, captured,
+                    "getCurrentApplicationName() should return the applicationName for statement activities");
+        }
+
+        // Connection-level activities that run after property parsing must report the app name.
+        assertTrue(connectionLevelAppNames.contains(appName),
+                "getCurrentApplicationName() should return the applicationName for connection activities. Captured: "
+                        + connectionLevelAppNames);
+
+        SQLServerDriver.unregisterPerformanceLogCallback();
+    }
+
+    /**
+     * Test to validate that getCurrentApplicationName() falls back to the driver default
+     * when the applicationName connection property is not set.
+     */
+    @Test
+    void testApplicationNameDefaultsWhenNotSet() throws Exception {
+        List<String> capturedAppNames = new ArrayList<>();
+
+        PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, long durationMs,
+                    Exception exception) {
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, int statementId,
+                    long durationMs, Exception exception) {
+                capturedAppNames.add(getCurrentApplicationName());
+            }
+        };
+
+        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
+
+        String connStr = TestUtils.removeProperty(connectionString, "applicationName");
+        try (Connection con = PrepUtil.getConnection(connStr);
+             Statement stmt = con.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT 1")) {
+            rs.next();
+        }
+
+        assertTrue(capturedAppNames.size() > 0, "Should have received statement-level callbacks");
+        for (String captured : capturedAppNames) {
+            assertEquals(SQLServerDriver.DEFAULT_APP_NAME, captured,
+                    "getCurrentApplicationName() should default to the driver app name when unset");
+        }
+
+        SQLServerDriver.unregisterPerformanceLogCallback();
+    }
+
+    /**
+     * Test that connections with different applicationName values report their own name,
+     * simulating multiple connection pools sharing a single registered callback.
+     */
+    @Test
+    void testApplicationNameIsolatedAcrossConnections() throws Exception {
+        final String appNameA = "PoolA_" + RandomUtil.getIdentifier("a");
+        final String appNameB = "PoolB_" + RandomUtil.getIdentifier("b");
+
+        // Maps applicationName -> set of SQL seen under that application name
+        Map<String, Set<String>> sqlByAppName = new ConcurrentHashMap<>();
+
+        PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, long durationMs,
+                    Exception exception) {
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, int statementId,
+                    long durationMs, Exception exception) {
+                String sql = getCurrentUserSql();
+                String app = getCurrentApplicationName();
+                if (sql != null && app != null) {
+                    sqlByAppName.computeIfAbsent(app, k -> ConcurrentHashMap.newKeySet()).add(sql);
+                }
+            }
+        };
+
+        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
+
+        final String sqlA = "SELECT 1 AS pool_a_marker";
+        final String sqlB = "SELECT 2 AS pool_b_marker";
+
+        String connStrA = TestUtils.addOrOverrideProperty(connectionString, "applicationName", appNameA);
+        try (Connection con = PrepUtil.getConnection(connStrA);
+             Statement stmt = con.createStatement();
+             ResultSet rs = stmt.executeQuery(sqlA)) {
+            rs.next();
+        }
+
+        String connStrB = TestUtils.addOrOverrideProperty(connectionString, "applicationName", appNameB);
+        try (Connection con = PrepUtil.getConnection(connStrB);
+             Statement stmt = con.createStatement();
+             ResultSet rs = stmt.executeQuery(sqlB)) {
+            rs.next();
+        }
+
+        assertTrue(sqlByAppName.containsKey(appNameA), "Should have events for " + appNameA);
+        assertTrue(sqlByAppName.containsKey(appNameB), "Should have events for " + appNameB);
+
+        assertTrue(sqlByAppName.get(appNameA).contains(sqlA),
+                appNameA + " should report its own SQL. Got: " + sqlByAppName.get(appNameA));
+        assertTrue(sqlByAppName.get(appNameB).contains(sqlB),
+                appNameB + " should report its own SQL. Got: " + sqlByAppName.get(appNameB));
+
+        // Ensure no cross-contamination between the two application names
+        assertTrue(!sqlByAppName.get(appNameA).contains(sqlB),
+                appNameA + " should not see SQL from " + appNameB);
+        assertTrue(!sqlByAppName.get(appNameB).contains(sqlA),
+                appNameB + " should not see SQL from " + appNameA);
+
+        SQLServerDriver.unregisterPerformanceLogCallback();
+    }
+
+    /**
+     * Test that an existing callback which does not use getCurrentApplicationName() continues
+     * to receive events unchanged, and that the value is not leaked outside publish().
+     */
+    @Test
+    void testApplicationNameNotLeakedOutsidePublish() throws Exception {
+        List<PerformanceActivity> activities = new ArrayList<>();
+
+        PerformanceLogCallback callbackInstance = new PerformanceLogCallback() {
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, long durationMs,
+                    Exception exception) {
+                activities.add(activity);
+            }
+
+            @Override
+            public void publish(PerformanceActivity activity, int connectionId, int statementId,
+                    long durationMs, Exception exception) {
+                activities.add(activity);
+            }
+        };
+
+        SQLServerDriver.registerPerformanceLogCallback(callbackInstance);
+
+        String connStr = TestUtils.addOrOverrideProperty(connectionString, "applicationName", "LeakCheckPool");
+        try (Connection con = PrepUtil.getConnection(connStr);
+             Statement stmt = con.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT 1")) {
+            rs.next();
+        }
+
+        assertTrue(activities.size() > 0, "Legacy-style callback should still receive events");
+
+        // Outside of publish(), the ThreadLocal must have been cleared
+        assertEquals(null, callbackInstance.getCurrentApplicationName(),
+                "getCurrentApplicationName() should return null outside of publish()");
+
+        SQLServerDriver.unregisterPerformanceLogCallback();
+    }
+
+    /**
      * Helper method to execute Statement and PreparedStatement queries in a loop.
      * Uses a provided connection. Returns the duration in nanoseconds.
      */


### PR DESCRIPTION
Applications using connection pools had no way to identify which pool a published performance event originated from. This adds a getCurrentApplicationName() default method to PerformanceLogCallback, returning the applicationName connection property of the connection that produced the event, so a pool can be identified by setting applicationName on its data source.

The value is supplied through a new PerformanceLog.currentApplicationName ThreadLocal, set immediately before callback.publish(...) and cleared in the finally block, mirroring the existing currentUserSql lifecycle. To provide the value, PerformanceLog.Scope now holds the SQLServerConnection, just as it already holds the SQLServerStatement.

The application name is resolved lazily at publish time rather than at scope creation time. The CONNECTION scope is opened at the top of connect(), before activeConnectionProperties has been parsed, so an eagerly captured value would be null for connection-level activities and would miss the DEFAULT_APP_NAME fallback when the property is not set.

Existing callback implementations are unaffected: publish() signatures are unchanged and the method is a default. The java.util.logging output format is also unchanged, and the application name is only resolved when a callback is registered.

Fixes #3009