### PR TITLE
Bump BouncyCastle to 1.84 and pin azure-core-http-netty to 1.16.6 to address component governance CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ dependencies {
 			'org.osgi:org.osgi.service.jdbc:1.1.0'
 	compileOnly 'com.azure:azure-security-keyvault-keys:4.11.1',
 			'com.azure:azure-identity:1.18.4',
+			'com.azure:azure-core-http-netty:1.16.6',
 			'org.antlr:antlr4-runtime:4.9.1',
 			'com.google.code.gson:gson:2.11.0',
 			'org.bouncycastle:bcprov-jdk18on:1.84',
@@ -159,6 +160,7 @@ dependencies {
 			'org.bouncycastle:bcprov-jdk18on:1.84',
 			'com.azure:azure-security-keyvault-keys:4.11.1',
 			'com.azure:azure-identity:1.18.4',
+			'com.azure:azure-core-http-netty:1.16.6',
 			'com.h2database:h2:2.2.220'
 
 	// Mockito and Byte Buddy dependencies based on JRE version

--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,8 @@ dependencies {
 			'com.azure:azure-identity:1.18.4',
 			'org.antlr:antlr4-runtime:4.9.1',
 			'com.google.code.gson:gson:2.11.0',
-			'org.bouncycastle:bcprov-jdk18on:1.79',
-			'org.bouncycastle:bcpkix-jdk18on:1.79'
+			'org.bouncycastle:bcprov-jdk18on:1.84',
+			'org.bouncycastle:bcpkix-jdk18on:1.84'
     testImplementation 'org.junit.platform:junit-platform-console:1.11.4',
 			'org.junit.platform:junit-platform-commons:1.11.4',
 			'org.junit.platform:junit-platform-engine:1.11.4',
@@ -156,7 +156,7 @@ dependencies {
 			'org.antlr:antlr4-runtime:4.9.3',
 			'org.eclipse.gemini.blueprint:gemini-blueprint-mock:3.0.0.M01',
 			'com.google.code.gson:gson:2.11.0',
-			'org.bouncycastle:bcprov-jdk18on:1.79',
+			'org.bouncycastle:bcprov-jdk18on:1.84',
 			'com.azure:azure-security-keyvault-keys:4.11.1',
 			'com.azure:azure-identity:1.18.4',
 			'com.h2database:h2:2.2.220'

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
 		<osgi.jdbc.version>1.1.0</osgi.jdbc.version>
 		<antlr-runtime.version>4.9.3</antlr-runtime.version>
 		<com.google.code.gson.version>2.11.0</com.google.code.gson.version>
-		<bcprov-jdk18on.version>1.79</bcprov-jdk18on.version>
-		<bcpkix-jdk18on.version>1.79</bcpkix-jdk18on.version>
+		<bcprov-jdk18on.version>1.84</bcprov-jdk18on.version>
+		<bcpkix-jdk18on.version>1.84</bcpkix-jdk18on.version>
 		<!-- JUnit Test Dependencies -->
 		<junit.platform.version>[1.3.2, 1.11.4]</junit.platform.version>
 		<junit.jupiter.version>5.11.4</junit.jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 		<org.osgi.core.version>6.0.0</org.osgi.core.version>
 		<azure-security-keyvault-keys.version>4.11.1</azure-security-keyvault-keys.version>
 		<azure-identity.version>1.18.4</azure-identity.version>
+		<azure-core-http-netty.version>1.16.6</azure-core-http-netty.version>
 		<osgi.jdbc.version>1.1.0</osgi.jdbc.version>
 		<antlr-runtime.version>4.9.3</antlr-runtime.version>
 		<com.google.code.gson.version>2.11.0</com.google.code.gson.version>
@@ -96,6 +97,14 @@
 					<artifactId>stax-api</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<!-- Pin azure-core-http-netty (transitive via azure-identity/azure-security-keyvault-keys)
+			to pull in patched Netty 4.1.137.Final and address Component Governance CVEs. -->
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-core-http-netty</artifactId>
+			<version>${azure-core-http-netty.version}</version>
+			<optional>true</optional>
 		</dependency>
 		<!-- dependencies for ANTLR -->
 		<dependency>


### PR DESCRIPTION
## Description

Addresses open security alerts from the Weekly Component Governance Report for `mssql-jdbc` by upgrading vulnerable dependencies:

1. **BouncyCastle** (direct, optional) 1.79 → 1.84.
2. **azure-core-http-netty** pinned to 1.16.6, which brings patched **Netty  4.1.137.Final** in place of the transitively-resolved 4.1.135.Final.

Investigation of the resolved dependency tree (`mvn dependency:tree`) showed the Netty jars are pulled in transitively via `azure-identity` /`azure-security-keyvault-keys` → `azure-core-http-netty:1.16.5`. The latest released Azure SDK versions still hard-pin http-netty 1.16.5, so a direct managed (optional) dependency on 1.16.6 is used to force the patched Netty line without disturbing the rest of the Azure SDK. This override can be removed once a future Azure SDK release references 1.16.6.

## Changes

- `pom.xml`:
  - `bcprov-jdk18on.version` / `bcpkix-jdk18on.version` → `1.84`
  - New `azure-core-http-netty.version` = `1.16.6` and matching optional dependency
- `build.gradle`:
  - BouncyCastle → `1.84` (both `compileOnly` and `testImplementation`)
  - `com.azure:azure-core-http-netty:1.16.6` added
- Transitive `bcutil-jdk18on` resolves to `1.84`; all `netty-*` artifacts resolve to `4.1.137.Final`.

## CVEs Resolved

| CVE | Component | Severity |
|-----|-----------|----------|
| CVE-2025-14813 | bcprov-jdk18on | Critical |
| CVE-2026-5588  | bcpkix-jdk18on | Medium |
| CVE-2026-0636  | bcprov-jdk18on | Medium |
| CVE-2026-56745 | netty-codec-http | High |
| CVE-2026-59899 | netty-codec-http | Medium |
| CVE-2026-59921 | netty-codec-http | Medium |
| CVE-2026-56746 | netty-codec-http | Medium |
| CVE-2026-56819 | netty-codec-http2 | High |
| CVE-2026-73508 | netty-codec-dns | Medium |

CVE validation confirms BouncyCastle 1.84 and Netty 4.1.137.Final carry no known CVEs.

## Testing

- `mvn dependency:tree` confirms BouncyCastle → 1.84 and all `netty-*` → 4.1.137.Final.
- No API or behavior changes; all bumped dependencies are optional/compile-only.