### PR TITLE
Fix silent drop of trailing SQL after VALUES in bulk copy batch insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Fixed
 
+- **Fix Silent Drop of Trailing SQL After VALUES in Bulk Copy Batch Insert** [#3037](https://github.com/microsoft/mssql-jdbc/pull/3037)
+  - **What was fixed**: Trailing content after the `VALUES` list, such as an `OPTION (...)` query hint or an extra value tuple, now triggers the existing fallback to the regular batch execution path instead of being discarded.
+  - **Who benefits**: Applications using `useBulkCopyForBatchInsert=true` with batched `INSERT` statements that carry trailing clauses.
+  - **Impact**: The full statement is sent to the server verbatim; statements with only trailing comments, whitespace, or semicolons continue to use Bulk Copy.
+
 - **Fix Closed-Statement NullPointerException in buildParamTypeDefinitions** [#2995](https://github.com/microsoft/mssql-jdbc/pull/2995)
   - **What was fixed**: Checked the statement's closed state before accessing a null parameter array in `buildParamTypeDefinitions()`.
   - **Who benefits**: Applications that invoke parameter-related methods after a prepared or callable statement is closed.

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -3043,6 +3043,16 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
     private void checkAdditionalQuery() {
         while (checkAndRemoveCommentsAndSpace(true)) {}
+
+        // Once the VALUES list has been consumed, only comments, whitespace or semicolons may remain.
+        // Any other trailing content (for example an OPTION (...) query hint) cannot be honored by the
+        // Bulk Copy API. Throw so the caller falls back to the regular batch execution path, which sends
+        // the full statement - including the trailing clause - to the server.
+        if (null != localUserSQL && !localUserSQL.trim().isEmpty()) {
+            MessageFormat form = new MessageFormat(SQLServerException.getErrString("R_invalidSQL"));
+            Object[] msgArgs = {localUserSQL};
+            throw new IllegalArgumentException(form.format(msgArgs));
+        }
     }
 
     private String parseUserSQLForTableNameDW(boolean hasInsertBeenFound, boolean hasIntoBeenFound,

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerPreparedStatement.java
@@ -2631,9 +2631,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
                     if (null == bcOperationValueList) {
                         bcOperationValueList = parseUserSQLForValueListDW(false);
-                    }
 
-                    checkAdditionalQuery();
+                        // Only meaningful right after the statement has been parsed. On subsequent calls the
+                        // parse results are served from the cache above and localUserSQL still holds the full,
+                        // unconsumed statement, which would incorrectly look like trailing content.
+                        checkAdditionalQuery();
+                    }
 
                     try (SQLServerStatement stmt = (SQLServerStatement) connection.createStatement(
                             ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY, connection.getHoldability(),
@@ -2851,9 +2854,12 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
 
                     if (null == bcOperationValueList) {
                         bcOperationValueList = parseUserSQLForValueListDW(false);
-                    }
 
-                    checkAdditionalQuery();
+                        // Only meaningful right after the statement has been parsed. On subsequent calls the
+                        // parse results are served from the cache above and localUserSQL still holds the full,
+                        // unconsumed statement, which would incorrectly look like trailing content.
+                        checkAdditionalQuery();
+                    }
 
                     try (SQLServerStatement stmt = (SQLServerStatement) connection.createStatement(
                             ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY, connection.getHoldability(),
@@ -3358,9 +3364,10 @@ public class SQLServerPreparedStatement extends SQLServerStatement implements IS
     private boolean checkAndRemoveCommentsAndSpace(boolean checkForSemicolon) {
         localUserSQL = localUserSQL.trim();
 
+        // Trim between semicolons as well, so whitespace separated ones such as "; ;" are fully consumed.
         while (checkForSemicolon && null != localUserSQL && localUserSQL.length() > 0
                 && localUserSQL.charAt(0) == ';') {
-            localUserSQL = localUserSQL.substring(1);
+            localUserSQL = localUserSQL.substring(1).trim();
         }
 
         if (null == localUserSQL || localUserSQL.length() < 2) {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -216,6 +216,44 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
         }
     }
 
+    /**
+     * Verifies that trailing SQL after the VALUES list (for example an OPTION query hint) causes
+     * checkAdditionalQuery to throw, so the driver falls back to the regular batch execution path
+     * instead of silently dropping the clause when using Bulk Copy for batch insert.
+     */
+    @Test
+    public void testCheckAdditionalQuery() throws Exception {
+        try (Connection connection = PrepUtil.getConnection(connectionString + ";useBulkCopyForBatchInsert=true;");
+                PreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement("");) {
+            Field f1 = pstmt.getClass().getDeclaredField("localUserSQL");
+            f1.setAccessible(true);
+
+            Method method = pstmt.getClass().getDeclaredMethod("checkAdditionalQuery");
+            method.setAccessible(true);
+
+            // Trailing content that cannot be honored by Bulk Copy must trigger a fallback.
+            String[] unsupportedTrailers = {" OPTION (OPTIMIZE FOR UNKNOWN)",
+                    " OPTION (RECOMPILE)", ", (?, ?)", " FROM x"};
+            for (String trailer : unsupportedTrailers) {
+                f1.set(pstmt, trailer);
+                try {
+                    method.invoke(pstmt);
+                    fail("Expected IllegalArgumentException for trailing SQL: " + trailer);
+                } catch (java.lang.reflect.InvocationTargetException e) {
+                    assertTrue(e.getCause() instanceof IllegalArgumentException);
+                }
+            }
+
+            // Only comments, whitespace and semicolons may remain - these must NOT trigger a fallback.
+            String[] supportedTrailers = {"", "   ", ";", " ; ", "/* trailing comment */",
+                    "-- trailing comment\n", " ;/* c */ ;"};
+            for (String trailer : supportedTrailers) {
+                f1.set(pstmt, trailer);
+                method.invoke(pstmt);
+            }
+        }
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testAll() throws Exception {

--- a/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/preparedStatement/BatchExecutionWithBulkCopyTest.java
@@ -34,6 +34,7 @@ import java.util.Calendar;
 import java.util.Random;
 import java.util.UUID;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -245,13 +246,117 @@ public class BatchExecutionWithBulkCopyTest extends AbstractTest {
             }
 
             // Only comments, whitespace and semicolons may remain - these must NOT trigger a fallback.
-            String[] supportedTrailers = {"", "   ", ";", " ; ", "/* trailing comment */",
+            String[] supportedTrailers = {"", "   ", ";", " ; ", "; ;", "/* trailing comment */",
                     "-- trailing comment\n", " ;/* c */ ;"};
             for (String trailer : supportedTrailers) {
                 f1.set(pstmt, trailer);
                 method.invoke(pstmt);
             }
         }
+    }
+
+    /**
+     * Verifies that a trailing clause after the VALUES list (an OPTION query hint) makes the driver fall back
+     * to the regular batch execution path, so that the full statement - including the trailing clause - reaches
+     * the server instead of being silently dropped.
+     */
+    @Test
+    public void testTrailingOptionClauseFallsBackAndInserts() throws Exception {
+        String localTableName = RandomUtil.getIdentifier("Table_BulkCopy_TrailingOption");
+        String insertSQL = "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(localTableName)
+                + " (Id, Data) VALUES (?, ?) OPTION (RECOMPILE)";
+
+        try (Connection connection = PrepUtil.getConnection(connectionString + ";useBulkCopyForBatchInsert=true;");
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement(insertSQL);
+                Statement stmt = (SQLServerStatement) connection.createStatement()) {
+
+            createTable_SQLFunction(localTableName);
+
+            pstmt.setInt(1, 1);
+            pstmt.setInt(2, 10);
+            pstmt.addBatch();
+            pstmt.setInt(1, 2);
+            pstmt.setInt(2, 20);
+            pstmt.addBatch();
+
+            try (AutoCloseable ignored = enableFineStatementLogging();
+                    FallbackWatcherLogHandler handler = new FallbackWatcherLogHandler()) {
+                pstmt.executeBatch();
+                assertTrue(handler.gotFallbackMessage, "Expected fallback to the regular batch path");
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT Id, Data FROM "
+                    + AbstractSQLGenerator.escapeIdentifier(localTableName) + " ORDER BY Id")) {
+                assertTrue(rs.next(), "Expected first row");
+                assertEquals(1, rs.getInt("Id"));
+                assertEquals(10, rs.getInt("Data"));
+                assertTrue(rs.next(), "Expected second row");
+                assertEquals(2, rs.getInt("Id"));
+                assertEquals(20, rs.getInt("Data"));
+                assertFalse(rs.next());
+            }
+        } finally {
+            try (Statement stmt = connection.createStatement()) {
+                TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(localTableName), stmt);
+            }
+        }
+    }
+
+    /**
+     * Verifies that reusing the same PreparedStatement for multiple batches keeps using Bulk Copy. The parsed
+     * table/column/value lists are cached after the first executeBatch, so the leftover-SQL validation must not
+     * run again against the unconsumed statement and wrongly force a fallback on every later batch.
+     */
+    @Test
+    public void testRepeatedBatchesKeepUsingBulkCopy() throws Exception {
+        String localTableName = RandomUtil.getIdentifier("Table_BulkCopy_RepeatedBatch");
+        String insertSQL = "INSERT INTO " + AbstractSQLGenerator.escapeIdentifier(localTableName)
+                + " (Id, Data) VALUES (?, ?)";
+
+        try (Connection connection = PrepUtil.getConnection(connectionString + ";useBulkCopyForBatchInsert=true;");
+                SQLServerPreparedStatement pstmt = (SQLServerPreparedStatement) connection.prepareStatement(insertSQL);
+                Statement stmt = (SQLServerStatement) connection.createStatement()) {
+
+            createTable_SQLFunction(localTableName);
+
+            try (AutoCloseable ignored = enableFineStatementLogging()) {
+                for (int batch = 0; batch < 3; batch++) {
+                    pstmt.setInt(1, batch * 2 + 1);
+                    pstmt.setInt(2, batch * 2 + 1);
+                    pstmt.addBatch();
+                    pstmt.setInt(1, batch * 2 + 2);
+                    pstmt.setInt(2, batch * 2 + 2);
+                    pstmt.addBatch();
+
+                    try (FallbackWatcherLogHandler handler = new FallbackWatcherLogHandler()) {
+                        pstmt.executeBatch();
+                        assertFalse("Batch " + batch + " unexpectedly fell back to the regular batch path",
+                                handler.gotFallbackMessage);
+                    }
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM "
+                    + AbstractSQLGenerator.escapeIdentifier(localTableName))) {
+                assertTrue(rs.next());
+                assertEquals(6, rs.getInt(1));
+            }
+        } finally {
+            try (Statement stmt = connection.createStatement()) {
+                TestUtils.dropTableIfExists(AbstractSQLGenerator.escapeIdentifier(localTableName), stmt);
+            }
+        }
+    }
+
+    /**
+     * Forces the internal statement logger to FINE so the fallback log message is actually published, making
+     * both positive and negative fallback assertions meaningful regardless of the ambient logging configuration.
+     */
+    private AutoCloseable enableFineStatementLogging() {
+        Logger stmtLogger = Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerStatement");
+        Level previousLevel = stmtLogger.getLevel();
+        stmtLogger.setLevel(Level.FINE);
+        return () -> stmtLogger.setLevel(previousLevel);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Problem

With `useBulkCopyForBatchInsert=true`, the driver parses a batched `INSERT` into its table, columns, and values and sends rows through Bulk Copy instead of executing the SQL text.

The parser stops after the first `VALUES (...)` tuple. Previously, `checkAdditionalQuery()` stripped comments, whitespace, and semicolons but did not reject remaining SQL. Trailing query hints such as `OPTION (RECOMPILE)` could therefore be ignored, and additional tuples in a multi-row `VALUES` list could be silently lost.

## Changes

- Reject meaningful SQL remaining after the first values tuple and use the existing normal prepared-batch fallback, preserving the complete statement.
- Validate trailing SQL only during parsing. Cached parsing results mean later executions have not consumed `localUserSQL`, so checking that full string again would incorrectly reject supported inserts.
- Remember rejected trailing SQL in `bulkCopyHasUnsupportedTrailingSQL`. Both `executeBatch()` and `executeLargeBatch()` bypass Bulk Copy on every subsequent execution of that statement.
- Continue accepting trailing comments, whitespace, and semicolons, including whitespace-separated semicolons such as `; ;`.

### Why the rejection must persist

The values list is cached before trailing-SQL validation runs. Throwing without remembering rejection only falls back for the current batch: the next batch skips parsing and validation and can silently drop the trailer again.

The rejection flag is set before throwing and lasts for the lifetime of the prepared statement, whose SQL text does not change. It survives `clearBatch()`, switching batch APIs, and failures in normal execution. It is separate from the configured Bulk Copy option and is not set for database or runtime failures. Supported inserts continue to reuse cached parsing and use Bulk Copy.

Focused code comments explain this state lifetime, why rejection must be recorded before throwing, and why regression tests check the execution path rather than relying on row counts or repeated fallback log messages alone.

## Expected behavior

| SQL / execution | Result |
|---|---|
| Trailing `OPTION (...)` | Normal batch execution preserves the hint on every batch |
| Additional `VALUES` tuples | Normal batch execution preserves all tuples and update counts |
| Reused statement with rejected trailing SQL | Remains on the normal path, including when switching batch APIs |
| Supported plain insert, including repeated batches | Continues using Bulk Copy |
| Only trailing comments, whitespace, or semicolons | Continues using Bulk Copy |

No public API or connection-string changes. **This PR does not modify `CHANGELOG.md`.**

## Regression coverage

`BatchExecutionWithBulkCopyTest` covers:

- Rejected and permitted trailers.
- Three successive batches with a query hint or an additional values tuple, using either batch API or alternating between them in either order.
- Exact update counts and inserted data, plus verification that rejected SQL never creates a Bulk Copy operation. Row counts alone would not detect a discarded query hint.
- Supported inserts retaining Bulk Copy across repeated and alternating batch calls.

Database-independent `BulkCopyTrailingSQLTest` verifies that rejected SQL stays on the normal batch path after simulated execution failures, `clearBatch()`, and switching batch APIs.

## Validation

The regression tests were written before the persistent-state fix: all 16 unsupported-trailer cases failed on statement reuse, while the four supported-insert cases passed.

After the behavioral fix and Eclipse formatting:

- `mvn -Pjre21 -Dtest=BulkCopyTrailingSQLTest,BatchExecutionWithBulkCopyTest test`: **57/57 cases passed** (49 integration-class cases and 8 isolated cases).
- `mvn -Pjre8 -Dmaven.test.skip=true clean compile`: passed on the installed JDK 21.

The final follow-up removes the changelog entry and adds explanatory comments only; it does not change executable code. Changed comments were formatted with the repository Eclipse configuration.