### PR TITLE
Make setObject scaleOrLength an advisory hint instead of an enforced limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
   - **What was added**: New parameter length hints that can be supplied through `defineParameterType` and `setObject` to inform the driver of expected parameter sizes.
   - **Who benefits**: Applications executing parameterized `varchar`/`nvarchar` statements against the server, particularly under high concurrency or large result sets.
   - **Impact**: Improves performance by reducing server-side memory grants. Without a length hint the driver defaults string parameters to the maximum declared size (4000 for `nvarchar`, 8000 for `varchar`), which inflates the query's memory grant; specifying a sensible length via the new APIs lets the server size the grant to the actual data, reducing memory pressure and improving throughput. Default behavior is unchanged when no length is specified.
-  - **Note**: The `defineParameterType` length is an explicit declaration and is enforced — a value longer than the declared `maxLength` raises an error. The `setObject(..., scaleOrLength)` length is advisory only: if the value does not fit, the driver widens the declared parameter length to the actual value length rather than failing or truncating, so existing `setObject` callers are unaffected.
-  - **Note**: Length validation measures the value in the same units the server uses for the declared type — bytes for `varchar`/`char`, characters for `nvarchar`/`nchar`, and bytes for `binary`/`varbinary`. Previously a `varchar` length was compared against the Java character count, so with `sendStringParametersAsUnicode=false` a multi-byte value could pass validation and then be silently truncated by the server. Such a value is now correctly rejected.
 
 - **Add Nanosecond Granularity Option to PerformanceLogCallback** [#2944](https://github.com/microsoft/mssql-jdbc/pull/2944)
   - **What was added**: An option to report timing in the `PerformanceLogCallback` with nanosecond granularity.
@@ -44,6 +42,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
   - **What was added**: Enabled vector(float16) tests to run on Azure SQL Database.
   - **Who benefits**: Contributors and CI validation pipelines.
   - **Impact**: Extends test coverage for vector(float16) scenarios on AzureDB.
+
+### Behavior Changes
+
+- **setObject parameter-length validation now throws instead of truncating silently** [#2960](https://github.com/microsoft/mssql-jdbc/pull/2960)
+  - **What changed**: The `setObject` overload that accepts a parameter length now validates the specified length against the actual parameter length.
+  - **Impact**: If the value exceeds the specified length, the driver now throws an exception instead of silently truncating data.
+  - **Action required**: Applications that relied on implicit truncation must provide a parameter length that is large enough for the actual value.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
   - **What was added**: New parameter length hints that can be supplied through `defineParameterType` and `setObject` to inform the driver of expected parameter sizes.
   - **Who benefits**: Applications executing parameterized `varchar`/`nvarchar` statements against the server, particularly under high concurrency or large result sets.
   - **Impact**: Improves performance by reducing server-side memory grants. Without a length hint the driver defaults string parameters to the maximum declared size (4000 for `nvarchar`, 8000 for `varchar`), which inflates the query's memory grant; specifying a sensible length via the new APIs lets the server size the grant to the actual data, reducing memory pressure and improving throughput. Default behavior is unchanged when no length is specified.
+  - **Note**: The `defineParameterType` length is an explicit declaration and is enforced — a value longer than the declared `maxLength` raises an error. The `setObject(..., scaleOrLength)` length is advisory only: if the value does not fit, the driver widens the declared parameter length to the actual value length rather than failing or truncating, so existing `setObject` callers are unaffected.
+  - **Note**: Length validation measures the value in the same units the server uses for the declared type — bytes for `varchar`/`char`, characters for `nvarchar`/`nchar`, and bytes for `binary`/`varbinary`. Previously a `varchar` length was compared against the Java character count, so with `sendStringParametersAsUnicode=false` a multi-byte value could pass validation and then be silently truncated by the server. Such a value is now correctly rejected.
 
 - **Add Nanosecond Granularity Option to PerformanceLogCallback** [#2944](https://github.com/microsoft/mssql-jdbc/pull/2944)
   - **What was added**: An option to report timing in the `PerformanceLogCallback` with nanosecond granularity.
@@ -42,13 +44,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
   - **What was added**: Enabled vector(float16) tests to run on Azure SQL Database.
   - **Who benefits**: Contributors and CI validation pipelines.
   - **Impact**: Extends test coverage for vector(float16) scenarios on AzureDB.
-
-### Behavior Changes
-
-- **setObject parameter-length validation now throws instead of truncating silently** [#2960](https://github.com/microsoft/mssql-jdbc/pull/2960)
-  - **What changed**: The `setObject` overload that accepts a parameter length now validates the specified length against the actual parameter length.
-  - **Impact**: If the value exceeds the specified length, the driver now throws an exception instead of silently truncating data.
-  - **Action required**: Applications that relied on implicit truncation must provide a parameter length that is large enough for the actual value.
 
 ### Changed
 

--- a/docs/parameter-hints/define-parameter-type.md
+++ b/docs/parameter-hints/define-parameter-type.md
@@ -460,7 +460,8 @@ non-positive `defineParameterType()` hint (`<= 0`) throws `R_invalidParameterLen
 the call site, and a value longer than the declared length throws
 `R_parameterTypeValueLengthExceedsHint` at execution time. The
 `setObject(..., scaleOrLength)` path never throws for either case: a non-positive hint is
-dropped, and an undersized hint is widened to the actual value length.
+ignored in favour of the driver's default sizing, and an undersized positive hint is widened to
+the actual value length.
 
 Length comparisons use the same units the server uses for the declared type: **bytes** for
 `varchar`/`char`, **characters** for `nvarchar`/`nchar`, and **bytes** for `binary`/`varbinary`.

--- a/docs/parameter-hints/define-parameter-type.md
+++ b/docs/parameter-hints/define-parameter-type.md
@@ -30,6 +30,7 @@ mssql-jdbc provides two APIs for parameter length hints:
 - **Primary API** — Set once before a batch loop
 - Hint persists across all `addBatch()` and `setString()` / `setNString()` / `setBytes()` calls
 - More discoverable (explicit method name)
+- **Enforced** — a value longer than `maxLength` raises `R_parameterTypeValueLengthExceedsHint`
 - Returns when using `defineParameterType()`, all parameter hints are not overridden
 
 ### `setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)`
@@ -38,6 +39,8 @@ mssql-jdbc provides two APIs for parameter length hints:
 - Hint is provided inline with the value
 - Less discoverable (standard JDBC parameter)
 - Must be supplied on every `setObject()` call
+- **Advisory only** — if the value does not fit, the declared length is widened to the actual
+  value length instead of raising an error
 
 ### Precedence Rule
 
@@ -451,11 +454,20 @@ if (AE active for param)  →  AE path (exact length from value; defines encrypt
 else if (defineParameterTypeSqlType != 0)  →  hint path
 else  →  conservative default (varchar(8000) etc.)
 
-For supported bounded variable-length types, the hint is validated during parameter type
+For supported bounded variable-length types, the hint is resolved during parameter type
 resolution in `Parameter.GetTypeDefinitionOp.getApplicationSpecifiedLengthHint(...)`. A
-non-positive hint (`<= 0`) throws `R_invalidParameterLength` eagerly at the
-`defineParameterType()` call site. For the `setObject(..., scaleOrLength)` path, non-positive
-hints are validated at execution time since the value isn't known until then.
+non-positive `defineParameterType()` hint (`<= 0`) throws `R_invalidParameterLength` eagerly at
+the call site, and a value longer than the declared length throws
+`R_parameterTypeValueLengthExceedsHint` at execution time. The
+`setObject(..., scaleOrLength)` path never throws for either case: a non-positive hint is
+dropped, and an undersized hint is widened to the actual value length.
+
+Length comparisons use the same units the server uses for the declared type: **bytes** for
+`varchar`/`char`, **characters** for `nvarchar`/`nchar`, and **bytes** for `binary`/`varbinary`.
+Character values are measured with the database collation's charset. Because `setValue()`
+re-tags character parameters as `NVARCHAR` when `sendStringParametersAsUnicode=true`, a
+parameter that still carries `JDBCType.VARCHAR`/`CHAR` at this point is genuinely sent as
+`varchar` on the wire, so the measurement unit always matches the declared type.
 ```
 
 No AE behaviour changes. The hint is silently ignored when AE is active, which is correct:

--- a/docs/parameter-hints/parameter-hints-overview.md
+++ b/docs/parameter-hints/parameter-hints-overview.md
@@ -135,7 +135,7 @@ The two APIs differ in how strictly they treat the supplied length.
 
 `setObject(..., scaleOrLength)` is an **advisory hint** and never fails because of the hint:
 
-- **Non-positive length**: Ignored; the parameter length is derived from the actual value
+- **Non-positive length**: Ignored; the driver uses its default parameter sizing
 - **Value exceeds the hint**: The declared length is widened to the actual value length
 - **Unsupported JDBC type**: Ignored, as before
 

--- a/docs/parameter-hints/parameter-hints-overview.md
+++ b/docs/parameter-hints/parameter-hints-overview.md
@@ -124,30 +124,39 @@ When SSPAU (`sendStringParametersAsUnicode`) is `true` (default), VARCHAR/CHAR h
 
 ## Error Handling
 
-Both APIs validate constraints and reject violations:
+The two APIs differ in how strictly they treat the supplied length.
 
-- **Non-positive length via `defineParameterType`**: Rejected eagerly at call time with error `R_invalidParameterLength`
-- **Non-positive length via `setObject`**: Rejected at execution time with error `R_invalidParameterLength`
+`defineParameterType()` is an explicit declaration and is **enforced**:
+
+- **Non-positive length**: Rejected eagerly at call time with error `R_invalidParameterLength`
 - **Unsupported JDBC type**: Rejected with error `R_unsupportedTypeForDefineParamType`
 - **Type family mismatch**: If `defineParameterType` declares a character type but the setter produces a binary type (or vice versa), execution fails with `R_defineParameterTypeTypeMismatch`
 - **Value exceeds declared length**: Execution fails with error `R_parameterTypeValueLengthExceedsHint` (prevents silent data corruption)
 
-### Breaking Behavioral Change: `setObject(..., scaleOrLength)` Enforcement
+`setObject(..., scaleOrLength)` is an **advisory hint** and never fails because of the hint:
 
-`setObject(parameterIndex, x, targetSqlType, scaleOrLength)` now enforces `scaleOrLength`
-as a maximum length constraint for character and binary target types (VARCHAR, CHAR, NVARCHAR,
-NVARCH, VARBINARY, BINARY). Previously, the JDBC 4.3 specification defined `scaleOrLength`
-only for DECIMAL/NUMERIC (as scale) and for InputStream/Reader (as stream length), so it was
-ignored for string and binary types.
+- **Non-positive length**: Ignored; the parameter length is derived from the actual value
+- **Value exceeds the hint**: The declared length is widened to the actual value length
+- **Unsupported JDBC type**: Ignored, as before
 
-With this change, if the actual value length exceeds the specified `scaleOrLength`, execution
-will fail with `R_parameterTypeValueLengthExceedsHint`. Applications that pass arbitrary or
-undersized `scaleOrLength` values to `setObject` for string/binary types must either:
-- Increase the value to accommodate their largest payload, or
-- Use a two-argument `setObject` overload that omits the length constraint
+### `setObject(..., scaleOrLength)` Is Advisory
+
+`setObject(parameterIndex, x, targetSqlType, scaleOrLength)` treats `scaleOrLength` as an
+optional length hint for character and binary target types (VARCHAR, CHAR, NVARCHAR, NCHAR,
+VARBINARY, BINARY). Per the JDBC 4.3 specification `scaleOrLength` is defined only for
+DECIMAL/NUMERIC (as scale) and for InputStream/Reader (as stream length), and is otherwise
+ignored — so the hint must never change whether an application succeeds.
+
+Accordingly, if the actual value is longer than `scaleOrLength`, the driver widens the declared
+parameter length to the actual value length instead of raising an error. Nothing is truncated and
+nothing fails; the only consequence is that the parameter's type definition changed, which may
+cause the statement to be re-prepared. A `FINER` log record is written to the
+`com.microsoft.sqlserver.jdbc.internals.Parameter` logger whenever this happens.
+
+Applications that want a hard maximum enforced should use `defineParameterType()` instead.
 
 This applies equally to the named-parameter callable statement variants
-(`setObject(String, Object, int, int)`).
+(`setObject(String, Object, int, int)` and `setObject(String, Object, int, int, boolean)`).
 
 ## Batch Workflows
 

--- a/docs/parameter-hints/setObject-scaleOrLength.md
+++ b/docs/parameter-hints/setObject-scaleOrLength.md
@@ -209,8 +209,9 @@ For more details, see **[README.md](README.md#precedence-rule-defineparametertyp
 ### Non-Positive Length
 
 Passing a non-positive `scaleOrLength` (`<= 0`) for a supported bounded variable-length type is
-not an error. The hint is ignored and the parameter length is derived from the actual value, the
-same as if no hint had been supplied.
+not an error. The application-provided hint is dropped; when the actual value length can be
+measured safely, the driver declares that length, otherwise it falls back to the driver's default
+sizing.
 
 (Note: for `defineParameterType()`, non-positive values *are* rejected eagerly at call time with
 `R_invalidParameterLength`.)

--- a/docs/parameter-hints/setObject-scaleOrLength.md
+++ b/docs/parameter-hints/setObject-scaleOrLength.md
@@ -209,9 +209,9 @@ For more details, see **[README.md](README.md#precedence-rule-defineparametertyp
 ### Non-Positive Length
 
 Passing a non-positive `scaleOrLength` (`<= 0`) for a supported bounded variable-length type is
-not an error. The application-provided hint is dropped; when the actual value length can be
-measured safely, the driver declares that length, otherwise it falls back to the driver's default
-sizing.
+not an error. It is not a usable declared length, so the hint is ignored entirely and the driver
+falls back to its default sizing (`varchar(8000)` / `nvarchar(4000)` / `varbinary(8000)`) — the
+same behavior as calling `setObject()` without a length.
 
 (Note: for `defineParameterType()`, non-positive values *are* rejected eagerly at call time with
 `R_invalidParameterLength`.)
@@ -268,7 +268,7 @@ int[] counts = ps.executeBatch();
 |---|---|---|
 | **Scope** | Per-call | Persists across calls |
 | **Enforcement** | Advisory — widened to fit if too small | Enforced — value longer than `maxLength` is an error |
-| **Non-positive length** | Ignored, hint dropped | Rejected with `R_invalidParameterLength` |
+| **Non-positive length** | Ignored, driver default sizing is used | Rejected with `R_invalidParameterLength` |
 | **Batch behavior** | Hint varies per row | Hint is consistent across all rows |
 | **Discoverability** | Less obvious (standard JDBC parameter) | More explicit (dedicated method) |
 | **Best for** | Single executions, non-batch scenarios | Batch inserts, consistent type contracts |
@@ -282,10 +282,10 @@ The `scaleOrLength` parameter is extracted by `SQLServerPreparedStatement.setObj
 
 1. **Is `defineParameterType()` called?** If yes, use that hint (takes precedence) and enforce it
     as a maximum
-2. **Is `scaleOrLength` present for a supported type?** If yes, use it as an advisory hint: honor
-    it when the value fits, widen it to the actual value length when it does not, and drop it
-    when it is non-positive or when the actual length cannot be measured (for example a `null`
-    value or a non-`String`/non-`byte[]` value)
+2. **Is `scaleOrLength` a positive value for a supported type?** If yes, use it as an advisory
+    hint: honor it when the value fits, and widen it to the actual value length when it does not.
+    Drop it when the actual length cannot be measured (for example a non-`String`/non-`byte[]`
+    value). A non-positive `scaleOrLength` is ignored outright.
 3. Otherwise, use the default TypeInfo (varchar(8000) / nvarchar(4000) / varbinary(8000))
 
 ### Interaction with Always Encrypted (AE)
@@ -302,8 +302,9 @@ See **[ParameterLengthHintTest.java](../../../../src/test/java/com/microsoft/sql
 
 - **SetObjectLengthHintTests**: Verifies `setObject()` scaleOrLength honored for all 6 supported types
 - **DefinePrecedesSetObjectTests**: Verifies `defineParameterType()` takes precedence over `setObject()` hints
-- **ErrorHandlingTests**: Verifies `defineParameterType()` value-exceeds-hint errors, and that
-  undersized or non-positive `setObject()` hints widen instead of failing
+- **ErrorHandlingTests**: Verifies `defineParameterType()` value-exceeds-hint errors, that
+  undersized `setObject()` hints widen instead of failing, and that non-positive `setObject()`
+  hints fall back to the driver's default sizing
 - **BatchTests**: Verifies batch behavior with both APIs and precedence
 
 See **[CallableParameterLengthHintTest.java](../../../../src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java)** for callable-statement coverage, including:

--- a/docs/parameter-hints/setObject-scaleOrLength.md
+++ b/docs/parameter-hints/setObject-scaleOrLength.md
@@ -4,14 +4,15 @@
 
 The `setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)` JDBC method accepts a `scaleOrLength` parameter. Although the JDBC 4.3 specification states this value is ignored for most types, mssql-jdbc extends this behavior for bounded variable-length types (VARCHAR, CHAR, NVARCHAR, NCHAR, VARBINARY, BINARY) to provide an optional length hint on a per-call basis.
 
-**Breaking Behavioral Change:** This is a breaking change from prior driver versions where
-`scaleOrLength` was silently ignored for string and binary types. With this change,
-`scaleOrLength` is now enforced as a maximum length constraint — if the actual value length
-exceeds the specified `scaleOrLength`, execution will fail with
-`R_parameterTypeValueLengthExceedsHint`. Applications that previously passed arbitrary or
-undersized `scaleOrLength` values for string/binary types must either increase the value to
-accommodate their largest payload or use a two-argument `setObject` overload that omits the
-length constraint.
+**The hint is advisory, not a constraint.** It is never enforced. If the actual value is longer
+than `scaleOrLength`, the driver widens the declared parameter length to the actual value length
+rather than failing or truncating. A zero or negative `scaleOrLength` is treated the same as
+omitting the hint. Applications that pass arbitrary or undersized `scaleOrLength` values for
+string and binary types therefore behave exactly as they did before length hints were introduced —
+the only cost of an inaccurate hint is a possible statement re-prepare.
+
+This differs from `defineParameterType()`, which is an explicit declaration and **is** enforced as
+a hard maximum.
 
 ## See Also
 
@@ -29,12 +30,14 @@ This document focuses specifically on the `setObject(..., scaleOrLength)` behavi
  * @param targetSqlType a java.sql.Types constant indicating the SQL type
  * @param scaleOrLength for most types this parameter is ignored; for supported
  *                      variable-length types (VARCHAR, CHAR, NVARCHAR, NCHAR,
- *                      VARBINARY, BINARY), this is treated as the maximum length
- *                      in characters (for string types) or bytes (for binary types).
+ *                      VARBINARY, BINARY), this is treated as an advisory length
+ *                      hint, in bytes for VARCHAR/CHAR/VARBINARY/BINARY and in
+ *                      characters for NVARCHAR/NCHAR.
  *                      When set, mssql-jdbc declares the parameter in TDS using
  *                      this length instead of the default maximum. If a value
- *                      exceeds this length, execution fails with an error to prevent
- *                      silent data truncation.
+ *                      exceeds this length, the declared length is widened to the
+ *                      actual value length; the value is never truncated and no
+ *                      error is raised.
  * @throws SQLException if an error occurs
  */
 public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
@@ -114,10 +117,33 @@ applies equally to the ordinal `SQLServerPreparedStatement.setObject(int, ...)` 
 
 When `setObject()` is called with `scaleOrLength > 0` for a supported type:
 
-1. The driver uses this value as the maximum length hint
+1. The driver uses this value as an advisory length hint
 2. The TDS TypeInfo for the parameter is declared using this hint instead of the default maximum
 3. The actual value is sent to the server as-is (no client-side truncation)
-4. If the value exceeds the hint, the server may truncate or reject it depending on the declared type and data
+4. If the actual value is longer than the hint, the declared length is widened to the actual value
+   length before the TDS message is built, so the value always fits
+
+### Widening When the Value Does Not Fit
+
+An undersized hint is corrected automatically:
+
+```java
+ps.setObject(1, "this_is_a_very_long_value", Types.VARCHAR, 5);
+ps.executeUpdate();
+// Hint of 5 is too small for a 25-byte value.
+// Wire sends: varchar(25) — the full value is stored, no error, no truncation.
+```
+
+The driver emits a `FINER` log record on the
+`com.microsoft.sqlserver.jdbc.internals.Parameter` logger when it widens a hint, which is useful
+for finding hints that are consistently too small.
+
+Because widening changes the parameter's type definition, it may cause the statement to be
+re-prepared on the server. To avoid that cost, size the hint for the largest value you expect.
+
+For VARCHAR and CHAR the comparison is done on the **encoded byte length** using the database
+collation's charset, not the Java character count, because `varchar(n)` counts bytes on the
+server. NVARCHAR and NCHAR are compared in characters, and binary types in bytes.
 
 ### Per-Call Application
 
@@ -182,27 +208,17 @@ For more details, see **[README.md](README.md#precedence-rule-defineparametertyp
 
 ### Non-Positive Length
 
-Passing a non-positive `scaleOrLength` (`<= 0`) for a supported bounded variable-length type
-is rejected with `R_invalidParameterLength` during parameter type resolution at execution time.
-(Note: for `defineParameterType()`, non-positive values are rejected eagerly at call time.)
+Passing a non-positive `scaleOrLength` (`<= 0`) for a supported bounded variable-length type is
+not an error. The hint is ignored and the parameter length is derived from the actual value, the
+same as if no hint had been supplied.
 
-### Value Exceeds Declared Length
+(Note: for `defineParameterType()`, non-positive values *are* rejected eagerly at call time with
+`R_invalidParameterLength`.)
 
-If a value exceeds the declared length, execution fails with an error to prevent silent data truncation.
-This is a **breaking behavioral change** from prior versions where `scaleOrLength` was ignored
-for string/binary types:
+### Value Exceeds the Hint
 
-```java
-ps.setObject(1, "this_is_a_very_long_value", Types.VARCHAR, 5);
-try {
-    ps.executeUpdate();
-} catch (SQLServerException e) {
-    // Error: R_parameterTypeValueLengthExceedsHint
-    // Actual value (25 chars) exceeds declared length (5 chars)
-}
-```
-
-This error occurs at **execution time**, not at the `setObject()` call, because the driver validates the value only when the TDS message is being prepared.
+This is not an error. The declared length is widened to the actual value length — see
+[Widening When the Value Does Not Fit](#widening-when-the-value-does-not-fit).
 
 ### Invalid Type for Hint
 
@@ -250,6 +266,8 @@ int[] counts = ps.executeBatch();
 | Aspect | `setObject(..., scaleOrLength)` | `defineParameterType()` |
 |---|---|---|
 | **Scope** | Per-call | Persists across calls |
+| **Enforcement** | Advisory — widened to fit if too small | Enforced — value longer than `maxLength` is an error |
+| **Non-positive length** | Ignored, hint dropped | Rejected with `R_invalidParameterLength` |
 | **Batch behavior** | Hint varies per row | Hint is consistent across all rows |
 | **Discoverability** | Less obvious (standard JDBC parameter) | More explicit (dedicated method) |
 | **Best for** | Single executions, non-batch scenarios | Batch inserts, consistent type contracts |
@@ -261,9 +279,12 @@ int[] counts = ps.executeBatch();
 
 The `scaleOrLength` parameter is extracted by `SQLServerPreparedStatement.setObject()` and passed as an integer to the internal parameter setting logic. When the TDS message is prepared, the type definition is computed by checking:
 
-1. **Is `defineParameterType()` called?** If yes, use that hint (takes precedence)
-2. **Is `scaleOrLength` present for a supported type?** If yes, validate that it is `> 0`
-    and then use that hint
+1. **Is `defineParameterType()` called?** If yes, use that hint (takes precedence) and enforce it
+    as a maximum
+2. **Is `scaleOrLength` present for a supported type?** If yes, use it as an advisory hint: honor
+    it when the value fits, widen it to the actual value length when it does not, and drop it
+    when it is non-positive or when the actual length cannot be measured (for example a `null`
+    value or a non-`String`/non-`byte[]` value)
 3. Otherwise, use the default TypeInfo (varchar(8000) / nvarchar(4000) / varbinary(8000))
 
 ### Interaction with Always Encrypted (AE)
@@ -280,7 +301,8 @@ See **[ParameterLengthHintTest.java](../../../../src/test/java/com/microsoft/sql
 
 - **SetObjectLengthHintTests**: Verifies `setObject()` scaleOrLength honored for all 6 supported types
 - **DefinePrecedesSetObjectTests**: Verifies `defineParameterType()` takes precedence over `setObject()` hints
-- **ErrorHandlingTests**: Verifies value-exceeds-hint errors
+- **ErrorHandlingTests**: Verifies `defineParameterType()` value-exceeds-hint errors, and that
+  undersized or non-positive `setObject()` hints widen instead of failing
 - **BatchTests**: Verifies batch behavior with both APIs and precedence
 
 See **[CallableParameterLengthHintTest.java](../../../../src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java)** for callable-statement coverage, including:
@@ -288,7 +310,7 @@ See **[CallableParameterLengthHintTest.java](../../../../src/test/java/com/micro
 - Named-parameter `setObject` scale-only overload behavior across all 6 supported types
 - Precedence (`defineParameterType` over callable `setObject` length hints) for both non-forceEncrypt and forceEncrypt overloads
 - `sendStringParametersAsUnicode` true/false declaration behavior
-- Boundary, NULL/empty, and value-exceeds-hint scenarios
+- Boundary, NULL/empty, and value-exceeds-hint widening scenarios
 - Guard test for callable precision+scale overload semantics
 
 ## Related Classes and Methods

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -563,7 +563,17 @@ final class Parameter {
             //    pre-existing behavior of setObject(), where scaleOrLength was ignored for
             //    character and binary types.
             boolean declaredViaDefineParameterType = param.defineParameterTypeSqlType != 0;
-            Integer lengthHint = declaredViaDefineParameterType ? param.defineParameterTypeLengthHint : dtv.getScale();
+
+            // Assigned in separate branches rather than with a conditional expression on purpose:
+            // defineParameterTypeLengthHint is a primitive int, so mixing it with the Integer
+            // returned by getScale() in a ternary would force the whole expression to int and
+            // auto-unbox a null scale into a NullPointerException.
+            Integer lengthHint;
+            if (declaredViaDefineParameterType) {
+                lengthHint = param.defineParameterTypeLengthHint;
+            } else {
+                lengthHint = dtv.getScale();
+            }
 
             if (null == lengthHint) {
                 return null;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -595,17 +595,24 @@ final class Parameter {
         /**
          * Resolves the effective declared length for a setObject(..., scaleOrLength) hint.
          *
-         * The hint is advisory only. It is honored when the value fits, widened to the actual
-         * value length when it does not, and dropped entirely when the actual length cannot be
-         * determined safely (in which case the driver falls back to its default sizing).
+         * The hint is advisory only. A non-positive length is not a usable declaration, so it is
+         * ignored entirely and the driver falls back to its default sizing. A positive length is
+         * honored when the value fits and widened to the actual value length when it does not, so
+         * an undersized hint never truncates and never fails.
          *
          * @return the length to declare, or null to use the driver's default type definition
          */
         private Integer resolveSetObjectLengthHint(DTV dtv, int lengthHint) throws SQLServerException {
+            if (lengthHint <= 0) {
+                // Not a usable length. Ignore the hint and let the driver size the parameter as
+                // it did before length hints existed.
+                return null;
+            }
+
             if (null == dtv.getSetterValue()) {
-                // Nothing to measure against, so there is nothing to widen. A positive hint is
-                // still useful for shaping the type definition of a null value.
-                return (lengthHint > 0) ? lengthHint : null;
+                // Nothing to measure against, so there is nothing to widen. The hint still shapes
+                // the type definition of a null value.
+                return lengthHint;
             }
 
             Integer actualLength = getActualValueLength(dtv);
@@ -616,7 +623,7 @@ final class Parameter {
                 return null;
             }
 
-            if (lengthHint > 0 && actualLength <= lengthHint) {
+            if (actualLength <= lengthHint) {
                 return lengthHint;
             }
 
@@ -627,9 +634,7 @@ final class Parameter {
                         + ". The statement will be re-prepared if the type definition changed.");
             }
 
-            // An empty value yields length 0, which is not a legal declared length. Fall back to
-            // the driver's default sizing in that case.
-            return (actualLength > 0) ? actualLength : null;
+            return actualLength;
         }
 
         /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.ResultSet;
@@ -23,6 +24,8 @@ import java.time.OffsetTime;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import microsoft.sql.Vector;
 
@@ -33,6 +36,8 @@ import microsoft.sql.Vector;
  */
 
 final class Parameter {
+    private static final Logger logger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.Parameter");
+
     // Value type info for OUT parameters (excluding return status)
     private TypeInfo typeInfo;
 
@@ -547,15 +552,18 @@ final class Parameter {
         }
 
         private Integer getApplicationSpecifiedLengthHint(DTV dtv) throws SQLServerException {
-            // Precedence rule for short character/binary families:
-            // 1) defineParameterType(maxLength) — stored in dedicated defineParameterTypeLengthHint field
-            // 2) setObject(..., scaleOrLength)
-            Integer lengthHint;
-            if (param.defineParameterTypeSqlType != 0) {
-                lengthHint = param.defineParameterTypeLengthHint;
-            } else {
-                lengthHint = dtv.getScale();
-            }
+            // Two independent sources can supply a length for short character/binary families:
+            //
+            // 1) defineParameterType(maxLength) - an explicit declaration. It is ENFORCED: a value
+            //    longer than the declared length is an error, because the application has asserted
+            //    a contract that it is violating.
+            // 2) setObject(..., scaleOrLength) - an advisory HINT. It is never enforced. If the
+            //    value does not fit, the declared length is silently widened to the actual value
+            //    length so that nothing is truncated and nothing fails. This preserves the
+            //    pre-existing behavior of setObject(), where scaleOrLength was ignored for
+            //    character and binary types.
+            boolean declaredViaDefineParameterType = param.defineParameterTypeSqlType != 0;
+            Integer lengthHint = declaredViaDefineParameterType ? param.defineParameterTypeLengthHint : dtv.getScale();
 
             if (null == lengthHint) {
                 return null;
@@ -568,13 +576,96 @@ final class Parameter {
                 case NVARCHAR:
                 case BINARY:
                 case VARBINARY:
-                    if (lengthHint <= 0) {
-                        throwInvalidParameterLength(lengthHint);
-                    }
-                    return lengthHint;
+                    break;
                 default:
                     return null;
             }
+
+            if (declaredViaDefineParameterType) {
+                if (lengthHint <= 0) {
+                    throwInvalidParameterLength(lengthHint);
+                }
+                validateApplicationSpecifiedLength(dtv, lengthHint);
+                return lengthHint;
+            }
+
+            return resolveSetObjectLengthHint(dtv, lengthHint);
+        }
+
+        /**
+         * Resolves the effective declared length for a setObject(..., scaleOrLength) hint.
+         *
+         * The hint is advisory only. It is honored when the value fits, widened to the actual
+         * value length when it does not, and dropped entirely when the actual length cannot be
+         * determined safely (in which case the driver falls back to its default sizing).
+         *
+         * @return the length to declare, or null to use the driver's default type definition
+         */
+        private Integer resolveSetObjectLengthHint(DTV dtv, int lengthHint) throws SQLServerException {
+            if (null == dtv.getSetterValue()) {
+                // Nothing to measure against, so there is nothing to widen. A positive hint is
+                // still useful for shaping the type definition of a null value.
+                return (lengthHint > 0) ? lengthHint : null;
+            }
+
+            Integer actualLength = getActualValueLength(dtv);
+            if (null == actualLength) {
+                // The value is not a String or byte[], or the collation needed to measure it is
+                // unavailable. Honoring the hint here could truncate, so fall back to the
+                // driver's default sizing - which is what setObject() did before length hints.
+                return null;
+            }
+
+            if (lengthHint > 0 && actualLength <= lengthHint) {
+                return lengthHint;
+            }
+
+            if (logger.isLoggable(Level.FINER)) {
+                logger.finer(param + " setObject length hint " + lengthHint + " is smaller than the actual value length "
+                        + actualLength + " for JDBC type " + dtv.getJdbcType()
+                        + "; widening the declared parameter length to " + actualLength
+                        + ". The statement will be re-prepared if the type definition changed.");
+            }
+
+            // An empty value yields length 0, which is not a legal declared length. Fall back to
+            // the driver's default sizing in that case.
+            return (actualLength > 0) ? actualLength : null;
+        }
+
+        /**
+         * Returns the length of the current setter value in the units the server uses for the
+         * target type, or null if it cannot be determined.
+         *
+         * VARCHAR and CHAR lengths are byte counts on the server, so the value is measured using
+         * the database collation's charset rather than the Java character count. Note that these
+         * JDBC types only reach this point when sendStringParametersAsUnicode=false, because
+         * {@link Parameter#setValue} re-tags character parameters as NVARCHAR otherwise - so the
+         * measurement unit always matches the type that is actually declared on the wire.
+         * NVARCHAR, NCHAR, BINARY and VARBINARY are already measured in the correct units by
+         * {@link Util#getValueLengthBaseOnJavaType}.
+         */
+        private Integer getActualValueLength(DTV dtv) throws SQLServerException {
+            Object setterValue = dtv.getSetterValue();
+            if (null == setterValue) {
+                return null;
+            }
+
+            JavaType javaType = dtv.getJavaType();
+            if (JavaType.STRING != javaType && JavaType.BYTEARRAY != javaType) {
+                return null;
+            }
+
+            JDBCType jdbcType = dtv.getJdbcType();
+            if (JavaType.STRING == javaType && (JDBCType.CHAR == jdbcType || JDBCType.VARCHAR == jdbcType)) {
+                SQLCollation collation = con.getDatabaseCollation();
+                if (null == collation) {
+                    return null;
+                }
+                Charset charset = collation.getCharset();
+                return (null == charset) ? null : ((String) setterValue).getBytes(charset).length;
+            }
+
+            return Util.getValueLengthBaseOnJavaType(setterValue, javaType, null, dtv.getScale(), jdbcType);
         }
 
         private Integer getBoundedDeclaredLengthHint(JDBCType jdbcType, int hintLength) {
@@ -609,8 +700,12 @@ final class Parameter {
                 return;
             }
 
-            int actualLength = Util.getValueLengthBaseOnJavaType(dtv.getSetterValue(), javaType, null, dtv.getScale(),
-                    dtv.getJdbcType());
+            // Measured in the same units the server uses for the target type: bytes for
+            // varchar/char, characters for nvarchar/nchar, bytes for binary/varbinary.
+            Integer actualLength = getActualValueLength(dtv);
+            if (null == actualLength) {
+                return;
+            }
 
             if (actualLength > boundedDeclaredLength) {
                 MessageFormat form = new MessageFormat(
@@ -624,10 +719,9 @@ final class Parameter {
             boolean aeActive = param.shouldHonorAEForParameter && (null != jdbcTypeSetByUser)
                     && !(null == param.getCryptoMetadata() && param.renewDefinition);
 
+            // Resolves the effective declared length from defineParameterType() (enforced) or
+            // setObject(..., scaleOrLength) (advisory, widened to fit the value when necessary).
             Integer applicationLengthHint = aeActive ? null : getApplicationSpecifiedLengthHint(dtv);
-            if (null != applicationLengthHint) {
-                validateApplicationSpecifiedLength(dtv, applicationLengthHint);
-            }
 
             switch (dtv.getJdbcType()) {
                 case TINYINT:
@@ -809,8 +903,8 @@ final class Parameter {
                             param.typeDefinition = VARBINARY_MAX;
                         }
                     } else if (null != applicationLengthHint) {
-                        // Application-provided hint from defineParameterType() or setObject(..., scaleOrLength):
-                        // declare the requested length for VARBINARY/BINARY.
+                        // Application-provided length from defineParameterType() (enforced) or
+                        // setObject(..., scaleOrLength) (advisory, already widened to fit the value).
                         int hint = applicationLengthHint;
                         if (hint > DataTypes.SHORT_VARTYPE_MAX_BYTES) {
                             param.typeDefinition = VARBINARY_MAX;
@@ -972,8 +1066,8 @@ final class Parameter {
                             }
                         }
                     } else if (null != applicationLengthHint) {
-                        // Application-provided hint from defineParameterType() or setObject(..., scaleOrLength):
-                        // declare the requested length for VARCHAR/CHAR.
+                        // Application-provided length from defineParameterType() (enforced) or
+                        // setObject(..., scaleOrLength) (advisory, already widened to fit the value).
                         int hint = applicationLengthHint;
                         if (hint > DataTypes.SHORT_VARTYPE_MAX_BYTES) {
                             param.typeDefinition = VARCHAR_MAX;
@@ -1113,8 +1207,8 @@ final class Parameter {
                         }
                         break;
                     } else if (null != applicationLengthHint) {
-                        // Application-provided hint from defineParameterType() or setObject(..., scaleOrLength):
-                        // declare the requested length for NVARCHAR/NCHAR.
+                        // Application-provided length from defineParameterType() (enforced) or
+                        // setObject(..., scaleOrLength) (advisory, already widened to fit the value).
                         int hint = applicationLengthHint;
                         if (hint > DataTypes.SHORT_VARTYPE_MAX_CHARS) {
                             param.typeDefinition = NVARCHAR_MAX;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Parameter.java
@@ -546,11 +546,6 @@ final class Parameter {
             this.con = con;
         }
 
-        private void throwInvalidParameterLength(int length) throws SQLServerException {
-            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidParameterLength"));
-            SQLServerException.makeFromDriverError(con, param, form.format(new Object[] {length}), null, false);
-        }
-
         private Integer getApplicationSpecifiedLengthHint(DTV dtv) throws SQLServerException {
             // Two independent sources can supply a length for short character/binary families:
             //
@@ -592,9 +587,9 @@ final class Parameter {
             }
 
             if (declaredViaDefineParameterType) {
-                if (lengthHint <= 0) {
-                    throwInvalidParameterLength(lengthHint);
-                }
+                // A non-positive maxLength is rejected eagerly by
+                // SQLServerPreparedStatement.defineParameterType() before the hint is ever stored,
+                // so lengthHint is always positive on this path and needs no re-validation here.
                 validateApplicationSpecifiedLength(dtv, lengthHint);
                 return lengthHint;
             }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1995,9 +1995,9 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
      * BINARY), {@code decimals} is interpreted as an advisory length hint that shapes the
      * parameter's declared type definition. It is never enforced: if the actual value is
      * longer than {@code decimals}, the driver widens the declared length to the actual
-     * value length instead of failing or truncating. Passing a zero or negative value disables the
-     * application-provided hint; in that case the driver derives the declared length from the actual
-     * value when possible, otherwise it falls back to default sizing. This keeps the historical behavior of
+     * value length instead of failing or truncating. Passing a zero or negative value disables
+     * the application-provided hint entirely, and the driver falls back to its default parameter
+     * sizing. This keeps the historical behavior of
      * {@code setObject}, where this parameter was ignored for string and binary types,
      * while allowing applications that supply an accurate hint to get a narrower parameter
      * declaration and better plan reuse.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1991,19 +1991,22 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     /**
      * {@inheritDoc}
      *
-     * Breaking Behavioral Change: For character and binary target types (VARCHAR, CHAR,
-     * NVARCHAR, NCHAR, VARBINARY, BINARY), {@code decimals} is now enforced as a
-     * maximum length constraint. Previously, the JDBC 4.3 specification defined
-     * this parameter only for DECIMAL/NUMERIC (as scale) and for InputStream/Reader
-     * (as stream length), so it was ignored for string and binary types. With this change,
-     * if the actual value length exceeds the specified {@code decimals}, execution
-     * will fail with {@code R_parameterTypeValueLengthExceedsHint}. Applications that pass
-     * arbitrary or undersized values for string/binary types must either increase the value
-     * to accommodate their largest payload or use a {@code setObject} overload that omits
-     * the length constraint.
+     * For character and binary target types (VARCHAR, CHAR, NVARCHAR, NCHAR, VARBINARY,
+     * BINARY), {@code decimals} is interpreted as an advisory length hint that shapes the
+     * parameter's declared type definition. It is never enforced: if the actual value is
+     * longer than {@code decimals}, the driver widens the declared length to the actual
+     * value length instead of failing or truncating. Passing a zero or negative value has
+     * the same effect as omitting the hint. This keeps the historical behavior of
+     * {@code setObject}, where this parameter was ignored for string and binary types,
+     * while allowing applications that supply an accurate hint to get a narrower parameter
+     * declaration and better plan reuse.
+     *
+     * Widening changes the parameter's type definition, so it may cause the statement to be
+     * re-prepared. Supply a hint large enough for the largest expected value to avoid this.
      *
      * If {@link #defineParameterType(int, int, int)} has been called for the same
-     * parameter, its {@code maxLength} takes precedence over {@code decimals}.
+     * parameter, its {@code maxLength} takes precedence over {@code decimals} and, unlike
+     * this hint, is enforced as a hard maximum.
      */
     @Override
     public void setObject(String parameterName, Object value, int sqlType, int decimals) throws SQLServerException {
@@ -2016,8 +2019,8 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         // this is the number of digits after the decimal point. For Java Object types
         // InputStream and Reader, this is the length of the data in the stream or reader.
         // For supported short character/binary SQL types (VARCHAR, CHAR, NVARCHAR, NCHAR,
-        // VARBINARY, BINARY), this is treated as application-provided length hint AND enforced
-        // as a maximum length constraint.
+        // VARBINARY, BINARY), this is treated as an advisory length hint that is widened to
+        // the actual value length when the value does not fit. It is never enforced.
         // Precedence: defineParameterType() hint (if present) takes priority over this value.
         // For all other types, this value will be ignored.
         Integer precision = null;
@@ -2043,10 +2046,10 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     /**
      * {@inheritDoc}
      *
-     * Breaking Behavioral Change: For character and binary target types (VARCHAR, CHAR,
-     * NVARCHAR, NCHAR, VARBINARY, BINARY), {@code decimals} is now enforced as a
-     * maximum length constraint. See {@link #setObject(String, Object, int, int)} for
-     * full details on this behavioral change.
+     * For character and binary target types (VARCHAR, CHAR, NVARCHAR, NCHAR, VARBINARY,
+     * BINARY), {@code decimals} is an advisory length hint that is widened to the actual
+     * value length when the value does not fit. See
+     * {@link #setObject(String, Object, int, int)} for full details.
      */
     @Override
     public void setObject(String parameterName, Object value, int sqlType, int decimals,
@@ -2060,8 +2063,8 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         // this is the number of digits after the decimal point. For Java Object types
         // InputStream and Reader, this is the length of the data in the stream or reader.
         // For supported short character/binary SQL types (VARCHAR, CHAR, NVARCHAR, NCHAR,
-        // VARBINARY, BINARY), this is treated as application-provided length hint AND enforced
-        // as a maximum length constraint.
+        // VARBINARY, BINARY), this is treated as an advisory length hint that is widened to
+        // the actual value length when the value does not fit. It is never enforced.
         // Precedence: defineParameterType() hint (if present) takes priority over this value.
         // For all other types, this value will be ignored.
         Integer precision = null;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1995,8 +1995,9 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
      * BINARY), {@code decimals} is interpreted as an advisory length hint that shapes the
      * parameter's declared type definition. It is never enforced: if the actual value is
      * longer than {@code decimals}, the driver widens the declared length to the actual
-     * value length instead of failing or truncating. Passing a zero or negative value has
-     * the same effect as omitting the hint. This keeps the historical behavior of
+     * value length instead of failing or truncating. Passing a zero or negative value disables the
+     * application-provided hint; in that case the driver derives the declared length from the actual
+     * value when possible, otherwise it falls back to default sizing. This keeps the historical behavior of
      * {@code setObject}, where this parameter was ignored for string and binary types,
      * while allowing applications that supply an accurate hint to get a narrower parameter
      * declaration and better plan reuse.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2042,9 +2042,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      * BINARY), {@code scaleOrLength} is interpreted as an advisory length hint that shapes
      * the parameter's declared type definition. It is never enforced: if the actual value is
      * longer than {@code scaleOrLength}, the driver widens the declared length to the actual
-     * value length instead of failing or truncating. Passing a zero or negative value disables the
-     * application-provided hint; in that case the driver derives the declared length from the actual
-     * value when possible, otherwise it falls back to default sizing. This keeps the historical behavior of
+     * value length instead of failing or truncating. Passing a zero or negative value disables
+     * the application-provided hint entirely, and the driver falls back to its default parameter
+     * sizing. This keeps the historical behavior of
      * {@code setObject}, where {@code scaleOrLength} was ignored for string and binary types
      * per the JDBC 4.3 specification, while allowing applications that supply an accurate
      * hint to get a narrower parameter declaration and better plan reuse.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2042,8 +2042,9 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
      * BINARY), {@code scaleOrLength} is interpreted as an advisory length hint that shapes
      * the parameter's declared type definition. It is never enforced: if the actual value is
      * longer than {@code scaleOrLength}, the driver widens the declared length to the actual
-     * value length instead of failing or truncating. Passing a zero or negative value has
-     * the same effect as omitting the hint. This keeps the historical behavior of
+     * value length instead of failing or truncating. Passing a zero or negative value disables the
+     * application-provided hint; in that case the driver derives the declared length from the actual
+     * value when possible, otherwise it falls back to default sizing. This keeps the historical behavior of
      * {@code setObject}, where {@code scaleOrLength} was ignored for string and binary types
      * per the JDBC 4.3 specification, while allowing applications that supply an accurate
      * hint to get a narrower parameter declaration and better plan reuse.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2038,19 +2038,22 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     /**
      * {@inheritDoc}
      *
-     * Breaking Behavioral Change: For character and binary target types (VARCHAR, CHAR,
-     * NVARCHAR, NCHAR, VARBINARY, BINARY), {@code scaleOrLength} is now enforced as a
-     * maximum length constraint. Previously, the JDBC 4.3 specification defined
-     * {@code scaleOrLength} only for DECIMAL/NUMERIC (as scale) and for InputStream/Reader
-     * (as stream length), so it was ignored for string and binary types. With this change,
-     * if the actual value length exceeds the specified {@code scaleOrLength}, execution
-     * will fail with {@code R_parameterTypeValueLengthExceedsHint}. Applications that pass
-     * arbitrary or undersized {@code scaleOrLength} values for string/binary types must
-     * either increase the value to accommodate their largest payload or use a two-argument
-     * {@code setObject} overload that omits the length constraint.
+     * For character and binary target types (VARCHAR, CHAR, NVARCHAR, NCHAR, VARBINARY,
+     * BINARY), {@code scaleOrLength} is interpreted as an advisory length hint that shapes
+     * the parameter's declared type definition. It is never enforced: if the actual value is
+     * longer than {@code scaleOrLength}, the driver widens the declared length to the actual
+     * value length instead of failing or truncating. Passing a zero or negative value has
+     * the same effect as omitting the hint. This keeps the historical behavior of
+     * {@code setObject}, where {@code scaleOrLength} was ignored for string and binary types
+     * per the JDBC 4.3 specification, while allowing applications that supply an accurate
+     * hint to get a narrower parameter declaration and better plan reuse.
+     *
+     * Widening changes the parameter's type definition, so it may cause the statement to be
+     * re-prepared. Supply a hint large enough for the largest expected value to avoid this.
      *
      * If {@link #defineParameterType(int, int, int)} has been called for the same
-     * parameter, its {@code maxLength} takes precedence over {@code scaleOrLength}.
+     * parameter, its {@code maxLength} takes precedence over {@code scaleOrLength} and,
+     * unlike this hint, is enforced as a hard maximum.
      */
     @Override
     public final void setObject(int parameterIndex, Object x, int targetSqlType,
@@ -2063,11 +2066,10 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         // scaleOrLength - for java.sql.Types.DECIMAL, java.sql.Types.NUMERIC or temporal types,
         // this is the number of digits after the decimal point. For Java Object types
         // InputStream and Reader, this is the length of the data in the stream or reader.
-        // For supported short character/binary SQL types, this is treated as an
-        // application-provided length hint AND enforced as a maximum length constraint.
-        // If the actual value exceeds scaleOrLength for these types, execution fails with
-        // R_parameterTypeValueLengthExceedsHint. This is a breaking behavioral change from
-        // prior versions where scaleOrLength was ignored for string/binary types.
+        // For supported short character/binary SQL types, this is treated as an advisory
+        // application-provided length hint. It is never enforced: if the actual value exceeds
+        // scaleOrLength, the declared parameter length is widened to the actual value length
+        // so that nothing is truncated and execution does not fail.
         // Precedence: defineParameterType() hint (if present) takes priority over this value.
 
         Integer precision = null;

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java
@@ -293,30 +293,6 @@ public class CallableParameterLengthHintTest extends AbstractTest {
         }
     }
 
-    @ParameterizedTest(name = "non-positive length hint ignored for type {0}")
-    @MethodSource("allSupportedTypeCasesForLengthError")
-    public void testCallableSetObjectNamedNonPositiveLengthHintIgnored(int sqlType, String parameterName,
-            Object value, boolean binaryType) throws Exception {
-        // A non-positive hint is not a usable length, so it is ignored and the driver falls back
-        // to its default parameter sizing rather than being rejected.
-        String procName = binaryType ? procVarbinary : procVarchar;
-        try (SQLServerCallableStatement cs = (SQLServerCallableStatement) connection
-                .prepareCall("{call " + procName + "(?)}")) {
-
-            cs.setObject(parameterName, value, sqlType, 0);
-            cs.execute();
-
-            assertEquals(binaryType ? "varbinary(8000)" : "nvarchar(4000)", getTypeDefinition(cs, 1),
-                    "A non-positive hint must fall back to the driver's default sizing");
-        }
-
-        if (binaryType) {
-            assertArrayEquals((byte[]) value, readLastVarbinary(), "Value must be stored untruncated");
-        } else {
-            assertEquals((String) value, readLastVarchar(), "Value must be stored untruncated");
-        }
-    }
-
     @ParameterizedTest(name = "defineParameterType value exceeds hint throws for type {0}")
     @MethodSource("allSupportedTypeCasesForLengthError")
     public void testCallableDefineParameterTypeValueExceedsHintThrowsForAllSupportedTypes(int sqlType,
@@ -463,18 +439,28 @@ public class CallableParameterLengthHintTest extends AbstractTest {
                 Arguments.of(Types.BINARY, "@b", oneByte, true, 0));
     }
 
-    @ParameterizedTest(name = "Callable setObject non-positive hint rejected: type={0}, hint={4}")
+    @ParameterizedTest(name = "Callable setObject non-positive hint ignored: type={0}, hint={4}")
     @MethodSource("nonPositiveHintCases")
-    public void testCallableSetObjectNonPositiveHintRejected(int sqlType, String parameterName, Object value,
+    public void testCallableSetObjectNonPositiveHintIgnored(int sqlType, String parameterName, Object value,
             boolean binaryType, int hintLength) throws Exception {
+        // A non-positive setObject length is not a usable declaration. Unlike defineParameterType,
+        // it is not rejected - the hint is ignored and the driver falls back to its default
+        // parameter sizing, which is how setObject behaved before length hints existed.
         String procName = binaryType ? procVarbinary : procVarchar;
         try (SQLServerCallableStatement cs = (SQLServerCallableStatement) connection
                 .prepareCall("{call " + procName + "(?)}")) {
 
             cs.setObject(parameterName, value, sqlType, hintLength);
-            SQLServerException e = org.junit.jupiter.api.Assertions.assertThrows(SQLServerException.class, cs::execute);
-            assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_invalidParameterLength")),
-                    "Unexpected error: " + e.getMessage());
+            cs.execute();
+
+            assertEquals(binaryType ? "varbinary(8000)" : "nvarchar(4000)", getTypeDefinition(cs, 1),
+                    "A non-positive hint must fall back to the driver's default sizing");
+        }
+
+        if (binaryType) {
+            assertArrayEquals((byte[]) value, readLastVarbinary(), "Value must be stored untruncated");
+        } else {
+            assertEquals((String) value, readLastVarchar(), "Value must be stored untruncated");
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java
@@ -297,13 +297,17 @@ public class CallableParameterLengthHintTest extends AbstractTest {
     @MethodSource("allSupportedTypeCasesForLengthError")
     public void testCallableSetObjectNamedNonPositiveLengthHintIgnored(int sqlType, String parameterName,
             Object value, boolean binaryType) throws Exception {
-        // A non-positive hint is dropped rather than rejected.
+        // A non-positive hint is not a usable length, so it is ignored and the driver falls back
+        // to its default parameter sizing rather than being rejected.
         String procName = binaryType ? procVarbinary : procVarchar;
         try (SQLServerCallableStatement cs = (SQLServerCallableStatement) connection
                 .prepareCall("{call " + procName + "(?)}")) {
 
             cs.setObject(parameterName, value, sqlType, 0);
             cs.execute();
+
+            assertEquals(binaryType ? "varbinary(8000)" : "nvarchar(4000)", getTypeDefinition(cs, 1),
+                    "A non-positive hint must fall back to the driver's default sizing");
         }
 
         if (binaryType) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableParameterLengthHintTest.java
@@ -232,7 +232,7 @@ public class CallableParameterLengthHintTest extends AbstractTest {
     }
 
     private static Stream<Arguments> allSupportedTypeCasesForLengthError() {
-        // Values intentionally exceed small hints to validate deterministic error behavior.
+        // Values intentionally exceed small hints to validate deterministic behavior.
         byte[] binaryValue = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05};
         return Stream.of(
                 Arguments.of(Types.VARCHAR, "@v", "Engineering", false),
@@ -243,23 +243,73 @@ public class CallableParameterLengthHintTest extends AbstractTest {
                 Arguments.of(Types.BINARY, "@b", binaryValue, true));
     }
 
-    @ParameterizedTest(name = "value exceeds length hint throws for type {0}")
+    @ParameterizedTest(name = "value exceeds length hint widens for type {0}")
     @MethodSource("allSupportedTypeCasesForLengthError")
-    public void testCallableSetObjectNamedLengthHintSmallerThanValueThrowsForAllSupportedTypes(int sqlType,
+    public void testCallableSetObjectNamedLengthHintSmallerThanValueWidensForAllSupportedTypes(int sqlType,
             String parameterName, Object value, boolean binaryType) throws Exception {
-        // setObject length hint path should fail fast when value exceeds declared hint.
+        // The callable setObject length hint is advisory: an undersized hint is widened to the
+        // actual value length rather than failing, so the full value is stored untruncated.
         String procName = binaryType ? procVarbinary : procVarchar;
         try (SQLServerCallableStatement cs = (SQLServerCallableStatement) connection
                 .prepareCall("{call " + procName + "(?)}")) {
 
             cs.setObject(parameterName, value, sqlType, 3);
-            try {
-                cs.execute();
-                fail("Expected SQLServerException for value length exceeding setObject scale hint");
-            } catch (SQLServerException e) {
-                assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                        "Unexpected error: " + e.getMessage());
+            cs.execute();
+
+            if (binaryType) {
+                assertEquals("varbinary(" + ((byte[]) value).length + ")", getTypeDefinition(cs, 1),
+                        "Expected the declared length to widen to the actual value length");
+            } else {
+                assertEquals("nvarchar(" + ((String) value).length() + ")", getTypeDefinition(cs, 1),
+                        "Expected the declared length to widen to the actual value length");
             }
+        }
+
+        if (binaryType) {
+            assertArrayEquals((byte[]) value, readLastVarbinary(), "Value must be stored untruncated");
+        } else {
+            assertEquals((String) value, readLastVarchar(), "Value must be stored untruncated");
+        }
+    }
+
+    @ParameterizedTest(name = "forceEncrypt overload widens for type {0}")
+    @MethodSource("allSupportedTypeCasesForLengthError")
+    public void testCallableSetObjectNamedForceEncryptLengthHintWidensForAllSupportedTypes(int sqlType,
+            String parameterName, Object value, boolean binaryType) throws Exception {
+        // Same advisory behavior on the forceEncrypt overload (forceEncrypt=false here, so the
+        // non-AE path is exercised).
+        String procName = binaryType ? procVarbinary : procVarchar;
+        try (SQLServerCallableStatement cs = (SQLServerCallableStatement) connection
+                .prepareCall("{call " + procName + "(?)}")) {
+
+            cs.setObject(parameterName, value, sqlType, 3, false);
+            cs.execute();
+        }
+
+        if (binaryType) {
+            assertArrayEquals((byte[]) value, readLastVarbinary(), "Value must be stored untruncated");
+        } else {
+            assertEquals((String) value, readLastVarchar(), "Value must be stored untruncated");
+        }
+    }
+
+    @ParameterizedTest(name = "non-positive length hint ignored for type {0}")
+    @MethodSource("allSupportedTypeCasesForLengthError")
+    public void testCallableSetObjectNamedNonPositiveLengthHintIgnored(int sqlType, String parameterName,
+            Object value, boolean binaryType) throws Exception {
+        // A non-positive hint is dropped rather than rejected.
+        String procName = binaryType ? procVarbinary : procVarchar;
+        try (SQLServerCallableStatement cs = (SQLServerCallableStatement) connection
+                .prepareCall("{call " + procName + "(?)}")) {
+
+            cs.setObject(parameterName, value, sqlType, 0);
+            cs.execute();
+        }
+
+        if (binaryType) {
+            assertArrayEquals((byte[]) value, readLastVarbinary(), "Value must be stored untruncated");
+        } else {
+            assertEquals((String) value, readLastVarchar(), "Value must be stored untruncated");
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
@@ -586,21 +586,33 @@ public class ParameterLengthHintTest extends AbstractTest {
             }
         }
 
-        @ParameterizedTest(name = "Non-positive setObject scaleOrLength hint rejected: {1}, hint={2}")
+        // A non-positive setObject scaleOrLength is not an error. The hint is ignored and the
+        // declared length is derived from the actual value instead.
+        @ParameterizedTest(name = "Non-positive setObject scaleOrLength hint ignored: {1}, hint={2}")
         @MethodSource("nonPositiveLengthCases")
-        void testSetObjectNonPositiveHintRejected(int sqlType, String typeName, int hintLength) throws Exception {
-            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
-                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+        void testSetObjectNonPositiveHintIgnored(int sqlType, String typeName, int hintLength) throws Exception {
+            boolean isBinary = (Types.VARBINARY == sqlType || Types.BINARY == sqlType);
+            String column = isBinary ? "bincol" : "vcol";
 
-                if (sqlType == Types.VARBINARY || sqlType == Types.BINARY) {
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (" + column + ") VALUES (?)")) {
+
+                if (isBinary) {
                     pstmt.setObject(1, new byte[] {0x01}, sqlType, hintLength);
                 } else {
                     pstmt.setObject(1, "a", sqlType, hintLength);
                 }
 
-                SQLServerException e = assertThrows(SQLServerException.class, pstmt::executeUpdate);
-                assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_invalidParameterLength")),
-                        "Unexpected error: " + e.getMessage());
+                pstmt.executeUpdate();
+
+                assertEquals(isBinary ? "varbinary(1)" : "nvarchar(1)", getTypeDefinition(pstmt, 1),
+                        "Non-positive hint must fall back to the actual value length");
+            }
+
+            if (isBinary) {
+                assertArrayEquals(new byte[] {0x01}, readLastVarbinary());
+            } else {
+                assertEquals("a", readLastVarchar());
             }
         }
 
@@ -778,6 +790,50 @@ public class ParameterLengthHintTest extends AbstractTest {
             }
         }
 
+        // varchar(n) is byte-counted on the server. With sendStringParametersAsUnicode=false a
+        // multi-byte value must be validated against its ENCODED BYTE length, not its Java char
+        // count - otherwise it passes validation and is then silently truncated server-side.
+        @Test
+        @DisplayName("defineParameterType validates VARCHAR against encoded byte length")
+        void testDefineParameterTypeVarcharValidatesByteLength() throws Exception {
+            // 4 characters, but more than 4 bytes in any non-Unicode collation.
+            String value = "caf\u00e9";
+            String connStr = connectionString + ";sendStringParametersAsUnicode=false;";
+
+            try (Connection con = PrepUtil.getConnection(connStr);
+                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con
+                         .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.defineParameterType(1, Types.VARCHAR, value.length());
+                pstmt.setString(1, value);
+
+                SQLServerException e = assertThrows(SQLServerException.class, pstmt::executeUpdate,
+                        "A value whose encoded byte length exceeds the declared varchar length must be rejected");
+                assertTrue(e.getMessage()
+                        .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
+                        "Unexpected error: " + e.getMessage());
+            }
+        }
+
+        // The same value under the default sendStringParametersAsUnicode=true goes on the wire as
+        // nvarchar(n), which is character-counted, so a char-sized declaration must still pass.
+        @Test
+        @DisplayName("defineParameterType validates NVARCHAR against character length")
+        void testDefineParameterTypeNvarcharValidatesCharLength() throws Exception {
+            String value = "caf\u00e9";
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.defineParameterType(1, Types.VARCHAR, value.length());
+                pstmt.setString(1, value);
+                pstmt.executeUpdate();
+
+                assertEquals("nvarchar(4)", getTypeDefinition(pstmt, 1),
+                        "Unicode parameters are character-counted, so 4 chars fits a length of 4");
+            }
+            assertEquals(value, readLastVarchar(), "Multi-byte value must round-trip intact");
+        }
+
         Stream<Arguments> binaryHintSmallerThanValueCases() {
             byte[] fiveBytes = {0x01, 0x02, 0x03, 0x04, 0x05};
             return Stream.of(
@@ -799,24 +855,25 @@ public class ParameterLengthHintTest extends AbstractTest {
                             "setObject NVARCHAR hint smaller than value"));
         }
 
+        // The setObject scaleOrLength hint is advisory. When it is smaller than the value, the
+        // driver widens the declared length to the actual value length instead of failing, so the
+        // full value is stored untruncated.
         @ParameterizedTest(name = "{3}")
         @MethodSource("setObjectHintSmallerThanValueCases")
-        void testSetObjectHintSmallerThanValueThrowsError(String value, int sqlType, int hintLength,
+        void testSetObjectHintSmallerThanValueWidens(String value, int sqlType, int hintLength,
                 String description) throws Exception {
             String column = Types.NVARCHAR == sqlType ? "nvcol" : "vcol";
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
                     .prepareStatement("INSERT INTO " + escapedTable + " (" + column + ") VALUES (?)")) {
 
                 pstmt.setObject(1, value, sqlType, hintLength);
-                try {
-                    pstmt.executeUpdate();
-                    fail("Expected SQLServerException for value length exceeding setObject scaleOrLength hint");
-                } catch (SQLServerException e) {
-                    assertTrue(e.getMessage()
-                            .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                            "Unexpected error: " + e.getMessage());
-                }
+                pstmt.executeUpdate();
+
+                // sendStringParametersAsUnicode=true (default) routes both cases through NVARCHAR.
+                assertEquals("nvarchar(" + value.length() + ")", getTypeDefinition(pstmt, 1),
+                        "Expected the declared length to widen to the actual value length");
             }
+            assertEquals(value, readLastString(column), "Value must be stored untruncated");
         }
 
         Stream<Arguments> setObjectBinaryHintSmallerThanValueCases() {
@@ -829,21 +886,18 @@ public class ParameterLengthHintTest extends AbstractTest {
 
         @ParameterizedTest(name = "{3}")
         @MethodSource("setObjectBinaryHintSmallerThanValueCases")
-        void testSetObjectBinaryHintSmallerThanValueThrowsError(byte[] value, int sqlType, int hintLength,
+        void testSetObjectBinaryHintSmallerThanValueWidens(byte[] value, int sqlType, int hintLength,
                 String description) throws Exception {
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
                     .prepareStatement("INSERT INTO " + escapedTable + " (bincol) VALUES (?)")) {
 
                 pstmt.setObject(1, value, sqlType, hintLength);
-                try {
-                    pstmt.executeUpdate();
-                    fail("Expected SQLServerException for value length exceeding setObject scaleOrLength hint");
-                } catch (SQLServerException e) {
-                    assertTrue(e.getMessage()
-                            .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                            "Unexpected error: " + e.getMessage());
-                }
+                pstmt.executeUpdate();
+
+                assertEquals("varbinary(" + value.length + ")", getTypeDefinition(pstmt, 1),
+                        "Expected the declared length to widen to the actual value length");
             }
+            assertArrayEquals(value, readLastVarbinary(), "Value must be stored untruncated");
         }
 
         // Verify binary data fails execution when the hint is smaller than the byte[] length.
@@ -883,21 +937,18 @@ public class ParameterLengthHintTest extends AbstractTest {
 
         @ParameterizedTest(name = "{4}")
         @MethodSource("setObjectLengthSmallerThanValueCases")
-        void testSetObjectLengthSmallerThanValueThrowsError(String value, int sqlType, int scaleOrLength,
+        void testSetObjectLengthSmallerThanValueWidens(String value, int sqlType, int scaleOrLength,
                 String column, String description) throws Exception {
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
                     .prepareStatement("INSERT INTO " + escapedTable + " (" + column + ") VALUES (?)")) {
 
                 pstmt.setObject(1, value, sqlType, scaleOrLength);
-                try {
-                    pstmt.executeUpdate();
-                    fail("Expected SQLServerException for setObject value length exceeding scaleOrLength");
-                } catch (SQLServerException e) {
-                    assertTrue(e.getMessage()
-                            .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                            "Unexpected error: " + e.getMessage());
-                }
+                pstmt.executeUpdate();
+
+                assertEquals("nvarchar(" + value.length() + ")", getTypeDefinition(pstmt, 1),
+                        "Expected the declared length to widen to the actual value length");
             }
+            assertEquals(value, readLastString(column), "Value must be stored untruncated");
         }
 
         Stream<Arguments> setObjectBinaryLengthSmallerThanValueCases() {
@@ -909,21 +960,18 @@ public class ParameterLengthHintTest extends AbstractTest {
 
         @ParameterizedTest(name = "{3}")
         @MethodSource("setObjectBinaryLengthSmallerThanValueCases")
-        void testSetObjectBinaryLengthSmallerThanValueThrowsError(byte[] value, int sqlType, int scaleOrLength,
+        void testSetObjectBinaryLengthSmallerThanValueWidens(byte[] value, int sqlType, int scaleOrLength,
                 String description) throws Exception {
             try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
                     .prepareStatement("INSERT INTO " + escapedTable + " (bincol) VALUES (?)")) {
 
                 pstmt.setObject(1, value, sqlType, scaleOrLength);
-                try {
-                    pstmt.executeUpdate();
-                    fail("Expected SQLServerException for setObject value length exceeding scaleOrLength");
-                } catch (SQLServerException e) {
-                    assertTrue(e.getMessage()
-                            .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                            "Unexpected error: " + e.getMessage());
-                }
+                pstmt.executeUpdate();
+
+                assertEquals("varbinary(" + value.length + ")", getTypeDefinition(pstmt, 1),
+                        "Expected the declared length to widen to the actual value length");
             }
+            assertArrayEquals(value, readLastVarbinary(), "Value must be stored untruncated");
         }
     }
 
@@ -1176,46 +1224,48 @@ public class ParameterLengthHintTest extends AbstractTest {
 
             Stream<Arguments> batchSetObjectHintTooSmallCases() {
                 return Stream.of(
-                    Arguments.of(Types.VARCHAR, "vcol", "0123456789", "Batch setObject VARCHAR over-length error"),
-                    Arguments.of(Types.CHAR, "vcol", "0123456789", "Batch setObject CHAR over-length error"),
-                    Arguments.of(Types.NVARCHAR, "nvcol", "0123456789", "Batch setObject NVARCHAR over-length error"),
-                    Arguments.of(Types.NCHAR, "nvcol", "0123456789", "Batch setObject NCHAR over-length error"),
+                    Arguments.of(Types.VARCHAR, "vcol", "0123456789", "Batch setObject VARCHAR over-length widens"),
+                    Arguments.of(Types.CHAR, "vcol", "0123456789", "Batch setObject CHAR over-length widens"),
+                    Arguments.of(Types.NVARCHAR, "nvcol", "0123456789", "Batch setObject NVARCHAR over-length widens"),
+                    Arguments.of(Types.NCHAR, "nvcol", "0123456789", "Batch setObject NCHAR over-length widens"),
                     Arguments.of(Types.VARBINARY, "bincol", new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-                        "Batch setObject VARBINARY over-length error"),
+                        "Batch setObject VARBINARY over-length widens"),
                     Arguments.of(Types.BINARY, "bincol", new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-                        "Batch setObject BINARY over-length error"));
+                        "Batch setObject BINARY over-length widens"));
             }
 
+            // A batch where the first row fits the setObject hint and the second does not. The
+            // second row widens the declared length, which re-prepares the statement mid-batch.
+            // Both rows must be inserted untruncated and no error may be raised.
             @ParameterizedTest(name = "{3}")
             @MethodSource("batchSetObjectHintTooSmallCases")
-            void testBatchSetObjectHintTooSmallThrowsError(int sqlType, String column, Object longValue,
+            void testBatchSetObjectHintTooSmallWidens(int sqlType, String column, Object longValue,
                 String description) throws Exception {
+                int maxIdBefore = getMaxId();
                 try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
                     .prepareStatement("INSERT INTO " + escapedTable + " (" + column + ") VALUES (?)")) {
 
-                if ("bincol".equals(column)) {
-                    pstmt.setObject(1, new byte[] {0x01, 0x02, 0x03}, sqlType, 5);
+                    if ("bincol".equals(column)) {
+                        pstmt.setObject(1, new byte[] {0x01, 0x02, 0x03}, sqlType, 5);
+                    } else {
+                        pstmt.setObject(1, "hi", sqlType, 5);
+                    }
                     pstmt.addBatch();
+
                     pstmt.setObject(1, longValue, sqlType, 5);
                     pstmt.addBatch();
-                } else {
-                    pstmt.setObject(1, "hi", sqlType, 5);
-                    pstmt.addBatch();
-                    pstmt.setObject(1, longValue, sqlType, 5);
+
+                    pstmt.executeBatch();
                 }
 
-                // Validation can throw while adding the over-length row in batch mode.
-                SQLException e = assertThrows(SQLException.class, () -> {
-                    pstmt.addBatch();
-                    pstmt.executeBatch();
-                });
-                String msg = e.getMessage();
-                String causeMsg = (null != e.getCause()) ? e.getCause().getMessage() : null;
-                assertTrue((null != msg
-                    && msg.matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")))
-                    || (null != causeMsg && causeMsg.matches(TestUtils
-                        .formatErrorMsg("R_parameterTypeValueLengthExceedsHint"))),
-                    "Unexpected error: " + e.getMessage());
+                assertEquals(2, countRowsSince(maxIdBefore), "Both batch rows must be inserted");
+
+                if ("bincol".equals(column)) {
+                    assertArrayEquals((byte[]) longValue, readLastVarbinary(),
+                            "Over-length batch row must be stored untruncated");
+                } else {
+                    assertEquals((String) longValue, readLastString(column),
+                            "Over-length batch row must be stored untruncated");
                 }
             }
 
@@ -1407,33 +1457,35 @@ public class ParameterLengthHintTest extends AbstractTest {
         }
 
         @Test
-        @DisplayName("PreparedStatement.setObject enforces scaleOrLength constraint")
-        void testSetObjectViaInterfaceRejectsOverLength() throws Exception {
-            // scaleOrLength=5, value="Engineering" (11 chars) — should fail at execution
+        @DisplayName("PreparedStatement.setObject widens an undersized scaleOrLength")
+        void testSetObjectViaInterfaceWidensOverLength() throws Exception {
+            // scaleOrLength=5, value="Engineering" (11 chars) — hint is advisory, so the declared
+            // length widens to 11 and the full value is stored.
+            String value = "Engineering";
             try (PreparedStatement pstmt = connection
                     .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
 
-                pstmt.setObject(1, "Engineering", Types.VARCHAR, 5);
-                SQLServerException e = assertThrows(SQLServerException.class, pstmt::executeUpdate);
-                assertTrue(e.getMessage()
-                        .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                        "Unexpected error: " + e.getMessage());
+                pstmt.setObject(1, value, Types.VARCHAR, 5);
+                pstmt.executeUpdate();
+
+                assertEquals("nvarchar(" + value.length() + ")", getTypeDefinition(pstmt, 1));
             }
+            assertEquals(value, readLastVarchar());
         }
 
         @Test
-        @DisplayName("PreparedStatement.setObject binary enforces scaleOrLength constraint")
-        void testSetObjectBinaryViaInterfaceRejectsOverLength() throws Exception {
+        @DisplayName("PreparedStatement.setObject binary widens an undersized scaleOrLength")
+        void testSetObjectBinaryViaInterfaceWidensOverLength() throws Exception {
             byte[] value = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
             try (PreparedStatement pstmt = connection
                     .prepareStatement("INSERT INTO " + escapedTable + " (bincol) VALUES (?)")) {
 
                 pstmt.setObject(1, value, Types.VARBINARY, 3);
-                SQLServerException e = assertThrows(SQLServerException.class, pstmt::executeUpdate);
-                assertTrue(e.getMessage()
-                        .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                        "Unexpected error: " + e.getMessage());
+                pstmt.executeUpdate();
+
+                assertEquals("varbinary(" + value.length + ")", getTypeDefinition(pstmt, 1));
             }
+            assertArrayEquals(value, readLastVarbinary());
         }
 
         @Test
@@ -1458,6 +1510,211 @@ public class ParameterLengthHintTest extends AbstractTest {
             assertEquals("row1", stored.get(0));
             assertEquals("row2", stored.get(1));
             assertEquals("row3", stored.get(2));
+        }
+    }
+
+    // =========================================================================
+    // setObject hint is advisory (widening)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("setObject scaleOrLength is advisory and widens to fit")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class SetObjectAdvisoryHintTests {
+
+        // An accurate hint is still honored exactly - widening must not kick in when the value fits.
+        @Test
+        @DisplayName("Hint larger than the value is honored, not widened")
+        void testHintLargerThanValueIsHonored() throws Exception {
+            String value = "short";
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, value, Types.VARCHAR, 100);
+                pstmt.executeUpdate();
+
+                assertEquals("nvarchar(100)", getTypeDefinition(pstmt, 1),
+                        "A hint that already fits must be used as-is");
+            }
+            assertEquals(value, readLastVarchar());
+        }
+
+        // A value exactly equal to the hint is not over-length and must not widen.
+        @Test
+        @DisplayName("Hint exactly equal to the value length is honored")
+        void testHintEqualToValueLengthIsHonored() throws Exception {
+            String value = "0123456789";
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, value, Types.VARCHAR, value.length());
+                pstmt.executeUpdate();
+
+                assertEquals("nvarchar(10)", getTypeDefinition(pstmt, 1));
+            }
+            assertEquals(value, readLastVarchar());
+        }
+
+        // Widening past the short-type boundary must promote to the corresponding max type
+        // rather than declaring an illegal nvarchar(4001).
+        @Test
+        @DisplayName("Widening past the NVARCHAR boundary promotes to nvarchar(max)")
+        void testWideningPastBoundaryPromotesToMax() throws Exception {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 5000; i++) {
+                sb.append('x');
+            }
+            String value = sb.toString();
+
+            try (Connection con = PrepUtil.getConnection(connectionString);
+                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con
+                         .prepareStatement("SELECT LEN(CAST(? AS NVARCHAR(MAX)))")) {
+
+                pstmt.setObject(1, value, Types.NVARCHAR, 10);
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(value.length(), rs.getInt(1),
+                            "The full value must reach the server untruncated");
+                }
+
+                assertEquals("nvarchar(max)", getTypeDefinition(pstmt, 1),
+                        "Widening beyond 4000 characters must promote to nvarchar(max)");
+            }
+        }
+
+        // Widening past the VARBINARY boundary must promote to varbinary(max).
+        @Test
+        @DisplayName("Widening past the VARBINARY boundary promotes to varbinary(max)")
+        void testBinaryWideningPastBoundaryPromotesToMax() throws Exception {
+            byte[] value = new byte[9000];
+            for (int i = 0; i < value.length; i++) {
+                value[i] = (byte) (i % 256);
+            }
+
+            try (Connection con = PrepUtil.getConnection(connectionString);
+                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con
+                         .prepareStatement("SELECT DATALENGTH(CAST(? AS VARBINARY(MAX)))")) {
+
+                pstmt.setObject(1, value, Types.VARBINARY, 10);
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(value.length, rs.getInt(1),
+                            "The full value must reach the server untruncated");
+                }
+
+                assertEquals("varbinary(max)", getTypeDefinition(pstmt, 1),
+                        "Widening beyond 8000 bytes must promote to varbinary(max)");
+            }
+        }
+
+        // varchar(n) counts BYTES on the server, but String.length() counts characters. A
+        // multi-byte value must be measured in encoded bytes, otherwise the widened declaration
+        // would still be too small and the server would truncate.
+        @Test
+        @DisplayName("VARCHAR widening measures encoded bytes, not Java chars, when SSPAU=false")
+        void testVarcharWideningUsesByteLength() throws Exception {
+            String value = "caf\u00e9 na\u00efve r\u00e9sum\u00e9";
+            String connStr = connectionString + ";sendStringParametersAsUnicode=false;";
+
+            try (Connection con = PrepUtil.getConnection(connStr);
+                 SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con
+                         .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                // Hint of 1 is far too small; the declared length must widen to at least the
+                // number of encoded bytes so that nothing is truncated server-side.
+                pstmt.setObject(1, value, Types.VARCHAR, 1);
+                pstmt.executeUpdate();
+
+                String typeDef = getTypeDefinition(pstmt, 1);
+                assertTrue(typeDef.startsWith("varchar("),
+                        "Expected a varchar declaration with SSPAU=false, got: " + typeDef);
+
+                int declared = Integer.parseInt(typeDef.substring("varchar(".length(), typeDef.length() - 1));
+                assertTrue(declared >= value.length(),
+                        "Declared length " + declared + " must cover the encoded byte length of the value");
+            }
+
+            assertEquals(value, readLastVarchar(), "Multi-byte value must be stored untruncated");
+        }
+
+        // A null value has no length to widen against, so a positive hint still shapes the
+        // declaration and execution succeeds.
+        @Test
+        @DisplayName("Null value with an undersized hint still succeeds")
+        void testNullValueWithHint() throws Exception {
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, null, Types.VARCHAR, 5);
+                pstmt.executeUpdate();
+            }
+            assertNull(readLastVarchar(), "Null must round-trip as null");
+        }
+
+        // Repeated executions on the same statement with progressively longer values must each
+        // succeed, re-preparing as the declared length grows.
+        @Test
+        @DisplayName("Successive executions widen progressively without error")
+        void testSuccessiveExecutionsWiden() throws Exception {
+            int maxIdBefore = getMaxId();
+            String[] values = {"a", "abcdefgh", "abcdefghijklmnopqrstuvwxyz"};
+
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                for (String value : values) {
+                    pstmt.setObject(1, value, Types.VARCHAR, 4);
+                    pstmt.executeUpdate();
+                }
+            }
+
+            List<String> stored = readVarcharsSince(maxIdBefore);
+            assertEquals(values.length, stored.size(), "Every execution must insert a row");
+            for (int i = 0; i < values.length; i++) {
+                assertEquals(values[i], stored.get(i), "Value must be stored untruncated");
+            }
+        }
+
+        // A hint on a value that is neither String nor byte[] cannot be measured, so it is
+        // dropped and the driver falls back to its default sizing. This must not fail.
+        @Test
+        @DisplayName("Hint on a non-string, non-binary value is ignored")
+        void testHintOnUnmeasurableValueIsIgnored() throws Exception {
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, 1234567890, Types.VARCHAR, 2);
+                pstmt.executeUpdate();
+            }
+            assertEquals("1234567890", readLastVarchar(),
+                    "Unmeasurable value must be stored untruncated");
+        }
+
+        // defineParameterType() keeps its enforced semantics even though setObject() no longer
+        // enforces. This guards against the two paths being conflated.
+        @Test
+        @DisplayName("defineParameterType still enforces while setObject does not")
+        void testDefineParameterTypeStillEnforces() throws Exception {
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.defineParameterType(1, Types.VARCHAR, 5);
+                pstmt.setString(1, "Engineering");
+
+                SQLServerException e = assertThrows(SQLServerException.class, pstmt::executeUpdate);
+                assertTrue(e.getMessage()
+                        .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
+                        "Unexpected error: " + e.getMessage());
+            }
+
+            // The same undersized length supplied through setObject widens instead of failing.
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, "Engineering", Types.VARCHAR, 5);
+                pstmt.executeUpdate();
+            }
+            assertEquals("Engineering", readLastVarchar());
         }
     }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
@@ -19,7 +19,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
@@ -1565,6 +1570,46 @@ public class ParameterLengthHintTest extends AbstractTest {
                 assertEquals("nvarchar(10)", getTypeDefinition(pstmt, 1));
             }
             assertEquals(value, readLastVarchar());
+        }
+
+        // The documented FINER diagnostic is the only signal an application has that its hint was
+        // too small, so it is asserted rather than left to manual inspection.
+        @Test
+        @DisplayName("Widening emits a FINER diagnostic naming both lengths")
+        void testWideningEmitsFinerLogMessage() throws Exception {
+            Logger paramLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.Parameter");
+            Level originalLevel = paramLogger.getLevel();
+            List<String> messages = Collections.synchronizedList(new ArrayList<String>());
+            Handler captureHandler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    messages.add(record.getMessage());
+                }
+
+                @Override
+                public void flush() {}
+
+                @Override
+                public void close() {}
+            };
+            captureHandler.setLevel(Level.FINER);
+            paramLogger.addHandler(captureHandler);
+            paramLogger.setLevel(Level.FINER);
+
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, "0123456789", Types.VARCHAR, 3);
+                pstmt.executeUpdate();
+            } finally {
+                paramLogger.removeHandler(captureHandler);
+                paramLogger.setLevel(originalLevel);
+            }
+
+            assertTrue(messages.stream().anyMatch(m -> m.contains("setObject length hint 3")
+                    && m.contains("actual value length 10")),
+                    "Expected a FINER widening diagnostic naming the hint and the actual length, but got: "
+                            + messages);
         }
 
         // Widening past the short-type boundary must promote to the corresponding max type

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
@@ -804,14 +804,25 @@ public class ParameterLengthHintTest extends AbstractTest {
                  SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) con
                          .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
 
-                pstmt.defineParameterType(1, Types.VARCHAR, value.length());
-                pstmt.setString(1, value);
+            // Compute the server-side byte length under the current database collation so the test is
+            // deterministic across code pages (e.g. Cp1252 vs UTF-8 collations).
+            int byteLen;
+            try (PreparedStatement lenStmt = con.prepareStatement("SELECT DATALENGTH(CAST(? AS VARCHAR(MAX)))")) {
+                lenStmt.setString(1, value);
+                try (ResultSet rs = lenStmt.executeQuery()) {
+                    assertTrue(rs.next());
+                    byteLen = rs.getInt(1);
+                }
+            }
 
-                SQLServerException e = assertThrows(SQLServerException.class, pstmt::executeUpdate,
-                        "A value whose encoded byte length exceeds the declared varchar length must be rejected");
-                assertTrue(e.getMessage()
-                        .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
-                        "Unexpected error: " + e.getMessage());
+            pstmt.defineParameterType(1, Types.VARCHAR, byteLen - 1);
+            pstmt.setString(1, value);
+
+            SQLServerException e = assertThrows(SQLServerException.class, pstmt::executeUpdate,
+                    "A value whose encoded byte length exceeds the declared varchar length must be rejected");
+            assertTrue(e.getMessage()
+                    .matches(TestUtils.formatErrorMsg("R_parameterTypeValueLengthExceedsHint")),
+                    "Unexpected error: " + e.getMessage());
             }
         }
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/ParameterLengthHintTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
@@ -605,8 +606,8 @@ public class ParameterLengthHintTest extends AbstractTest {
 
                 pstmt.executeUpdate();
 
-                assertEquals(isBinary ? "varbinary(1)" : "nvarchar(1)", getTypeDefinition(pstmt, 1),
-                        "Non-positive hint must fall back to the actual value length");
+                assertEquals(isBinary ? "varbinary(8000)" : "nvarchar(4000)", getTypeDefinition(pstmt, 1),
+                        "Non-positive hint must be ignored in favour of the driver's default sizing");
             }
 
             if (isBinary) {
@@ -1684,6 +1685,42 @@ public class ParameterLengthHintTest extends AbstractTest {
             for (int i = 0; i < values.length; i++) {
                 assertEquals(values[i], stored.get(i), "Value must be stored untruncated");
             }
+        }
+
+        // A non-positive length is not a usable declaration, so it is ignored outright and the
+        // driver falls back to its default sizing rather than deriving a length from the value.
+        @ParameterizedTest(name = "Non-positive hint {0} falls back to default sizing")
+        @ValueSource(ints = {0, -1, -100})
+        @DisplayName("Non-positive hint falls back to default sizing")
+        void testNonPositiveHintFallsBackToDefault(int hintLength) throws Exception {
+            String value = "abc";
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, value, Types.VARCHAR, hintLength);
+                pstmt.executeUpdate();
+
+                assertEquals("nvarchar(4000)", getTypeDefinition(pstmt, 1),
+                        "A non-positive hint must be ignored, not turned into the value length");
+            }
+            assertEquals(value, readLastVarchar());
+        }
+
+        // An empty value combined with a positive hint must still declare the hint - a declared
+        // length of zero would be illegal.
+        @Test
+        @DisplayName("Empty value with a positive hint declares the hint")
+        void testEmptyValueWithPositiveHint() throws Exception {
+            try (SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection
+                    .prepareStatement("INSERT INTO " + escapedTable + " (vcol) VALUES (?)")) {
+
+                pstmt.setObject(1, "", Types.VARCHAR, 10);
+                pstmt.executeUpdate();
+
+                assertEquals("nvarchar(10)", getTypeDefinition(pstmt, 1),
+                        "An empty value must never produce a zero-length declaration");
+            }
+            assertEquals("", readLastVarchar());
         }
 
         // A hint on a value that is neither String nor byte[] cannot be measured, so it is


### PR DESCRIPTION
## Problem

[#2960](https://github.com/microsoft/mssql-jdbc/pull/2960) introduced parameter length hints via `defineParameterType()` and `setObject(..., scaleOrLength)`. As part of that change, `setObject(int, Object, int, int)` (and the `SQLServerCallableStatement.setObject(String, Object, int, int)` variants) began treating `scaleOrLength` as an **enforced maximum length** for character and binary target types, throwing `R_parameterTypeValueLengthExceedsHint` when the value was longer.

Per the JDBC 4.3 specification, `scaleOrLength` is only defined for `DECIMAL`/`NUMERIC` (as scale) and `InputStream`/`Reader` (as stream length) — it was previously **ignored** for string and binary types. Applications that had been passing an inaccurate or placeholder length were silently fine before, and started failing at execution time after the change.

## Fix

`setObject` length hints are now **advisory**. A positive hint is used to size the parameter when it fits and quietly widened when it does not, so nothing truncates and nothing throws. A non-positive hint is not a usable declaration and is ignored outright.

| `scaleOrLength` | Behavior |
|---|---|
| `<= 0` | Ignored — driver default sizing (`nvarchar(4000)` / `varchar(8000)` / `varbinary(8000)`), same as calling `setObject` without a length |
| `> 0`, value fits | Hint honored exactly |
| `> 0`, value longer than the hint | Declared length **widened to the actual value length**, logged at `FINER` |
| `> 0`, value not `String`/`byte[]` or collation unavailable | Ignored — driver default sizing |

Widening happens while the type definition string is built, **before** prepare. `SQLServerPreparedStatement.buildPreparedStrings()` only re-prepares when the type definition actually changed, so the cost is at most one re-prepare and no extra round trip.

Because widening is only reachable when the actual length already exceeds a positive hint, a zero-length declaration such as `varchar(0)` is unreachable by construction.

`defineParameterType()` is **unchanged and remains enforced** — it is an explicit declaration by the application, not a hint, so violating it is still an error.

## Also fixed: length validation units

While isolating the two paths, we found that length validation compared the value against `String.length()` — a **character** count — regardless of the declared type.

`varchar(n)` and `char(n)` are **byte**-counted on the server. With `sendStringParametersAsUnicode=false`, a multi-byte value such as `"café"` (4 chars, 5+ bytes) would pass validation against `defineParameterType(1, VARCHAR, 4)` and then be **silently truncated by the server**.

Values are now measured in the units the server uses for the declared type:

| Declared type | Unit |
|---|---|
| `varchar` / `char` | bytes, via the database collation's charset |
| `nvarchar` / `nchar` | characters |
| `binary` / `varbinary` | bytes |

This is well-defined because `Parameter.setValue()` re-tags character parameters as `NVARCHAR` when `sendStringParametersAsUnicode=true`. A parameter that still carries `JDBCType.VARCHAR`/`CHAR` by the time it reaches length resolution is therefore genuinely sent as `varchar` on the wire, so the measurement unit always matches the type being declared.

Note that this makes the enforced `defineParameterType` path **stricter** in one narrow case: a multi-byte value that previously passed validation and was then truncated by the server is now correctly rejected up front. This only affects `sendStringParametersAsUnicode=false` with non-ASCII data, and the previous behavior was silent data loss.

## Changes

**Driver**
- `Parameter.java` — split hint resolution into an enforced `defineParameterType` path and an advisory `setObject` path (`resolveSetObjectLengthHint`); added `getActualValueLength` for unit-correct measurement, now shared by both paths; added a `FINER` logger.
- `SQLServerPreparedStatement.java` — rewrote the `setObject(int, Object, int, int)` javadoc; removed the "Breaking Behavioral Change" note.
- `SQLServerCallableStatement.java` — same for `setObject(String, Object, int, int)` and the `forceEncrypt` overload.

**Docs**
- `docs/parameter-hints/setObject-scaleOrLength.md`, `parameter-hints-overview.md`, `define-parameter-type.md` — documented advisory vs. enforced semantics, the widening rule, non-positive handling, and the measurement units.

**Tests**
- `ParameterLengthHintTest.java` — converted 8 `setObject` "throws" tests to "widens"; added a `SetObjectAdvisoryHintTests` class covering hint-honored-when-it-fits, exact fit, widening past the short-type boundary into `nvarchar(max)`/`varbinary(max)`, multi-byte VARCHAR byte measurement under `SSPAU=false`, non-positive hints falling back to default sizing, empty and null values, successive widening across executions, unmeasurable values, and a guard that `defineParameterType` still enforces. Added two tests pinning the byte-vs-character validation units.
- `CallableParameterLengthHintTest.java` — converted the named-parameter `setObject` enforcement test to widening; added coverage for the `forceEncrypt` overload and non-positive hints.

No `CHANGELOG.md` change — the existing #2960 entry already describes the length-hint feature, and this PR restores the `setObject` behavior that entry originally implied.

## Validation

- `mvn -P jre11 -DskipTests test-compile` passes.
- `defineParameterType` enforcement tests were intentionally left untouched and still assert `R_parameterTypeValueLengthExceedsHint`.

The parameter-hint test classes require a live SQL Server instance and have not been executed in this environment — they need a run against a configured test server before merge.
