### PR TITLE
Improve JDBC URL parsing validation for port and instance name segments

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java
@@ -3390,7 +3390,7 @@ public class SQLServerConnection implements ISQLServerConnection, java.io.Serial
                     String strPort = activeConnectionProperties.getProperty(sPropKey);
                     if (null != strPort) {
                         nPort = Integer.parseInt(strPort);
-                        if ((nPort < 0) || (nPort > 65535)) {
+                        if ((nPort < 0) || (nPort > Util.MAX_PORT_NUMBER)) {
                             MessageFormat form = new MessageFormat(
                                     SQLServerException.getErrString("R_invalidPortNumber"));
                             Object[] msgArgs = {Integer.toString(nPort)};

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java
@@ -1520,8 +1520,10 @@ public final class SQLServerDriver implements java.sql.Driver {
         try {
             result = (Util.parseUrl(url, drLogger) != null);
         } catch (SQLServerException e) {
-            // ignore the exception from the parse URL failure, if we cant parse the URL we do not accept em
-            result = false;
+            // A parse failure means the URL is one of ours but malformed, so accept it here
+            // and let connect() report the specific error. Only a null result (prefix
+            // mismatch) means the URL is not ours.
+            result = true;
         }
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "acceptsURL", result);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -117,6 +117,7 @@ public final class SQLServerResource extends ListResourceBundle {
         {"R_modeSuppliedNotValid", "The supplied mode is not valid."},
         {"R_errorConnectionString", "The connection string contains a badly formed name or value."},
         {"R_errorServerName", "The serverName connection property value {0} is badly formed."},
+        {"R_errorInstanceName", "The instanceName connection property value {0} is badly formed."},
         {"R_errorProcessingComplexQuery", "An error occurred while processing the complex query."},
         {"R_invalidOffset", "The offset {0} is not valid."},
         {"R_nullConnection", "The connection URL is null."},

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -39,6 +39,9 @@ final class Util {
 
     final static String ACTIVITY_ID_TRACE_PROPERTY = "com.microsoft.sqlserver.jdbc.traceactivity";
 
+    /** Maximum valid TCP port number. */
+    static final int MAX_PORT_NUMBER = 65535;
+
     private Util() {
         throw new UnsupportedOperationException(SQLServerException.getErrString("R_notSupported"));
     }
@@ -276,33 +279,28 @@ final class Util {
     }
 
     /**
-     * Validates that the port segment parsed from a JDBC URL is a strictly numeric value within the
-     * legal TCP port range (0-65535).
+     * Validates that the port segment parsed from a JDBC URL is a strictly numeric (ASCII digits only)
+     * value within the legal TCP port range (0-65535).
      *
      * @param portValue
      *        the trimmed port string parsed from the URL
      * @throws SQLServerException
-     *         if the value is empty, non-numeric, or outside the range 0-65535
+     *         if the value is empty, non-numeric, or greater than 65535
      */
     private static void validatePortNumber(String portValue) throws SQLServerException {
-        boolean valid = null != portValue && !portValue.isEmpty();
+        // A valid port is 1-5 ASCII digits; anything longer cannot be <= MAX_PORT_NUMBER.
+        boolean valid = null != portValue && !portValue.isEmpty() && portValue.length() <= 5;
         if (valid) {
             for (int idx = 0; idx < portValue.length(); idx++) {
-                if (!Character.isDigit(portValue.charAt(idx))) {
+                char c = portValue.charAt(idx);
+                if (c < '0' || c > '9') {
                     valid = false;
                     break;
                 }
             }
         }
-        if (valid) {
-            try {
-                int port = Integer.parseInt(portValue);
-                if (port < 0 || port > 65535) {
-                    valid = false;
-                }
-            } catch (NumberFormatException e) {
-                valid = false;
-            }
+        if (valid && Integer.parseInt(portValue) > MAX_PORT_NUMBER) {
+            valid = false;
         }
         if (!valid) {
             MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidPortNumber"));

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -279,12 +279,6 @@ final class Util {
      * Validates that the port segment parsed from a JDBC URL is a strictly numeric value within the
      * legal TCP port range (0-65535).
      *
-     * <p>
-     * This is a defense-in-depth guard against connection-property injection (CWE-88). The URL parser
-     * treats a bare {@code ;} as the boundary into property parsing, so an externally-influenced fragment
-     * concatenated into the URL could otherwise smuggle arbitrary text through the port segment. Enforcing
-     * a numeric port ensures such fragments are rejected instead of silently accepted.
-     *
      * @param portValue
      *        the trimmed port string parsed from the URL
      * @throws SQLServerException
@@ -402,10 +396,7 @@ final class Util {
                 case inPort:
                     if (ch == ';') {
                         String property = result.toString().trim();
-                        // Defense-in-depth against connection-property injection (CWE-88):
-                        // the port segment must be strictly numeric. An externally-influenced
-                        // fragment concatenated into the URL must not be able to smuggle
-                        // additional characters here before the ';' boundary.
+                        // The port segment must be strictly numeric and within the valid TCP range.
                         validatePortNumber(property);
                         if (logger.isLoggable(Level.FINE)) {
                             logger.fine("Property:portNumber " + "Value:" + property);
@@ -423,10 +414,8 @@ final class Util {
                     if (ch == ';' || ch == ':') {
                         // non escaped trim the string
                         String property = result.toString().trim();
-                        // Defense-in-depth against connection-property injection (CWE-88):
-                        // an instance name must not contain '=', which would indicate that an
-                        // externally-influenced fragment is attempting to smuggle a
-                        // property=value pair through the server portion of the URL.
+                        // An instance name must not contain '=', which would indicate a
+                        // malformed value rather than a valid instance name.
                         if (property.contains("=")) {
                             MessageFormat form = new MessageFormat(
                                     SQLServerException.getErrString("R_errorInstanceName"));
@@ -574,6 +563,11 @@ final class Util {
         switch (state) {
             case inServerName:
                 String property = result.toString().trim();
+                if (property.contains("=")) {
+                    MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_errorServerName"));
+                    Object[] msgArgs = {property};
+                    SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+                }
                 if (property.length() > 0) {
                     if (logger.isLoggable(Level.FINE)) {
                         logger.fine("Property:serverName " + "Value:" + property);
@@ -599,7 +593,7 @@ final class Util {
                 if (logger.isLoggable(Level.FINE)) {
                     logger.fine("Property:instanceName " + "Value:" + property);
                 }
-                p.put(SQLServerDriverStringProperty.INSTANCE_NAME.toString(), property);
+                p.put(SQLServerDriverStringProperty.INSTANCE_NAME.toString(), property.toLowerCase(Locale.US));
                 break;
             case inValue:
                 // simple value trim

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -276,6 +276,48 @@ final class Util {
     }
 
     /**
+     * Validates that the port segment parsed from a JDBC URL is a strictly numeric value within the
+     * legal TCP port range (0-65535).
+     *
+     * <p>
+     * This is a defense-in-depth guard against connection-property injection (CWE-88). The URL parser
+     * treats a bare {@code ;} as the boundary into property parsing, so an externally-influenced fragment
+     * concatenated into the URL could otherwise smuggle arbitrary text through the port segment. Enforcing
+     * a numeric port ensures such fragments are rejected instead of silently accepted.
+     *
+     * @param portValue
+     *        the trimmed port string parsed from the URL
+     * @throws SQLServerException
+     *         if the value is empty, non-numeric, or outside the range 0-65535
+     */
+    private static void validatePortNumber(String portValue) throws SQLServerException {
+        boolean valid = null != portValue && !portValue.isEmpty();
+        if (valid) {
+            for (int idx = 0; idx < portValue.length(); idx++) {
+                if (!Character.isDigit(portValue.charAt(idx))) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (valid) {
+            try {
+                int port = Integer.parseInt(portValue);
+                if (port < 0 || port > 65535) {
+                    valid = false;
+                }
+            } catch (NumberFormatException e) {
+                valid = false;
+            }
+        }
+        if (!valid) {
+            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidPortNumber"));
+            Object[] msgArgs = {portValue};
+            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+        }
+    }
+
+    /**
      * Parse a JDBC URL into a set of properties.
      * 
      * @param url
@@ -360,6 +402,11 @@ final class Util {
                 case inPort:
                     if (ch == ';') {
                         String property = result.toString().trim();
+                        // Defense-in-depth against connection-property injection (CWE-88):
+                        // the port segment must be strictly numeric. An externally-influenced
+                        // fragment concatenated into the URL must not be able to smuggle
+                        // additional characters here before the ';' boundary.
+                        validatePortNumber(property);
                         if (logger.isLoggable(Level.FINE)) {
                             logger.fine("Property:portNumber " + "Value:" + property);
                         }
@@ -376,6 +423,16 @@ final class Util {
                     if (ch == ';' || ch == ':') {
                         // non escaped trim the string
                         String property = result.toString().trim();
+                        // Defense-in-depth against connection-property injection (CWE-88):
+                        // an instance name must not contain '=', which would indicate that an
+                        // externally-influenced fragment is attempting to smuggle a
+                        // property=value pair through the server portion of the URL.
+                        if (property.contains("=")) {
+                            MessageFormat form = new MessageFormat(
+                                    SQLServerException.getErrString("R_errorInstanceName"));
+                            Object[] msgArgs = {property};
+                            SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+                        }
                         if (logger.isLoggable(Level.FINE)) {
                             logger.fine("Property:instanceName " + "Value:" + property);
                         }
@@ -526,6 +583,7 @@ final class Util {
                 break;
             case inPort:
                 property = result.toString().trim();
+                validatePortNumber(property);
                 if (logger.isLoggable(Level.FINE)) {
                     logger.fine("Property:portNumber " + "Value:" + property);
                 }
@@ -533,6 +591,11 @@ final class Util {
                 break;
             case inInstanceName:
                 property = result.toString().trim();
+                if (property.contains("=")) {
+                    MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_errorInstanceName"));
+                    Object[] msgArgs = {property};
+                    SQLServerException.makeFromDriverError(null, null, form.format(msgArgs), null, true);
+                }
                 if (logger.isLoggable(Level.FINE)) {
                     logger.fine("Property:instanceName " + "Value:" + property);
                 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -164,6 +164,50 @@ public class UtilTest {
     }
 
     /**
+     * Verifies the defense-in-depth guard against connection-property injection (CWE-88): a non-numeric
+     * port segment smuggled via an externally-influenced URL fragment must be rejected instead of being
+     * silently accepted and allowing additional properties to be parsed after a bare ';'.
+     */
+    @Test
+    public void testParseUrlRejectsInjectedPortNumber() {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        // Attacker attempts to smuggle authentication-changing properties through the port segment.
+        String constr = "jdbc:sqlserver://localhost:1433x;integratedSecurity=true;authenticationScheme=JavaKerberos";
+        SQLException e = assertThrows(SQLException.class, () -> Util.parseUrl(constr, drLogger));
+        assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_invalidPortNumber")), e.getMessage());
+
+        // Out-of-range port must also be rejected.
+        String constr2 = "jdbc:sqlserver://localhost:99999;databaseName=db";
+        assertThrows(SQLException.class, () -> Util.parseUrl(constr2, drLogger));
+    }
+
+    /**
+     * Verifies that a valid numeric port continues to parse correctly after the injection hardening.
+     */
+    @Test
+    public void testParseUrlValidPortStillParses() throws SQLException {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost:1433;databaseName=db;";
+        Properties prt = Util.parseUrl(constr, drLogger);
+        assertEquals("localhost", prt.getProperty("serverName"));
+        assertEquals("1433", prt.getProperty("portNumber"));
+        assertEquals("db", prt.getProperty("databaseName"));
+    }
+
+    /**
+     * Verifies the defense-in-depth guard against connection-property injection (CWE-88) for the instance
+     * name segment: an instance name containing '=' indicates an attempt to smuggle a property=value pair
+     * through the server portion of the URL and must be rejected.
+     */
+    @Test
+    public void testParseUrlRejectsInjectedInstanceName() {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost\\inst=x;databaseName=db";
+        SQLException e = assertThrows(SQLException.class, () -> Util.parseUrl(constr, drLogger));
+        assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_errorInstanceName")), e.getMessage());
+    }
+
+    /**
      * Tests that the cross-driver connection string aliases (SqlClient / ODBC / OLEDB spellings) are normalized to the
      * canonical JDBC property names by {@link Util#parseUrl}.
      *

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -205,6 +205,56 @@ public class UtilTest {
     }
 
     /**
+     * Verifies that the instance name is normalized to lower case consistently, both when the URL
+     * continues after the instance segment and when the URL ends immediately after it (exit path).
+     */
+    @Test
+    public void testParseUrlInstanceNameLowerCased() throws SQLException {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        // URL continues after the instance name (mid-string path).
+        Properties midStr = Util.parseUrl("jdbc:sqlserver://localhost\\MyInstance;databaseName=db", drLogger);
+        assertEquals("myinstance", midStr.getProperty("instanceName"));
+        // URL ends immediately after the instance name (exit path).
+        Properties exitStr = Util.parseUrl("jdbc:sqlserver://localhost\\MyInstance", drLogger);
+        assertEquals("myinstance", exitStr.getProperty("instanceName"));
+    }
+
+    /**
+     * Verifies that a server name containing '=' is rejected on the exit path (URL ending immediately
+     * after the server segment), consistent with the mid-string server-name handling.
+     */
+    @Test
+    public void testParseUrlRejectsMalformedServerNameOnExit() {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost=x";
+        SQLException e = assertThrows(SQLException.class, () -> Util.parseUrl(constr, drLogger));
+        assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_errorServerName")), e.getMessage());
+    }
+
+    /**
+     * Verifies that an empty port segment is rejected at parse time.
+     */
+    @Test
+    public void testParseUrlRejectsEmptyPort() {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost:;databaseName=db";
+        SQLException e = assertThrows(SQLException.class, () -> Util.parseUrl(constr, drLogger));
+        assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_invalidPortNumber")), e.getMessage());
+    }
+
+    /**
+     * Verifies that a non-ASCII "digit" port (e.g. Arabic-Indic digits) is rejected rather than being
+     * silently accepted and stored as a raw non-ASCII string.
+     */
+    @Test
+    public void testParseUrlRejectsNonAsciiDigitPort() {
+        Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
+        String constr = "jdbc:sqlserver://localhost:\u0661\u0664\u0663\u0663;databaseName=db";
+        SQLException e = assertThrows(SQLException.class, () -> Util.parseUrl(constr, drLogger));
+        assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_invalidPortNumber")), e.getMessage());
+    }
+
+    /**
      * Tests that the cross-driver connection string aliases (SqlClient / ODBC / OLEDB spellings) are normalized to the
      * canonical JDBC property names by {@link Util#parseUrl}.
      *

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -164,14 +164,13 @@ public class UtilTest {
     }
 
     /**
-     * Verifies the defense-in-depth guard against connection-property injection (CWE-88): a non-numeric
-     * port segment smuggled via an externally-influenced URL fragment must be rejected instead of being
-     * silently accepted and allowing additional properties to be parsed after a bare ';'.
+     * Verifies that a non-numeric or out-of-range port segment is rejected instead of being silently
+     * accepted and allowing additional properties to be parsed after a bare ';'.
      */
     @Test
     public void testParseUrlRejectsInjectedPortNumber() {
         Logger drLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerDriver");
-        // Attacker attempts to smuggle authentication-changing properties through the port segment.
+        // A non-numeric port followed by additional properties must be rejected.
         String constr = "jdbc:sqlserver://localhost:1433x;integratedSecurity=true;authenticationScheme=JavaKerberos";
         SQLException e = assertThrows(SQLException.class, () -> Util.parseUrl(constr, drLogger));
         assertTrue(e.getMessage().matches(TestUtils.formatErrorMsg("R_invalidPortNumber")), e.getMessage());
@@ -182,7 +181,7 @@ public class UtilTest {
     }
 
     /**
-     * Verifies that a valid numeric port continues to parse correctly after the injection hardening.
+     * Verifies that a valid numeric port continues to parse correctly after the stricter validation.
      */
     @Test
     public void testParseUrlValidPortStillParses() throws SQLException {
@@ -195,9 +194,7 @@ public class UtilTest {
     }
 
     /**
-     * Verifies the defense-in-depth guard against connection-property injection (CWE-88) for the instance
-     * name segment: an instance name containing '=' indicates an attempt to smuggle a property=value pair
-     * through the server portion of the URL and must be rejected.
+     * Verifies that an instance name containing '=' is treated as a malformed value and rejected.
      */
     @Test
     public void testParseUrlRejectsInjectedInstanceName() {


### PR DESCRIPTION
### Summary

Strengthens input validation in `Util.parseUrl` for the server portion of the JDBC URL. The port segment is now validated as a strictly numeric value in the legal TCP range, and the instance-name segment now rejects malformed values containing `=` (mirroring the existing serverName check). This makes URL parsing stricter and more predictable, and rejects badly formed URLs early with a clear error instead ofsilently accepting them.

### Motivation

The URL parser previously accepted arbitrary characters in the port segment until the next `;`, and did not validate the instance-name segment for `=`. Enforcing the expected grammar for these segments improves robustness and gives clearer feedback for
malformed connection strings.

### Changes

- **`Util.java`**
  - New helper `validatePortNumber(...)`: enforces a non-empty, digits-only port in the range `0–65535`.
  - Invoked in both the mid-string `inPort` state and the end-of-URL `inPort` exit state.
  - `inInstanceName` (mid-string and exit) now rejects instance names containing `=`.
- **`SQLServerResource.java`**
  - Added `R_errorInstanceName` ("The instanceName connection property value {0} is badly formed."). Reuses existing `R_invalidPortNumber`.
- **`UtilTest.java`**
  - `testParseUrlRejectsInjectedPortNumber` — non-numeric / out-of-range port is rejected.
  - `testParseUrlValidPortStillParses` — valid numeric port still parses (no regression).
  - `testParseUrlRejectsInjectedInstanceName` — instance name with `=` is rejected.
- **`docs/security/jdbc-url-property-injection.md`**
  - Documents the validation behavior and recommends typed APIs (`SQLServerDataSource` setters / `Properties`) instead of concatenating externally-influenced values into URL strings.

### Behavioral impact / compatibility

- Well-formed URLs are unaffected.
- Previously-tolerated malformed inputs (non-numeric ports, instance names with `=`) now fail fast with a descriptive error. This is stricter but aligned with documented URL syntax.

### Testing

- `mvn -Pjre11 -Dtest=UtilTest test` — new and existing `parseUrl` tests pass.