### PR TITLE
Revert "Add Java SE API link to Javadoc configuration"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -751,9 +751,6 @@
 				<configuration>
 					<failOnError>true</failOnError>
 					<excludePackageNames>mssql.*</excludePackageNames>
-					<links>
-						<link>https://docs.oracle.com/javase/8/docs/api/</link>
-					</links>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
This reverts #3025. JDK 25 Javadoc requests the Java 8 `element-list`; Oracle redirects that missing URL to Java 26; Javadoc rejects the unexpected redirect. Validation commands `mvn -Pjre25 -DskipTests javadoc:jar` and `mvn -Pjre25 -DskipTests package` both succeed.