### PR TITLE
Add Java SE API link to Javadoc configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -751,6 +751,9 @@
 				<configuration>
 					<failOnError>true</failOnError>
 					<excludePackageNames>mssql.*</excludePackageNames>
+					<links>
+						<link>https://docs.oracle.com/javase/8/docs/api/</link>
+					</links>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
## Summary

- Add the Java SE 8 API documentation as an external link in the Maven Javadoc configuration.
- Allow documentation tooling to resolve external Java types and render the appropriate deprecation labels.

Fixes #3024

## Testing

- Confirmed the link appears in the effective POM for the `jre8` and `jre11` profiles.
- Ran `mvn -Pjre8 -DskipTests javadoc:javadoc` successfully with JDK 11.
- Verified the generated Javadocs link Java SE types to the configured Oracle documentation.

## Breaking changes / migration notes

None.