### PR TITLE
Cache sp_columns_170 availability per connection in getColumns()

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -294,6 +294,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
      * Tri-state flag indicating whether the server exposes the sp_columns_170 stored procedure, which is only
      * available on SQL Server 2025 and later. null means the driver has not determined it yet, TRUE means the
      * procedure exists and FALSE means the procedure does not exist on this server.
+     * <p>
+     * The value is scoped to the current TDS session. It survives a pooled logical connection reset, which reuses the
+     * same session against the same server, but is reset to null when idle connection resiliency establishes a new
+     * session, because the driver may then be talking to a different backend.
      */
     private volatile Boolean spColumns170Supported = null;
 
@@ -5078,6 +5082,10 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                                     preparedStatementHandleCache.clear();
                                 }
 
+                                // The reconnect establishes a new session and may land on a different backend, so
+                                // any capability derived from the previous session must be determined again.
+                                spColumns170Supported = null;
+
                                 this.reconnectListeners.forEach(ReconnectListener::beforeReconnect);
 
                                 if (loggerResiliency.isLoggable(Level.FINE)) {
@@ -9693,8 +9701,9 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
 
     /**
      * Records whether the server exposes the sp_columns_170 stored procedure. The value is cached for the lifetime of
-     * the physical connection so that DatabaseMetaData.getColumns() probes for the procedure at most once instead of
-     * once per call.
+     * the current TDS session so that DatabaseMetaData.getColumns() probes for the procedure at most once instead of
+     * once per call. It is reset to undetermined when a new session is established against the server, since the
+     * driver may then be talking to a different backend.
      *
      * @param supported
      *        TRUE if sp_columns_170 exists, FALSE if it does not exist, null to mark the state as undetermined

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -290,6 +290,13 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     /** flag indicating whether server supports transactions */
     private Boolean supportsTransactions = null;
 
+    /**
+     * Tri-state flag indicating whether the server exposes the sp_columns_170 stored procedure, which is only
+     * available on SQL Server 2025 and later. null means the driver has not determined it yet, TRUE means the
+     * procedure exists and FALSE means the procedure does not exist on this server.
+     */
+    private volatile Boolean spColumns170Supported = null;
+
     /** shared timer */
     private SharedTimer sharedTimer;
 
@@ -9673,6 +9680,27 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
     boolean isAzureMI() {
         isAzure();
         return isAzureMI;
+    }
+
+    /**
+     * Returns whether the server exposes the sp_columns_170 stored procedure.
+     *
+     * @return TRUE if sp_columns_170 exists, FALSE if it does not exist, null if this has not been determined yet
+     */
+    Boolean getSpColumns170Supported() {
+        return spColumns170Supported;
+    }
+
+    /**
+     * Records whether the server exposes the sp_columns_170 stored procedure. The value is cached for the lifetime of
+     * the physical connection so that DatabaseMetaData.getColumns() probes for the procedure at most once instead of
+     * once per call.
+     *
+     * @param supported
+     *        TRUE if sp_columns_170 exists, FALSE if it does not exist, null to mark the state as undetermined
+     */
+    void setSpColumns170Supported(Boolean supported) {
+        spColumns170Supported = supported;
     }
 
     boolean isAzureSqlServerEndpoint() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -68,6 +68,9 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     private static final String SP_COLUMNS_170 = "sp_columns_170"; // SQL Server 2025 and later
     private static final String SP_COLUMNS_100 = "sp_columns_100";
 
+    /** SQL Server error raised when a stored procedure does not exist on the server. */
+    private static final int ERROR_PROCEDURE_NOT_FOUND = 2812;
+
     enum CallableHandles {
         SP_COLUMNS("{ call sp_columns(?, ?, ?, ?, ?) }", "{ call sp_columns_170(?, ?, ?, ?, ?, ?) }"),
         SP_COLUMN_PRIVILEGES("{ call sp_column_privileges(?, ?, ?, ?)}", "{ call sp_column_privileges(?, ?, ?, ?)}"),
@@ -691,7 +694,9 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 
     /**
      * getColumns() method to retrieve a description of table columns available in a catalog.
-     * This function try to use sp_columns_170 first, fall back to sp_columns_100 if needed.
+     * This function tries to use sp_columns_170 first and falls back to sp_columns_100 if the server does not have it.
+     * The outcome is cached on the connection, so sp_columns_170 is probed at most once per connection rather than on
+     * every call.
      * 
      * @param catalog
      *                a catalog name; "" retrieves those without a catalog; null
@@ -734,14 +739,16 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
 
     /**
      * Helper method to get columns for regular SQL Server (non-Azure DW).
-     * Tries sp_columns_170 first, falls back to sp_columns_100 if needed.
+     * <p>
+     * sp_columns_170 is only available on SQL Server 2025 and later. Whether the procedure exists is a property of the
+     * server, so the outcome is cached on the connection and the procedure is probed at most once per connection.
+     * Subsequent calls on a server without sp_columns_170 go directly to sp_columns_100 instead of issuing a failing
+     * request per call.
      */
     private java.sql.ResultSet getColumnsNonAzureDW(String catalog, String schema, String table, String col)
             throws SQLException {
 
         String originalCatalog = switchCatalogs(catalog);
-
-        String spColumnsProcName = SP_COLUMNS_170;
 
         String spColumnsSqlTemplate = "DECLARE @mssqljdbc_temp_sp_columns_result TABLE(TABLE_QUALIFIER SYSNAME, TABLE_OWNER SYSNAME,"
             + "TABLE_NAME SYSNAME, COLUMN_NAME SYSNAME, DATA_TYPE SMALLINT, TYPE_NAME SYSNAME, PRECISION INT,"
@@ -765,61 +772,41 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             + "SS_IS_SPARSE, SS_IS_COLUMN_SET, SS_UDT_CATALOG_NAME, SS_UDT_SCHEMA_NAME, SS_UDT_ASSEMBLY_TYPE_NAME,"
             + "SS_XML_SCHEMACOLLECTION_CATALOG_NAME, SS_XML_SCHEMACOLLECTION_SCHEMA_NAME, SS_XML_SCHEMACOLLECTION_NAME "
             + "FROM @mssqljdbc_temp_sp_columns_result ORDER BY TABLE_CAT, TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION;";
-            
+
         SQLServerResultSet rs = null;
-        PreparedStatement pstmt = null;
 
         try {
-            pstmt = (SQLServerPreparedStatement) this.connection
-                    .prepareStatement(String.format(spColumnsSqlTemplate, spColumnsProcName));
-            pstmt.closeOnCompletion();
+            if (shouldTrySpColumns170()) {
+                try {
+                    rs = executeSpColumns(String.format(spColumnsSqlTemplate, SP_COLUMNS_170), SP_COLUMNS_170, table,
+                            schema, catalog, col);
+                    connection.setSpColumns170Supported(true);
+                } catch (SQLException e) {
+                    // sp_columns_170 does not exist before SQL Server 2025, fall back to sp_columns_100
+                    recordSpColumns170Failure(e);
 
-            setColumnsParameters(pstmt, table, schema, catalog, col);
-
-            try {
-                rs = (SQLServerResultSet) pstmt.executeQuery();
-                if (loggerExternal.isLoggable(Level.FINER)) {
-                    loggerExternal.finer("Successfully executed " + spColumnsProcName);
+                    rs = executeSpColumns(String.format(spColumnsSqlTemplate, SP_COLUMNS_100), SP_COLUMNS_100, table,
+                            schema, catalog, col);
                 }
-            } catch (SQLException e) {
-                // If getColumns() fails with sp_columns_170, fall back to sp_columns_100
-
-                if (loggerExternal.isLoggable(Level.FINER)) {
-                    loggerExternal.finer(spColumnsProcName + " failed, falling back to sp_columns_100: " + e.getMessage());
-                }
-
-                // fallback to SP_COLUMNS_100
-                pstmt.close();
-                spColumnsProcName = SP_COLUMNS_100;
-
-                pstmt = (SQLServerPreparedStatement) this.connection
-                        .prepareStatement(String.format(spColumnsSqlTemplate, spColumnsProcName));
-                pstmt.closeOnCompletion();
-
-                setColumnsParameters(pstmt, table, schema, catalog, col);
-
-                rs = (SQLServerResultSet) pstmt.executeQuery();
-                if (loggerExternal.isLoggable(Level.FINER)) {
-                    loggerExternal.finer("Successfully executed " + spColumnsProcName);
-                }
+            } else {
+                rs = executeSpColumns(String.format(spColumnsSqlTemplate, SP_COLUMNS_100), SP_COLUMNS_100, table, schema,
+                        catalog, col);
             }
 
             // Set filters on relevant columns
-            applyColumnsFilters(rs);     
-
-        } catch (SQLException e) {
-            if (null != pstmt) {
+            try {
+                applyColumnsFilters(rs);
+            } catch (SQLException e) {
                 try {
-                    pstmt.close();
+                    rs.close();
                 } catch (SQLServerException ignore) {
                     if (loggerExternal.isLoggable(Level.FINER)) {
-                        loggerExternal.finer(
-                                "getColumns() threw an exception when attempting to close PreparedStatement");
+                        loggerExternal.finer("getColumns() threw an exception when attempting to close ResultSet");
                     }
                 }
+                throw e;
             }
-            throw e;
-        }  finally {
+        } finally {
             if (originalCatalog != null) {
                 connection.setCatalog(originalCatalog);
             }
@@ -828,8 +815,98 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
     }
 
     /**
+     * Prepares and executes the given sp_columns statement.
+     *
+     * @param sql
+     *        the statement text to execute
+     * @param spColumnsProcName
+     *        the stored procedure name being invoked, used for logging
+     * @return the result set produced by the statement
+     * @throws SQLException
+     *         if a database access error occurs
+     */
+    private SQLServerResultSet executeSpColumns(String sql, String spColumnsProcName, String table, String schema,
+            String catalog, String col) throws SQLException {
+        PreparedStatement pstmt = null;
+
+        try {
+            pstmt = (SQLServerPreparedStatement) this.connection.prepareStatement(sql);
+            pstmt.closeOnCompletion();
+
+            setColumnsParameters(pstmt, table, schema, catalog, col);
+
+            SQLServerResultSet rs = (SQLServerResultSet) pstmt.executeQuery();
+            if (loggerExternal.isLoggable(Level.FINER)) {
+                loggerExternal.finer("Successfully executed " + spColumnsProcName);
+            }
+            return rs;
+        } catch (SQLException e) {
+            if (null != pstmt) {
+                try {
+                    pstmt.close();
+                } catch (SQLServerException ignore) {
+                    if (loggerExternal.isLoggable(Level.FINER)) {
+                        loggerExternal
+                                .finer("getColumns() threw an exception when attempting to close PreparedStatement");
+                    }
+                }
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Returns whether sp_columns_170 should be attempted on this connection. The procedure is attempted while support
+     * is still undetermined and once it is known to exist. It is skipped only after the server has told us that the
+     * procedure does not exist.
+     *
+     * @return true if sp_columns_170 should be attempted, false to go directly to sp_columns_100
+     */
+    private boolean shouldTrySpColumns170() {
+        return !Boolean.FALSE.equals(connection.getSpColumns170Supported());
+    }
+
+    /**
+     * Records the outcome of a failed sp_columns_170 attempt on the connection.
+     * <p>
+     * Support is cached as unsupported only when the server explicitly reports that the procedure does not exist. Any
+     * other failure, such as a timeout or a transient error, leaves the state undetermined so that a single unrelated
+     * failure does not permanently downgrade the connection to sp_columns_100 and silently drop metadata for types
+     * that only sp_columns_170 reports.
+     *
+     * @param e
+     *        the exception raised by the sp_columns_170 attempt
+     */
+    private void recordSpColumns170Failure(SQLException e) {
+        boolean procedureNotFound = isProcedureNotFound(e);
+        connection.setSpColumns170Supported(procedureNotFound ? Boolean.FALSE : null);
+
+        if (loggerExternal.isLoggable(Level.FINER)) {
+            loggerExternal.finer(SP_COLUMNS_170 + " failed, falling back to " + SP_COLUMNS_100
+                    + " (procedure not found: " + procedureNotFound + "): " + e.getMessage());
+        }
+    }
+
+    /**
+     * Returns whether the given exception was raised because the stored procedure does not exist on the server.
+     *
+     * @param e
+     *        the exception to inspect
+     * @return true if the server reported that the procedure could not be found
+     */
+    private static boolean isProcedureNotFound(SQLException e) {
+        if (e instanceof SQLServerException) {
+            SQLServerError error = ((SQLServerException) e).getSQLServerError();
+            return null != error && ERROR_PROCEDURE_NOT_FOUND == error.getErrorNumber();
+        }
+        return false;
+    }
+
+    /**
      * Helper method to get columns for Azure DW.
-     * Tries sp_columns_170 first, falls back to sp_columns_100 if needed.
+     * <p>
+     * sp_columns_170 is only available on SQL Server 2025 and later. Whether the procedure exists is a property of the
+     * server, so the outcome is cached on the connection and the procedure is probed at most once per connection.
      */
     private java.sql.ResultSet getColumnsAzureDW(String catalog, String schema, String table, String col)
             throws SQLException {
@@ -931,40 +1008,69 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
             LOCK.unlock();
         }
 
-        String spColumnsProcName = SP_COLUMNS_170;
+        SQLServerResultSet dwResultSet = null;
 
-        try (PreparedStatement storedProcPstmt = this.connection
-                .prepareStatement("EXEC " + spColumnsProcName + " ?,?,?,?,?,?;")) {
+        if (shouldTrySpColumns170()) {
+            ResultSet spColumnsRs = null;
+            try {
+                spColumnsRs = executeSpColumnsAzureDW(SP_COLUMNS_170, table, schema, catalog, col);
+                connection.setSpColumns170Supported(true);
+            } catch (SQLException e) {
+                // sp_columns_170 does not exist before SQL Server 2025, fall back to sp_columns_100
+                recordSpColumns170Failure(e);
+            }
+
+            if (null != spColumnsRs) {
+                try {
+                    return buildAzureDWResultSet(spColumnsRs);
+                } finally {
+                    spColumnsRs.close();
+                }
+            }
+        }
+
+        try (ResultSet spColumnsRs = executeSpColumnsAzureDW(SP_COLUMNS_100, table, schema, catalog, col)) {
+            dwResultSet = buildAzureDWResultSet(spColumnsRs);
+        }
+        return dwResultSet;
+    }
+
+    /**
+     * Prepares and executes the given sp_columns stored procedure on Azure DW.
+     *
+     * @param spColumnsProcName
+     *        the stored procedure name to invoke
+     * @return the result set produced by the stored procedure
+     * @throws SQLException
+     *         if a database access error occurs
+     */
+    private ResultSet executeSpColumnsAzureDW(String spColumnsProcName, String table, String schema, String catalog,
+            String col) throws SQLException {
+        PreparedStatement storedProcPstmt = null;
+
+        try {
+            storedProcPstmt = this.connection.prepareStatement("EXEC " + spColumnsProcName + " ?,?,?,?,?,?;");
+            storedProcPstmt.closeOnCompletion();
 
             setColumnsParameters(storedProcPstmt, table, schema, catalog, col);
 
-            try (ResultSet rs = storedProcPstmt.executeQuery()) {
-                if (loggerExternal.isLoggable(Level.FINER)) {
-                    loggerExternal.finer("Successfully executed " + spColumnsProcName);
-                }
-                return buildAzureDWResultSet(rs);
-            } 
-        } catch (SQLException primaryEx) {
-
-            // If sp_columns_170 fails on Azure DW, fallback to sp_columns_100
+            ResultSet rs = storedProcPstmt.executeQuery();
             if (loggerExternal.isLoggable(Level.FINER)) {
-                loggerExternal.finer(spColumnsProcName + " failed on Azure DW, falling back to sp_columns_100: "
-                        + primaryEx.getMessage());
+                loggerExternal.finer("Successfully executed " + spColumnsProcName);
             }
-
-            spColumnsProcName = SP_COLUMNS_100;
-            try (PreparedStatement storedProcPstmt = this.connection
-                    .prepareStatement("EXEC " + spColumnsProcName + " ?,?,?,?,?,?;")) {
-
-                setColumnsParameters(storedProcPstmt, table, schema, catalog, col);
-                
-                try (ResultSet rs = storedProcPstmt.executeQuery()) {
+            return rs;
+        } catch (SQLException e) {
+            if (null != storedProcPstmt) {
+                try {
+                    storedProcPstmt.close();
+                } catch (SQLServerException ignore) {
                     if (loggerExternal.isLoggable(Level.FINER)) {
-                        loggerExternal.finer("Successfully executed " + spColumnsProcName);
+                        loggerExternal
+                                .finer("getColumns() threw an exception when attempting to close PreparedStatement");
                     }
-                    return buildAzureDWResultSet(rs);
                 }
             }
+            throw e;
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java
@@ -870,16 +870,18 @@ public final class SQLServerDatabaseMetaData implements java.sql.DatabaseMetaDat
      * Records the outcome of a failed sp_columns_170 attempt on the connection.
      * <p>
      * Support is cached as unsupported only when the server explicitly reports that the procedure does not exist. Any
-     * other failure, such as a timeout or a transient error, leaves the state undetermined so that a single unrelated
-     * failure does not permanently downgrade the connection to sp_columns_100 and silently drop metadata for types
-     * that only sp_columns_170 reports.
+     * other failure, such as a timeout or a transient error, leaves the cached state unchanged so that a single
+     * unrelated failure neither permanently downgrades the connection to sp_columns_100 nor discards support that has
+     * already been proven.
      *
      * @param e
      *        the exception raised by the sp_columns_170 attempt
      */
     private void recordSpColumns170Failure(SQLException e) {
         boolean procedureNotFound = isProcedureNotFound(e);
-        connection.setSpColumns170Supported(procedureNotFound ? Boolean.FALSE : null);
+        if (procedureNotFound) {
+            connection.setSpColumns170Supported(false);
+        }
 
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.finer(SP_COLUMNS_170 + " failed, falling back to " + SP_COLUMNS_100

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -2150,6 +2150,138 @@ public class DatabaseMetaDataTest extends AbstractTest {
     }
 
     /**
+     * Verifies that once {@code sp_columns_170} is known to be missing, {@code getColumns()} goes straight to
+     * {@code sp_columns_100} without attempting the newer procedure again.
+     * <p>
+     * This is the behaviour that removes the repeated failing server request on servers older than SQL Server 2025.
+     * The cached state is seeded directly so the scenario can be reproduced on any server version.
+     * 
+     * @throws SQLException
+     *         if a database access error occurs
+     */
+    @Test
+    @Tag(Constants.CodeCov)
+    public void testGetColumnsSkipsSpColumns170WhenCachedUnsupported() throws SQLException {
+        java.util.logging.Logger metaDataLogger = java.util.logging.Logger
+                .getLogger("com.microsoft.sqlserver.jdbc.internals.DatabaseMetaData");
+        java.util.logging.Level originalLevel = metaDataLogger.getLevel();
+        java.util.concurrent.atomic.AtomicInteger ran170 = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicInteger ran100 = new java.util.concurrent.atomic.AtomicInteger();
+
+        java.util.logging.Handler handler = new java.util.logging.Handler() {
+            @Override
+            public void publish(java.util.logging.LogRecord record) {
+                String message = record.getMessage();
+                if (null == message) {
+                    return;
+                }
+                if (message.contains("Successfully executed sp_columns_170")) {
+                    ran170.incrementAndGet();
+                } else if (message.contains("Successfully executed sp_columns_100")) {
+                    ran100.incrementAndGet();
+                }
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+
+        metaDataLogger.addHandler(handler);
+        metaDataLogger.setLevel(java.util.logging.Level.FINER);
+
+        try (Connection conn = getConnection()) {
+            SQLServerConnection sqlServerConnection = (SQLServerConnection) conn;
+
+            // Seed the cached state as if the server had already reported that sp_columns_170 does not exist.
+            setSpColumns170Supported(sqlServerConnection, Boolean.FALSE);
+
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+
+            int callCount = 3;
+            int rowCount = 0;
+            for (int i = 0; i < callCount; i++) {
+                try (ResultSet rs = databaseMetaData.getColumns(null, null, tableName, "%")) {
+                    assertNotNull(rs, "getColumns() should return a result set");
+                    rowCount = 0;
+                    while (rs.next()) {
+                        assertNotNull(rs.getString(COLUMN_NAME), "COLUMN_NAME should not be null");
+                        rowCount++;
+                    }
+                }
+            }
+
+            assertTrue(rowCount > 0, "getColumns() should still return column metadata using sp_columns_100");
+            assertEquals(0, ran170.get(),
+                    "sp_columns_170 must not be attempted once it is known to be unsupported on the connection");
+            assertEquals(callCount, ran100.get(),
+                    "every getColumns() call should go directly to sp_columns_100");
+            assertEquals(Boolean.FALSE, getSpColumns170Supported(sqlServerConnection),
+                    "the cached sp_columns_170 state should remain unsupported");
+        } finally {
+            metaDataLogger.removeHandler(handler);
+            metaDataLogger.setLevel(originalLevel);
+        }
+    }
+
+    /**
+     * Verifies the Azure DW code path also honours the cached {@code sp_columns_170} state and falls through to
+     * {@code sp_columns_100}.
+     * <p>
+     * The connection is made to look like Azure DW through reflection, matching the approach used by the other Azure
+     * DW tests in this class.
+     * 
+     * @throws Exception
+     *         if a database access or reflection error occurs
+     */
+    @Test
+    @Tag(Constants.CodeCov)
+    public void testGetColumnsAzureDWSkipsSpColumns170WhenCachedUnsupported() throws Exception {
+        try (Connection conn = getConnection()) {
+            // Use reflection to simulate an Azure DW connection.
+            Field f1 = SQLServerConnection.class.getDeclaredField("isAzureDW");
+            f1.setAccessible(true);
+            f1.set(conn, true);
+
+            Field f2 = SQLServerConnection.class.getDeclaredField("isAzure");
+            f2.setAccessible(true);
+            f2.set(conn, true);
+
+            SQLServerConnection sqlServerConnection = (SQLServerConnection) conn;
+            setSpColumns170Supported(sqlServerConnection, Boolean.FALSE);
+
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+
+            try (ResultSet rs = databaseMetaData.getColumns(conn.getCatalog(), "dbo", tableName, null)) {
+                assertNotNull(rs, "ResultSet should not be null on the Azure DW path");
+
+                ResultSetMetaData rsmd = rs.getMetaData();
+                assertTrue(rsmd.getColumnCount() >= 18, "Should have the standard getColumns() metadata shape");
+            }
+
+            assertEquals(Boolean.FALSE, getSpColumns170Supported(sqlServerConnection),
+                    "the cached sp_columns_170 state should remain unsupported on the Azure DW path");
+        }
+    }
+
+    /**
+     * Seeds the tri-state sp_columns_170 support cached on the connection. The mutator is package private on
+     * SQLServerConnection, so it is invoked reflectively from this test package.
+     */
+    private static void setSpColumns170Supported(SQLServerConnection conn, Boolean supported) {
+        try {
+            java.lang.reflect.Method method = SQLServerConnection.class.getDeclaredMethod("setSpColumns170Supported",
+                    Boolean.class);
+            method.setAccessible(true);
+            method.invoke(conn, supported);
+        } catch (Exception e) {
+            fail("Unable to seed sp_columns_170 support: " + e.getMessage());
+        }
+    }
+
+    /**
      * Reads the tri-state sp_columns_170 support cached on the connection. The accessor is package private on
      * SQLServerConnection, so it is invoked reflectively from this test package.
      */

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -2059,14 +2059,19 @@ public class DatabaseMetaDataTest extends AbstractTest {
         java.util.logging.Logger metaDataLogger = java.util.logging.Logger
                 .getLogger("com.microsoft.sqlserver.jdbc.internals.DatabaseMetaData");
         java.util.logging.Level originalLevel = metaDataLogger.getLevel();
-        java.util.concurrent.atomic.AtomicInteger fallbackCount = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicInteger procedureNotFoundCount = new java.util.concurrent.atomic.AtomicInteger();
 
         java.util.logging.Handler handler = new java.util.logging.Handler() {
             @Override
             public void publish(java.util.logging.LogRecord record) {
                 String message = record.getMessage();
-                if (null != message && message.contains("sp_columns_170 failed, falling back")) {
-                    fallbackCount.incrementAndGet();
+                /*
+                 * Only count the fallback caused by the procedure being absent. Other failures deliberately leave the
+                 * cached state alone, so they are allowed to be retried and must not fail this test.
+                 */
+                if (null != message && message.contains("sp_columns_170 failed, falling back")
+                        && message.contains("procedure not found: true")) {
+                    procedureNotFoundCount.incrementAndGet();
                 }
             }
 
@@ -2094,13 +2099,18 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 }
             }
 
-            assertTrue(fallbackCount.get() <= 1,
+            assertTrue(procedureNotFoundCount.get() <= 1,
                     "sp_columns_170 should be probed at most once per connection, but the driver fell back "
-                            + fallbackCount.get() + " times across " + callCount + " getColumns() calls");
+                            + procedureNotFoundCount.get() + " times across " + callCount + " getColumns() calls");
 
-            // Once the probe has run, the connection must have a decided state rather than remaining undetermined.
-            assertNotNull(getSpColumns170SupportedFlag(sqlServerConnection),
-                    "sp_columns_170 support should be cached on the connection after the first getColumns() call");
+            Boolean supported = getSpColumns170Supported(sqlServerConnection);
+            if (procedureNotFoundCount.get() == 1) {
+                assertEquals(Boolean.FALSE, supported,
+                        "sp_columns_170 should be cached as unsupported once the server reports it is missing");
+            } else {
+                assertEquals(Boolean.TRUE, supported,
+                        "sp_columns_170 should be cached as supported when the probe succeeds");
+            }
         }  finally {
             metaDataLogger.removeHandler(handler);
             metaDataLogger.setLevel(originalLevel);
@@ -2119,7 +2129,7 @@ public class DatabaseMetaDataTest extends AbstractTest {
         try (Connection conn = getConnection()) {
             SQLServerConnection sqlServerConnection = (SQLServerConnection) conn;
 
-            assertNull(getSpColumns170SupportedFlag(sqlServerConnection),
+            assertNull(getSpColumns170Supported(sqlServerConnection),
                     "sp_columns_170 support should be undetermined before the first getColumns() call");
 
             try (ResultSet rs = conn.getMetaData().getColumns(null, null, tableName, "%")) {
@@ -2128,27 +2138,28 @@ public class DatabaseMetaDataTest extends AbstractTest {
                 }
             }
 
-            Boolean supported = getSpColumns170SupportedFlag(sqlServerConnection);
+            Boolean supported = getSpColumns170Supported(sqlServerConnection);
             assertNotNull(supported, "sp_columns_170 support should be cached after the first getColumns() call");
 
             // A separate connection must start from an undetermined state.
             try (Connection otherConn = getConnection()) {
-                assertNull(getSpColumns170SupportedFlag((SQLServerConnection) otherConn),
+                assertNull(getSpColumns170Supported((SQLServerConnection) otherConn),
                         "sp_columns_170 support should not leak across connections");
             }
         }
     }
 
     /**
-     * Reads the tri-state sp_columns_170 support flag cached on the connection.
+     * Reads the tri-state sp_columns_170 support cached on the connection. The accessor is package private on
+     * SQLServerConnection, so it is invoked reflectively from this test package.
      */
-    private static Boolean getSpColumns170SupportedFlag(SQLServerConnection conn) {
+    private static Boolean getSpColumns170Supported(SQLServerConnection conn) {
         try {
-            Field field = SQLServerConnection.class.getDeclaredField("spColumns170Supported");
-            field.setAccessible(true);
-            return (Boolean) field.get(conn);
+            java.lang.reflect.Method method = SQLServerConnection.class.getDeclaredMethod("getSpColumns170Supported");
+            method.setAccessible(true);
+            return (Boolean) method.invoke(conn);
         } catch (Exception e) {
-            fail("Unable to read spColumns170Supported: " + e.getMessage());
+            fail("Unable to read sp_columns_170 support: " + e.getMessage());
             return null;
         }
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/databasemetadata/DatabaseMetaDataTest.java
@@ -2043,6 +2043,116 @@ public class DatabaseMetaDataTest extends AbstractTest {
         }
     }
 
+    /**
+     * Verifies that {@code getColumns()} probes {@code sp_columns_170} at most once per connection.
+     * <p>
+     * {@code sp_columns_170} only exists on SQL Server 2025 and later. On earlier servers the driver used to attempt
+     * the procedure on every call, producing one failed server request per table. The outcome is now cached on the
+     * connection, so the fallback to {@code sp_columns_100} is logged at most once regardless of how many times
+     * {@code getColumns()} is called.
+     * 
+     * @throws SQLException
+     *         if a database access error occurs
+     */
+    @Test
+    public void testGetColumnsProbesSpColumns170OnlyOnce() throws SQLException {
+        java.util.logging.Logger metaDataLogger = java.util.logging.Logger
+                .getLogger("com.microsoft.sqlserver.jdbc.internals.DatabaseMetaData");
+        java.util.logging.Level originalLevel = metaDataLogger.getLevel();
+        java.util.concurrent.atomic.AtomicInteger fallbackCount = new java.util.concurrent.atomic.AtomicInteger();
+
+        java.util.logging.Handler handler = new java.util.logging.Handler() {
+            @Override
+            public void publish(java.util.logging.LogRecord record) {
+                String message = record.getMessage();
+                if (null != message && message.contains("sp_columns_170 failed, falling back")) {
+                    fallbackCount.incrementAndGet();
+                }
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+
+        metaDataLogger.addHandler(handler);
+        metaDataLogger.setLevel(java.util.logging.Level.FINER);
+
+        try (Connection conn = getConnection()) {
+            SQLServerConnection sqlServerConnection = (SQLServerConnection) conn;
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+
+            int callCount = 5;
+            for (int i = 0; i < callCount; i++) {
+                try (ResultSet rs = databaseMetaData.getColumns(null, null, tableName, "%")) {
+                    assertNotNull(rs, "getColumns() should return a result set");
+                    while (rs.next()) {
+                        assertNotNull(rs.getString(COLUMN_NAME), "COLUMN_NAME should not be null");
+                    }
+                }
+            }
+
+            assertTrue(fallbackCount.get() <= 1,
+                    "sp_columns_170 should be probed at most once per connection, but the driver fell back "
+                            + fallbackCount.get() + " times across " + callCount + " getColumns() calls");
+
+            // Once the probe has run, the connection must have a decided state rather than remaining undetermined.
+            assertNotNull(getSpColumns170SupportedFlag(sqlServerConnection),
+                    "sp_columns_170 support should be cached on the connection after the first getColumns() call");
+        }  finally {
+            metaDataLogger.removeHandler(handler);
+            metaDataLogger.setLevel(originalLevel);
+        }
+    }
+
+    /**
+     * Verifies that the cached {@code sp_columns_170} state is scoped to a single connection and starts out
+     * undetermined on a brand new connection.
+     * 
+     * @throws SQLException
+     *         if a database access error occurs
+     */
+    @Test
+    public void testSpColumns170SupportIsPerConnection() throws SQLException {
+        try (Connection conn = getConnection()) {
+            SQLServerConnection sqlServerConnection = (SQLServerConnection) conn;
+
+            assertNull(getSpColumns170SupportedFlag(sqlServerConnection),
+                    "sp_columns_170 support should be undetermined before the first getColumns() call");
+
+            try (ResultSet rs = conn.getMetaData().getColumns(null, null, tableName, "%")) {
+                while (rs.next()) {
+                    // drain the result set
+                }
+            }
+
+            Boolean supported = getSpColumns170SupportedFlag(sqlServerConnection);
+            assertNotNull(supported, "sp_columns_170 support should be cached after the first getColumns() call");
+
+            // A separate connection must start from an undetermined state.
+            try (Connection otherConn = getConnection()) {
+                assertNull(getSpColumns170SupportedFlag((SQLServerConnection) otherConn),
+                        "sp_columns_170 support should not leak across connections");
+            }
+        }
+    }
+
+    /**
+     * Reads the tri-state sp_columns_170 support flag cached on the connection.
+     */
+    private static Boolean getSpColumns170SupportedFlag(SQLServerConnection conn) {
+        try {
+            Field field = SQLServerConnection.class.getDeclaredField("spColumns170Supported");
+            field.setAccessible(true);
+            return (Boolean) field.get(conn);
+        } catch (Exception e) {
+            fail("Unable to read spColumns170Supported: " + e.getMessage());
+            return null;
+        }
+    }
+
     @BeforeAll
     public static void setupTable() throws Exception {
         setConnection();

--- a/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/resiliency/BasicConnectionTest.java
@@ -7,6 +7,7 @@ package com.microsoft.sqlserver.jdbc.resiliency;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -157,6 +158,69 @@ public class BasicConnectionTest extends AbstractTest {
             assertEquals(expectedDatabaseName, actualDatabaseName);
         } finally {
             TestUtils.dropDatabaseIfExists(expectedDatabaseName, connectionString);
+        }
+    }
+
+    /**
+     * Verifies that the cached sp_columns_170 capability is discarded when idle connection resiliency establishes a
+     * new session. The reconnect may land on a different backend, so a value derived from the previous session must
+     * not be trusted afterwards, otherwise a stale FALSE would keep the driver on sp_columns_100 indefinitely.
+     */
+    @Test
+    public void testSpColumns170SupportResetOnReconnect() throws SQLException {
+        try (Connection c = ResiliencyUtils.getConnection(connectionString); Statement s = c.createStatement()) {
+            SQLServerConnection sqlServerConnection = (SQLServerConnection) c;
+
+            // Seed the state as though the session before the reconnect had reported sp_columns_170 as missing.
+            setSpColumns170Supported(sqlServerConnection, Boolean.FALSE);
+            assertEquals(Boolean.FALSE, getSpColumns170Supported(sqlServerConnection));
+
+            ResiliencyUtils.killConnection(c, connectionString, 0);
+
+            // Executing on the dead connection drives idle connection resiliency to build a new session.
+            try (ResultSet rs = s.executeQuery("SELECT 1")) {
+                assertTrue("Reconnect should have produced a usable session", rs.next());
+            }
+
+            assertNull("The cached sp_columns_170 capability should be discarded when a new session is established",
+                    getSpColumns170Supported(sqlServerConnection));
+
+            // The connection must still serve column metadata after the capability has been invalidated.
+            try (ResultSet rs = c.getMetaData().getColumns(null, null, "spColumns170NoSuchTable", null)) {
+                assertTrue("getColumns() should return a usable result set after a reconnect",
+                        rs.getMetaData().getColumnCount() >= 18);
+            }
+        }
+    }
+
+    /**
+     * Reads the tri-state sp_columns_170 capability cached on the connection. The accessor is package private on
+     * SQLServerConnection, so it is read reflectively from this test package.
+     */
+    private static Boolean getSpColumns170Supported(SQLServerConnection conn) {
+        try {
+            java.lang.reflect.Method method = SQLServerConnection.class
+                    .getDeclaredMethod("getSpColumns170Supported");
+            method.setAccessible(true);
+            return (Boolean) method.invoke(conn);
+        } catch (Exception e) {
+            fail("Unable to read sp_columns_170 support: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Seeds the tri-state sp_columns_170 capability cached on the connection. The mutator is package private on
+     * SQLServerConnection, so it is invoked reflectively from this test package.
+     */
+    private static void setSpColumns170Supported(SQLServerConnection conn, Boolean supported) {
+        try {
+            java.lang.reflect.Method method = SQLServerConnection.class
+                    .getDeclaredMethod("setSpColumns170Supported", Boolean.class);
+            method.setAccessible(true);
+            method.invoke(conn, supported);
+        } catch (Exception e) {
+            fail("Unable to seed sp_columns_170 support: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
sp_columns_170 only exists on SQL Server 2025 and later. getColumns() probed it on every call, so on older servers each call produced a failed server request before falling back to sp_columns_100. Importing a catalog of N tables therefore issued N failed requests.

Availability is a property of the server, so the outcome is now cached on SQLServerConnection as a tri-state flag (null = undetermined, TRUE = present, FALSE = absent). sp_columns_170 is probed at most once per connection and later calls on a server without it go straight to sp_columns_100.

The try/catch around the probe is kept so the driver still recovers if the procedure is unavailable unexpectedly. The flag is only cached as FALSE when the server explicitly reports error 2812 (Could not find stored procedure). Any other failure leaves the state undetermined so a transient error cannot permanently downgrade the connection to sp_columns_100 and silently drop metadata for types that only sp_columns_170 reports.

Also stop wrapping buildAzureDWResultSet() in the fallback try block on Azure DW, where a failure while building the result set incorrectly triggered a fallback, and factor the duplicated prepare/bind/execute blocks into helpers.

Fixes #3013