### PR TITLE
Revert DateTimeOffset deprecation for GA compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,11 +205,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Changed
 
-- **Deprecate microsoft.sql.DateTimeOffset in Favor of java.time.OffsetDateTime** [#2920](https://github.com/microsoft/mssql-jdbc/pull/2920)
-**What was changed**: Deprecated the proprietary `microsoft.sql.DateTimeOffset` type and added new `getOffsetDateTime()`, `setOffsetDateTime()`, and `updateOffsetDateTime()` methods to promote `java.time.OffsetDateTime` (JSR-310) as the canonical Java mapping for SQL Server `datetimeoffset` columns.
-**Who benefits**: Applications seeking standards-based, vendor-neutral date/time handling.
-**Impact**: Improves portability and ORM/middleware interoperability while preserving full backward compatibility with existing DateTimeOffset APIs.
-
 - **Improve Class Validation in Util.newInstance() by Deferring Initialization** [#2914](https://github.com/microsoft/mssql-jdbc/pull/2914)
 **What was changed**: Updated `Util.newInstance()` to use `Class.forName(className, false, classLoader)` to defer class initialization until after `isAssignableFrom()` validation completes, with a classloader fallback strategy.
 **Who benefits**: Applications using connection properties such as `trustManagerClass`, `socketFactoryClass`, and `accessTokenCallbackClass`.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/DataTypes.java
@@ -128,7 +128,6 @@ enum SSType {
     DATE(Category.DATE, "date", JDBCType.DATE),
     TIME(Category.TIME, "time", JDBCType.TIME),
     DATETIME2(Category.DATETIME2, "datetime2", JDBCType.TIMESTAMP),
-    /** SQL Server {@code datetimeoffset} type. The canonical Java mapping is {@link java.time.OffsetDateTime}. */
     DATETIMEOFFSET(Category.DATETIMEOFFSET, "datetimeoffset", JDBCType.DATETIMEOFFSET),
     SMALLMONEY(Category.NUMERIC, "smallmoney", JDBCType.SMALLMONEY),
     MONEY(Category.NUMERIC, "money", JDBCType.MONEY),

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerCallableStatement.java
@@ -149,9 +149,7 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      * @throws SQLServerException
      *         if parameterIndex is out of range; if a database access error occurs or this method is called on a closed
      *         <code>CallableStatement</code>
-     * @deprecated Use {@link #getOffsetDateTime(int)} instead.
      */
-    @Deprecated(since = "13.5.0")
     microsoft.sql.DateTimeOffset getDateTimeOffset(int parameterIndex) throws SQLServerException;
 
     /**
@@ -163,38 +161,8 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      * @throws SQLServerException
      *         if parameterName does not correspond to a named parameter; if a database access error occurs or this
      *         method is called on a closed <code>CallableStatement</code>
-     * @deprecated Use {@link #getOffsetDateTime(String)} instead.
      */
-    @Deprecated(since = "13.5.0")
     microsoft.sql.DateTimeOffset getDateTimeOffset(String parameterName) throws SQLServerException;
-
-    /**
-     * Returns the {@link java.time.OffsetDateTime} value of parameter with index parameterIndex. This is the
-     * preferred way to retrieve SQL Server {@code datetimeoffset} output parameters. The equivalent JDBC-standard
-     * approach is {@code callableStatement.getObject(parameterIndex, java.time.OffsetDateTime.class)}.
-     *
-     * @param parameterIndex
-     *        the first parameter is 1, the second is 2, and so on
-     * @return {@code java.time.OffsetDateTime} value; if the value is SQL NULL, the value returned is {@code null}
-     * @throws SQLServerException
-     *         if parameterIndex is out of range; if a database access error occurs or this method is called on a closed
-     *         <code>CallableStatement</code>
-     */
-    java.time.OffsetDateTime getOffsetDateTime(int parameterIndex) throws SQLServerException;
-
-    /**
-     * Returns the {@link java.time.OffsetDateTime} value of parameter with name parameterName. This is the preferred
-     * way to retrieve SQL Server {@code datetimeoffset} output parameters. The equivalent JDBC-standard approach is
-     * {@code callableStatement.getObject(parameterName, java.time.OffsetDateTime.class)}.
-     *
-     * @param parameterName
-     *        the name of the parameter
-     * @return {@code java.time.OffsetDateTime} value; if the value is SQL NULL, the value returned is {@code null}
-     * @throws SQLServerException
-     *         if parameterName does not correspond to a named parameter; if a database access error occurs or this
-     *         method is called on a closed <code>CallableStatement</code>
-     */
-    java.time.OffsetDateTime getOffsetDateTime(String parameterName) throws SQLServerException;
 
     /**
      * Returns the value of the designated column in the current row of this <code>ResultSet</code> object as a stream
@@ -532,9 +500,7 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      *        DateTimeOffset value
      * @throws SQLServerException
      *         if an error occurs
-     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value) throws SQLServerException;
 
     /**
@@ -548,9 +514,7 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      *        the scale of the parameter
      * @throws SQLServerException
      *         if an error occurs
-     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime, int)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value,
             int scale) throws SQLServerException;
 
@@ -569,57 +533,8 @@ public interface ISQLServerCallableStatement extends java.sql.CallableStatement,
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         if an error occurs
-     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime, int, boolean)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value, int scale,
-            boolean forceEncrypt) throws SQLServerException;
-
-    /**
-     * Sets parameter parameterName to the given {@link java.time.OffsetDateTime} value. This is the preferred way
-     * to set SQL Server {@code datetimeoffset} parameters using the standard Java time API. The equivalent
-     * JDBC-standard approach is {@code callableStatement.setObject(parameterName, offsetDateTimeValue)}.
-     *
-     * @param parameterName
-     *        the name of the parameter
-     * @param value
-     *        {@code java.time.OffsetDateTime} value
-     * @throws SQLServerException
-     *         if an error occurs
-     */
-    void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value) throws SQLServerException;
-
-    /**
-     * Sets parameter parameterName to the given {@link java.time.OffsetDateTime} value.
-     *
-     * @param parameterName
-     *        the name of the parameter
-     * @param value
-     *        {@code java.time.OffsetDateTime} value
-     * @param scale
-     *        the scale of the parameter
-     * @throws SQLServerException
-     *         if an error occurs
-     */
-    void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value, int scale) throws SQLServerException;
-
-    /**
-     * Sets parameter parameterName to the given {@link java.time.OffsetDateTime} value.
-     *
-     * @param parameterName
-     *        the name of the parameter
-     * @param value
-     *        {@code java.time.OffsetDateTime} value
-     * @param scale
-     *        the scale of the parameter
-     * @param forceEncrypt
-     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
-     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
-     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
-     * @throws SQLServerException
-     *         if an error occurs
-     */
-    void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value, int scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerPreparedStatement.java
@@ -25,25 +25,8 @@ public interface ISQLServerPreparedStatement extends java.sql.PreparedStatement,
      * @throws SQLServerException
      *         if parameterIndex does not correspond to a parameter marker in the SQL statement; if a database access
      *         error occurs or this method is called on a closed <code>PreparedStatement</code>
-     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x) throws SQLServerException;
-
-    /**
-     * Sets the designated parameter to the given {@link java.time.OffsetDateTime} value. This is the preferred way
-     * to set SQL Server {@code datetimeoffset} parameters using the standard Java time API. The equivalent
-     * JDBC-standard approach is {@code preparedStatement.setObject(parameterIndex, offsetDateTimeValue)}.
-     *
-     * @param parameterIndex
-     *        the first parameter is 1, the second is 2, ...
-     * @param x
-     *        the parameter value
-     * @throws SQLServerException
-     *         if parameterIndex does not correspond to a parameter marker in the SQL statement; if a database access
-     *         error occurs or this method is called on a closed <code>PreparedStatement</code>
-     */
-    void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x) throws SQLServerException;
 
     /**
      * Sets the value of the designated parameter with the given object.
@@ -665,9 +648,7 @@ public interface ISQLServerPreparedStatement extends java.sql.PreparedStatement,
      *        the scale of the column
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime, int)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x, int scale) throws SQLServerException;
 
     /**
@@ -685,43 +666,8 @@ public interface ISQLServerPreparedStatement extends java.sql.PreparedStatement,
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime, int, boolean)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void setDateTimeOffset(int parameterIndex, microsoft.sql.DateTimeOffset x, int scale,
-            boolean forceEncrypt) throws SQLServerException;
-
-    /**
-     * Sets the designated parameter to the given {@link java.time.OffsetDateTime} value.
-     *
-     * @param parameterIndex
-     *        the first parameter is 1, the second is 2, ...
-     * @param x
-     *        the parameter value
-     * @param scale
-     *        the scale of the column
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x, int scale) throws SQLServerException;
-
-    /**
-     * Sets the designated parameter to the given {@link java.time.OffsetDateTime} value.
-     *
-     * @param parameterIndex
-     *        the first parameter is 1, the second is 2, ...
-     * @param x
-     *        the parameter value
-     * @param scale
-     *        the scale of the column
-     * @param forceEncrypt
-     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
-     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
-     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    void setOffsetDateTime(int parameterIndex, java.time.OffsetDateTime x, int scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerResultSet.java
@@ -247,9 +247,7 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      * @return A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #getOffsetDateTime(int)} instead.
      */
-    @Deprecated(since = "13.5.0")
     microsoft.sql.DateTimeOffset getDateTimeOffset(int columnIndex) throws SQLServerException;
 
     /**
@@ -260,38 +258,8 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      * @return A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #getOffsetDateTime(String)} instead.
      */
-    @Deprecated(since = "13.5.0")
     microsoft.sql.DateTimeOffset getDateTimeOffset(String columnName) throws SQLServerException;
-
-    /**
-     * Returns the value of the designated column as a {@link java.time.OffsetDateTime} object, given a zero-based
-     * column ordinal. This is the preferred way to retrieve SQL Server {@code datetimeoffset} values using the
-     * standard Java time API. The equivalent JDBC-standard approach is
-     * {@code resultSet.getObject(columnIndex, java.time.OffsetDateTime.class)}.
-     *
-     * @param columnIndex
-     *        The zero-based ordinal of a column.
-     * @return A {@code java.time.OffsetDateTime} value, or {@code null} if the column value is SQL NULL.
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    java.time.OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLServerException;
-
-    /**
-     * Returns the value of the column specified as a {@link java.time.OffsetDateTime} object, given a column name.
-     * This is the preferred way to retrieve SQL Server {@code datetimeoffset} values using the standard Java time API.
-     * The equivalent JDBC-standard approach is
-     * {@code resultSet.getObject(columnName, java.time.OffsetDateTime.class)}.
-     *
-     * @param columnName
-     *        The name of a column.
-     * @return A {@code java.time.OffsetDateTime} value, or {@code null} if the column value is SQL NULL.
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    java.time.OffsetDateTime getOffsetDateTime(String columnName) throws SQLServerException;
 
     /**
      * Returns the value of the column specified as a java.math.BigDecimal object.
@@ -346,9 +314,7 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x) throws SQLServerException;
 
     /**
@@ -360,35 +326,8 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        A DateTimeOffset Class object.
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x) throws SQLServerException;
-
-    /**
-     * Updates the value of the column specified to a {@link java.time.OffsetDateTime} value, given a zero-based column
-     * ordinal.
-     *
-     * @param index
-     *        The zero-based ordinal of a column.
-     * @param x
-     *        A {@code java.time.OffsetDateTime} value.
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    void updateOffsetDateTime(int index, java.time.OffsetDateTime x) throws SQLServerException;
-
-    /**
-     * Updates the value of the column specified to a {@link java.time.OffsetDateTime} value, given a column name.
-     *
-     * @param columnName
-     *        The name of a column.
-     * @param x
-     *        A {@code java.time.OffsetDateTime} value.
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x) throws SQLServerException;
 
     /**
      * Updates the designated column with an {@code Object} value.
@@ -1042,9 +981,7 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        scale of the column
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime, Integer)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x, Integer scale) throws SQLServerException;
 
     /**
@@ -1062,45 +999,8 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         when an error occurs
-     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime, Integer, boolean)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x, Integer scale,
-            boolean forceEncrypt) throws SQLServerException;
-
-    /**
-     * Updates the value of the column specified to a {@link java.time.OffsetDateTime} value, given a zero-based column
-     * ordinal.
-     *
-     * @param index
-     *        The zero-based ordinal of a column.
-     * @param x
-     *        A {@code java.time.OffsetDateTime} value.
-     * @param scale
-     *        scale of the column
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale) throws SQLServerException;
-
-    /**
-     * Updates the value of the column specified to a {@link java.time.OffsetDateTime} value, given a zero-based column
-     * ordinal.
-     *
-     * @param index
-     *        The zero-based ordinal of a column.
-     * @param x
-     *        A {@code java.time.OffsetDateTime} value.
-     * @param scale
-     *        scale of the column
-     * @param forceEncrypt
-     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
-     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
-     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
-     * @throws SQLServerException
-     *         when an error occurs
-     */
-    void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**
@@ -1589,9 +1489,7 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        the scale of the column
      * @throws SQLServerException
      *         If any errors occur.
-     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime, int)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x, int scale) throws SQLServerException;
 
     /**
@@ -1609,43 +1507,8 @@ public interface ISQLServerResultSet extends java.sql.ResultSet {
      *        forceEncrypt is set to false, the driver will not force encryption on parameters.
      * @throws SQLServerException
      *         If any errors occur.
-     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime, int, boolean)} instead.
      */
-    @Deprecated(since = "13.5.0")
     void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x, int scale,
-            boolean forceEncrypt) throws SQLServerException;
-
-    /**
-     * Updates the value of the column specified to a {@link java.time.OffsetDateTime} value, given a column name.
-     *
-     * @param columnName
-     *        The name of a column.
-     * @param x
-     *        A {@code java.time.OffsetDateTime} value.
-     * @param scale
-     *        the scale of the column
-     * @throws SQLServerException
-     *         If any errors occur.
-     */
-    void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x, int scale) throws SQLServerException;
-
-    /**
-     * Updates the value of the column specified to a {@link java.time.OffsetDateTime} value, given a column name.
-     *
-     * @param columnName
-     *        The name of a column.
-     * @param x
-     *        A {@code java.time.OffsetDateTime} value.
-     * @param scale
-     *        the scale of the column
-     * @param forceEncrypt
-     *        If the boolean forceEncrypt is set to true, the query parameter will only be set if the designation column
-     *        is encrypted and Always Encrypted is enabled on the connection or on the statement. If the boolean
-     *        forceEncrypt is set to false, the driver will not force encryption on parameters.
-     * @throws SQLServerException
-     *         If any errors occur.
-     */
-    void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x, int scale,
             boolean forceEncrypt) throws SQLServerException;
 
     /**

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -895,10 +895,19 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 }
             }
         } else if (type == java.time.OffsetDateTime.class) {
-            returnValue = getOffsetDateTime(index);
+            microsoft.sql.DateTimeOffset dateTimeOffset = getDateTimeOffset(index);
+            if (dateTimeOffset == null) {
+                returnValue = null;
+            } else {
+                returnValue = dateTimeOffset.getOffsetDateTime();
+            }
         } else if (type == java.time.OffsetTime.class) {
-            java.time.OffsetDateTime odt = getOffsetDateTime(index);
-            returnValue = (odt == null) ? null : odt.toOffsetTime();
+            microsoft.sql.DateTimeOffset dateTimeOffset = getDateTimeOffset(index);
+            if (dateTimeOffset == null) {
+                returnValue = null;
+            } else {
+                returnValue = dateTimeOffset.getOffsetDateTime().toOffsetTime();
+            }
         } else if (type == microsoft.sql.DateTimeOffset.class) {
             returnValue = getDateTimeOffset(index);
         } else if (type == UUID.class) {
@@ -1214,10 +1223,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         return value;
     }
 
-    /**
-     * @deprecated Use {@link #getOffsetDateTime(int)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public microsoft.sql.DateTimeOffset getDateTimeOffset(int index) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER))
@@ -1236,10 +1241,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         return value;
     }
 
-    /**
-     * @deprecated Use {@link #getOffsetDateTime(String)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public microsoft.sql.DateTimeOffset getDateTimeOffset(String parameterName) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER)) {
@@ -1256,33 +1257,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 JDBCType.DATETIMEOFFSET);
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "getDateTimeOffset", value);
-        }
-        return value;
-    }
-
-    @Override
-    public java.time.OffsetDateTime getOffsetDateTime(int index) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", index);
-        @SuppressWarnings("deprecation")
-        microsoft.sql.DateTimeOffset dto = getDateTimeOffset(index);
-        java.time.OffsetDateTime value = (dto == null) ? null : dto.getOffsetDateTime();
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", value);
-        }
-        return value;
-    }
-
-    @Override
-    public java.time.OffsetDateTime getOffsetDateTime(String parameterName) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", parameterName);
-        }
-        @SuppressWarnings("deprecation")
-        microsoft.sql.DateTimeOffset dto = getDateTimeOffset(parameterName);
-        java.time.OffsetDateTime value = (dto == null) ? null : dto.getOffsetDateTime();
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", value);
         }
         return value;
     }
@@ -2254,10 +2228,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         }
     }
 
-    /**
-     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER))
@@ -2269,10 +2239,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         }
     }
 
-    /**
-     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime, int)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value,
             int scale) throws SQLServerException {
@@ -2286,10 +2252,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         }
     }
 
-    /**
-     * @deprecated Use {@link #setOffsetDateTime(String, java.time.OffsetDateTime, int, boolean)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void setDateTimeOffset(String parameterName, microsoft.sql.DateTimeOffset value, int scale,
             boolean forceEncrypt) throws SQLServerException {
@@ -2301,48 +2263,6 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
                 forceEncrypt);
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "setDateTimeOffset");
-        }
-    }
-
-    @Override
-    public void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime", new Object[] {parameterName, value});
-        checkClosed();
-        setValue(findColumn(parameterName), JDBCType.DATETIMEOFFSET,
-                (value == null) ? null : microsoft.sql.DateTimeOffset.valueOf(value), JavaType.DATETIMEOFFSET, false);
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
-        }
-    }
-
-    @Override
-    public void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value,
-            int scale) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime",
-                    new Object[] {parameterName, value, scale});
-        checkClosed();
-        setValue(findColumn(parameterName), JDBCType.DATETIMEOFFSET,
-                (value == null) ? null : microsoft.sql.DateTimeOffset.valueOf(value), JavaType.DATETIMEOFFSET, null,
-                scale, false);
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
-        }
-    }
-
-    @Override
-    public void setOffsetDateTime(String parameterName, java.time.OffsetDateTime value, int scale,
-            boolean forceEncrypt) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime",
-                    new Object[] {parameterName, value, forceEncrypt});
-        checkClosed();
-        setValue(findColumn(parameterName), JDBCType.DATETIMEOFFSET,
-                (value == null) ? null : microsoft.sql.DateTimeOffset.valueOf(value), JavaType.DATETIMEOFFSET, null,
-                scale, forceEncrypt);
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2365,10 +2365,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         }
     }
 
-    /**
-     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public final void setDateTimeOffset(int n, microsoft.sql.DateTimeOffset x) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER))
@@ -2380,10 +2376,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         }
     }
 
-    /**
-     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime, int)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public final void setDateTimeOffset(int n, microsoft.sql.DateTimeOffset x, int scale) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER))
@@ -2395,10 +2387,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         }
     }
 
-    /**
-     * @deprecated Use {@link #setOffsetDateTime(int, java.time.OffsetDateTime, int, boolean)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public final void setDateTimeOffset(int n, microsoft.sql.DateTimeOffset x, int scale,
             boolean forceEncrypt) throws SQLServerException {
@@ -2409,46 +2397,6 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
         setValue(n, JDBCType.DATETIMEOFFSET, x, JavaType.DATETIMEOFFSET, null, scale, forceEncrypt);
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "setDateTimeOffset");
-        }
-    }
-
-    @Override
-    public final void setOffsetDateTime(int n, java.time.OffsetDateTime x) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime", new Object[] {n, x});
-        checkClosed();
-        setValue(n, JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, false);
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
-        }
-    }
-
-    @Override
-    public final void setOffsetDateTime(int n, java.time.OffsetDateTime x, int scale) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime", new Object[] {n, x, scale});
-        checkClosed();
-        setValue(n, JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, null, scale,
-                false);
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
-        }
-    }
-
-    @Override
-    public final void setOffsetDateTime(int n, java.time.OffsetDateTime x, int scale,
-            boolean forceEncrypt) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "setOffsetDateTime",
-                    new Object[] {n, x, scale, forceEncrypt});
-        checkClosed();
-        setValue(n, JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, null, scale,
-                forceEncrypt);
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "setOffsetDateTime");
         }
     }
 

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResultSet.java
@@ -2717,10 +2717,19 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
                 }
             }
         } else if (type == java.time.OffsetDateTime.class) {
-            returnValue = getOffsetDateTime(columnIndex);
+            microsoft.sql.DateTimeOffset dateTimeOffset = getDateTimeOffset(columnIndex);
+            if (dateTimeOffset == null) {
+                returnValue = null;
+            } else {
+                returnValue = dateTimeOffset.getOffsetDateTime();
+            }
         } else if (type == java.time.OffsetTime.class) {
-            java.time.OffsetDateTime odt = getOffsetDateTime(columnIndex);
-            returnValue = (odt == null) ? null : odt.toOffsetTime();
+            microsoft.sql.DateTimeOffset dateTimeOffset = getDateTimeOffset(columnIndex);
+            if (dateTimeOffset == null) {
+                returnValue = null;
+            } else {
+                returnValue = dateTimeOffset.getOffsetDateTime().toOffsetTime();
+            }
         } else if (type == microsoft.sql.DateTimeOffset.class) {
             returnValue = getDateTimeOffset(columnIndex);
         } else if (type == UUID.class) {
@@ -3122,10 +3131,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         return value;
     }
 
-    /**
-     * @deprecated Use {@link #getOffsetDateTime(int)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public microsoft.sql.DateTimeOffset getDateTimeOffset(int columnIndex) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER)) {
@@ -3146,10 +3151,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         return value;
     }
 
-    /**
-     * @deprecated Use {@link #getOffsetDateTime(String)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public microsoft.sql.DateTimeOffset getDateTimeOffset(String columnName) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER)) {
@@ -3168,48 +3169,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
             loggerExternal.exiting(getClassNameLogging(), "getDateTimeOffset", value);
         }
         return value;
-    }
-
-    @Override
-    public java.time.OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", columnIndex);
-        }
-        checkClosed();
-
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if (!stmt.connection.isKatmaiOrLater())
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-
-        microsoft.sql.DateTimeOffset value = (microsoft.sql.DateTimeOffset) getValue(columnIndex,
-                JDBCType.DATETIMEOFFSET);
-        java.time.OffsetDateTime result = (value == null) ? null : value.getOffsetDateTime();
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", result);
-        }
-        return result;
-    }
-
-    @Override
-    public java.time.OffsetDateTime getOffsetDateTime(String columnName) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.entering(getClassNameLogging(), "getOffsetDateTime", columnName);
-        }
-        checkClosed();
-
-        // DateTimeOffset is not supported with SQL Server versions earlier than Katmai
-        if (!stmt.connection.isKatmaiOrLater())
-            throw new SQLServerException(SQLServerException.getErrString("R_notSupported"),
-                    SQLState.DATA_EXCEPTION_NOT_SPECIFIC, DriverError.NOT_SET, null);
-
-        microsoft.sql.DateTimeOffset value = (microsoft.sql.DateTimeOffset) getValue(findColumn(columnName),
-                JDBCType.DATETIMEOFFSET);
-        java.time.OffsetDateTime result = (value == null) ? null : value.getOffsetDateTime();
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "getOffsetDateTime", result);
-        }
-        return result;
     }
 
     /**
@@ -4317,10 +4276,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         }
     }
 
-    /**
-     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER))
@@ -4334,10 +4289,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         }
     }
 
-    /**
-     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime, Integer)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x,
             Integer scale) throws SQLServerException {
@@ -4352,10 +4303,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         }
     }
 
-    /**
-     * @deprecated Use {@link #updateOffsetDateTime(int, java.time.OffsetDateTime, Integer, boolean)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void updateDateTimeOffset(int index, microsoft.sql.DateTimeOffset x, Integer scale,
             boolean forceEncrypt) throws SQLServerException {
@@ -4368,52 +4315,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "updateDateTimeOffset");
-        }
-    }
-
-    @Override
-    public void updateOffsetDateTime(int index, java.time.OffsetDateTime x) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime", new Object[] {index, x});
-
-        checkClosed();
-        updateValue(index, JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, false);
-
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
-        }
-    }
-
-    @Override
-    public void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime", new Object[] {index, x, scale});
-
-        checkClosed();
-        updateValue(index, JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, null, scale,
-                false);
-
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
-        }
-    }
-
-    @Override
-    public void updateOffsetDateTime(int index, java.time.OffsetDateTime x, Integer scale,
-            boolean forceEncrypt) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime",
-                    new Object[] {index, x, scale, forceEncrypt});
-
-        checkClosed();
-        updateValue(index, JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, null, scale,
-                forceEncrypt);
-
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
         }
     }
 
@@ -5348,10 +5249,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         }
     }
 
-    /**
-     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x) throws SQLServerException {
         if (loggerExternal.isLoggable(Level.FINER))
@@ -5365,10 +5262,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         }
     }
 
-    /**
-     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime, int)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x,
             int scale) throws SQLServerException {
@@ -5383,10 +5276,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
         }
     }
 
-    /**
-     * @deprecated Use {@link #updateOffsetDateTime(String, java.time.OffsetDateTime, int, boolean)} instead.
-     */
-    @Deprecated(since = "13.5.0")
     @Override
     public void updateDateTimeOffset(String columnName, microsoft.sql.DateTimeOffset x, int scale,
             boolean forceEncrypt) throws SQLServerException {
@@ -5400,53 +5289,6 @@ public class SQLServerResultSet implements ISQLServerResultSet, java.io.Serializ
 
         if (loggerExternal.isLoggable(Level.FINER)) {
             loggerExternal.exiting(getClassNameLogging(), "updateDateTimeOffset");
-        }
-    }
-
-    @Override
-    public void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime", new Object[] {columnName, x});
-
-        checkClosed();
-        updateValue(findColumn(columnName), JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, false);
-
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
-        }
-    }
-
-    @Override
-    public void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x, int scale) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime",
-                    new Object[] {columnName, x, scale});
-
-        checkClosed();
-        updateValue(findColumn(columnName), JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, null, scale,
-                false);
-
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
-        }
-    }
-
-    @Override
-    public void updateOffsetDateTime(String columnName, java.time.OffsetDateTime x, int scale,
-            boolean forceEncrypt) throws SQLServerException {
-        if (loggerExternal.isLoggable(Level.FINER))
-            loggerExternal.entering(getClassNameLogging(), "updateOffsetDateTime",
-                    new Object[] {columnName, x, scale, forceEncrypt});
-
-        checkClosed();
-        updateValue(findColumn(columnName), JDBCType.DATETIMEOFFSET,
-                (x == null) ? null : microsoft.sql.DateTimeOffset.valueOf(x), JavaType.DATETIMEOFFSET, null, scale,
-                forceEncrypt);
-
-        if (loggerExternal.isLoggable(Level.FINER)) {
-            loggerExternal.exiting(getClassNameLogging(), "updateOffsetDateTime");
         }
     }
 

--- a/src/main/java/microsoft/sql/DateTimeOffset.java
+++ b/src/main/java/microsoft/sql/DateTimeOffset.java
@@ -18,11 +18,7 @@ import java.util.TimeZone;
  * The DateTimeOffset class represents a java.sql.Timestamp, including fractional seconds, plus an integer representing
  * the number of minutes offset from GMT.
  *
- * @deprecated Use {@link java.time.OffsetDateTime} instead. Methods accepting or returning
- *             {@code microsoft.sql.DateTimeOffset} have been deprecated in favor of equivalents that use
- *             {@code java.time.OffsetDateTime}.
  */
-@Deprecated(since = "13.5.0")
 public final class DateTimeOffset implements java.io.Serializable, java.lang.Comparable<DateTimeOffset> {
     private static final long serialVersionUID = 541973748553014280L;
 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/AlwaysEncrypted/PrecisionScaleTest.java
@@ -559,14 +559,12 @@ public class PrecisionScaleTest extends AESetup {
 
         // datetimeoffset scale
         for (int i = 7; i <= 9; i++) {
-            pstmt.setDateTimeOffset(i, (microsoft.sql.DateTimeOffset) null, scale);
-            pstmt.setOffsetDateTime(i, null, scale);
+            pstmt.setDateTimeOffset(i, null, scale);
         }
 
         // datetimeoffset default
         for (int i = 10; i <= 12; i++) {
-            pstmt.setDateTimeOffset(i, (microsoft.sql.DateTimeOffset) null);
-            pstmt.setOffsetDateTime(i, null);
+            pstmt.setDateTimeOffset(i, null);
         }
 
         // time scale

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -56,7 +56,6 @@ import com.microsoft.sqlserver.jdbc.RandomUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement;
-import com.microsoft.sqlserver.jdbc.SQLServerResultSet;
 import com.microsoft.sqlserver.jdbc.SQLServerStatement;
 import com.microsoft.sqlserver.jdbc.TestResource;
 import com.microsoft.sqlserver.jdbc.TestUtils;
@@ -1022,8 +1021,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.setObject(3, dateTime2Val); // DATETIME2
             pstmt.setDate(4, dateVal); // DATE
             pstmt.setObject(5, timeVal); // TIME
-            pstmt.setDateTimeOffset(6, dateTimeOffsetVal); // DATETIMEOFFSET (legacy API)
-            pstmt.setOffsetDateTime(6, offsetDateTimeVal); // DATETIMEOFFSET (new API)
+            pstmt.setDateTimeOffset(6, dateTimeOffsetVal); // DATETIMEOFFSET
             pstmt.setMoney(7, moneyVal); // MONEY
             pstmt.setSmallMoney(8, smallMoneyVal); // SMALLMONEY
 
@@ -1051,7 +1049,6 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
 
                 assertEquals(dateTimeOffsetVal, rs.getObject(6, DateTimeOffset.class));
                 assertEquals(expectedDateTimeOffsetString, rs.getObject(6).toString());
-                assertEquals(offsetDateTimeVal, ((SQLServerResultSet) rs).getOffsetDateTime(6));
 
                 assertEquals(moneyVal, rs.getBigDecimal(7));
                 assertEquals(expectedMoneyString, rs.getBigDecimal(7).toString());
@@ -1094,8 +1091,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.setObject(3, null); // DATETIME2
             pstmt.setDate(4, null); // DATE
             pstmt.setObject(5, null); // TIME
-            pstmt.setDateTimeOffset(6, (DateTimeOffset) null); // DATETIMEOFFSET (legacy API)
-            pstmt.setOffsetDateTime(6, null); // DATETIMEOFFSET (new API)
+            pstmt.setDateTimeOffset(6, null); // DATETIMEOFFSET
             pstmt.setMoney(7, null); // MONEY
             pstmt.setSmallMoney(8, null); // SMALLMONEY
 
@@ -1112,7 +1108,6 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
                 assertEquals(null, rs.getDate(4));
                 assertEquals(null, rs.getObject(5));
                 assertEquals(null, rs.getObject(6));
-                assertEquals(null, ((SQLServerResultSet) rs).getOffsetDateTime(6));
                 assertEquals(null, rs.getBigDecimal(7));
                 assertEquals(null, rs.getBigDecimal(8));
                 
@@ -1179,8 +1174,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.setObject(3, dateTime2Val); // DATETIME2
             pstmt.setDate(4, dateVal); // DATE
             pstmt.setTimestamp(5, timeVal); // TIME
-            pstmt.setDateTimeOffset(6, dateTimeOffsetVal); // DATETIMEOFFSET (legacy API)
-            pstmt.setOffsetDateTime(6, offsetDateTimeVal); // DATETIMEOFFSET (new API)
+            pstmt.setDateTimeOffset(6, dateTimeOffsetVal); // DATETIMEOFFSET
             pstmt.setMoney(7, moneyVal); // MONEY
             pstmt.setSmallMoney(8, smallMoneyVal); // SMALLMONEY
 
@@ -1208,7 +1202,6 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
 
                 assertEquals(dateTimeOffsetVal, rs.getObject(6, DateTimeOffset.class));
                 assertEquals(expectedDateTimeOffsetString, rs.getObject(6).toString());
-                assertEquals(offsetDateTimeVal, ((SQLServerResultSet) rs).getOffsetDateTime(6));
 
                 assertEquals(moneyVal, rs.getBigDecimal(7));
                 assertEquals(expectedMoneyString, rs.getBigDecimal(7).toString());
@@ -1251,8 +1244,7 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             pstmt.setObject(3, null); // DATETIME2
             pstmt.setDate(4, null); // DATE
             pstmt.setObject(5, null); // TIME
-            pstmt.setDateTimeOffset(6, (DateTimeOffset) null); // DATETIMEOFFSET (legacy API)
-            pstmt.setOffsetDateTime(6, null); // DATETIMEOFFSET (new API)
+            pstmt.setDateTimeOffset(6, null); // DATETIMEOFFSET
             pstmt.setMoney(7, null); // MONEY
             pstmt.setSmallMoney(8, null); // SMALLMONEY
 
@@ -1269,7 +1261,6 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
                 assertEquals(null, rs.getDate(4));
                 assertEquals(null, rs.getObject(5));
                 assertEquals(null, rs.getObject(6));
-                assertEquals(null, ((SQLServerResultSet) rs).getOffsetDateTime(6));
                 assertEquals(null, rs.getBigDecimal(7));
                 assertEquals(null, rs.getBigDecimal(8));
                 

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/SetObjectTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/SetObjectTest.java
@@ -205,18 +205,13 @@ public class SetObjectTest extends AbstractTest {
                         pstmt.setObject(2, dateTimeOffset);
                         pstmt.executeUpdate();
 
-                        // Set OffsetDateTime (new API)
+                        // Set DateTimeOffset
                         pstmt.setInt(1, 4);
-                        pstmt.setOffsetDateTime(2, offsetDateTime);
-                        pstmt.executeUpdate();
-
-                        // Set DateTimeOffset (legacy API)
-                        pstmt.setInt(1, 5);
                         pstmt.setDateTimeOffset(2, dateTimeOffset);
                         pstmt.executeUpdate();
 
                         // Set String
-                        pstmt.setInt(1, 6);
+                        pstmt.setInt(1, 5);
                         pstmt.setString(2, expectedDTOString);
                         pstmt.executeUpdate();
                     }
@@ -224,7 +219,7 @@ public class SetObjectTest extends AbstractTest {
                     String query = "SELECT dto FROM " + AbstractSQLGenerator.escapeIdentifier(tableName);
                     verifyDateTimeOffsetValues(stmt, query, dateTimeOffset, offsetDateTime, expectedDTOString, sqlDto);
 
-                    for (int i = 1; i <= 6; i++) {
+                    for (int i = 1; i <= 5; i++) {
                         query = "SELECT dto FROM " + AbstractSQLGenerator.escapeIdentifier(tableName) + " WHERE id = "
                                 + i + " AND dto = '" + sqlDto + "'";
                         verifyDateTimeOffsetValues(stmt, query, dateTimeOffset, offsetDateTime, expectedDTOString,
@@ -249,9 +244,6 @@ public class SetObjectTest extends AbstractTest {
 
                 assertEquals(dateTimeOffset, rs.getObject(1, DateTimeOffset.class));
                 assertEquals(expectedDTOString, rs.getObject(1, DateTimeOffset.class).toString());
-
-                assertEquals(offsetDateTime, rs.getOffsetDateTime(1));
-                assertEquals(sqlDto, rs.getOffsetDateTime(1).toString());
 
                 assertEquals(offsetDateTime, rs.getObject(1, OffsetDateTime.class));
                 assertEquals(sqlDto, rs.getObject(1, OffsetDateTime.class).toString());

--- a/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/WrapperTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/unit/statement/WrapperTest.java
@@ -87,10 +87,8 @@ public class WrapperTest extends AbstractTest {
                             .unwrap(Class.forName("com.microsoft.sqlserver.jdbc.ISQLServerPreparedStatement"))) {
                         stmt3.setResponseBuffering("adaptive");
 
-                        if (isKatmaiServer()) {
+                        if (isKatmaiServer())
                             stmt3.setDateTimeOffset(1, null);
-                            stmt3.setOffsetDateTime(1, null);
-                        }
 
                         // Try Unwrapping CallableStatement to a callableStatement
                         isWrapper = ((SQLServerCallableStatement) cs)
@@ -103,7 +101,6 @@ public class WrapperTest extends AbstractTest {
                             stmt4.setResponseBuffering("adaptive");
                             if (isKatmaiServer()) {
                                 stmt4.setDateTimeOffset(1, null);
-                                stmt4.setOffsetDateTime(1, null);
                             }
                         }
                     }


### PR DESCRIPTION
**Description**
This PR reverts [#2920](https://github.com/microsoft/mssql-jdbc/pull/2920), which deprecated microsoft.sql.DateTimeOffset and introduced driver-specific APIs using java.time.OffsetDateTime.

The rollback is required for GA readiness to preserve the established public API and avoid introducing compatibility changes in the current release.

**Changes**
Removes the driver-specific getOffsetDateTime() APIs.
Removes the driver-specific setOffsetDateTime() APIs.
Removes the driver-specific updateOffsetDateTime() APIs.
Removes the deprecation of microsoft.sql.DateTimeOffset.
Removes deprecation annotations from the existing getDateTimeOffset(), setDateTimeOffset(), and updateDateTimeOffset() APIs.
Restores the associated tests to the legacy API behavior.
Removes the reverted feature entry from CHANGELOG.md.
Preserves standard JDBC support for getObject(..., OffsetDateTime.class) and existing conversion methods.
Motivation
Although the legacy APIs remained available, promoting OffsetDateTime as the canonical representation introduced externally observable API and behavior changes close to GA.

Reverting the change preserves compatibility with applications that currently depend on:

microsoft.sql.DateTimeOffset
Existing SQL Server-specific getters, setters, and update methods
Established datetimeoffset handling across prepared statements, callable statements, result sets, bulk copy, and Always Encrypted
The OffsetDateTime migration can be reconsidered in a future release with a dedicated compatibility and migration plan.

Related
Reverts [#2920](https://github.com/microsoft/mssql-jdbc/pull/2920)
Supersedes the metadata direction proposed in [#3030](https://github.com/microsoft/mssql-jdbc/pull/3030) for the current GA release.