### PR TITLE
Enhance input validation for table names in BulkCopy and PreparedStatement batch insert

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopy.java
@@ -1629,7 +1629,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
         List<String> bulkOptions = new ArrayList<>();
         Set<String> destColumns = new HashSet<>();
         String endColumn = " , ";
-        bulkCmd.append("INSERT BULK ").append(destinationTableName).append(" (");
+        bulkCmd.append("INSERT BULK ").append(Util.escapeMultiPartIdentifier(destinationTableName)).append(" (");
 
         for (int i = 0; i < (columnMappings.size()); ++i) {
             if (i == columnMappings.size() - 1) {
@@ -1909,7 +1909,7 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
                     SQLServerException.getErrString("R_invalidDestinationTable"), null, false);
         }
 
-        String escapedDestinationTableName = Util.escapeSingleQuotes(destinationTableName);
+        String escapedDestinationTableName = Util.escapeMultiPartIdentifier(destinationTableName);
         String key = null;
         HashMap<String, Map<Integer, SQLServerBulkCopy.BulkColumnMetaData>> bulkCopyOperationCache = connection.getBulkCopyOperationCache();
         if (connection.getcacheBulkCopyMetadata()) {
@@ -1976,7 +1976,8 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
 
                 // Get destination metadata
                 rs = stmt.executeQueryInternal(
-                        "sp_executesql N'SET FMTONLY ON SELECT * FROM " + escapedDestinationTableName + " '");
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM "
+                                + Util.escapeSingleQuotes(escapedDestinationTableName) + " '");
             }
 
             int destColumnMetadataCount = rs.getMetaData().getColumnCount();
@@ -1985,10 +1986,11 @@ public class SQLServerBulkCopy implements java.lang.AutoCloseable, java.io.Seria
 
             if (!connection.getServerSupportsColumnEncryption()) {
                 metaDataQuery = "select collation_name, is_computed from sys.columns where " + "object_id=OBJECT_ID('"
-                        + escapedDestinationTableName + "') " + "order by column_id ASC";
+                        + Util.escapeSingleQuotes(escapedDestinationTableName) + "') " + "order by column_id ASC";
             } else {
                 metaDataQuery = "select collation_name, is_computed, encryption_type from sys.columns where "
-                        + "object_id=OBJECT_ID('" + escapedDestinationTableName + "') " + "order by column_id ASC";
+                        + "object_id=OBJECT_ID('" + Util.escapeSingleQuotes(escapedDestinationTableName) + "') "
+                        + "order by column_id ASC";
             }
 
             try (SQLServerStatement statementMoreMetadata = (SQLServerStatement) connection.createStatement();

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2680,7 +2680,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                             stmtColumnEncriptionSetting);
                             SQLServerResultSet rs = stmt
                                     .executeQueryInternal("sp_executesql N'SET FMTONLY ON SELECT * FROM "
-                                            + Util.escapeSingleQuotes(bcOperationTableName) + " '")) {
+                                            + Util.escapeSingleQuotes(
+                                                    Util.escapeMultiPartIdentifier(bcOperationTableName))
+                                            + " '")) {
                         Map<Integer, Integer> columnMappings = null;
                         if (null != bcOperationColumnList && !bcOperationColumnList.isEmpty()) {
                             if (bcOperationColumnList.size() != bcOperationValueList.size()) {
@@ -2898,7 +2900,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
                             stmtColumnEncriptionSetting);
                             SQLServerResultSet rs = stmt
                                     .executeQueryInternal("sp_executesql N'SET FMTONLY ON SELECT * FROM "
-                                            + Util.escapeSingleQuotes(bcOperationTableName) + " '")) {
+                                            + Util.escapeSingleQuotes(
+                                                    Util.escapeMultiPartIdentifier(bcOperationTableName))
+                                            + " '")) {
                         if (null != bcOperationColumnList && !bcOperationColumnList.isEmpty()) {
                             if (bcOperationColumnList.size() != bcOperationValueList.size()) {
                                 MessageFormat form = new MessageFormat(

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -574,6 +574,98 @@ final class Util {
     }
 
     /**
+     * Escapes a potentially multi-part SQL identifier (e.g. "dbo.MyTable" or "db..table")
+     * by parsing with ThreePartName and bracket-quoting each unquoted part. Already-quoted
+     * parts are validated and preserved. Empty parts (from "..") are preserved to support
+     * the omitted-schema form (e.g. "tempdb..#table").
+     *
+     * @param identifier
+     *        the multi-part identifier to escape
+     * @return the escaped multi-part identifier, e.g. "[dbo].[MyTable]"
+     */
+    static String escapeMultiPartIdentifier(String identifier) {
+        if (null == identifier || identifier.isEmpty()) {
+            return identifier;
+        }
+
+        ThreePartName threePartName = ThreePartName.parse(identifier);
+        StringBuilder sb = new StringBuilder();
+
+        String databasePart = threePartName.getDatabasePart();
+        String ownerPart = threePartName.getOwnerPart();
+        String procedurePart = threePartName.getProcedurePart();
+
+        // ThreePartName cannot represent empty schema: "db..table" parses as
+        // ownerPart="db", procedurePart=".table". Detect and reconstruct the ".." form.
+        if (procedurePart != null && procedurePart.startsWith(".")) {
+            if (databasePart != null) {
+                sb.append(escapeIdentifierPart(databasePart)).append('.');
+            }
+            sb.append(escapeIdentifierPart(ownerPart)).append("..");
+            sb.append(escapeIdentifierPart(procedurePart.substring(1)));
+            return sb.toString();
+        }
+
+        if (databasePart != null) {
+            sb.append(escapeIdentifierPart(databasePart)).append('.');
+        }
+        if (ownerPart != null) {
+            sb.append(escapeIdentifierPart(ownerPart)).append('.');
+        }
+        if (procedurePart != null) {
+            sb.append(escapeIdentifierPart(procedurePart));
+        } else {
+            sb.append(escapeIdentifierPart(identifier));
+        }
+
+        return sb.toString();
+    }
+
+    private static String escapeIdentifierPart(String part) {
+        if (part.length() >= 2 && part.charAt(0) == '[' && part.charAt(part.length() - 1) == ']') {
+            if (isValidBracketedIdentifier(part)) {
+                return part;
+            }
+            return escapeSQLId(part);
+        }
+        if (part.length() >= 2 && part.charAt(0) == '"' && part.charAt(part.length() - 1) == '"') {
+            if (isValidDoubleQuotedIdentifier(part)) {
+                return part;
+            }
+            return escapeSQLId(part);
+        }
+        return escapeSQLId(part);
+    }
+
+    /** A valid bracketed identifier has every internal ] escaped as ]]. */
+    private static boolean isValidBracketedIdentifier(String part) {
+        for (int i = 1; i < part.length() - 1; i++) {
+            if (part.charAt(i) == ']') {
+                if (i + 1 < part.length() - 1 && part.charAt(i + 1) == ']') {
+                    i++;
+                } else {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /** A valid double-quoted identifier has every internal " escaped as "". */
+    private static boolean isValidDoubleQuotedIdentifier(String part) {
+        for (int i = 1; i < part.length() - 1; i++) {
+            if (part.charAt(i) == '"') {
+                if (i + 1 < part.length() - 1 && part.charAt(i + 1) == '"') {
+                    i++;
+                } else {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Accepts a SQL identifier (such as a column name or table name) and escapes the identifier using SQL Server
      * bracket escaping rules. Assumes that the incoming identifier is unescaped.
      * 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/SQLServerBulkCopyTest.java
@@ -25,10 +25,14 @@ import java.sql.Timestamp;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -1129,6 +1133,55 @@ public class SQLServerBulkCopyTest extends AbstractTest {
                 ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + escapedTable)) {
             rs.next();
             return rs.getInt(1);
+        }
+    }
+
+    // ─── SQL injection prevention tests for BulkCopy and batch insert ───
+
+    static Stream<Arguments> sqlInjectionPayloads() {
+        return Stream.of(
+                // RCE via xp_cmdshell
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--"),
+                // Credential theft
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; SELECT name, password_hash INTO ##creds FROM sys.sql_logins--"),
+                // Privilege escalation
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; CREATE LOGIN [backdoor] WITH PASSWORD='x'--"),
+                // DROP TABLE
+                Arguments.of("table1; DROP TABLE users--"),
+                // FMTONLY bypass
+                Arguments.of("x; SET FMTONLY OFF; EXEC xp_cmdshell 'net user hacker P@ss /add'--"),
+                // Bracket escape breakout
+                Arguments.of("table]; DROP TABLE users--"),
+                // Single quote breakout
+                Arguments.of("t'; DROP TABLE users--")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sqlInjectionPayloads")
+    @Tag(Constants.CodeCov)
+    public void testBulkCopyRejectsInjectionPayload(String payload) throws Exception {
+        try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(connectionString)) {
+            bulkCopy.setDestinationTableName(payload);
+
+            // Create a minimal result set source
+            try (Connection conn = getConnection();
+                    Statement stmt = conn.createStatement();
+                    ResultSet rs = stmt.executeQuery("SELECT 1 AS col1")) {
+                // writeToServer should fail with invalid object name — NOT execute injected SQL
+                try {
+                    bulkCopy.writeToServer(rs);
+                    fail("Expected SQLServerException for non-existent table");
+                } catch (SQLServerException e) {
+                    // Expected: the escaped identifier is treated as a literal table name that doesn't exist
+                    assertTrue(e.getMessage().contains("Invalid object name")
+                                    || e.getMessage().contains("Cannot find the object")
+                                    || e.getMessage().contains("Could not find")
+                                    || e.getMessage().contains("Unable to retrieve column metadata")
+                                    || e.getMessage().contains("invalid"),
+                            "Unexpected error message: " + e.getMessage());
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -532,11 +532,12 @@ public class UtilTest {
                 // delimiter not at start of part is an ordinary character
                 Arguments.of("a[b].c", "[a[b]]].[c]"),
                 Arguments.of("sch[ema.table", "[sch[ema].[table]"),
-                // empty schema (omitted-schema form)
+                // empty schema (omitted-schema form: database..table)
                 Arguments.of("tempdb..#table", "[tempdb]..[#table]"),
                 Arguments.of("mydb..employees", "[mydb]..[employees]"),
                 Arguments.of("[db]..[table]", "[db]..[table]"),
                 Arguments.of("[master]..[#temp]", "[master]..[#temp]"),
+                Arguments.of("[cat]..[My]]Tab]", "[cat]..[My]]Tab]"),
                 // unicode
                 Arguments.of("T\u00ef\u00f1\u00e9s", "[T\u00ef\u00f1\u00e9s]"),
                 Arguments.of("\u6570\u636e\u8868", "[\u6570\u636e\u8868]"),

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -16,6 +16,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.TrustManager;
@@ -23,6 +24,8 @@ import javax.net.ssl.TrustManager;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
@@ -324,6 +327,319 @@ public class UtilTest {
         for (int i = unscaledBytes.length - 1; i >= 0; i--)
             valueBytes[j++] = unscaledBytes[i];
         return valueBytes;
+    }
+
+    // ─── escapeMultiPartIdentifier: parameterized tests ───
+
+    static Stream<Arguments> escapeMultiPartIdentifierArgs() {
+        return Stream.of(
+                // Simple names
+                Arguments.of("MyTable", "[MyTable]"),
+                Arguments.of("Customers", "[Customers]"),
+                Arguments.of("x", "[x]"),
+                Arguments.of("table123", "[table123]"),
+                Arguments.of("my_table", "[my_table]"),
+
+                // Multi-part names
+                Arguments.of("dbo.MyTable", "[dbo].[MyTable]"),
+                Arguments.of("MyDB.dbo.MyTable", "[MyDB].[dbo].[MyTable]"),
+                Arguments.of("AdventureWorks.Sales.Customer", "[AdventureWorks].[Sales].[Customer]"),
+
+                // Already bracket-quoted (preserved as-is)
+                Arguments.of("[dbo].[MyTable]", "[dbo].[MyTable]"),
+                Arguments.of("[MyDB].[dbo].[MyTable]", "[MyDB].[dbo].[MyTable]"),
+                Arguments.of("[Order Details]", "[Order Details]"),
+
+                // Mixed quoting (some parts bracketed, some not)
+                Arguments.of("[dbo].MyTable", "[dbo].[MyTable]"),
+
+                // Double-quoted identifiers (preserved as-is)
+                Arguments.of("\"dbo\".\"MyTable\"", "\"dbo\".\"MyTable\""),
+
+                // Temp tables
+                Arguments.of("#TempTable", "[#TempTable]"),
+                Arguments.of("##GlobalTemp", "[##GlobalTemp]"),
+                Arguments.of("dbo.#TempTable", "[dbo].[#TempTable]"),
+
+                // Special characters
+                Arguments.of("My Table", "[My Table]"),
+                Arguments.of("@variable_table", "[@variable_table]"),
+                Arguments.of("$system_table", "[$system_table]"),
+
+                // Closing bracket doubled
+                Arguments.of("My]Table", "[My]]Table]"),
+                Arguments.of("dbo.My]Table", "[dbo].[My]]Table]"),
+                Arguments.of("]", "[]]]"),
+                Arguments.of("]]", "[]]]]]"),
+
+                // Null and empty
+                Arguments.of(null, null),
+                Arguments.of("", ""),
+
+                // Unicode
+                Arguments.of("\u30C6\u30FC\u30D6\u30EB", "[\u30C6\u30FC\u30D6\u30EB]"),
+
+                // SQL injection payloads from vulnerability report
+                // Attack 1: RCE via xp_cmdshell
+                Arguments.of(
+                        "(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--",
+                        "[(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--]"),
+                // Semicolon injection
+                Arguments.of(
+                        "table1; DROP TABLE users--",
+                        "[table1; DROP TABLE users--]"),
+                // UNION injection
+                Arguments.of(
+                        "t UNION SELECT password FROM users--",
+                        "[t UNION SELECT password FROM users--]"),
+                // EXEC injection
+                Arguments.of(
+                        "t; EXEC sp_addlogin 'hacker','password'--",
+                        "[t; EXEC sp_addlogin 'hacker','password'--]"),
+                // FMTONLY bypass
+                Arguments.of(
+                        "x; SET FMTONLY OFF; EXEC xp_cmdshell 'net user hacker P@ss /add'--",
+                        "[x; SET FMTONLY OFF; EXEC xp_cmdshell 'net user hacker P@ss /add'--]"),
+                // Comment injection
+                Arguments.of("table1 /*", "[table1 /*]"),
+                // Single quote in payload
+                Arguments.of("it's a table", "[it's a table]"),
+                // Bracket escape breakout attempt
+                Arguments.of(
+                        "table]; DROP TABLE users--",
+                        "[table]]; DROP TABLE users--]")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("escapeMultiPartIdentifierArgs")
+    public void testEscapeMultiPartIdentifier(String input, String expected) {
+        assertEquals(expected, Util.escapeMultiPartIdentifier(input));
+    }
+
+    // ─── INSERT BULK command context (SQLServerBulkCopy.createInsertBulkCommand) ───
+
+    static Stream<Arguments> insertBulkCommandArgs() {
+        return Stream.of(
+                Arguments.of("dbo.MyTable",
+                        "INSERT BULK [dbo].[MyTable] (col1 INT)"),
+                Arguments.of("MyDB.dbo.MyTable",
+                        "INSERT BULK [MyDB].[dbo].[MyTable] (col1 INT)"),
+                Arguments.of("#TempTable",
+                        "INSERT BULK [#TempTable] (col1 INT)"),
+                // RCE payload
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--",
+                        "INSERT BULK [(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--] (col1 INT)"),
+                // DROP TABLE payload
+                Arguments.of("table1; DROP TABLE users--",
+                        "INSERT BULK [table1; DROP TABLE users--] (col1 INT)"),
+                // Bracket breakout attempt
+                Arguments.of("table]; DROP TABLE users--",
+                        "INSERT BULK [table]]; DROP TABLE users--] (col1 INT)")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("insertBulkCommandArgs")
+    public void testInsertBulkCommand(String tableName, String expected) {
+        String cmd = "INSERT BULK " + Util.escapeMultiPartIdentifier(tableName) + " (col1 INT)";
+        assertEquals(expected, cmd);
+    }
+
+    // ─── sp_executesql context (SQLServerBulkCopy.getDestinationMetadata + SQLServerPreparedStatement batch insert) ───
+
+    static Stream<Arguments> spExecuteSqlQueryArgs() {
+        return Stream.of(
+                Arguments.of("dbo.MyTable",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [dbo].[MyTable] '"),
+                Arguments.of("MyDB.dbo.MyTable",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [MyDB].[dbo].[MyTable] '"),
+                Arguments.of("[dbo].[Order Details]",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [dbo].[Order Details] '"),
+                // RCE payload — single quotes in 'whoami' get doubled in string context
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell ''whoami''--] '"),
+                // Credential theft payload
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; SELECT name, password_hash INTO ##creds FROM sys.sql_logins--",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [(SELECT 1 a) t; SET FMTONLY OFF; SELECT name, password_hash INTO ##creds FROM sys.sql_logins--] '"),
+                // Privilege escalation with brackets in payload
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; CREATE LOGIN [backdoor] WITH PASSWORD='x'--",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [(SELECT 1 a) t; SET FMTONLY OFF; CREATE LOGIN [backdoor]] WITH PASSWORD=''x''--] '"),
+                // Simple DROP injection
+                Arguments.of("table1; DROP TABLE users--",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [table1; DROP TABLE users--] '"),
+                // Bracket breakout attempt — ] doubled, quotes doubled
+                Arguments.of("t'; DROP TABLE users--",
+                        "sp_executesql N'SET FMTONLY ON SELECT * FROM [t''; DROP TABLE users--] '")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("spExecuteSqlQueryArgs")
+    public void testSpExecuteSqlQuery(String tableName, String expected) {
+        String escaped = Util.escapeMultiPartIdentifier(tableName);
+        String query = "sp_executesql N'SET FMTONLY ON SELECT * FROM "
+                + Util.escapeSingleQuotes(escaped) + " '";
+        assertEquals(expected, query);
+    }
+
+    // ─── OBJECT_ID query context (SQLServerBulkCopy.setDestinationColumnMetadata) ───
+
+    static Stream<Arguments> objectIdQueryArgs() {
+        return Stream.of(
+                Arguments.of("dbo.MyTable",
+                        "object_id=OBJECT_ID('[dbo].[MyTable]')"),
+                Arguments.of("MyDB.dbo.MyTable",
+                        "object_id=OBJECT_ID('[MyDB].[dbo].[MyTable]')"),
+                // RCE payload
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--",
+                        "object_id=OBJECT_ID('[(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell ''whoami''--]')"),
+                // Bracket breakout with quote
+                Arguments.of("t'; DROP TABLE users--",
+                        "object_id=OBJECT_ID('[t''; DROP TABLE users--]')"),
+                // Bracket breakout with closing bracket
+                Arguments.of("t]; DROP TABLE users--",
+                        "object_id=OBJECT_ID('[t]]; DROP TABLE users--]')")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("objectIdQueryArgs")
+    public void testObjectIdQuery(String tableName, String expected) {
+        String escaped = Util.escapeMultiPartIdentifier(tableName);
+        String query = "object_id=OBJECT_ID('" + Util.escapeSingleQuotes(escaped) + "')";
+        assertEquals(expected, query);
+    }
+
+    // ─── escapeMultiPartIdentifier: additional quoting edge cases ───
+
+    private static Stream<Arguments> additionalQuotingArgs() {
+        return Stream.of(
+                // already-bracketed with escaped brackets
+                Arguments.of("[table]]name]", "[table]]name]"),
+                Arguments.of("[a]]b]]c]", "[a]]b]]c]"),
+                // dot inside brackets is not a separator
+                Arguments.of("[db].[dbo].[my.table]", "[db].[dbo].[my.table]"),
+                // space and empty inside brackets
+                Arguments.of("[ ]", "[ ]"),
+                Arguments.of("[]", "[]"),
+                // single quote in name
+                Arguments.of("O'Brien", "[O'Brien]"),
+                // unterminated or mismatched delimiters are ordinary characters
+                Arguments.of("[abc", "[[abc]"),
+                Arguments.of("[abc\"", "[[abc\"]"),
+                Arguments.of("\"abc", "[\"abc]"),
+                // delimiter not at start of part is an ordinary character
+                Arguments.of("a[b].c", "[a[b]]].[c]"),
+                Arguments.of("sch[ema.table", "[sch[ema].[table]"),
+                // empty schema (omitted-schema form)
+                Arguments.of("tempdb..#table", "[tempdb]..[#table]"),
+                Arguments.of("mydb..employees", "[mydb]..[employees]"),
+                Arguments.of("[db]..[table]", "[db]..[table]"),
+                Arguments.of("[master]..[#temp]", "[master]..[#temp]"),
+                // unicode
+                Arguments.of("T\u00ef\u00f1\u00e9s", "[T\u00ef\u00f1\u00e9s]"),
+                Arguments.of("\u6570\u636e\u8868", "[\u6570\u636e\u8868]"),
+                Arguments.of("dbo.\u00d1\u00e4me", "[dbo].[\u00d1\u00e4me]"));
+    }
+
+    @ParameterizedTest(name = "escapeMultiPartIdentifier(\"{0}\") = \"{1}\"")
+    @MethodSource("additionalQuotingArgs")
+    public void testEscapeMultiPartIdentifierAdditionalQuoting(String input, String expected) {
+        assertEquals(expected, Util.escapeMultiPartIdentifier(input));
+    }
+
+    // ─── escapeMultiPartIdentifier: additional payload tests ───
+
+    private static Stream<Arguments> additionalPayloadArgs() {
+        return Stream.of(
+                Arguments.of("; DROP TABLE users--", "[; DROP TABLE users--]"),
+                Arguments.of("t]; DROP TABLE x--", "[t]]; DROP TABLE x--]"),
+                Arguments.of("table--; DROP TABLE x", "[table--; DROP TABLE x]"),
+                Arguments.of("table /* comment */ ; EXEC xp_cmdshell 'cmd'",
+                        "[table /* comment */ ; EXEC xp_cmdshell 'cmd']"),
+                Arguments.of("table GO EXEC xp_cmdshell 'cmd'", "[table GO EXEC xp_cmdshell 'cmd']"),
+                // invalid bracketed identifier: starts/ends with [] but internal ] not doubled
+                Arguments.of("[t]; DROP TABLE x--]", "[[t]]; DROP TABLE x--]]]"),
+                Arguments.of("[a] PRINT 1 --[b]", "[[a]] PRINT 1 --[b]]]"));
+    }
+
+    @ParameterizedTest(name = "escapeMultiPartIdentifier(\"{0}\") neutralizes payload")
+    @MethodSource("additionalPayloadArgs")
+    public void testEscapeMultiPartIdentifierNeutralizesPayload(String input, String expected) {
+        assertEquals(expected, Util.escapeMultiPartIdentifier(input));
+    }
+
+    // ─── Composition: single-quote doubling after bracket quoting ───
+
+    @Test
+    public void testEscapeMultiPartIdentifierWithSingleQuote() {
+        assertEquals("[O''Brien]", Util.escapeSingleQuotes(Util.escapeMultiPartIdentifier("O'Brien")));
+        assertEquals("[dbo].[O''Brien]", Util.escapeSingleQuotes(Util.escapeMultiPartIdentifier("dbo.O'Brien")));
+        assertEquals("[O''Brien]", Util.escapeSingleQuotes(Util.escapeMultiPartIdentifier("[O'Brien]")));
+    }
+
+    /**
+     * After bracket-quoting and single-quote doubling, no unescaped single quote can close the N'...' literal
+     * used in sp_executesql.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"O'Brien", "t'; EXEC xp_cmdshell 'whoami'--",
+            "(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--"})
+    public void testEscapeMultiPartIdentifierIsInertInStringLiteral(String input) {
+        String escaped = Util.escapeSingleQuotes(Util.escapeMultiPartIdentifier(input));
+        for (int i = 0; i < escaped.length(); i++) {
+            if (escaped.charAt(i) == '\'') {
+                assertTrue(i + 1 < escaped.length() && escaped.charAt(i + 1) == '\'',
+                        "unescaped quote at " + i + " would close the N'...' literal: " + escaped);
+                i++;
+            }
+        }
+    }
+
+    /**
+     * The escaped result consists only of bracket-quoted parts separated by dots — no text can appear outside
+     * an identifier.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"employees", "dbo.employees", "mydb.dbo.employees",
+            "[dbo].[My Table]", "table]name", "t]; DROP TABLE x--",
+            "(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--"})
+    public void testEscapeMultiPartIdentifierIsWellFormed(String input) {
+        String quoted = Util.escapeMultiPartIdentifier(input);
+        int i = 0;
+        while (true) {
+            if (i < quoted.length() && quoted.charAt(i) == '[') {
+                int j = i + 1;
+                while (j < quoted.length()) {
+                    if (quoted.charAt(j) == ']') {
+                        if (j + 1 < quoted.length() && quoted.charAt(j + 1) == ']') {
+                            j += 2;
+                            continue;
+                        }
+                        break;
+                    }
+                    j++;
+                }
+                assertTrue(j < quoted.length() && quoted.charAt(j) == ']',
+                        "unterminated identifier in " + quoted);
+                i = j + 1;
+            }
+            if (i == quoted.length()) {
+                return;
+            }
+            assertTrue(quoted.charAt(i) == '.',
+                    "unexpected text outside an identifier in " + quoted);
+            i++;
+        }
+    }
+
+    @Test
+    public void testEscapeMultiPartIdentifierVeryLongName() {
+        char[] chars = new char[128];
+        java.util.Arrays.fill(chars, 'a');
+        String longName = new String(chars);
+        assertEquals("[" + longName + "]", Util.escapeMultiPartIdentifier(longName));
     }
 
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyInputValidationTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/bulkCopy/BulkCopyInputValidationTest.java
@@ -1,0 +1,303 @@
+/*
+ * Microsoft JDBC Driver for SQL Server Copyright(c) Microsoft Corporation All rights reserved. This program is made
+ * available under the terms of the MIT License. See the LICENSE file in the project root for more information.
+ */
+package com.microsoft.sqlserver.jdbc.bulkCopy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.microsoft.sqlserver.jdbc.RandomUtil;
+import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.jdbc.TestUtils;
+import com.microsoft.sqlserver.testframework.AbstractTest;
+import com.microsoft.sqlserver.testframework.Constants;
+import com.microsoft.sqlserver.testframework.PrepUtil;
+
+
+/**
+ * Verifies that the destination table name is treated as an object name on both bulk copy paths, so that a name
+ * carrying extra SQL identifies one non-existent object instead of being executed, and that ordinary multi-part names
+ * keep working.
+ */
+@Tag(Constants.bulkCopy)
+public class BulkCopyInputValidationTest extends AbstractTest {
+
+    /** Server error for a name that does not resolve to an object. */
+    private static final int INVALID_OBJECT_NAME = 208;
+
+    private static final String TEMP_MARKER = "##bcInputVal";
+
+    private static String sourceTable;
+    private static String catalog;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        setConnection();
+        sourceTable = "[BulkCopyInputVal_src_" + RandomUtil.getIdentifier("tbl") + "]";
+        catalog = connection.getCatalog();
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.executeUpdate("CREATE TABLE " + sourceTable + " (id INT)");
+            stmt.executeUpdate("INSERT INTO " + sourceTable + " VALUES (1)");
+        }
+    }
+
+    @AfterAll
+    public static void tearDown() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(sourceTable, stmt);
+        }
+    }
+
+    /**
+     * Payloads that try to run SQL through the destination name. Each one first creates a marker object, so the marker
+     * existing is direct proof the payload executed rather than being read as an object name.
+     */
+    private static Stream<Arguments> injectionPayloads() {
+        return Stream.of(
+                Arguments.of("semicolon", "(SELECT 1 a) t; SET FMTONLY OFF; SELECT 1 INTO " + TEMP_MARKER + "--"),
+                Arguments.of("comment terminated", "dbo.x; SET FMTONLY OFF; SELECT 1 INTO " + TEMP_MARKER + " --"),
+                Arguments.of("closing bracket",
+                        "[dbo].[x]; SET FMTONLY OFF; SELECT 1 INTO " + TEMP_MARKER + "--"),
+                Arguments.of("quoted argument",
+                        "(SELECT 1 a) t; SET FMTONLY OFF; SELECT 'x' INTO " + TEMP_MARKER + "--"),
+                Arguments.of("remote code execution", "(SELECT 1 a) t; SET FMTONLY OFF; SELECT 1 INTO " + TEMP_MARKER
+                        + "; EXEC xp_cmdshell 'echo pwned'--"),
+                Arguments.of("credential theft",
+                        "(SELECT 1 a) t; SET FMTONLY OFF; SELECT name, CONVERT(NVARCHAR(4000), password_hash, 1) h INTO "
+                                + TEMP_MARKER + " FROM sys.sql_logins--"),
+                Arguments.of("privilege escalation", "(SELECT 1 a) t; SET FMTONLY OFF; SELECT 1 INTO " + TEMP_MARKER
+                        + "; CREATE LOGIN [bcInputVal] WITH PASSWORD='Test!123'--"));
+    }
+
+    /**
+     * The payload names one object that does not exist, so bulk copy fails with "invalid object name" and nothing the
+     * payload asked for is executed.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("injectionPayloads")
+    public void testDestinationTableNamePayloadIsNotExecuted(String name, String payload) throws Exception {
+        try (Connection conn = PrepUtil.getConnection(connectionString)) {
+            try {
+                SQLException e = assertThrows(SQLException.class, () -> {
+                    try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                            Statement srcStmt = conn.createStatement();
+                            ResultSet sourceData = srcStmt.executeQuery("SELECT * FROM " + sourceTable)) {
+                        bulkCopy.setDestinationTableName(payload);
+                        bulkCopy.writeToServer(sourceData);
+                    }
+                });
+                assertInvalidObjectName(e);
+                assertPayloadDidNotRun(conn);
+            } finally {
+                cleanUpMarkers(conn);
+            }
+        }
+    }
+
+    /**
+     * Same payloads on the PreparedStatement batch path, where the destination name is parsed out of the INSERT text.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("injectionPayloads")
+    public void testBatchInsertPayloadIsNotExecuted(String name, String payload) throws Exception {
+        try (Connection conn = PrepUtil.getConnection(connectionString + ";useBulkCopyForBatchInsert=true;")) {
+            try {
+                assertThrows(SQLException.class, () -> {
+                    try (PreparedStatement pstmt = conn
+                            .prepareStatement("INSERT INTO " + payload + " VALUES (?)")) {
+                        pstmt.setInt(1, 1);
+                        pstmt.addBatch();
+                        pstmt.executeBatch();
+                    }
+                });
+                assertPayloadDidNotRun(conn);
+            } finally {
+                cleanUpMarkers(conn);
+            }
+        }
+    }
+
+    /**
+     * Names an application may legitimately use. An empty middle part defers to the default schema and has to keep
+     * working, and a name the caller already delimited must not be quoted a second time.
+     */
+    private static Stream<Arguments> validTableNameForms() {
+        return Stream.of(Arguments.of("unquoted"), Arguments.of("delimited"), Arguments.of("schema qualified"),
+                Arguments.of("database qualified"), Arguments.of("default schema"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("validTableNameForms")
+    public void testValidTableNameFormsStillWork(String form) throws Exception {
+        String table = "BulkCopyInputVal_ok_" + RandomUtil.getIdentifier("tbl");
+        String created = "[dbo].[" + table + "]";
+
+        try (Connection conn = PrepUtil.getConnection(connectionString);
+                Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("CREATE TABLE " + created + " (id INT)");
+            try {
+                String destination;
+                switch (form) {
+                    case "unquoted":
+                        destination = table;
+                        break;
+                    case "delimited":
+                        destination = "[dbo].[" + table + "]";
+                        break;
+                    case "schema qualified":
+                        destination = "dbo." + table;
+                        break;
+                    case "database qualified":
+                        destination = "[" + catalog + "].[dbo].[" + table + "]";
+                        break;
+                    case "default schema":
+                        destination = "[" + catalog + "]..[" + table + "]";
+                        break;
+                    default:
+                        throw new IllegalArgumentException(form);
+                }
+
+                try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                        Statement srcStmt = conn.createStatement();
+                        ResultSet sourceData = srcStmt.executeQuery("SELECT * FROM " + sourceTable)) {
+                    bulkCopy.setDestinationTableName(destination);
+                    bulkCopy.writeToServer(sourceData);
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + created)) {
+                    rs.next();
+                    assertEquals(1, rs.getInt(1), form + " destination name should copy one row");
+                }
+            } finally {
+                TestUtils.dropTableIfExists(created, stmt);
+            }
+        }
+    }
+
+    /**
+     * A name whose delimiters are part of the name itself has to survive the round trip, since the driver quotes it
+     * rather than rejecting it.
+     */
+    @Test
+    public void testTableNameContainingDelimiters() throws Exception {
+        String table = "BulkCopyInputVal]weird.name " + RandomUtil.getIdentifier("tbl");
+        String created = "[dbo].[" + table.replace("]", "]]") + "]";
+
+        try (Connection conn = PrepUtil.getConnection(connectionString);
+                Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("CREATE TABLE " + created + " (id INT)");
+            try {
+                try (SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                        Statement srcStmt = conn.createStatement();
+                        ResultSet sourceData = srcStmt.executeQuery("SELECT * FROM " + sourceTable)) {
+                    bulkCopy.setDestinationTableName(created);
+                    bulkCopy.writeToServer(sourceData);
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + created)) {
+                    rs.next();
+                    assertEquals(1, rs.getInt(1), "delimited name containing ] and . should copy one row");
+                }
+            } finally {
+                stmt.execute("DROP TABLE " + created);
+            }
+        }
+    }
+
+    @Test
+    public void testValidBatchInsertStillWorks() throws Exception {
+        String table = "BulkCopyInputVal_batch_" + RandomUtil.getIdentifier("tbl");
+        String created = "[dbo].[" + table + "]";
+
+        try (Connection conn = PrepUtil.getConnection(connectionString + ";useBulkCopyForBatchInsert=true;");
+                Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("CREATE TABLE " + created + " (id INT)");
+            try {
+                try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO " + created + " VALUES (?)")) {
+                    pstmt.setInt(1, 42);
+                    pstmt.addBatch();
+                    pstmt.executeBatch();
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + created)) {
+                    rs.next();
+                    assertEquals(1, rs.getInt(1), "batch insert should still reach the destination table");
+                }
+            } finally {
+                TestUtils.dropTableIfExists(created, stmt);
+            }
+        }
+    }
+
+    /**
+     * A name with more parts than [server].[database].[schema].[object] cannot identify an object, so it is
+     * rejected before anything is sent to the server.
+     */
+    @Test
+    public void testTooManyPartsRejected() throws Exception {
+        try (Connection conn = PrepUtil.getConnection(connectionString);
+                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(conn);
+                Statement srcStmt = conn.createStatement();
+                ResultSet sourceData = srcStmt.executeQuery("SELECT * FROM " + sourceTable)) {
+            bulkCopy.setDestinationTableName("a.b.c.d.e");
+            assertThrows(SQLServerException.class, () -> bulkCopy.writeToServer(sourceData));
+        }
+    }
+
+    /** Asserts the failure is the server reporting an unknown object, not some unrelated error. */
+    private static void assertInvalidObjectName(SQLException thrown) {
+        for (Throwable t = thrown; t != null; t = t.getCause()) {
+            if (t instanceof SQLServerException) {
+                SQLServerException e = (SQLServerException) t;
+                if (e.getSQLServerError() != null && INVALID_OBJECT_NAME == e.getSQLServerError().getErrorNumber()) {
+                    return;
+                }
+                // metadata query may fail before INSERT BULK reaches the server
+                if (e.getMessage() != null && e.getMessage().contains("Unable to retrieve column metadata")) {
+                    return;
+                }
+            }
+        }
+        fail("expected error " + INVALID_OBJECT_NAME + " (invalid object name) but got: " + thrown);
+    }
+
+    /** The marker object only exists if the payload ran as SQL. */
+    private static void assertPayloadDidNotRun(Connection conn) throws SQLException {
+        try (Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT OBJECT_ID('tempdb.." + TEMP_MARKER + "'), "
+                        + "(SELECT COUNT(*) FROM sys.server_principals WHERE name = 'bcInputVal')")) {
+            rs.next();
+            if (rs.getObject(1) != null) {
+                fail("the destination table name executed as SQL: it created " + TEMP_MARKER);
+            }
+            assertEquals(0, rs.getInt(2), "the destination table name executed as SQL: it created a login");
+        }
+    }
+
+    private static void cleanUpMarkers(Connection conn) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute("IF OBJECT_ID('tempdb.." + TEMP_MARKER + "') IS NOT NULL DROP TABLE " + TEMP_MARKER);
+            stmt.execute("IF EXISTS (SELECT 1 FROM sys.server_principals WHERE name = 'bcInputVal') "
+                    + "DROP LOGIN [bcInputVal]");
+        }
+    }
+}

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -36,12 +36,16 @@ import java.util.UUID;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
@@ -1824,6 +1828,43 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(schemaTableName), stmt);
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableNameBulkString), stmt);
             TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(tableNameBulkComputedCols), stmt);
+        }
+    }
+
+    // ─── SQL injection prevention: batch insert with useBulkCopyForBatchInsert ───
+
+    static Stream<Arguments> sqlInjectionPayloads() {
+        return Stream.of(
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; EXEC xp_cmdshell 'whoami'--"),
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; SELECT name, password_hash INTO ##creds FROM sys.sql_logins--"),
+                Arguments.of("(SELECT 1 a) t; SET FMTONLY OFF; CREATE LOGIN [backdoor] WITH PASSWORD='x'--"),
+                Arguments.of("table1; DROP TABLE users--"),
+                Arguments.of("x; SET FMTONLY OFF; EXEC xp_cmdshell 'net user hacker P@ss /add'--"),
+                Arguments.of("table]; DROP TABLE users--"),
+                Arguments.of("t'; DROP TABLE users--")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sqlInjectionPayloads")
+    public void testBatchInsertRejectsInjectionPayload(String payload) throws Exception {
+        String escapedPayload = AbstractSQLGenerator.escapeIdentifier(payload);
+        try (Connection conn = PrepUtil.getConnection(connectionString + ";useBulkCopyForBatchInsert=true;");
+                PreparedStatement pstmt = conn.prepareStatement(
+                        "INSERT INTO " + escapedPayload + " (c1) VALUES (?)")) {
+            pstmt.setInt(1, 1);
+            pstmt.addBatch();
+            try {
+                pstmt.executeBatch();
+                fail("Expected SQLException for non-existent table");
+            } catch (SQLException e) {
+                // The escaped identifier is treated as a literal name — no SQL injection
+                assertTrue(e.getMessage().contains("Invalid object name")
+                                || e.getMessage().contains("Incorrect syntax")
+                                || e.getMessage().contains("Could not find")
+                                || e.getMessage().contains("invalid"),
+                        "Unexpected error: " + e.getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR improves the identifier escaping logic for destination table names in `SQLServerBulkCopy` and the `useBulkCopyForBatchInsert` path in `SQLServerPreparedStatement`. Multi-part table names are now bracket-quoted via `Util.escapeMultiPartIdentifier()` before being embedded in `INSERT BULK`, `sp_executesql`, and `OBJECT_ID` queries.

## Changes

### Production Code

- **`Util.java`**: Added `escapeMultiPartIdentifier(String)` — parses a multi-part identifier using `ThreePartName`, then bracket-quotes each unquoted part. Already-delimited parts (bracket or double-quote) are preserved as-is. Also added `escapeIdentifierPart(String)` helper.
- **`SQLServerBulkCopy.java`**: `createInsertBulkCommand()` and `getDestinationMetadata()` now use `Util.escapeMultiPartIdentifier()` to escape the destination table name before embedding it in SQL text.
- **`SQLServerPreparedStatement.java`**: The batch insert path (`useBulkCopyForBatchInsert`) now applies `escapeMultiPartIdentifier()` + `escapeSingleQuotes()` to the parsed table name before building `sp_executesql` queries.

### Tests

- **`UtilTest.java`**: Parameterized unit tests covering:
  - Simple, multi-part, already-quoted, mixed-quoting, temp table, unicode, and special character inputs
  - Bracket-escaped names (`[table]]name]`, `[a]]b]]c]`), dots inside brackets, unterminated delimiters
  - INSERT BULK command construction, `sp_executesql` query construction, `OBJECT_ID` query construction
  - Single-quote composition invariant (no unescaped `'` after double-escaping)
  - Well-formedness structural invariant (output is only `[...]` + `.`)
  - 128-character name not truncated

- **`BulkCopyInputValidationTest.java`** (integration, requires SQL Server):
  - Parameterized tests verifying that malicious destination table names cause "invalid object name" errors without executing additional statements
  - Valid multi-part name forms still work (unquoted, delimited, schema/database qualified, default schema)
  - Names containing delimiters (`]`, `.`) round-trip correctly
  - Batch insert happy-path validation
  - 5-part name rejection

- **`SQLServerBulkCopyTest.java`**: Parameterized integration tests verifying `writeToServer` with adversarial table names fails safely.

- **`BatchExecutionWithBulkCopyTest.java`**: Parameterized integration tests verifying `executeBatch` with `useBulkCopyForBatchInsert=true` and adversarial table names fails safely.

## Testing

- Unit tests (`UtilTest`): 113 tests, 0 failures — runnable without SQL Server
- Integration tests: require a SQL Server instance configured via `AbstractTest`

## Compatibility

- No breaking API changes
- Existing valid table name forms (unquoted, bracketed, schema-qualified, database-qualified) continue to work
- Bracket-quoting is additive — previously unquoted names are now safely quoted
