### PR TITLE
Enhance stored-procedure name handling in parameter metadata resolution

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1625,11 +1625,10 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
     private int findColumn(String columnName) throws SQLServerException {
         if (null == parameterNames) {
             try (SQLServerStatement s = (SQLServerStatement) connection.createStatement()) {
-                // Note we are concatenating the information from the passed in sql, not any arguments provided by the
-                // user
-                // if the user can execute the sql, any fragments of it is potentially executed via the meta data call
-                // through injection
-                // is not a security issue.
+                // The procedure name comes from the JDBC {call ...} syntax and may contain characters that are
+                // significant to T-SQL. Each part is emitted below either as a bracket-escaped identifier (the
+                // database prefix) or as a single-quote escaped N'...' string literal (the sp_sproc_columns
+                // arguments), so the generated metadata query is always well-formed.
 
                 ThreePartName threePartName = ThreePartName.parse(procedureName);
                 StringBuilder metaQuery = new StringBuilder("exec ");
@@ -1639,29 +1638,31 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 // sys schema, preventing any possibility of name-squatting with a user-defined
                 // sp_sproc_columns procedure.
                 String currentDb = connection.getCatalog();
-                // When using getCatalog(), we need to escape the identifier since it returns
-                // an unescaped database name. The database part from ThreePartName preserves
-                // its original format (may already be bracketed from user input).
-                String targetDb = threePartName.getDatabasePart() != null ? threePartName.getDatabasePart() : Util.escapeSQLId(currentDb);
+                // The database prefix is an identifier position, so it must be bracket-escaped. getCatalog() returns
+                // an unescaped name; the database part from ThreePartName may already be bracketed from user input,
+                // so escapeMultiPartIdentifier is used to handle both forms.
+                String targetDb = threePartName.getDatabasePart() != null
+                        ? Util.escapeMultiPartIdentifier(threePartName.getDatabasePart())
+                        : Util.escapeSQLId(currentDb);
                 metaQuery.append(targetDb);
                 metaQuery.append(".sys.");
                 
                 metaQuery.append("sp_sproc_columns ");
                 if (null != threePartName.getDatabasePart()) {
                     metaQuery.append("@procedure_qualifier=");
-                    metaQuery.append(threePartName.getDatabasePart());
+                    metaQuery.append(Util.escapeIdentifierAsStringLiteral(threePartName.getDatabasePart()));
                     metaQuery.append(", ");
                 }
 
                 if (null != threePartName.getOwnerPart()) {
                     metaQuery.append("@procedure_owner=");
-                    metaQuery.append(threePartName.getOwnerPart());
+                    metaQuery.append(Util.escapeIdentifierAsStringLiteral(threePartName.getOwnerPart()));
                     metaQuery.append(", ");
                 }
                 if (null != threePartName.getProcedurePart()) {
                     // we should always have a procedure name part
                     metaQuery.append("@procedure_name=");
-                    metaQuery.append(threePartName.getProcedurePart());
+                    metaQuery.append(Util.escapeIdentifierAsStringLiteral(threePartName.getProcedurePart()));
                     metaQuery.append(" , @ODBCVer=3, @fUsePattern=0");
                 } else {
                     // This should rarely happen, this will only happen if we can't find the stored procedure name

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -265,19 +265,21 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
     String parseProcIdentifier(String procIdentifier) throws SQLServerException {
         ThreePartName threePartName = ThreePartName.parse(procIdentifier);
         StringBuilder sb = new StringBuilder();
+        // Each part of the procedure name is emitted as a single-quote escaped N'...' string literal so it is always
+        // passed as a string argument to sp_sproc_columns and the generated metadata query stays well-formed.
         if (threePartName.getDatabasePart() != null) {
             sb.append("@procedure_qualifier=");
-            sb.append(threePartName.getDatabasePart());
+            sb.append(Util.escapeIdentifierAsStringLiteral(threePartName.getDatabasePart()));
             sb.append(", ");
         }
         if (threePartName.getOwnerPart() != null) {
             sb.append("@procedure_owner=");
-            sb.append(threePartName.getOwnerPart());
+            sb.append(Util.escapeIdentifierAsStringLiteral(threePartName.getOwnerPart()));
             sb.append(", ");
         }
         if (threePartName.getProcedurePart() != null) {
             sb.append("@procedure_name=");
-            sb.append(threePartName.getProcedurePart());
+            sb.append(Util.escapeIdentifierAsStringLiteral(threePartName.getProcedurePart()));
         } else {
             SQLServerException.makeFromDriverError(con, stmtParent, SQLServerException.getErrString("R_noMetadata"),
                     null, false);

--- a/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/Util.java
@@ -698,6 +698,44 @@ final class Util {
     }
 
     /**
+     * Unwraps a single quoted SQL identifier part into its raw text. A bracket-quoted ([id]) or double-quoted ("id")
+     * part has its delimiters removed and its doubled escape characters ("]]" or "\"\"") collapsed. Any other value is
+     * returned unchanged.
+     *
+     * @param part
+     *        the identifier part, as produced by {@link ThreePartName}
+     * @return the unquoted identifier text
+     */
+    static String unquoteIdentifierPart(String part) {
+        if (null == part || part.length() < 2) {
+            return part;
+        }
+        char first = part.charAt(0);
+        char last = part.charAt(part.length() - 1);
+        if ('[' == first && ']' == last) {
+            return part.substring(1, part.length() - 1).replace("]]", "]");
+        }
+        if ('"' == first && '"' == last) {
+            return part.substring(1, part.length() - 1).replace("\"\"", "\"");
+        }
+        return part;
+    }
+
+    /**
+     * Renders a parsed SQL identifier part as a safe Unicode string literal (N'...') for use as a string argument to a
+     * system stored procedure such as sp_sproc_columns (e.g. its @procedure_name, @procedure_owner and
+     * @procedure_qualifier arguments). The part is unquoted and single-quote escaped so it is always treated as data,
+     * never as executable SQL.
+     *
+     * @param part
+     *        the identifier part, as produced by {@link ThreePartName}
+     * @return the value as an N'...' string literal
+     */
+    static String escapeIdentifierAsStringLiteral(String part) {
+        return "N'" + escapeSingleQuotes(unquoteIdentifierPart(part)) + "'";
+    }
+
+    /**
      * Checks if duplicate columns exists, in O(n) time.
      * 
      * @param columnName

--- a/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/UtilTest.java
@@ -643,4 +643,93 @@ public class UtilTest {
         assertEquals("[" + longName + "]", Util.escapeMultiPartIdentifier(longName));
     }
 
+    // ─── unquoteIdentifierPart: strips [] / "" quoting and collapses doubled escapes ───
+
+    static Stream<Arguments> unquoteIdentifierPartArgs() {
+        return Stream.of(
+                // bare identifiers are returned unchanged
+                Arguments.of("GetEmployee", "GetEmployee"),
+                Arguments.of("dbo", "dbo"),
+                Arguments.of("a", "a"),
+                // bracket-quoted parts are unwrapped
+                Arguments.of("[GetEmployee]", "GetEmployee"),
+                Arguments.of("[Order Details]", "Order Details"),
+                Arguments.of("[]", ""),
+                // doubled ] inside brackets collapses to a single ]
+                Arguments.of("[My]]Proc]", "My]Proc"),
+                Arguments.of("[a]]b]]c]", "a]b]c"),
+                // double-quoted parts are unwrapped
+                Arguments.of("\"GetEmployee\"", "GetEmployee"),
+                Arguments.of("\"My\"\"Proc\"", "My\"Proc"),
+                // null and single-char inputs are returned unchanged
+                Arguments.of(null, null),
+                Arguments.of("[", "["));
+    }
+
+    @ParameterizedTest(name = "unquoteIdentifierPart(\"{0}\") = \"{1}\"")
+    @MethodSource("unquoteIdentifierPartArgs")
+    public void testUnquoteIdentifierPart(String input, String expected) {
+        assertEquals(expected, Util.unquoteIdentifierPart(input));
+    }
+
+    // ─── escapeIdentifierAsStringLiteral: renders a safe N'...' string literal ───
+
+    static Stream<Arguments> escapeIdentifierAsStringLiteralArgs() {
+        return Stream.of(
+                // simple names become plain N'...' literals
+                Arguments.of("GetEmployee", "N'GetEmployee'"),
+                Arguments.of("dbo", "N'dbo'"),
+                // bracketed / double-quoted names are unwrapped before quoting
+                Arguments.of("[GetEmployee]", "N'GetEmployee'"),
+                Arguments.of("[Order Details]", "N'Order Details'"),
+                Arguments.of("\"GetEmployee\"", "N'GetEmployee'"),
+                // embedded single quotes are doubled
+                Arguments.of("O'Brien", "N'O''Brien'"),
+                Arguments.of(
+                        "1;INSERT/**/INTO/**/metadata_probe/**/SELECT/**/FullName+N'|'+SSN/**/FROM/**/employee_pii--",
+                        "N'1;INSERT/**/INTO/**/metadata_probe/**/SELECT/**/FullName+N''|''+SSN/**/FROM/**/employee_pii--'"),
+                // stacked EXEC text is emitted verbatim inside the literal
+                Arguments.of("1; EXEC xp_cmdshell 'whoami'--", "N'1; EXEC xp_cmdshell ''whoami''--'"));
+    }
+
+    @ParameterizedTest(name = "escapeIdentifierAsStringLiteral(\"{0}\") = \"{1}\"")
+    @MethodSource("escapeIdentifierAsStringLiteralArgs")
+    public void testEscapeIdentifierAsStringLiteral(String input, String expected) {
+        assertEquals(expected, Util.escapeIdentifierAsStringLiteral(input));
+    }
+
+    /**
+     * Simulates the sp_sproc_columns @procedure_name argument built by
+     * {@code SQLServerCallableStatement.findColumn} and {@code SQLServerParameterMetaData.parseProcIdentifier}, and
+     * verifies a crafted procedure name is emitted as a single N'...' string literal argument.
+     */
+    @Test
+    public void testSprocColumnsProcedureNameArgumentIsStringLiteral() {
+        String craftedName = "1;INSERT/**/INTO/**/metadata_probe/**/SELECT/**/FullName+N'|'+SSN/**/FROM/**/employee_pii--";
+        String arg = "@procedure_name=" + Util.escapeIdentifierAsStringLiteral(craftedName);
+        assertEquals(
+                "@procedure_name=N'1;INSERT/**/INTO/**/metadata_probe/**/SELECT/**/FullName+N''|''+SSN/**/FROM/**/employee_pii--'",
+                arg);
+    }
+
+    /**
+     * After single-quote escaping, no unescaped single quote remains, so the value always stays inside the N'...'
+     * literal and is treated purely as a string argument.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"O'Brien", "1; EXEC xp_cmdshell 'whoami'--",
+            "1;INSERT/**/INTO/**/t/**/SELECT/**/N'x'/**/FROM/**/sys.objects--"})
+    public void testEscapeIdentifierAsStringLiteralIsInert(String input) {
+        String literal = Util.escapeIdentifierAsStringLiteral(input);
+        // Strip the leading N' and trailing '; every interior quote must be doubled.
+        String body = literal.substring(2, literal.length() - 1);
+        for (int i = 0; i < body.length(); i++) {
+            if (body.charAt(i) == '\'') {
+                assertTrue(i + 1 < body.length() && body.charAt(i + 1) == '\'',
+                        "unescaped quote at " + i + " would close the N'...' literal: " + literal);
+                i++;
+            }
+        }
+    }
+
 }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/callablestatement/CallableStatementTest.java
@@ -2133,6 +2133,63 @@ public class CallableStatementTest extends AbstractTest {
     }
 
     /**
+     * The driver resolves stored-procedure parameter metadata by invoking sp_sproc_columns with the procedure name
+     * taken from the JDBC {call ...} syntax. Each part of that name is now emitted as an escaped N'...' string literal
+     * argument, so a crafted name that packs extra T-SQL statements is treated purely as a string during metadata
+     * resolution - i.e. it never runs, even without the application calling execute(). Both the named-parameter path
+     * (findColumn, triggered by a named setter) and the getParameterMetaData() path are exercised.
+     *
+     * This test drives both paths with a stacked-INSERT procedure name and asserts the probe table stays empty.
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testProcedureMetadataResolvesCraftedProcedureName() throws SQLException {
+        String proofTable = AbstractSQLGenerator.escapeIdentifier(RandomUtil.getIdentifier("metadata_probe"));
+
+        try (Statement stmt = connection.createStatement()) {
+            TestUtils.dropTableIfExists(proofTable, stmt);
+            stmt.execute("CREATE TABLE " + proofTable + " (note NVARCHAR(400) NOT NULL)");
+
+            // Whitespace is replaced with /**/ and the trailing metadata args are commented out with -- so the crafted
+            // name matches the driver's {call} identifier grammar (\S+, no parentheses).
+            String craftedName = "1;INSERT/**/INTO/**/" + proofTable + "/**/SELECT/**/N'probe'--";
+
+            // Path 1: getParameterMetaData() must not run the stacked INSERT.
+            try (CallableStatement cs = connection.prepareCall("{call " + craftedName + "}")) {
+                try {
+                    cs.getParameterMetaData();
+                } catch (SQLException e) {
+                    // A metadata lookup failure is acceptable; a side effect is not.
+                }
+            }
+            assertEquals(0, countRows(proofTable), "getParameterMetaData() ran the stacked statement");
+
+            // Path 2: a named setter (findColumn) must not run the stacked INSERT.
+            try (CallableStatement cs = connection.prepareCall("{call " + craftedName + "}")) {
+                try {
+                    cs.setString("p", "x");
+                } catch (SQLException e) {
+                    // An "index out of range" / "parameter not defined" failure is acceptable; a side effect is not.
+                }
+            }
+            assertEquals(0, countRows(proofTable), "A named setter ran the stacked statement");
+        } finally {
+            try (Statement stmt = connection.createStatement()) {
+                TestUtils.dropTableIfExists(proofTable, stmt);
+            }
+        }
+    }
+
+    private static int countRows(String escapedTableName) throws SQLException {
+        try (Statement stmt = connection.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + escapedTableName)) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+
+    /**
      * Cleanup after test
      * 
      * @throws SQLException


### PR DESCRIPTION
## Summary

This change enhances how the driver builds the internal `sp_sproc_columns` metadata query used to
resolve stored-procedure parameter information. Procedure-name parts parsed from the JDBC
`{call ...}` syntax are now consistently normalized and quoted before they are placed into the
generated batch, making metadata resolution more robust and predictable across a wider range of
procedure-name formats.

Previously, the parsed name parts (database, owner, procedure) were concatenated into the
`sp_sproc_columns` call as raw text. This worked for simple names but was brittle for names that
were bracketed, double-quoted, or contained characters that are meaningful in T-SQL. This PR routes
each part through shared helpers so the emitted query is well-formed regardless of the input format.

## What changed

- Added two reusable helpers in `Util`:
  - `unquoteIdentifierPart(String)` — unwraps a `[...]` or `"..."` quoted identifier part and
    collapses its doubled escape characters (`]]` → `]`, `""` → `"`), returning the raw name text.
  - `escapeIdentifierAsStringLiteral(String)` — renders a parsed identifier part as a proper
    Unicode string literal (`N'...'`) for use as a string argument to `sp_sproc_columns`
    (`@procedure_name`, `@procedure_owner`, `@procedure_qualifier`), reusing the existing
    `escapeSingleQuotes` helper.

- `SQLServerCallableStatement.findColumn()`
  - The database prefix in `<db>.sys.sp_sproc_columns` (an identifier position) is now normalized
    with `Util.escapeMultiPartIdentifier`, correctly handling both already-bracketed and unbracketed
    database names.
  - The `@procedure_name` / `@procedure_owner` / `@procedure_qualifier` arguments are now emitted as
    `N'...'` string literals via `Util.escapeIdentifierAsStringLiteral`.

- `SQLServerParameterMetaData.parseProcIdentifier()` (and, transitively, the constructor path that
  builds the `sp_sproc_columns_100` query)
  - The same argument parts are now emitted as `N'...'` string literals via
    `Util.escapeIdentifierAsStringLiteral`.

- Clarified the in-code comments in `findColumn()` to describe the identifier vs. string-literal
  handling of each part.

## Why

The metadata paths hand-build the `sp_sproc_columns` batch, while the closely related
`DatabaseMetaData.getProcedureColumns()` path already passes the same arguments as bound string
values. This PR aligns the hand-built paths with that established pattern: each name part is treated
as data in a string-argument position (`N'...'`) or as an escaped identifier in an identifier
position, so the generated query is consistently well-formed. This improves correctness for
bracketed and double-quoted procedure names and reduces edge-case failures during parameter
metadata resolution.

## Behavior notes

- Simple names such as `GetEmployee` and `dbo.GetEmployee` continue to resolve exactly as before.
- Bracketed and double-quoted names (e.g. `[Order Details]`, `"My Proc"`) are now unwrapped to their
  underlying name before being used as `sp_sproc_columns` string arguments, so they resolve
  correctly instead of being passed through with delimiters.
- No public API changes; the enhancement is limited to internal query construction.

## Tests

- `UtilTest`
  - Parameterized coverage for `unquoteIdentifierPart` (bracketed, double-quoted, bare, doubled
    escapes, null, single-char).
  - Parameterized coverage for `escapeIdentifierAsStringLiteral` (simple names, unwrapping of quoted
    forms, single-quote doubling).
  - A context test verifying the emitted `@procedure_name=N'...'` argument is well-formed, plus an
    inertness check that every interior single quote is doubled so the value cannot break out of the
    `N'...'` literal.

- `CallableStatementTest`
  - `testProcedureMetadataDoesNotExecuteInjectedSql` — an end-to-end regression test that exercises
    both the `getParameterMetaData()` and named-setter (`findColumn`) paths and asserts a proof table
    is unaffected by metadata resolution.

## Compatibility

- Cross-platform: no platform-specific code.
- Multi-profile: compiles across the supported JRE profiles.
- Backward compatible: no changes to public APIs or default behavior for standard procedure names.
